### PR TITLE
feat: harden blowback risk controller

### DIFF
--- a/blowback_risk_controller.py
+++ b/blowback_risk_controller.py
@@ -1,0 +1,395 @@
+"""Planner for modeling blowback risks and integrity responses.
+
+This module provides data classes capturing different components of a
+blowback-risk analysis such as paths, provocations, cooling plays and
+indicators.  It is intended as a light-weight, in-memory structure that
+other systems can populate and inspect in order to tune responses to
+provocations while respecting civil liberties.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional, Any
+
+
+class ValidationError(ValueError):
+    """Raised when controller configuration is inconsistent."""
+
+
+@dataclass
+class RiskScoreConfig:
+    """Configuration used to tune the blowback risk score."""
+
+    likelihood_weight: float = 1.0
+    impact_weight: float = 1.0
+    reversibility_weight: float = 1.0
+    reversibility_ceiling: float = 10.0
+    reversibility_floor: float = 0.0
+    tuning_parameter_weights: Dict[str, float] = field(default_factory=dict)
+    audience_weights: Dict[str, float] = field(default_factory=dict)
+
+    def apply_tuning(self, score: float, path: "BlowbackPath") -> float:
+        """Adjust the risk score using tuning parameters and audience weights."""
+
+        adjusted = score
+        for key, weight in self.tuning_parameter_weights.items():
+            if weight == 0:
+                continue
+            value = path.tuning_parameters.get(key)
+            if value is None:
+                continue
+            adjusted *= 1 + max(0.0, value) * weight
+        if path.audience_segments:
+            for audience in path.audience_segments:
+                multiplier = self.audience_weights.get(audience)
+                if multiplier is None:
+                    continue
+                adjusted *= multiplier
+        return adjusted
+
+    def validate(self) -> None:
+        """Validate that weights are non-negative."""
+
+        invalid = [
+            name
+            for name, value in [
+                ("likelihood_weight", self.likelihood_weight),
+                ("impact_weight", self.impact_weight),
+                ("reversibility_weight", self.reversibility_weight),
+                ("reversibility_ceiling", self.reversibility_ceiling),
+                ("reversibility_floor", self.reversibility_floor),
+            ]
+            if value < 0
+        ]
+        if invalid:
+            raise ValidationError(
+                f"RiskScoreConfig has negative weights: {', '.join(sorted(invalid))}"
+            )
+        for mapping_name, mapping in (
+            ("tuning_parameter_weights", self.tuning_parameter_weights),
+            ("audience_weights", self.audience_weights),
+        ):
+            for key, value in mapping.items():
+                if value < 0:
+                    raise ValidationError(
+                        f"{mapping_name} contains negative weight for '{key}'"
+                    )
+
+
+@dataclass
+class BlowbackPath:
+    """Represents a single potential blowback escalation path."""
+
+    path: str
+    trigger: str
+    likelihood: int
+    impact: int
+    reversibility: int
+    tripwires: List[str] = field(default_factory=list)
+    tuning_parameters: Dict[str, float] = field(default_factory=dict)
+    audience_segments: List[str] = field(default_factory=list)
+    channels: List[str] = field(default_factory=list)
+    notes: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self._validate_scale(self.likelihood, "likelihood")
+        self._validate_scale(self.impact, "impact")
+        self._validate_scale(self.reversibility, "reversibility")
+        for key, value in self.tuning_parameters.items():
+            if not 0.0 <= value <= 1.0:
+                raise ValidationError(
+                    f"Tuning parameter '{key}' for path '{self.path}' must be between 0 and 1"
+                )
+
+    @staticmethod
+    def _validate_scale(value: int, field_name: str) -> None:
+        if not 1 <= value <= 10:
+            raise ValidationError(
+                f"{field_name} must be between 1 and 10 inclusive; received {value}"
+            )
+
+    def risk_score(self, config: Optional[RiskScoreConfig] = None) -> float:
+        """Compute an adjustable composite risk score."""
+
+        config = config or RiskScoreConfig()
+        config.validate()
+        likelihood_term = self.likelihood * config.likelihood_weight
+        impact_term = self.impact * config.impact_weight
+        reversibility_gap = config.reversibility_ceiling - self.reversibility
+        reversibility_term = max(config.reversibility_floor, reversibility_gap)
+        base_score = likelihood_term * impact_term * (
+            reversibility_term * config.reversibility_weight
+        )
+        return config.apply_tuning(base_score, self)
+
+    def risk_details(self, config: Optional[RiskScoreConfig] = None) -> Dict[str, float]:
+        """Return a breakdown of the components used for the score."""
+
+        config = config or RiskScoreConfig()
+        config.validate()
+        likelihood_term = self.likelihood * config.likelihood_weight
+        impact_term = self.impact * config.impact_weight
+        reversibility_gap = config.reversibility_ceiling - self.reversibility
+        reversibility_term = max(config.reversibility_floor, reversibility_gap)
+        base_score = likelihood_term * impact_term * (
+            reversibility_term * config.reversibility_weight
+        )
+        adjusted = config.apply_tuning(base_score, self)
+        return {
+            "likelihood_term": likelihood_term,
+            "impact_term": impact_term,
+            "reversibility_term": reversibility_term * config.reversibility_weight,
+            "base_score": base_score,
+            "adjusted_score": adjusted,
+        }
+
+
+@dataclass
+class Provocation:
+    """Describes a piece of bait and the safest counter-moves."""
+
+    bait: str
+    counter_moves: List[str]
+    confidence: str
+    tuning_rules: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class CoolingPlay:
+    """Structured cooling response with timing and channel details."""
+
+    tier: int
+    audience: str
+    messenger: str
+    channel: str
+    timing: str
+    expected_effect: str
+    risks: str
+    tuning_sliders: Dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class IntegrityFriction:
+    """Lawful friction measure with policy references."""
+
+    name: str
+    references: List[str]
+    intensity_levels: Dict[str, float]
+    audience_applications: List[str]
+
+
+@dataclass
+class Indicator:
+    """Indicator & warning entry with thresholds and triggers."""
+
+    name: str
+    green: str
+    amber: str
+    red: str
+    play_trigger: str
+    customizable_params: Dict[str, float]
+    fusion_logic: str
+
+
+@dataclass
+class MessengerProfile:
+    """Entry in the credible-messenger matrix."""
+
+    audience: str
+    messenger: str
+    cred_score: float
+    reach: str
+    notes: str
+    selection_algo: str
+    variants: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class TimebandAction:
+    """Actions and pivots for a given timeband."""
+
+    band: str
+    actions: List[str]
+    resources: List[str]
+    conditions: List[str]
+    pivots: List[str]
+
+
+@dataclass
+class MeasurementPlan:
+    """Metric and audit plan for assessing impact."""
+
+    metrics: List[str]
+    dashboards: List[str]
+    cadence: str
+    weights: Dict[str, float]
+    tuning_views: List[str]
+
+
+@dataclass
+class BlowbackRiskController:
+    """Container orchestrating all blowback-risk elements.
+
+    The controller stores the different analytical components in-memory and
+    can export the full plan as a nested dictionary for downstream
+    serialization or inspection.
+    """
+
+    paths: List[BlowbackPath] = field(default_factory=list)
+    provocations: List[Provocation] = field(default_factory=list)
+    cooling_plays: List[CoolingPlay] = field(default_factory=list)
+    frictions: List[IntegrityFriction] = field(default_factory=list)
+    indicators: List[Indicator] = field(default_factory=list)
+    messengers: List[MessengerProfile] = field(default_factory=list)
+    timebands: List[TimebandAction] = field(default_factory=list)
+    measurement_plan: Optional[MeasurementPlan] = None
+    transparency_note: Optional[str] = None
+
+    def add_path(self, path: BlowbackPath) -> None:
+        self.paths.append(path)
+
+    def add_provocation(self, provocation: Provocation) -> None:
+        self.provocations.append(provocation)
+
+    def add_cooling_play(self, play: CoolingPlay) -> None:
+        self.cooling_plays.append(play)
+
+    def add_friction(self, friction: IntegrityFriction) -> None:
+        self.frictions.append(friction)
+
+    def add_indicator(self, indicator: Indicator) -> None:
+        self.indicators.append(indicator)
+
+    def add_messenger(self, messenger: MessengerProfile) -> None:
+        self.messengers.append(messenger)
+
+    def add_timeband(self, timeband: TimebandAction) -> None:
+        self.timebands.append(timeband)
+
+    def set_measurement_plan(self, plan: MeasurementPlan) -> None:
+        self.measurement_plan = plan
+
+    def set_transparency_note(self, note: str) -> None:
+        self.transparency_note = note
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a dictionary representation of the full plan."""
+
+        return {
+            "blowback_map": [asdict(p) for p in self.paths],
+            "provocations": [asdict(p) for p in self.provocations],
+            "cooling_plays": [asdict(p) for p in self.cooling_plays],
+            "integrity_frictions": [asdict(f) for f in self.frictions],
+            "indicators": [asdict(i) for i in self.indicators],
+            "credible_messengers": [asdict(m) for m in self.messengers],
+            "timeband_playbook": [asdict(t) for t in self.timebands],
+            "measurement_plan": asdict(self.measurement_plan)
+            if self.measurement_plan
+            else None,
+            "transparency_note": self.transparency_note,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BlowbackRiskController":
+        """Recreate a controller from a serialized dictionary."""
+        controller = cls()
+        for p in data.get("blowback_map", []):
+            controller.add_path(BlowbackPath(**p))
+        for p in data.get("provocations", []):
+            controller.add_provocation(Provocation(**p))
+        for p in data.get("cooling_plays", []):
+            controller.add_cooling_play(CoolingPlay(**p))
+        for f in data.get("integrity_frictions", []):
+            controller.add_friction(IntegrityFriction(**f))
+        for i in data.get("indicators", []):
+            controller.add_indicator(Indicator(**i))
+        for m in data.get("credible_messengers", []):
+            controller.add_messenger(MessengerProfile(**m))
+        for t in data.get("timeband_playbook", []):
+            controller.add_timeband(TimebandAction(**t))
+        if mp := data.get("measurement_plan"):
+            controller.set_measurement_plan(MeasurementPlan(**mp))
+        if note := data.get("transparency_note"):
+            controller.set_transparency_note(note)
+        return controller
+
+    def rank_paths(
+        self, config: Optional[RiskScoreConfig] = None
+    ) -> List[BlowbackPath]:
+        """Return paths ordered by descending risk score."""
+
+        config = config or RiskScoreConfig()
+        return sorted(self.paths, key=lambda p: p.risk_score(config), reverse=True)
+
+    def aggregate_risk(self, config: Optional[RiskScoreConfig] = None) -> Dict[str, Any]:
+        """Return summary statistics for stored blowback paths."""
+
+        config = config or RiskScoreConfig()
+        config.validate()
+        if not self.paths:
+            return {
+                "total_paths": 0,
+                "highest_risk_path": None,
+                "average_score": 0.0,
+                "audience_totals": {},
+            }
+
+        scores = [(path, path.risk_score(config)) for path in self.paths]
+        highest_path, highest_score = max(scores, key=lambda item: item[1])
+        average_score = sum(score for _, score in scores) / len(scores)
+        audience_totals: Dict[str, float] = {}
+        for path, score in scores:
+            segments = path.audience_segments or ["general"]
+            for segment in segments:
+                audience_totals[segment] = audience_totals.get(segment, 0.0) + score
+        return {
+            "total_paths": len(self.paths),
+            "highest_risk_path": {"path": highest_path.path, "score": highest_score},
+            "average_score": average_score,
+            "audience_totals": audience_totals,
+        }
+
+    def high_risk_tripwires(
+        self, threshold: float, config: Optional[RiskScoreConfig] = None
+    ) -> Dict[str, List[str]]:
+        """Return tripwires for paths exceeding the given risk threshold."""
+
+        if threshold < 0:
+            raise ValidationError("Threshold must be non-negative")
+        config = config or RiskScoreConfig()
+        alerts: Dict[str, List[str]] = {}
+        for path in self.paths:
+            score = path.risk_score(config)
+            if score >= threshold:
+                alerts[path.path] = list(path.tripwires)
+        return alerts
+
+    def validate(self, config: Optional[RiskScoreConfig] = None) -> None:
+        """Validate controller contents and optional scoring configuration."""
+
+        if config is not None:
+            config.validate()
+
+        errors: List[str] = []
+        seen_paths = set()
+        for path in self.paths:
+            if path.path in seen_paths:
+                errors.append(f"Duplicate blowback path id '{path.path}' detected")
+            seen_paths.add(path.path)
+
+        for messenger in self.messengers:
+            if not 0.0 <= messenger.cred_score <= 1.0:
+                errors.append(
+                    f"Messenger '{messenger.messenger}' cred_score must be between 0 and 1"
+                )
+
+        if self.measurement_plan:
+            for metric, weight in self.measurement_plan.weights.items():
+                if weight < 0:
+                    errors.append(
+                        f"Measurement weight for '{metric}' must be non-negative"
+                    )
+
+        if errors:
+            raise ValidationError("; ".join(errors))

--- a/tests/test_blowback_risk_controller.py
+++ b/tests/test_blowback_risk_controller.py
@@ -1,0 +1,233 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from blowback_risk_controller import (  # noqa: E402
+    BlowbackRiskController,
+    BlowbackPath,
+    Provocation,
+    CoolingPlay,
+    IntegrityFriction,
+    Indicator,
+    MessengerProfile,
+    TimebandAction,
+    MeasurementPlan,
+    RiskScoreConfig,
+    ValidationError,
+)
+
+
+def test_to_dict_roundtrip() -> None:
+    controller = BlowbackRiskController()
+    controller.add_path(
+        BlowbackPath(
+            path="A",
+            trigger="test",
+            likelihood=5,
+            impact=7,
+            reversibility=4,
+            tripwires=["x"],
+            tuning_parameters={"likelihood": 0.5},
+        )
+    )
+    controller.add_path(
+        BlowbackPath(
+            path="B",
+            trigger="test2",
+            likelihood=8,
+            impact=5,
+            reversibility=2,
+        )
+    )
+    controller.add_provocation(
+        Provocation(
+            bait="leak",
+            counter_moves=["delay"],
+            confidence="High",
+            tuning_rules={"if urgency >0.7": "delay"},
+        )
+    )
+    controller.add_cooling_play(
+        CoolingPlay(
+            tier=1,
+            audience="public",
+            messenger="spokesperson",
+            channel="web",
+            timing="immediate",
+            expected_effect="neutral",
+            risks="ignored",
+            tuning_sliders={"virality_reduction": 0.2},
+        )
+    )
+    controller.add_friction(
+        IntegrityFriction(
+            name="Provenance",
+            references=["EU DSA"],
+            intensity_levels={"light": 0.2},
+            audience_applications=["public"],
+        )
+    )
+    controller.add_indicator(
+        Indicator(
+            name="Mention spike",
+            green="<100%",
+            amber="100-200%",
+            red=">200%",
+            play_trigger="monitor",
+            customizable_params={"threshold": 150.0},
+            fusion_logic="mentions*sentiment",
+        )
+    )
+    controller.add_messenger(
+        MessengerProfile(
+            audience="public",
+            messenger="journalist",
+            cred_score=0.8,
+            reach="high",
+            notes="no myths",
+            selection_algo="trust*reach",
+            variants={"A": "video"},
+        )
+    )
+    controller.add_timeband(
+        TimebandAction(
+            band="0-24h",
+            actions=["document"],
+            resources=["legal"],
+            conditions=["provocation confirmed"],
+            pivots=["if virality>threshold prep tier2"],
+        )
+    )
+    controller.set_measurement_plan(
+        MeasurementPlan(
+            metrics=["rumor velocity"],
+            dashboards=["sentiment"],
+            cadence="daily",
+            weights={"safety": 0.6},
+            tuning_views=["audience"],
+        )
+    )
+    controller.set_transparency_note("We will publish updates.")
+
+    plan_dict = controller.to_dict()
+    rebuilt = BlowbackRiskController.from_dict(plan_dict)
+    assert rebuilt.to_dict() == plan_dict
+    ranked = rebuilt.rank_paths()
+    assert [p.path for p in ranked] == ["B", "A"]
+
+
+def test_path_risk_score_custom_config() -> None:
+    path = BlowbackPath(
+        path="A",
+        trigger="test",
+        likelihood=5,
+        impact=6,
+        reversibility=4,
+        tuning_parameters={"likelihood": 0.5},
+        audience_segments=["public"],
+    )
+
+    default_score = path.risk_score()
+    assert default_score == 5 * 6 * (10 - 4)
+
+    config = RiskScoreConfig(
+        likelihood_weight=1.2,
+        impact_weight=0.8,
+        reversibility_weight=1.1,
+        tuning_parameter_weights={"likelihood": 0.5},
+        audience_weights={"public": 1.3},
+    )
+    details = path.risk_details(config)
+    assert details["likelihood_term"] == pytest.approx(6.0)
+    assert details["impact_term"] == pytest.approx(4.8)
+    assert details["reversibility_term"] == pytest.approx(6 * 1.1)
+    assert details["base_score"] == pytest.approx(190.08)
+    assert details["adjusted_score"] == pytest.approx(308.88)
+    assert path.risk_score(config) == pytest.approx(308.88)
+
+
+def test_invalid_path_inputs_raise() -> None:
+    with pytest.raises(ValidationError):
+        BlowbackPath(
+            path="bad",
+            trigger="t",
+            likelihood=0,
+            impact=5,
+            reversibility=5,
+        )
+
+    with pytest.raises(ValidationError):
+        BlowbackPath(
+            path="bad",
+            trigger="t",
+            likelihood=5,
+            impact=5,
+            reversibility=5,
+            tuning_parameters={"likelihood": 2.0},
+        )
+
+
+def test_controller_summary_and_validation() -> None:
+    controller = BlowbackRiskController()
+    controller.add_path(
+        BlowbackPath(
+            path="A",
+            trigger="test",
+            likelihood=6,
+            impact=7,
+            reversibility=3,
+            tripwires=["rumor spike"],
+            tuning_parameters={"likelihood": 0.4},
+            audience_segments=["general", "allies"],
+        )
+    )
+    controller.add_path(
+        BlowbackPath(
+            path="B",
+            trigger="test2",
+            likelihood=4,
+            impact=4,
+            reversibility=8,
+            tripwires=["tone backlash"],
+            audience_segments=["allies"],
+        )
+    )
+    controller.add_messenger(
+        MessengerProfile(
+            audience="general",
+            messenger="trusted",
+            cred_score=0.7,
+            reach="medium",
+            notes="",
+            selection_algo="trust*reach",
+        )
+    )
+
+    config = RiskScoreConfig(audience_weights={"allies": 1.2})
+    summary = controller.aggregate_risk(config)
+    assert summary["total_paths"] == 2
+    assert summary["highest_risk_path"]["path"] == "A"
+    assert summary["average_score"] > 0
+    assert summary["audience_totals"]["allies"] > summary["audience_totals"]["general"]
+
+    alerts = controller.high_risk_tripwires(threshold=50, config=config)
+    assert alerts["A"] == ["rumor spike"]
+    assert "B" not in alerts
+
+    controller.validate(config)
+
+    controller.add_messenger(
+        MessengerProfile(
+            audience="general",
+            messenger="invalid",
+            cred_score=1.5,
+            reach="low",
+            notes="",
+            selection_algo="trust",
+        )
+    )
+    with pytest.raises(ValidationError):
+        controller.validate(config)


### PR DESCRIPTION
### **User description**
## Summary
- add configurable risk scoring with validation, audience weighting, and score breakdown helpers for blowback paths
- extend the controller with aggregation summaries, tripwire alerts, and input validation hooks to tighten planning workflows
- expand the unit test suite to exercise custom scoring, failure paths, and controller integrity checks

## Testing
- `pytest tests/test_blowback_risk_controller.py`


------
https://chatgpt.com/codex/tasks/task_e_68b144988dc08333879c32cf28348bc5


___

### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive blowback risk assessment controller with configurable scoring

- Implement validation, audience weighting, and risk aggregation features

- Create extensive test suite covering custom scoring and failure scenarios

- Provide serialization support and tripwire alert functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BlowbackPath"] --> B["RiskScoreConfig"]
  B --> C["Risk Calculation"]
  C --> D["BlowbackRiskController"]
  D --> E["Aggregation & Alerts"]
  F["Validation"] --> D
  G["Serialization"] --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blowback_risk_controller.py</strong><dd><code>Complete blowback risk assessment framework implementation</code></dd></summary>
<hr>

blowback_risk_controller.py

<ul><li>Implement <code>BlowbackRiskController</code> class with comprehensive risk <br>modeling components<br> <li> Add <code>RiskScoreConfig</code> with configurable weights and audience-based <br>adjustments<br> <li> Create <code>BlowbackPath</code> dataclass with risk scoring and validation methods<br> <li> Include supporting classes for provocations, cooling plays, and <br>measurement plans</ul>


</details>


  </td>
  <td><a href="https://github.com/BrianCLong/summit/pull/1329/files#diff-7b72e4cf6112595433ed1a0e4502ddf1c6a197102ce01d9a761218bde29a53b9">+395/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_blowback_risk_controller.py</strong><dd><code>Comprehensive test suite for risk controller</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_blowback_risk_controller.py

<ul><li>Add comprehensive test suite for controller serialization and <br>roundtrip functionality<br> <li> Test custom risk scoring configurations with tuning parameters and <br>audience weights<br> <li> Validate input validation and error handling for invalid path <br>configurations<br> <li> Test aggregation summaries, tripwire alerts, and controller validation <br>methods</ul>


</details>


  </td>
  <td><a href="https://github.com/BrianCLong/summit/pull/1329/files#diff-3eeaf320629f8faebe1a94795e43e2728d695a76ff605f81425dcff3985f7979">+233/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

