### PR TITLE
Refactor ingest wizard into modular components

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,0 +1,15 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(ts|tsx)'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {}
+  },
+  docs: {
+    autodocs: 'tag'
+  }
+};
+
+export default config;

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,0 +1,16 @@
+import type { Preview } from '@storybook/react';
+import '../src/index.css';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/
+      }
+    }
+  }
+};
+
+export default preview;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,13 +7,18 @@
     "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "cytoscape": "^3.23.0",
-    "cytoscape-cose-bilkent": "^4.1.0"
+    "cytoscape-cose-bilkent": "^4.1.0",
+    "@reduxjs/toolkit": "^1.9.7",
+    "react-redux": "^8.1.3",
+    "nanoid": "^4.0.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",
@@ -23,6 +28,11 @@
     "vitest": "^0.34.6",
     "@testing-library/react": "^14.0.0",
     "@testing-library/jest-dom": "^6.0.0",
-    "jsdom": "^24.0.0"
+    "jsdom": "^24.0.0",
+    "@storybook/react-vite": "^7.6.17",
+    "@storybook/addon-essentials": "^7.6.17",
+    "@storybook/addon-interactions": "^7.6.17",
+    "@storybook/test": "^7.6.17",
+    "storybook": "^7.6.17"
   }
 }

--- a/frontend/src/ingestWizard/IngestWizard.tsx
+++ b/frontend/src/ingestWizard/IngestWizard.tsx
@@ -1,0 +1,180 @@
+import { Dispatch, useCallback, useMemo, useReducer } from 'react';
+import DataSourceSelection from './components/DataSourceSelection';
+import SchemaMappingStep from './components/SchemaMappingStep';
+import ValidationStep from './components/ValidationStep';
+import {
+  IngestWizardAction,
+  ingestWizardReducer,
+  initialWizardState,
+  setCurrentStep,
+  setValidation,
+  updateDataSource,
+  updateSchemaMapping
+} from './state';
+import {
+  DataSourceConfig,
+  IngestWizardState,
+  SchemaMappingState,
+  ValidationIssue,
+  WizardCompletion
+} from './types';
+import './styles.css';
+
+export interface IngestWizardProps {
+  state?: IngestWizardState;
+  dispatch?: Dispatch<IngestWizardAction>;
+  onComplete?: (result: WizardCompletion) => void;
+  onCancel?: () => void;
+  autoValidate?: boolean;
+}
+
+const WIZARD_STEPS = ['Data source', 'Schema mapping', 'Validation'];
+
+const performLocalValidation = (
+  dataSource: Partial<DataSourceConfig>,
+  mapping: SchemaMappingState
+) => {
+  const issues: ValidationIssue[] = [];
+
+  if (!dataSource.name) {
+    issues.push({
+      id: 'name',
+      severity: 'error',
+      message: 'Provide a descriptive data source name before activating the connector.'
+    });
+  }
+
+  if (!dataSource.source_type) {
+    issues.push({
+      id: 'source-type',
+      severity: 'error',
+      message: 'Choose a connector type so that the orchestrator can load the correct adapter.'
+    });
+  }
+
+  if (!dataSource.tos_accepted) {
+    issues.push({
+      id: 'tos',
+      severity: 'warning',
+      message: 'Accept the ingestion terms to document provider approval.'
+    });
+  }
+
+  if (mapping.mappings.length === 0) {
+    issues.push({
+      id: 'mapping-empty',
+      severity: 'error',
+      message: 'Map at least one source column to the canonical schema before continuing.'
+    });
+  }
+
+  return issues;
+};
+
+export const IngestWizard = ({
+  state: externalState,
+  dispatch: externalDispatch,
+  onComplete,
+  onCancel,
+  autoValidate = true
+}: IngestWizardProps) => {
+  const [localState, localDispatch] = useReducer(ingestWizardReducer, initialWizardState);
+  const state = externalState ?? localState;
+  const dispatch = externalDispatch ?? localDispatch;
+
+  const stepLabel = useMemo(() => WIZARD_STEPS[state.currentStep] ?? 'Data source', [state.currentStep]);
+
+  const goToStep = useCallback(
+    (step: number) => dispatch(setCurrentStep(Math.min(Math.max(step, 0), WIZARD_STEPS.length - 1))),
+    [dispatch]
+  );
+
+  const handleDataSourceChange = useCallback(
+    (config: Partial<DataSourceConfig>) => dispatch(updateDataSource(config)),
+    [dispatch]
+  );
+
+  const handleSchemaChange = useCallback(
+    (mapping: SchemaMappingState) => dispatch(updateSchemaMapping(mapping)),
+    [dispatch]
+  );
+
+  const runValidation = useCallback(() => {
+    const issues = performLocalValidation(state.dataSource, state.schemaMapping);
+    dispatch(
+      setValidation({
+        status: issues.some((issue) => issue.severity === 'error') ? 'failed' : 'passed',
+        issues,
+        lastRun: new Date().toISOString()
+      })
+    );
+    return issues;
+  }, [dispatch, state.dataSource, state.schemaMapping]);
+
+  const advance = useCallback(() => goToStep(state.currentStep + 1), [goToStep, state.currentStep]);
+  const retreat = useCallback(() => goToStep(state.currentStep - 1), [goToStep, state.currentStep]);
+
+  const handleSubmit = useCallback(() => {
+    const issues = autoValidate ? runValidation() : state.validation.issues;
+    if (issues.some((issue) => issue.severity === 'error')) {
+      return;
+    }
+
+    if (!state.dataSource.name || !state.dataSource.source_type) {
+      return;
+    }
+
+    if (!onComplete) {
+      return;
+    }
+
+    const completion: WizardCompletion = {
+      dataSource: state.dataSource as DataSourceConfig,
+      schemaMapping: state.schemaMapping,
+      validation: {
+        ...state.validation,
+        issues: issues.length ? issues : state.validation.issues
+      }
+    };
+
+    onComplete(completion);
+  }, [autoValidate, onComplete, runValidation, state.dataSource, state.schemaMapping, state.validation]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '24px', width: '100%' }}>
+      <div className="iw-wizard-header">
+        <div>
+          <p>Step {state.currentStep + 1} of {WIZARD_STEPS.length}</p>
+          <h1>{stepLabel}</h1>
+        </div>
+
+        {onCancel && (
+          <button type="button" className="iw-button iw-button-tertiary" onClick={onCancel}>
+            Cancel
+          </button>
+        )}
+      </div>
+
+      {state.currentStep === 0 && (
+        <DataSourceSelection value={state.dataSource} onChange={handleDataSourceChange} onNext={advance} />
+      )}
+
+      {state.currentStep === 1 && (
+        <SchemaMappingStep value={state.schemaMapping} onChange={handleSchemaChange} onBack={retreat} onNext={advance} />
+      )}
+
+      {state.currentStep === 2 && (
+        <ValidationStep
+          dataSource={state.dataSource}
+          schemaMapping={state.schemaMapping}
+          validation={state.validation}
+          onBack={retreat}
+          onRunValidation={runValidation}
+          onSubmit={handleSubmit}
+        />
+      )}
+    </div>
+  );
+};
+
+export default IngestWizard;

