### PR TITLE
ci(mc): add staleness check and publish catalog doc

### DIFF
--- a/.github/workflows/model-catalog-staleness.yml
+++ b/.github/workflows/model-catalog-staleness.yml
@@ -1,0 +1,80 @@
+name: Model Catalog Staleness Check
+
+on:
+  schedule:
+    - cron: '21 08 * * 1'  # Mondays 08:21 UTC
+  workflow_dispatch:
+
+jobs:
+  stale-check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm i yaml@2
+      - name: Check last_verified freshness and open issue if stale
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const YAML = require('yaml');
+            const path = 'model-catalog/catalog.yaml';
+            if (!fs.existsSync(path)) {
+              core.setOutput('status','no-catalog');
+              return;
+            }
+            const cat = YAML.parse(fs.readFileSync(path,'utf8')) || {};
+            const models = Array.isArray(cat.models) ? cat.models : [];
+            const now = new Date();
+            const stale = [];
+            for (const m of models) {
+              if (!m.last_verified) continue;
+              const d = new Date(m.last_verified);
+              const ageDays = Math.floor((now - d) / 86400000);
+              if (ageDays > 30) stale.push({id: m.id, last_verified: m.last_verified, ageDays});
+            }
+            if (!stale.length) {
+              core.info('Model Catalog is fresh (< 30d).');
+              return;
+            }
+            const title = 'MC: Refresh needed for stale last_verified entries';
+            const body = [
+              'The following Model Catalog entries have last_verified older than 30 days:',
+              '',
+              '| Model ID | last_verified | Age (days) |',
+              '|---------:|---------------|------------:|',
+              ...stale.map(s => `| ${s.id} | ${s.last_verified} | ${s.ageDays} |`),
+              '',
+              'Action: Review sources and update last_verified with evidence links in PR.'
+            ].join('\n');
+            // Find existing open issue with same title
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+            const existing = issues.data.find(i => i.title === title);
+            if (existing) {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.number,
+                body
+              });
+              core.info(`Updated existing issue #${existing.number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: ['mc','docs','maintenance']
+              });
+              core.info(`Created issue #${created.data.number}`);
+            }
+

--- a/.github/workflows/publish-model-catalog-doc.yml
+++ b/.github/workflows/publish-model-catalog-doc.yml
@@ -1,0 +1,54 @@
+name: Publish Model Catalog Doc
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'model-catalog/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm i yaml@2
+      - name: Render catalog.md
+        run: |
+          node -e '
+          const fs=require("fs");
+          const YAML=require("yaml");
+          const p="model-catalog/catalog.yaml";
+          if(!fs.existsSync(p)){ process.exit(0); }
+          const cat=YAML.parse(fs.readFileSync(p,"utf8"));
+          let out="# IntelGraph Model Catalog\n\n";
+          for (const m of cat.models||[]) {
+            out+=`## ${m.id}\n**Vendor:** ${m.vendor} · **Family:** ${m.family} · **Last verified:** ${m.last_verified}\n\n`;
+            if (Array.isArray(m.capability_highlights) && m.capability_highlights.length) {
+              out += m.capability_highlights.map(x=>`- ${x}`).join("\n")+"\n\n";
+            }
+            if (m.defaults) { out += `**Defaults:** ${JSON.stringify(m.defaults)}\n\n`; }
+          }
+          fs.mkdirSync("docs/model-catalog",{recursive:true});
+          fs.writeFileSync("docs/model-catalog/catalog.md", out);
+          '
+      - name: Commit docs if changed
+        run: |
+          if ! git diff --quiet -- docs/model-catalog/catalog.md; then
+            git config user.email "actions@github.com"
+            git config user.name "github-actions"
+            git add docs/model-catalog/catalog.md
+            git commit -m "docs(mc): update generated Model Catalog doc"
+            git push
+          else
+            echo "No changes to publish."
+          fi
+


### PR DESCRIPTION
Adds weekly staleness check (opens/updates issue when last_verified >30d) and a publish workflow that writes generated Model Catalog doc to docs/model-catalog/catalog.md on main.
Risk: low; reversible; no impact on merge queue.