### PR TITLE
UI Docker: adopt client Dockerfiles into merge/all-to-main-20250915-022508

### DIFF
--- a/client/Dockerfile.prod
+++ b/client/Dockerfile.prod
@@ -1,13 +1,13 @@
 FROM node:20-alpine AS builder
 
 WORKDIR /app
-RUN npm install -g pnpm
-COPY client/package.json pnpm-lock.yaml ./
+
+COPY package.json package-lock.json ./
 
 # Ensure node_modules is clean before install
 RUN rm -rf node_modules
 
-RUN pnpm install --frozen-lockfile
+RUN npm install --no-optional
 
 COPY . .
 


### PR DESCRIPTION
### **User description**
Minimal-risk fix for UI Docker build issues by adopting client Dockerfiles from fix/ui-docker-build without merging unrelated workflow or docs changes.

Scope
- client/Dockerfile.dev
- client/Dockerfile.prod

Rationale
- Avoids large workflow/docs churn seen in the full branch
- Targets only the build breakage in UI container


___

### **PR Type**
Bug fix


___

### **Description**
- Switch from pnpm to npm package manager

- Update package files and installation commands

- Remove pnpm global installation step


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["pnpm package manager"] -- "replace with" --> B["npm package manager"]
  C["pnpm-lock.yaml"] -- "replace with" --> D["package-lock.json"]
  E["pnpm install"] -- "replace with" --> F["npm install"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile.prod</strong><dd><code>Switch from pnpm to npm package manager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

client/Dockerfile.prod

<ul><li>Replace pnpm with npm package manager<br> <li> Update package files from pnpm-lock.yaml to package-lock.json<br> <li> Remove pnpm global installation step<br> <li> Change install command to npm install --no-optional</ul>


</details>


  </td>
  <td><a href="https://github.com/BrianCLong/summit/pull/1263/files#diff-4207b82ce3e2d93a66107f6209ff16cba83d8a00ab64a55ce663d98e10c8f231">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