--- a/frontend/src/ingestWizard/README.md
+++ b/frontend/src/ingestWizard/README.md
@@ -1,0 +1,41 @@
+# Ingest wizard components
+
+This directory contains a modular implementation of the Summit ingest wizard. The refactor breaks the flow into independent pieces that can be composed in feature screens or tested in isolation.
+
+## Package layout
+
+- `types.ts` — shared TypeScript interfaces for data source configuration, schema mapping, and validation output.
+- `state.ts` — Redux-compatible slice that exposes actions/reducer for persisting wizard progress.
+- `components/` — leaf UI components for each step (`DataSourceSelection`, `SchemaMappingStep`, `ValidationStep`).
+- `IngestWizard.tsx` — orchestrator that wires the steps together using the exported reducer.
+- `__stories__/` — Storybook stories for each component and the composed wizard.
+
+## Usage
+
+```tsx
+import { IngestWizard, ingestWizardReducer, initialWizardState } from './ingestWizard';
+import { configureStore } from '@reduxjs/toolkit';
+
+const store = configureStore({
+  reducer: {
+    ingestWizard: ingestWizardReducer
+  },
+  preloadedState: {
+    ingestWizard: initialWizardState
+  }
+});
+
+<Provider store={store}>
+  <IngestWizard onComplete={(result) => console.log(result)} />
+</Provider>;
+```
+
+Each step component also accepts `value`/`onChange` props so they can be embedded into bespoke layouts or used in form builders without the full wizard container. Include `import './ingestWizard/styles.css';` in the screen where you compose the wizard to pick up the shared styling tokens.
+
+## Validation
+
+The wizard ships with a lightweight synchronous validator that mirrors the previous DPIA gating logic. For production connectors you can swap `performLocalValidation` with an async call and dispatch `setValidation` when the job completes.
+
+## Storybook
+
+Run `npm run storybook` from `frontend/` to launch the component catalog. Stories demonstrate default state, partially completed flows, and error handling.

