### PR TITLE
docs(mc): bootstrap Model Catalog (schema + validator)

### DIFF
--- a/.github/workflows/validate-model-catalog.yml
+++ b/.github/workflows/validate-model-catalog.yml
@@ -1,0 +1,42 @@
+name: Validate Model Catalog
+
+on: [pull_request, push]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install validators
+        run: npm i -g ajv-cli@5 && npm i yaml@2
+      - name: Validate schema
+        run: |
+          ajv validate -s model-catalog/schemas/model.schema.json -d model-catalog/cataloga?.yaml --errors=text || \
+          ajv validate -s model-catalog/schemas/model.schema.json -d model-catalog/catalog.yaml
+      - name: Render Markdown
+        run: |
+          node -e '
+          const fs=require("fs");
+          const YAML=require("yaml");
+          const cat=YAML.parse(fs.readFileSync("model-catalog/catalog.yaml","utf8"));
+          let out="# IntelGraph Model Catalog\n\n";
+          for (const m of cat.models||[]) {
+            out+=`## ${m.id}\n**Vendor:** ${m.vendor} · **Family:** ${m.family} · **Last verified:** ${m.last_verified}\n\n`;
+            if (Array.isArray(m.capability_highlights) && m.capability_highlights.length) {
+              out += m.capability_highlights.map(x=>`- ${x}`).join("\n")+"\n\n";
+            }
+            if (m.defaults) {
+              out += `**Defaults:** ${JSON.stringify(m.defaults)}\n\n`;
+            }
+          }
+          fs.mkdirSync("model-catalog/generated",{recursive:true});
+          fs.writeFileSync("model-catalog/generated/catalog.md",out);
+          '
+      - uses: actions/upload-artifact@v4
+        with:
+          name: catalog-md
+          path: model-catalog/generated/catalog.md
+

--- a/model-catalog/catalog.yaml
+++ b/model-catalog/catalog.yaml
@@ -1,0 +1,65 @@
+catalog_version: "1.0"
+models:
+  - id: zhipu-glm-4.5-suite
+    vendor: "Zhipu AI (Z.ai)"
+    family: "GLM / ChatGLM"
+    last_verified: "2025-09-25"
+    labels: ["llm","vlm","reasoning","coding","agentic"]
+    models:
+      - name: "GLM-4.5"
+        class: "flagship LLM (reasoning/coding/agents)"
+        context: "128k"
+        modes: ["thinking","fast"]
+        best_for: ["complex reasoning","artifact-codegen","agents"]
+        pricing_ref: "BigModel portal"
+        notes: "MoE; 2025-07-28 launch; agent-first"
+      - name: "GLM-4.5-Air"
+        class: "latency/cost-optimized LLM"
+        role: "default agent brain when cost/latency matter"
+      - name: "GLM-4.5V"
+        class: "VLM (image+text)"
+        context: "~66k multimodal (provider-dependent)"
+        providers: ["SiliconFlow"]
+      - name: "GLM-4 (family legacy)"
+        variants: ["GLM-4","GLM-4-Air","GLM-4-9B"]
+        purpose: "stable API docs & comparisons"
+    open_weights:
+      - name: "GLM-4-9B-Chat"
+        license: "vendor license on HF"
+        capability: "competitive 9B; 1M ctx variant exists"
+        runtimes: ["chatglm.cpp"]
+    access_and_pricing:
+      primary_portal: "BigModel (official)"
+      mirrors: ["CometAPI","OpenRouter","SiliconFlow (VLM)"]
+      migration_note: "2025-09 Claude→GLM switch offer"
+    capability_highlights:
+      - "dual-mode execution (deep vs fast)"
+      - "long context + artifact-level code gen (HTML/SVG/Python)"
+      - "4.5V for grounded image understanding"
+      - "local/open path with 9B"
+    defaults:
+      choose:
+        - "Max-IQ: GLM-4.5; fallback 4.5-Air for latency/cost"
+        - "Multimodal: GLM-4.5V"
+        - "On-prem/local: GLM-4-9B-Chat via chatglm.cpp"
+    risk_notes:
+      - "Always verify BigModel pricing before quoting"
+      - "Provider features vary; pin per env"
+      - "Policy/geography can affect access; keep fallback"
+    policy:
+      license_class: "Restricted-TOS"
+      purpose_tags: ["investigation","threat-intel","fraud-risk","t&s","benchmarking","training","demo"]
+      retention: "standard-365d"
+    slo:
+      api:
+        reads_p95_ms: 350
+        writes_p95_ms: 700
+        availability_pct: 99.9
+      cost_guardrails:
+        dev_monthly_usd: 1000
+        prod_monthly_usd: 18000
+    sources:
+      - "Reuters/Z.ai launch & blog"
+      - "BigModel pricing console"
+      - "SiliconFlow model page"
+      - "HF model cards"

--- a/model-catalog/schemas/model.schema.json
+++ b/model-catalog/schemas/model.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "IntelGraph Model Catalog",
+  "type": "object",
+  "properties": {
+    "catalog_version": { "type": "string" },
+    "models": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "vendor", "family", "last_verified", "defaults"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^[a-z0-9-]+$" },
+          "vendor": { "type": "string" },
+          "family": { "type": "string" },
+          "last_verified": { "type": "string", "format": "date" },
+          "labels": { "type": "array", "items": { "type": "string" } },
+          "models": { "type": "array", "items": { "type": "object" } },
+          "open_weights": { "type": "array", "items": { "type": "object" } },
+          "access_and_pricing": { "type": "object" },
+          "capability_highlights": { "type": "array", "items": { "type": "string" } },
+          "defaults": { "type": "object" },
+          "risk_notes": { "type": "array", "items": { "type": "string" } },
+          "policy": {
+            "type": "object",
+            "properties": {
+              "license_class": { "type": "string", "enum": ["MIT-OK", "Open-Data-OK", "Restricted-TOS", "Proprietary-Client", "Embargoed"] },
+              "purpose_tags": { "type": "array", "items": { "type": "string" } },
+              "retention": { "type": "string", "enum": ["ephemeral-7d", "short-30d", "standard-365d", "long-1825d", "legal-hold"] }
+            }
+          },
+          "slo": {
+            "type": "object",
+            "properties": {
+              "api": { "type": "object" },
+              "cost_guardrails": { "type": "object" }
+            }
+          },
+          "sources": { "type": "array", "items": { "type": "string" } }
+        }
+      }
+    }
+  },
+  "required": ["catalog_version", "models"]
+}


### PR DESCRIPTION
Adds Model Catalog skeleton with JSON Schema, zhipu-glm-4.5-suite entry, and CI validation that also renders catalog.md as artifact.
Risk: low. Reversible via revert.
Sets repo as source of truth; complements existing docs.