--- a/frontend/src/ingestWizard/__stories__/DataSourceSelection.stories.tsx
+++ b/frontend/src/ingestWizard/__stories__/DataSourceSelection.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import DataSourceSelection from '../components/DataSourceSelection';
+import { DataSourceConfig } from '../types';
+
+const meta: Meta<typeof DataSourceSelection> = {
+  title: 'Ingest Wizard/DataSourceSelection',
+  component: DataSourceSelection,
+  parameters: {
+    layout: 'centered'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DataSourceSelection>;
+
+const Template = (initialValue: Partial<DataSourceConfig>) => {
+  const [value, setValue] = useState(initialValue);
+  return <DataSourceSelection value={value} onChange={setValue} />;
+};
+
+export const Empty: Story = {
+  render: () => Template({})
+};
+
+export const Prefilled: Story = {
+  render: () =>
+    Template({
+      name: 'Sanctions feed',
+      source_type: 'csv',
+      license_template: 'cc-by-4.0',
+      retention_period: 180,
+      geographic_restrictions: ['US', 'EU'],
+      tos_accepted: true
+    })
+};

--- a/frontend/src/ingestWizard/__stories__/IngestWizard.stories.tsx
+++ b/frontend/src/ingestWizard/__stories__/IngestWizard.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useReducer } from 'react';
+import IngestWizard from '../IngestWizard';
+import { ingestWizardReducer, initialWizardState } from '../state';
+
+const meta: Meta<typeof IngestWizard> = {
+  title: 'Ingest Wizard/Wizard',
+  component: IngestWizard,
+  parameters: {
+    layout: 'fullscreen'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof IngestWizard>;
+
+export const Default: Story = {
+  render: () => {
+    const [state, dispatch] = useReducer(
+      ingestWizardReducer,
+      initialWizardState,
+      () => ({
+        ...initialWizardState,
+        schemaMapping: {
+          sourceSample: [
+            { name: 'full_name', type: 'string' },
+            { name: 'email', type: 'string' }
+          ],
+          targetSchema: [
+            { name: 'person_name', type: 'string', required: true },
+            { name: 'contact_email', type: 'string' }
+          ],
+          mappings: [],
+          autoMappedFields: []
+        }
+      })
+    );
+
+    return (
+      <div className="mx-auto max-w-4xl p-6">
+        <IngestWizard state={state} dispatch={dispatch} onComplete={(result) => console.log('Complete', result)} />
+      </div>
+    );
+  }
+};

--- a/frontend/src/ingestWizard/__stories__/SchemaMappingStep.stories.tsx
+++ b/frontend/src/ingestWizard/__stories__/SchemaMappingStep.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import SchemaMappingStep from '../components/SchemaMappingStep';
+import { SchemaMappingState } from '../types';
+
+const baseState: SchemaMappingState = {
+  sourceSample: [
+    { name: 'full_name', type: 'string', example: 'Jane Doe' },
+    { name: 'email', type: 'string', example: 'jane@example.com' },
+    { name: 'country', type: 'string', example: 'US' }
+  ],
+  targetSchema: [
+    { name: 'person_name', type: 'string', required: true },
+    { name: 'contact_email', type: 'string' },
+    { name: 'residency', type: 'string' }
+  ],
+  mappings: [],
+  autoMappedFields: ['full_name']
+};
+
+const meta: Meta<typeof SchemaMappingStep> = {
+  title: 'Ingest Wizard/SchemaMappingStep',
+  component: SchemaMappingStep,
+  parameters: {
+    layout: 'centered'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SchemaMappingStep>;
+
+export const Empty: Story = {
+  render: () => {
+    const [value, setValue] = useState(baseState);
+    return <SchemaMappingStep value={value} onChange={setValue} />;
+  }
+};
+
+export const WithMappings: Story = {
+  render: () => {
+    const [value, setValue] = useState<SchemaMappingState>({
+      ...baseState,
+      mappings: [
+        { id: '1', sourceField: 'full_name', targetField: 'person_name', required: true },
+        { id: '2', sourceField: 'email', targetField: 'contact_email' }
+      ]
+    });
+    return <SchemaMappingStep value={value} onChange={setValue} />;
+  }
+};

--- a/frontend/src/ingestWizard/__stories__/ValidationStep.stories.tsx
+++ b/frontend/src/ingestWizard/__stories__/ValidationStep.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ValidationStep from '../components/ValidationStep';
+import { SchemaMappingState } from '../types';
+
+const schemaMapping: SchemaMappingState = {
+  sourceSample: [],
+  targetSchema: [],
+  mappings: [
+    { id: '1', sourceField: 'full_name', targetField: 'person_name', required: true },
+    { id: '2', sourceField: 'email', targetField: 'contact_email' }
+  ],
+  autoMappedFields: []
+};
+
+const meta: Meta<typeof ValidationStep> = {
+  title: 'Ingest Wizard/ValidationStep',
+  component: ValidationStep,
+  parameters: {
+    layout: 'centered'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ValidationStep>;
+
+export const NoIssues: Story = {
+  args: {
+    dataSource: {
+      name: 'Sanctions feed',
+      source_type: 'csv',
+      retention_period: 90,
+      tos_accepted: true
+    },
+    schemaMapping,
+    validation: {
+      status: 'passed',
+      issues: [],
+      lastRun: new Date().toISOString()
+    }
+  }
+};
+
+export const WithWarnings: Story = {
+  args: {
+    dataSource: {
+      name: 'OSINT stream',
+      source_type: 'api',
+      retention_period: 45,
+      tos_accepted: false
+    },
+    schemaMapping,
+    validation: {
+      status: 'failed',
+      issues: [
+        {
+          id: 'tos',
+          severity: 'warning',
+          message: 'Terms of service acknowledgement is missing.',
+          suggestion: 'Review provider agreement and check the acknowledgement box.'
+        },
+        {
+          id: 'mapping-empty',
+          severity: 'error',
+          message: 'At least one mandatory canonical field is not mapped.'
+        }
+      ],
+      lastRun: new Date().toISOString()
+    }
+  }
+};

--- a/frontend/src/ingestWizard/components/DataSourceSelection.tsx
+++ b/frontend/src/ingestWizard/components/DataSourceSelection.tsx
@@ -1,0 +1,167 @@
+import { useMemo } from 'react';
+import { DataSourceConfig, SourceType } from '../types';
+import '../styles.css';
+
+export interface DataSourceSelectionProps {
+  value: Partial<DataSourceConfig>;
+  onChange: (value: Partial<DataSourceConfig>) => void;
+  onNext?: () => void;
+  disabled?: boolean;
+}
+
+const SOURCE_OPTIONS: { label: string; value: SourceType }[] = [
+  { label: 'CSV Upload', value: 'csv' },
+  { label: 'JSON API', value: 'json' },
+  { label: 'Elasticsearch', value: 'elasticsearch' },
+  { label: 'ESRI ArcGIS', value: 'esri' },
+  { label: 'REST API', value: 'api' }
+];
+
+const LICENSE_OPTIONS = [
+  { value: 'cc-by-4.0', label: 'Creative Commons Attribution 4.0' },
+  { value: 'commercial-restricted', label: 'Commercial License - Export Restricted' },
+  { value: 'research-only', label: 'Academic Research Only' },
+  { value: 'custom', label: 'Custom License' }
+];
+
+const formatGeographicValue = (regions: string[] | undefined) => (regions || []).join(', ');
+
+export const DataSourceSelection = ({ value, onChange, onNext, disabled }: DataSourceSelectionProps) => {
+  const isComplete = useMemo(() => {
+    return Boolean(value.name && value.source_type && (value.license_template || value.custom_license));
+  }, [value.custom_license, value.license_template, value.name, value.source_type]);
+
+  const handleRegionChange = (input: string) => {
+    const regions = input
+      .split(',')
+      .map((region) => region.trim())
+      .filter(Boolean);
+    onChange({ ...value, geographic_restrictions: regions });
+  };
+
+  return (
+    <section className="iw-section">
+      <header>
+        <h2>Data source</h2>
+        <p className="description">
+          Describe the origin of the dataset and pick the connector template that matches your source.
+        </p>
+      </header>
+
+      <div className="iw-grid two-column">
+        <label className="iw-field">
+          <span className="iw-label">Name</span>
+          <input
+            type="text"
+            className="iw-text-input"
+            placeholder="e.g. OSINT Leads Feed"
+            value={value.name ?? ''}
+            onChange={(event) => onChange({ ...value, name: event.target.value })}
+            disabled={disabled}
+            required
+          />
+        </label>
+
+        <label className="iw-field">
+          <span className="iw-label">Source type</span>
+          <select
+            className="iw-select"
+            value={value.source_type ?? ''}
+            onChange={(event) => onChange({ ...value, source_type: event.target.value as SourceType })}
+            disabled={disabled}
+            required
+          >
+            <option value="" disabled>
+              Choose a connector
+            </option>
+            {SOURCE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="iw-field" style={{ gridColumn: '1 / -1' }}>
+          <span className="iw-label">Short description</span>
+          <textarea
+            className="iw-textarea"
+            placeholder="Summarize the content, cadence, and any sensitivity of the source"
+            value={value.description ?? ''}
+            onChange={(event) => onChange({ ...value, description: event.target.value })}
+            disabled={disabled}
+          />
+        </label>
+
+        <label className="iw-field">
+          <span className="iw-label">License template</span>
+          <select
+            className="iw-select"
+            value={value.license_template ?? ''}
+            onChange={(event) => onChange({ ...value, license_template: event.target.value })}
+            disabled={disabled}
+          >
+            <option value="" disabled>
+              Choose a template
+            </option>
+            {LICENSE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="iw-field">
+          <span className="iw-label">Retention period (days)</span>
+          <input
+            type="number"
+            min={1}
+            max={2555}
+            className="iw-text-input"
+            value={value.retention_period ?? 30}
+            onChange={(event) =>
+              onChange({ ...value, retention_period: Number.parseInt(event.target.value || '0', 10) })
+            }
+            disabled={disabled}
+          />
+        </label>
+
+        <label className="iw-field" style={{ gridColumn: '1 / -1' }}>
+          <span className="iw-label">Geographic restrictions</span>
+          <input
+            type="text"
+            className="iw-text-input"
+            placeholder="Comma separated, e.g. US, EU, UK"
+            value={formatGeographicValue(value.geographic_restrictions)}
+            onChange={(event) => handleRegionChange(event.target.value)}
+            disabled={disabled}
+          />
+        </label>
+
+        <label className="iw-checkbox-row" style={{ gridColumn: '1 / -1' }}>
+          <input
+            type="checkbox"
+            checked={Boolean(value.tos_accepted)}
+            onChange={(event) => onChange({ ...value, tos_accepted: event.target.checked })}
+            disabled={disabled}
+          />
+          <span>I confirm that the data provider has authorized IntelGraph to ingest and process this dataset.</span>
+        </label>
+      </div>
+
+      <footer className="iw-actions">
+        <button
+          type="button"
+          className="iw-button iw-button-primary"
+          onClick={onNext}
+          disabled={disabled || !isComplete}
+        >
+          Continue to mapping
+        </button>
+      </footer>
+    </section>
+  );
+};
+
+export default DataSourceSelection;

--- a/frontend/src/ingestWizard/components/SchemaMappingStep.tsx
+++ b/frontend/src/ingestWizard/components/SchemaMappingStep.tsx
@@ -1,0 +1,185 @@
+import { nanoid } from 'nanoid';
+import { SchemaMappingState } from '../types';
+import '../styles.css';
+
+export interface SchemaMappingStepProps {
+  value: SchemaMappingState;
+  onChange: (value: SchemaMappingState) => void;
+  onNext?: () => void;
+  onBack?: () => void;
+  disabled?: boolean;
+}
+
+const ensureId = (value: SchemaMappingState) => ({
+  ...value,
+  mappings: value.mappings.map((mapping) => ({
+    ...mapping,
+    id: mapping.id || nanoid(8)
+  }))
+});
+
+export const SchemaMappingStep = ({ value, onChange, onNext, onBack, disabled }: SchemaMappingStepProps) => {
+  const hydrated = ensureId(value);
+
+  const handleMappingChange = (index: number, field: 'sourceField' | 'targetField' | 'transformation' | 'required', input: string | boolean) => {
+    const next = hydrated.mappings.map((mapping, mappingIndex) => {
+      if (mappingIndex !== index) return mapping;
+      return {
+        ...mapping,
+        [field]: field === 'required' ? Boolean(input) : input
+      };
+    });
+    onChange({ ...hydrated, mappings: next });
+  };
+
+  const handleAddMapping = () => {
+    const next = {
+      ...hydrated,
+      mappings: [
+        ...hydrated.mappings,
+        {
+          id: nanoid(8),
+          sourceField: hydrated.sourceSample[0]?.name ?? '',
+          targetField: hydrated.targetSchema[0]?.name ?? '',
+          required: false
+        }
+      ]
+    };
+    onChange(next);
+  };
+
+  const handleRemoveMapping = (index: number) => {
+    const next = hydrated.mappings.filter((_, mappingIndex) => mappingIndex !== index);
+    onChange({ ...hydrated, mappings: next });
+  };
+
+  const availableSourceFields = hydrated.sourceSample.map((field) => field.name);
+  const availableTargetFields = hydrated.targetSchema.map((field) => field.name);
+
+  return (
+    <section className="iw-section">
+      <header>
+        <h2>Schema mapping</h2>
+        <p className="description">
+          Align the incoming feed columns to IntelGraph's canonical schema. Automatic suggestions are highlighted and can be overridden.
+        </p>
+      </header>
+
+      <div className="iw-table-wrapper">
+        <table className="iw-table">
+          <thead>
+            <tr>
+              <th>Source field</th>
+              <th>Target field</th>
+              <th>Transformation</th>
+              <th>Required</th>
+              <th style={{ textAlign: 'right' }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {hydrated.mappings.length === 0 && (
+              <tr>
+                <td colSpan={5} style={{ padding: '24px', textAlign: 'center', color: '#61748f' }}>
+                  No field mappings yet. Use the button below to begin aligning fields.
+                </td>
+              </tr>
+            )}
+
+            {hydrated.mappings.map((mapping, index) => (
+              <tr key={mapping.id}>
+                <td>
+                  <select
+                    className="iw-select"
+                    value={mapping.sourceField}
+                    onChange={(event) => handleMappingChange(index, 'sourceField', event.target.value)}
+                    disabled={disabled}
+                  >
+                    {availableSourceFields.map((sourceField) => (
+                      <option key={sourceField} value={sourceField}>
+                        {sourceField}
+                      </option>
+                    ))}
+                  </select>
+                </td>
+                <td>
+                  <select
+                    className="iw-select"
+                    value={mapping.targetField}
+                    onChange={(event) => handleMappingChange(index, 'targetField', event.target.value)}
+                    disabled={disabled}
+                  >
+                    {availableTargetFields.map((targetField) => (
+                      <option key={targetField} value={targetField}>
+                        {targetField}
+                      </option>
+                    ))}
+                  </select>
+                </td>
+                <td>
+                  <input
+                    type="text"
+                    className="iw-text-input"
+                    placeholder="Optional transformation"
+                    value={mapping.transformation ?? ''}
+                    onChange={(event) => handleMappingChange(index, 'transformation', event.target.value)}
+                    disabled={disabled}
+                  />
+                </td>
+                <td style={{ textAlign: 'center' }}>
+                  <input
+                    type="checkbox"
+                    checked={Boolean(mapping.required)}
+                    onChange={(event) => handleMappingChange(index, 'required', event.target.checked)}
+                    disabled={disabled}
+                  />
+                </td>
+                <td style={{ textAlign: 'right' }}>
+                  <button
+                    type="button"
+                    className="iw-button iw-button-tertiary"
+                    onClick={() => handleRemoveMapping(index)}
+                    disabled={disabled}
+                  >
+                    Remove
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div style={{ marginTop: '16px', display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between', gap: '12px' }}>
+        <button
+          type="button"
+          className="iw-button iw-button-tertiary"
+          onClick={handleAddMapping}
+          disabled={disabled || availableSourceFields.length === 0 || availableTargetFields.length === 0}
+        >
+          + Add mapping
+        </button>
+
+        <div style={{ display: 'flex', gap: '12px' }}>
+          <button
+            type="button"
+            className="iw-button iw-button-secondary"
+            onClick={onBack}
+            disabled={disabled}
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            className="iw-button iw-button-primary"
+            onClick={onNext}
+            disabled={disabled || hydrated.mappings.length === 0}
+          >
+            Continue to validation
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default SchemaMappingStep;

--- a/frontend/src/ingestWizard/components/ValidationStep.tsx
+++ b/frontend/src/ingestWizard/components/ValidationStep.tsx
@@ -1,0 +1,122 @@
+import { DataSourceConfig, SchemaMappingState, ValidationState } from '../types';
+import '../styles.css';
+
+export interface ValidationStepProps {
+  dataSource: Partial<DataSourceConfig>;
+  schemaMapping: SchemaMappingState;
+  validation: ValidationState;
+  onRunValidation?: () => void;
+  onBack?: () => void;
+  onSubmit?: () => void;
+  disabled?: boolean;
+}
+
+export const ValidationStep = ({
+  dataSource,
+  schemaMapping,
+  validation,
+  onRunValidation,
+  onBack,
+  onSubmit,
+  disabled
+}: ValidationStepProps) => {
+  const hasBlockingIssues = validation.issues.some((issue) => issue.severity === 'error');
+
+  return (
+    <section className="iw-section">
+      <header>
+        <h2>Validation &amp; review</h2>
+        <p className="description">
+          Run automated checks to confirm licensing, schema alignment, and privacy posture before activating the connector.
+        </p>
+      </header>
+
+      <div style={{ display: 'grid', gap: '16px' }}>
+        <section className="iw-validation-card">
+          <h3 style={{ textTransform: 'uppercase', fontSize: '0.75rem', color: '#829ab1', letterSpacing: '0.08em', margin: 0 }}>
+            Summary
+          </h3>
+          <dl className="iw-summary-grid">
+            <div>
+              <dt>Data source</dt>
+              <dd>{dataSource.name ?? 'Not provided'}</dd>
+            </div>
+            <div>
+              <dt>Connector type</dt>
+              <dd>{dataSource.source_type ?? 'Not selected'}</dd>
+            </div>
+            <div>
+              <dt>Mapped fields</dt>
+              <dd>{schemaMapping.mappings.length}</dd>
+            </div>
+            <div>
+              <dt>Retention</dt>
+              <dd>{dataSource.retention_period ? `${dataSource.retention_period} days` : 'Default (30 days)'}</dd>
+            </div>
+          </dl>
+        </section>
+
+        <section className="iw-validation-card">
+          <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <h3 style={{ textTransform: 'uppercase', fontSize: '0.75rem', color: '#829ab1', letterSpacing: '0.08em' }}>
+              Automated checks
+            </h3>
+            <button
+              type="button"
+              className="iw-button iw-button-primary"
+              onClick={onRunValidation}
+              disabled={disabled}
+            >
+              Run validation
+            </button>
+          </header>
+
+          <div className="iw-validation-issues">
+            {validation.issues.length === 0 && (
+              <p style={{ color: '#61748f', fontSize: '0.9rem' }}>
+                No issues detected yet. Trigger a validation run to populate automated checks.
+              </p>
+            )}
+
+            {validation.issues.map((issue) => (
+              <article key={issue.id} className={`iw-issue ${issue.severity}`}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <h4 style={{ margin: 0, fontWeight: 600, textTransform: 'capitalize' }}>{issue.severity}</h4>
+                  {issue.field && (
+                    <span style={{ fontSize: '0.7rem', textTransform: 'uppercase', letterSpacing: '0.08em' }}>{issue.field}</span>
+                  )}
+                </div>
+                <p style={{ margin: 0 }}>{issue.message}</p>
+                {issue.suggestion && (
+                  <p style={{ margin: 0, fontSize: '0.75rem', color: '#486581' }}>Suggested fix: {issue.suggestion}</p>
+                )}
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+
+      <footer className="iw-actions" style={{ justifyContent: 'space-between' }}>
+        <button
+          type="button"
+          className="iw-button iw-button-secondary"
+          onClick={onBack}
+          disabled={disabled}
+        >
+          Back to mapping
+        </button>
+
+        <button
+          type="button"
+          className="iw-button iw-button-primary"
+          onClick={onSubmit}
+          disabled={disabled || hasBlockingIssues}
+        >
+          Activate connector
+        </button>
+      </footer>
+    </section>
+  );
+};
+
+export default ValidationStep;

--- a/frontend/src/ingestWizard/index.ts
+++ b/frontend/src/ingestWizard/index.ts
@@ -1,0 +1,6 @@
+export * from './types';
+export * from './state';
+export { default as DataSourceSelection } from './components/DataSourceSelection';
+export { default as SchemaMappingStep } from './components/SchemaMappingStep';
+export { default as ValidationStep } from './components/ValidationStep';
+export { default as IngestWizard } from './IngestWizard';

--- a/frontend/src/ingestWizard/state.ts
+++ b/frontend/src/ingestWizard/state.ts
@@ -1,0 +1,120 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import {
+  DataSourceConfig,
+  FieldMapping,
+  IngestWizardState,
+  SchemaMappingState,
+  ValidationState
+} from './types';
+
+export const createEmptyMapping = (): SchemaMappingState => ({
+  sourceSample: [],
+  targetSchema: [],
+  mappings: [],
+  autoMappedFields: []
+});
+
+export const createEmptyValidation = (): ValidationState => ({
+  status: 'idle',
+  issues: []
+});
+
+export const initialWizardState: IngestWizardState = {
+  currentStep: 0,
+  dataSource: {
+    source_config: {},
+    geographic_restrictions: [],
+    retention_period: 30,
+    tos_accepted: false
+  },
+  schemaMapping: createEmptyMapping(),
+  validation: createEmptyValidation()
+};
+
+const mergeDataSource = (
+  existing: Partial<DataSourceConfig>,
+  incoming: Partial<DataSourceConfig>
+): Partial<DataSourceConfig> => ({
+  ...existing,
+  ...incoming,
+  geographic_restrictions:
+    incoming.geographic_restrictions ?? existing.geographic_restrictions ?? [],
+  source_config: {
+    ...(existing.source_config || {}),
+    ...(incoming.source_config || {})
+  }
+});
+
+const replaceMapping = (
+  _current: SchemaMappingState,
+  next: SchemaMappingState
+): SchemaMappingState => ({
+  ...next,
+  sourceSample: [...next.sourceSample],
+  targetSchema: [...next.targetSchema],
+  mappings: next.mappings.map((mapping) => ({ ...mapping }))
+});
+
+const ingestWizardSlice = createSlice({
+  name: 'ingestWizard',
+  initialState: initialWizardState,
+  reducers: {
+    setCurrentStep(state, action: PayloadAction<number>) {
+      state.currentStep = action.payload;
+    },
+    updateDataSource(state, action: PayloadAction<Partial<DataSourceConfig>>) {
+      state.dataSource = mergeDataSource(state.dataSource, action.payload);
+    },
+    addFieldMapping(state, action: PayloadAction<FieldMapping>) {
+      const existingIndex = state.schemaMapping.mappings.findIndex(
+        (mapping) => mapping.id === action.payload.id
+      );
+      if (existingIndex >= 0) {
+        state.schemaMapping.mappings[existingIndex] = action.payload;
+      } else {
+        state.schemaMapping.mappings.push(action.payload);
+      }
+    },
+    removeFieldMapping(state, action: PayloadAction<string>) {
+      state.schemaMapping.mappings = state.schemaMapping.mappings.filter(
+        (mapping) => mapping.id !== action.payload
+      );
+    },
+    updateSchemaMapping(state, action: PayloadAction<SchemaMappingState>) {
+      state.schemaMapping = replaceMapping(state.schemaMapping, action.payload);
+    },
+    setValidation(state, action: PayloadAction<ValidationState>) {
+      state.validation = { ...action.payload, issues: [...action.payload.issues] };
+    },
+    resetWizard() {
+      return initialWizardState;
+    }
+  }
+});
+
+export const {
+  setCurrentStep,
+  updateDataSource,
+  addFieldMapping,
+  removeFieldMapping,
+  updateSchemaMapping,
+  setValidation,
+  resetWizard
+} = ingestWizardSlice.actions;
+
+export const ingestWizardReducer = ingestWizardSlice.reducer;
+
+export type IngestWizardAction = ReturnType<
+  | typeof setCurrentStep
+  | typeof updateDataSource
+  | typeof addFieldMapping
+  | typeof removeFieldMapping
+  | typeof updateSchemaMapping
+  | typeof setValidation
+  | typeof resetWizard
+>;
+
+export const selectDataSource = (state: IngestWizardState) => state.dataSource;
+export const selectSchemaMapping = (state: IngestWizardState) => state.schemaMapping;
+export const selectValidation = (state: IngestWizardState) => state.validation;
+export const selectCurrentStep = (state: IngestWizardState) => state.currentStep;

--- a/frontend/src/ingestWizard/styles.css
+++ b/frontend/src/ingestWizard/styles.css
@@ -1,0 +1,226 @@
+.iw-section {
+  background: #ffffff;
+  border: 1px solid #d7dde9;
+  border-radius: 12px;
+  box-shadow: 0 2px 6px rgba(18, 38, 63, 0.08);
+  padding: 24px;
+}
+
+.iw-section header {
+  margin-bottom: 24px;
+}
+
+.iw-section h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #102a43;
+}
+
+.iw-section p.description {
+  color: #486581;
+  margin-top: 4px;
+  font-size: 0.95rem;
+}
+
+.iw-grid {
+  display: grid;
+  gap: 16px;
+}
+
+@media (min-width: 768px) {
+  .iw-grid.two-column {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.iw-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.iw-label {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #243b53;
+}
+
+.iw-text-input,
+.iw-select,
+.iw-textarea {
+  border: 1px solid #cbd2d9;
+  border-radius: 8px;
+  padding: 8px 12px;
+  font-size: 0.95rem;
+  color: #102a43;
+}
+
+.iw-textarea {
+  min-height: 72px;
+  resize: vertical;
+}
+
+.iw-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  color: #334e68;
+}
+
+.iw-actions {
+  margin-top: 24px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.iw-button {
+  border-radius: 8px;
+  border: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: 10px 16px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.iw-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.iw-button-primary {
+  background: #2f5dff;
+  color: #ffffff;
+}
+
+.iw-button-primary:hover:not(:disabled) {
+  background: #2546cc;
+}
+
+.iw-button-secondary {
+  background: #d9e2ec;
+  color: #243b53;
+}
+
+.iw-button-secondary:hover:not(:disabled) {
+  background: #bcccdc;
+}
+
+.iw-button-tertiary {
+  background: transparent;
+  color: #486581;
+  border: 1px solid #cbd2d9;
+}
+
+.iw-button-tertiary:hover:not(:disabled) {
+  background: #f0f4f8;
+}
+
+.iw-table-wrapper {
+  overflow: hidden;
+  border: 1px solid #d7dde9;
+  border-radius: 12px;
+}
+
+.iw-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+.iw-table thead {
+  background: #f0f4f8;
+  color: #52606d;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.04em;
+}
+
+.iw-table th,
+.iw-table td {
+  padding: 12px;
+  border-bottom: 1px solid #e4e7eb;
+}
+
+.iw-table tbody tr:hover {
+  background: #f8f9fb;
+}
+
+.iw-validation-card {
+  border: 1px solid #d7dde9;
+  border-radius: 12px;
+  padding: 16px;
+}
+
+.iw-validation-issues {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.iw-issue {
+  border-left: 4px solid transparent;
+  border-radius: 8px;
+  padding: 12px;
+  display: grid;
+  gap: 4px;
+}
+
+.iw-issue.info {
+  background: #ebf8ff;
+  border-color: #0091ff;
+  color: #0b69a3;
+}
+
+.iw-issue.warning {
+  background: #fffaf0;
+  border-color: #f0b429;
+  color: #8d6d1f;
+}
+
+.iw-issue.error {
+  background: #ffeeee;
+  border-color: #f05252;
+  color: #9b1c1c;
+}
+
+.iw-wizard-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.iw-wizard-header h1 {
+  margin: 4px 0 0;
+  font-size: 1.75rem;
+  color: #102a43;
+}
+
+.iw-wizard-header p {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #829ab1;
+}
+
+.iw-summary-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin-top: 12px;
+}
+
+.iw-summary-grid dt {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  color: #829ab1;
+}
+
+.iw-summary-grid dd {
+  margin: 4px 0 0;
+  font-size: 0.95rem;
+  color: #243b53;
+}

--- a/frontend/src/ingestWizard/types.ts
+++ b/frontend/src/ingestWizard/types.ts
@@ -1,0 +1,80 @@
+export type SourceType = 'csv' | 'json' | 'elasticsearch' | 'esri' | 'api';
+
+export interface LicenseRestrictions {
+  commercial_use: boolean;
+  export_allowed: boolean;
+  research_only: boolean;
+  attribution_required: boolean;
+  share_alike: boolean;
+}
+
+export interface CustomLicense {
+  name: string;
+  type: 'commercial' | 'open_source' | 'proprietary' | 'restricted';
+  restrictions: LicenseRestrictions;
+}
+
+export interface DataSourceConfig {
+  id?: string;
+  name: string;
+  description?: string;
+  source_type: SourceType;
+  source_config: Record<string, unknown>;
+  license_template?: string;
+  custom_license?: CustomLicense;
+  tos_accepted: boolean;
+  retention_period: number;
+  geographic_restrictions: string[];
+}
+
+export interface FieldPreview {
+  name: string;
+  type: string;
+  pii?: 'none' | 'low' | 'medium' | 'high' | 'critical';
+  required?: boolean;
+  example?: string;
+}
+
+export interface FieldMapping {
+  id: string;
+  sourceField: string;
+  targetField: string;
+  transformation?: string;
+  required?: boolean;
+}
+
+export interface SchemaMappingState {
+  sourceSample: FieldPreview[];
+  targetSchema: FieldPreview[];
+  mappings: FieldMapping[];
+  autoMappedFields: string[];
+}
+
+export type ValidationStatus = 'idle' | 'pending' | 'passed' | 'failed';
+
+export interface ValidationIssue {
+  id: string;
+  field?: string;
+  message: string;
+  severity: 'info' | 'warning' | 'error';
+  suggestion?: string;
+}
+
+export interface ValidationState {
+  status: ValidationStatus;
+  issues: ValidationIssue[];
+  lastRun?: string;
+}
+
+export interface IngestWizardState {
+  currentStep: number;
+  dataSource: Partial<DataSourceConfig>;
+  schemaMapping: SchemaMappingState;
+  validation: ValidationState;
+}
+
+export interface WizardCompletion {
+  dataSource: DataSourceConfig;
+  schemaMapping: SchemaMappingState;
+  validation: ValidationState;
+}


### PR DESCRIPTION
## Summary
- refactor the ingest wizard into composed data source, schema mapping, and validation components backed by shared types and reducer logic
- add styling tokens and usage documentation so the modular wizard can plug into Redux-based screens
- configure Storybook for the frontend package and add stories that exercise each step and the full wizard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d62cd3892c833386b63c5863bc84ca