### PR TITLE
feat: implement backend multi-tenancy support

### DIFF
--- a/docs/multi-tenancy-testing.md
+++ b/docs/multi-tenancy-testing.md
@@ -1,0 +1,101 @@
+# Multi-Tenancy Testing Guide
+
+This guide outlines how to validate Summit's multi-tenant backend after the schema- and graph-level isolation changes.
+
+## Prerequisites
+
+- PostgreSQL and Neo4j instances reachable from the backend.
+- `DATABASE_URL`, `NEO4J_URI`, and related credentials set in the environment.
+- A JWT issuer capable of minting tokens that include `tenantId` (or equivalent) and role claims.
+
+## Database Preparation
+
+1. **Run migrations**
+   ```bash
+   cd server
+   npm run db:migrate
+   ```
+   This creates the `tenants` metadata table plus helper functions that provision per-tenant schemas on demand.
+
+2. **Provision tenant schemas**
+   - Tenant schemas are created automatically the first time a request executes with a new `tenantId`.
+   - To pre-create a schema, call the helper function directly:
+     ```sql
+     SELECT ensure_tenant_schema('acme-corp');
+     ```
+
+3. **Verify schema contents**
+   ```sql
+   SET search_path TO tenant_acme_corp, public;
+   \dt
+   ```
+   Ensure core tables (`entities`, `relationships`, `investigations`, etc.) exist inside the tenant schema.
+
+## Neo4j Namespace Verification
+
+1. Authenticate to Neo4j with admin rights and list databases:
+   ```cypher
+   SHOW DATABASES;
+   ```
+   After executing a tenant-scoped resolver, a database named `tenant_<normalized_id>` should appear.
+
+2. Switch to the tenant graph and confirm isolation:
+   ```cypher
+   :use tenant_acme_corp
+   MATCH (n) RETURN count(n);
+   ```
+   Data from other tenants should be invisible.
+
+## GraphQL End-to-End Tests
+
+1. **Create JWTs**
+   - Include `tenantId` and role claims (e.g., `roles: ["ADMIN"]`).
+   - Example payload snippet:
+     ```json
+     {
+       "userId": "user-123",
+       "email": "admin@acme.example",
+       "roles": ["ADMIN"],
+       "tenantId": "acme-corp"
+     }
+     ```
+
+2. **Run tenant-scoped mutations**
+   - Create an entity:
+     ```graphql
+     mutation {
+       createEntity(input: {
+         tenantId: "acme-corp",
+         kind: "Person",
+         labels: ["Executive"],
+         props: { name: "Ada" }
+       }) {
+         id
+       }
+     }
+     ```
+   - Verify the entity exists only when querying with the same tenant token.
+
+3. **Cross-tenant rejection**
+   - Reuse the entity ID with a token that has a different `tenantId` claim and confirm a `CROSS_TENANT_ACCESS_DENIED` error is returned.
+
+4. **Schema isolation checks**
+   - Execute a query against another tenant and confirm no shared data is returned.
+   - Inspect PostgreSQL to ensure rows are written into the tenant-specific schema.
+
+5. **OPA/RBAC compatibility**
+   - Validate feature-gated mutations (e.g., `triggerN8n`) still consult tenant-aware RBAC policies.
+
+## Cleanup
+
+- Remove test data by dropping the tenant schema:
+  ```sql
+  DROP SCHEMA tenant_acme_corp CASCADE;
+  ```
+- Drop the Neo4j tenant database if needed:
+  ```cypher
+  :use system
+  DROP DATABASE tenant_acme_corp IF EXISTS;
+  ```
+
+Document results and share with the security team for audit sign-off.

--- a/server/migrations/003_enable_multi_tenancy.sql
+++ b/server/migrations/003_enable_multi_tenancy.sql
@@ -1,0 +1,101 @@
+-- Multi-tenancy enablement for Summit backend
+-- Introduces tenant metadata and schema isolation helpers
+
+CREATE TABLE IF NOT EXISTS tenants (
+  id TEXT PRIMARY KEY,
+  schema_name TEXT NOT NULL,
+  neo4j_namespace TEXT NOT NULL,
+  display_name TEXT,
+  opa_policy_tag TEXT,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tenants_schema_name ON tenants(schema_name);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tenants_neo4j_namespace ON tenants(neo4j_namespace);
+
+CREATE OR REPLACE FUNCTION format_tenant_schema(p_tenant_id TEXT)
+RETURNS TEXT AS
+$$
+DECLARE
+  normalized TEXT := regexp_replace(lower(p_tenant_id), '[^a-z0-9]+', '_', 'g');
+BEGIN
+  RETURN 'tenant_' || normalized;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION ensure_tenant_schema(p_tenant_id TEXT)
+RETURNS TEXT AS
+$$
+DECLARE
+  schema_name TEXT := format_tenant_schema(p_tenant_id);
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_namespace WHERE nspname = schema_name
+  ) THEN
+    EXECUTE format('CREATE SCHEMA IF NOT EXISTS %I', schema_name);
+
+    -- Ensure tenant scoped tables exist by cloning canonical definitions
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.tables WHERE table_schema = schema_name AND table_name = 'entities'
+    ) THEN
+      EXECUTE format('CREATE TABLE %I.entities (LIKE public.entities INCLUDING ALL)', schema_name);
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.tables WHERE table_schema = schema_name AND table_name = 'relationships'
+    ) THEN
+      EXECUTE format('CREATE TABLE %I.relationships (LIKE public.relationships INCLUDING ALL)', schema_name);
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.tables WHERE table_schema = schema_name AND table_name = 'investigations'
+    ) THEN
+      EXECUTE format('CREATE TABLE %I.investigations (LIKE public.investigations INCLUDING ALL)', schema_name);
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.tables WHERE table_schema = schema_name AND table_name = 'provenance'
+    ) THEN
+      EXECUTE format('CREATE TABLE %I.provenance (LIKE public.provenance INCLUDING ALL)', schema_name);
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.tables WHERE table_schema = schema_name AND table_name = 'outbox_events'
+    ) THEN
+      EXECUTE format('CREATE TABLE %I.outbox_events (LIKE public.outbox_events INCLUDING ALL)', schema_name);
+    END IF;
+  END IF;
+
+  INSERT INTO tenants (id, schema_name, neo4j_namespace, updated_at)
+  VALUES (
+    p_tenant_id,
+    schema_name,
+    schema_name,
+    now()
+  )
+  ON CONFLICT (id) DO UPDATE
+  SET
+    schema_name = EXCLUDED.schema_name,
+    neo4j_namespace = EXCLUDED.neo4j_namespace,
+    updated_at = now();
+
+  RETURN schema_name;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION set_tenant_search_path(p_tenant_id TEXT)
+RETURNS TEXT AS
+$$
+DECLARE
+  schema_name TEXT;
+BEGIN
+  schema_name := ensure_tenant_schema(p_tenant_id);
+  EXECUTE format('SET LOCAL search_path TO %I, public', schema_name);
+  RETURN schema_name;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+GRANT EXECUTE ON FUNCTION ensure_tenant_schema(TEXT) TO PUBLIC;
+GRANT EXECUTE ON FUNCTION set_tenant_search_path(TEXT) TO PUBLIC;

--- a/server/src/db/neo4j.ts
+++ b/server/src/db/neo4j.ts
@@ -1,6 +1,7 @@
 import neo4j from 'neo4j-driver';
 import { trace, Span } from '@opentelemetry/api';
 import { Counter, Histogram, Gauge } from 'prom-client';
+import { ensureTenantNamespace } from './tenants/neo4jTenancy.js';
 
 const tracer = trace.getTracer('maestro-neo4j', '24.3.0');
 
@@ -69,8 +70,13 @@ export const neo = {
         'tenant_id': options?.tenantId || 'unknown'
       });
 
+      const database = options?.tenantId
+        ? await ensureTenantNamespace(driver, options.tenantId)
+        : process.env.NEO4J_DATABASE || 'neo4j';
+
       const session = driver.session({
-        defaultAccessMode: neo4j.session.WRITE
+        defaultAccessMode: neo4j.session.WRITE,
+        database
       });
 
       // Enhanced tenant scoping for Neo4j queries
@@ -104,8 +110,13 @@ export const neo = {
         'tenant_id': options?.tenantId || 'unknown'
       });
 
+      const database = options?.tenantId
+        ? await ensureTenantNamespace(driver, options.tenantId)
+        : process.env.NEO4J_DATABASE || 'neo4j';
+
       const session = driver.session({
-        defaultAccessMode: neo4j.session.WRITE
+        defaultAccessMode: neo4j.session.WRITE,
+        database
       });
 
       const scopedQuery = validateAndScopeNeo4jQuery(query, params, options?.tenantId);

--- a/server/src/db/tenants/neo4jTenancy.ts
+++ b/server/src/db/tenants/neo4jTenancy.ts
@@ -1,0 +1,38 @@
+import type { Driver } from 'neo4j-driver';
+import baseLogger from '../../config/logger.js';
+
+const logger = baseLogger.child({ name: 'Neo4jTenancy' });
+const namespaceCache: Set<string> = new Set();
+
+export function formatTenantNamespace(tenantId: string): string {
+  const normalized = tenantId.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  return `tenant_${normalized}`;
+}
+
+export async function ensureTenantNamespace(driver: Driver, tenantId: string): Promise<string> {
+  const namespace = formatTenantNamespace(tenantId);
+  if (namespaceCache.has(namespace)) {
+    return namespace;
+  }
+
+  const systemSession = driver.session({ database: 'system' });
+  try {
+    const existsResult = await systemSession.run(
+      'SHOW DATABASES YIELD name WHERE name = $name RETURN name',
+      { name: namespace }
+    );
+
+    if (existsResult.records.length === 0) {
+      try {
+        await systemSession.run(`CREATE DATABASE ${namespace}`);
+      } catch (error) {
+        logger.warn({ namespace, error }, 'Failed to create tenant namespace database');
+      }
+    }
+
+    namespaceCache.add(namespace);
+    return namespace;
+  } finally {
+    await systemSession.close();
+  }
+}

--- a/server/src/db/tenants/postgresTenancy.ts
+++ b/server/src/db/tenants/postgresTenancy.ts
@@ -1,0 +1,87 @@
+import type { Pool, PoolClient } from 'pg';
+import baseLogger from '../../config/logger.js';
+import { getPostgresPool } from '../postgres.js';
+
+const logger = baseLogger.child({ name: 'PostgresTenancy' });
+const schemaCache: Set<string> = new Set();
+
+export function formatTenantSchema(tenantId: string): string {
+  const normalized = tenantId.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  return `tenant_${normalized}`;
+}
+
+async function runEnsureSchema(client: PoolClient, tenantId: string): Promise<string> {
+  const { rows } = await client.query<{ ensure_tenant_schema: string }>(
+    'SELECT ensure_tenant_schema($1) AS ensure_tenant_schema',
+    [tenantId]
+  );
+  const schemaName = rows[0]?.ensure_tenant_schema ?? formatTenantSchema(tenantId);
+  schemaCache.add(schemaName);
+  return schemaName;
+}
+
+export async function ensureTenantSchema(tenantId: string, client?: PoolClient): Promise<string> {
+  const schemaName = formatTenantSchema(tenantId);
+  if (schemaCache.has(schemaName)) {
+    return schemaName;
+  }
+
+  if (client) {
+    return await runEnsureSchema(client, tenantId);
+  }
+
+  const pool = getPostgresPool();
+  const scopedClient = await pool.connect();
+  try {
+    await scopedClient.query('BEGIN');
+    const ensured = await runEnsureSchema(scopedClient, tenantId);
+    await scopedClient.query('COMMIT');
+    return ensured;
+  } catch (error) {
+    await scopedClient.query('ROLLBACK').catch(() => undefined);
+    logger.error({ tenantId, error }, 'Failed to ensure tenant schema');
+    throw error;
+  } finally {
+    scopedClient.release();
+  }
+}
+
+export interface TenantConnectionOptions {
+  pool?: Pool;
+  transactional?: boolean;
+}
+
+export async function withTenantConnection<T>(
+  tenantId: string,
+  fn: (client: PoolClient) => Promise<T>,
+  options: TenantConnectionOptions = {}
+): Promise<T> {
+  const pool = options.pool ?? getPostgresPool();
+  const transactional = options.transactional ?? true;
+  const client = await pool.connect();
+
+  try {
+    if (transactional) {
+      await client.query('BEGIN');
+    }
+
+    await runEnsureSchema(client, tenantId);
+    await client.query('SELECT set_tenant_search_path($1)', [tenantId]);
+
+    const result = await fn(client);
+
+    if (transactional) {
+      await client.query('COMMIT');
+    }
+
+    return result;
+  } catch (error) {
+    if (transactional) {
+      await client.query('ROLLBACK').catch(() => undefined);
+    }
+    logger.error({ tenantId, error }, 'Tenant scoped query failed');
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/server/src/graphql/schema.core.js
+++ b/server/src/graphql/schema.core.js
@@ -103,6 +103,7 @@ export const coreTypeDefs = gql`
 
   input EntityUpdateInput {
     id: ID!
+    tenantId: String!
     labels: [String!]
     props: JSON
   }
@@ -126,6 +127,7 @@ export const coreTypeDefs = gql`
 
   input InvestigationUpdateInput {
     id: ID!
+    tenantId: String!
     name: String
     description: String
     status: InvestigationStatus

--- a/server/src/graphql/schema.core.js.rehydrated
+++ b/server/src/graphql/schema.core.js.rehydrated
@@ -103,6 +103,7 @@ export const coreTypeDefs = gql`
 
   input EntityUpdateInput {
     id: ID!
+    tenantId: String!
     labels: [String!]
     props: JSON
   }
@@ -126,6 +127,7 @@ export const coreTypeDefs = gql`
 
   input InvestigationUpdateInput {
     id: ID!
+    tenantId: String!
     name: String
     description: String
     status: InvestigationStatus

--- a/server/src/graphql/schema/crudSchema.ts
+++ b/server/src/graphql/schema/crudSchema.ts
@@ -234,6 +234,7 @@ export const crudTypeDefs = gql`
     confidence: Float
     source: String
     canonicalId: ID
+    tenantId: String!
   }
 
   input RelationshipInput {
@@ -281,6 +282,7 @@ export const crudTypeDefs = gql`
     tags: [String!]
     metadata: JSON
     customSchema: JSON
+    tenantId: String!
   }
 
   # Filter inputs

--- a/server/src/graphql/utils/tenantGuard.ts
+++ b/server/src/graphql/utils/tenantGuard.ts
@@ -1,0 +1,57 @@
+import { GraphQLError } from 'graphql';
+
+function normalizeRoles(context: any): string[] {
+  const rawRoles: string[] = [];
+  if (Array.isArray(context?.roles)) {
+    rawRoles.push(...context.roles);
+  }
+  if (Array.isArray(context?.user?.roles)) {
+    rawRoles.push(...context.user.roles);
+  }
+  if (context?.user?.role) {
+    rawRoles.push(context.user.role);
+  }
+  return Array.from(new Set(rawRoles.map((role) => role?.toString().toUpperCase())));
+}
+
+export function resolveTenantId(context: any, requestedTenantId?: string): string {
+  const claimTenant =
+    context?.tenantId ||
+    context?.user?.tenantId ||
+    context?.user?.tenant ||
+    context?.user?.tenant_id ||
+    context?.claims?.tenantId;
+
+  if (!claimTenant) {
+    throw new GraphQLError('Tenant claim missing', {
+      extensions: {
+        code: 'TENANT_REQUIRED',
+        http: { status: 403 },
+      },
+    });
+  }
+
+  if (!requestedTenantId) {
+    return claimTenant;
+  }
+
+  if (requestedTenantId === claimTenant) {
+    return requestedTenantId;
+  }
+
+  const roles = normalizeRoles(context);
+  const canBypass = roles.includes('SUPER_ADMIN') || roles.includes('SYSTEM');
+
+  if (!canBypass) {
+    throw new GraphQLError('Cross-tenant access denied', {
+      extensions: {
+        code: 'CROSS_TENANT_ACCESS_DENIED',
+        http: { status: 403 },
+        tenantId: claimTenant,
+        requestedTenantId,
+      },
+    });
+  }
+
+  return requestedTenantId;
+}

--- a/server/src/lib/auth.ts
+++ b/server/src/lib/auth.ts
@@ -13,12 +13,18 @@ interface User {
   email: string;
   username?: string;
   role?: string;
+  roles: string[];
+  tenantId: string;
+  permissions: string[];
 }
 
 interface AuthContext {
   user?: User;
   isAuthenticated: boolean;
   requestId: string;
+  tenantId?: string;
+  roles: string[];
+  permissions: string[];
 }
 
 export const getContext = async ({ req }: { req: any }): Promise<AuthContext> => {
@@ -27,15 +33,22 @@ export const getContext = async ({ req }: { req: any }): Promise<AuthContext> =>
     const token = extractToken(req);
     if (!token) {
       logger.info({ requestId }, 'Unauthenticated request');
-      return { isAuthenticated: false, requestId };
+      return { isAuthenticated: false, requestId, roles: [], permissions: [] };
     }
 
     const user = await verifyToken(token);
-    logger.info({ requestId, userId: user.id }, 'Authenticated request');
-    return { user, isAuthenticated: true, requestId };
+    logger.info({ requestId, userId: user.id, tenantId: user.tenantId }, 'Authenticated request');
+    return {
+      user,
+      isAuthenticated: true,
+      requestId,
+      tenantId: user.tenantId,
+      roles: user.roles,
+      permissions: user.permissions,
+    };
   } catch (error) {
     logger.warn({ requestId, error: (error as Error).message }, 'Authentication failed');
-    return { isAuthenticated: false, requestId };
+    return { isAuthenticated: false, requestId, roles: [], permissions: [] };
   }
 };
 
@@ -48,23 +61,87 @@ export const verifyToken = async (token: string): Promise<User> => {
         email: 'developer@intelgraph.com',
         username: 'developer',
         role: 'ADMIN',
+        roles: ['ADMIN'],
+        tenantId: 'dev-tenant',
+        permissions: ['*'],
       };
     }
 
     // Verify JWT token
     const decoded = jwt.verify(token, JWT_SECRET) as any;
 
+    const tenantClaim =
+      decoded.tenantId ||
+      decoded.tenant_id ||
+      decoded['https://summit.ai/tenant'] ||
+      decoded['https://summit.ai/tenant_id'] ||
+      decoded['https://intelgraph.com/tenant'] ||
+      decoded['https://intelgraph.com/tenant_id'];
+
+    if (!tenantClaim) {
+      throw new GraphQLError('Tenant claim missing', {
+        extensions: {
+          code: 'TENANT_REQUIRED',
+          http: { status: 403 },
+        },
+      });
+    }
+
+    const roleClaims: string[] = [];
+    if (Array.isArray(decoded.roles)) {
+      roleClaims.push(...decoded.roles);
+    }
+    if (decoded.role) {
+      roleClaims.push(decoded.role);
+    }
+    if (decoded.realm_access?.roles) {
+      roleClaims.push(...decoded.realm_access.roles);
+    }
+
+    const roles = Array.from(new Set(roleClaims.map((role) => role?.toString())));
+    const primaryRole = decoded.role || roles[0] || 'USER';
+
+    const permissionClaims: string[] = [];
+    if (Array.isArray(decoded.permissions)) {
+      permissionClaims.push(...decoded.permissions);
+    }
+    if (typeof decoded.scope === 'string') {
+      permissionClaims.push(...decoded.scope.split(' '));
+    }
+
     // Get user from database
+    const userId = decoded.userId || decoded.sub;
+    if (!userId) {
+      throw new GraphQLError('Token missing subject identifier', {
+        extensions: {
+          code: 'UNAUTHENTICATED',
+          http: { status: 401 },
+        },
+      });
+    }
+
     const pool = getPostgresPool();
     const result = await pool.query('SELECT id, email, username, role FROM users WHERE id = $1', [
-      decoded.userId,
+      userId,
     ]);
 
     if (result.rows.length === 0) {
       throw new Error('User not found');
     }
 
-    return result.rows[0];
+    const dbUser = result.rows[0];
+
+    const userRoles = Array.from(new Set([dbUser.role, primaryRole, ...roles].filter(Boolean)));
+
+    return {
+      id: dbUser.id,
+      email: dbUser.email,
+      username: dbUser.username,
+      role: userRoles[0],
+      roles: userRoles,
+      tenantId: tenantClaim,
+      permissions: Array.from(new Set(permissionClaims)),
+    };
   } catch (error) {
     throw new GraphQLError('Invalid or expired token', {
       extensions: {
@@ -81,6 +158,9 @@ export const generateToken = (user: User): string => {
       userId: user.id,
       email: user.email,
       role: user.role,
+      roles: user.roles,
+      tenantId: user.tenantId,
+      permissions: user.permissions,
     },
     JWT_SECRET,
     { expiresIn: '1h' },
@@ -101,7 +181,9 @@ export const requireAuth = (context: AuthContext): User => {
 
 export const requireRole = (context: AuthContext, requiredRole: string): User => {
   const user = requireAuth(context);
-  if (user.role !== requiredRole && user.role !== 'ADMIN') {
+  const normalizedRoles = new Set(user.roles.map((role) => role.toUpperCase()));
+  normalizedRoles.add((user.role || '').toUpperCase());
+  if (!normalizedRoles.has(requiredRole.toUpperCase()) && !normalizedRoles.has('ADMIN')) {
     throw new GraphQLError('Insufficient permissions', {
       extensions: {
         code: 'FORBIDDEN',

--- a/server/src/repos/EntityRepo.ts
+++ b/server/src/repos/EntityRepo.ts
@@ -3,10 +3,12 @@
  * Replaces demo resolvers with PostgreSQL (canonical) + Neo4j (graph) dual-write
  */
 
-import { Pool, PoolClient } from 'pg';
-import { Driver, Session } from 'neo4j-driver';
+import { Pool } from 'pg';
+import { Driver } from 'neo4j-driver';
 import { randomUUID as uuidv4 } from 'crypto';
 import logger from '../config/logger.js';
+import { withTenantConnection } from '../db/tenants/postgresTenancy.js';
+import { ensureTenantNamespace } from '../db/tenants/neo4jTenancy.js';
 
 const repoLogger = logger.child({ name: 'EntityRepo' });
 
@@ -30,6 +32,7 @@ export interface EntityInput {
 
 export interface EntityUpdateInput {
   id: string;
+  tenantId: string;
   labels?: string[];
   props?: Record<string, any>;
 }
@@ -56,195 +59,178 @@ export class EntityRepo {
    */
   async create(input: EntityInput, userId: string): Promise<Entity> {
     const id = uuidv4();
-    const client = await this.pg.connect();
+
+    const entity = await withTenantConnection(
+      input.tenantId,
+      async (client) => {
+        const { rows } = await client.query<EntityRow>(
+          `INSERT INTO entities (id, tenant_id, kind, labels, props, created_by)
+           VALUES ($1, $2, $3, $4, $5, $6)
+           RETURNING *`,
+          [
+            id,
+            input.tenantId,
+            input.kind,
+            input.labels || [],
+            JSON.stringify(input.props || {}),
+            userId,
+          ],
+        );
+
+        await client.query(
+          `INSERT INTO outbox_events (id, topic, payload)
+           VALUES ($1, $2, $3)`,
+          [uuidv4(), 'entity.upsert', JSON.stringify({ id: rows[0].id, tenantId: rows[0].tenant_id })],
+        );
+
+        return rows[0];
+      },
+      { pool: this.pg }
+    );
 
     try {
-      await client.query('BEGIN');
-
-      // 1. Write to PostgreSQL (source of truth)
-      const { rows } = await client.query<EntityRow>(
-        `INSERT INTO entities (id, tenant_id, kind, labels, props, created_by)
-         VALUES ($1, $2, $3, $4, $5, $6)
-         RETURNING *`,
-        [
-          id,
-          input.tenantId,
-          input.kind,
-          input.labels || [],
-          JSON.stringify(input.props || {}),
-          userId,
-        ],
+      await this.upsertNeo4jNode({
+        id: entity.id,
+        tenantId: entity.tenant_id,
+        kind: entity.kind,
+        labels: entity.labels,
+        props: entity.props,
+      });
+    } catch (neo4jError) {
+      repoLogger.warn(
+        { entityId: id, error: neo4jError },
+        'Neo4j write failed, will retry via outbox',
       );
-
-      const entity = rows[0];
-
-      // 2. Outbox event for Neo4j sync
-      await client.query(
-        `INSERT INTO outbox_events (id, topic, payload)
-         VALUES ($1, $2, $3)`,
-        [uuidv4(), 'entity.upsert', JSON.stringify({ id: entity.id, tenantId: entity.tenant_id })],
-      );
-
-      await client.query('COMMIT');
-
-      // 3. Attempt immediate Neo4j write (best effort)
-      try {
-        await this.upsertNeo4jNode({
-          id: entity.id,
-          tenantId: entity.tenant_id,
-          kind: entity.kind,
-          labels: entity.labels,
-          props: entity.props,
-        });
-      } catch (neo4jError) {
-        repoLogger.warn(
-          { entityId: id, error: neo4jError },
-          'Neo4j write failed, will retry via outbox',
-        );
-      }
-
-      return this.mapRow(entity);
-    } catch (error) {
-      await client.query('ROLLBACK');
-      throw error;
-    } finally {
-      client.release();
     }
+
+    return this.mapRow(entity);
   }
 
   /**
    * Update entity with dual-write
    */
   async update(input: EntityUpdateInput): Promise<Entity | null> {
-    const client = await this.pg.connect();
+    const entity = await withTenantConnection(
+      input.tenantId,
+      async (client) => {
+        const updateFields: string[] = [];
+        const params: any[] = [input.id];
+        let paramIndex = 2;
+
+        if (input.labels !== undefined) {
+          updateFields.push(`labels = $${paramIndex}`);
+          params.push(input.labels);
+          paramIndex++;
+        }
+
+        if (input.props !== undefined) {
+          updateFields.push(`props = $${paramIndex}`);
+          params.push(JSON.stringify(input.props));
+          paramIndex++;
+        }
+
+        updateFields.push(`updated_at = now()`);
+
+        const { rows } = await client.query<EntityRow>(
+          `UPDATE entities SET ${updateFields.join(', ')}
+           WHERE id = $1
+           RETURNING *`,
+          params,
+        );
+
+        if (rows.length === 0) {
+          return null;
+        }
+
+        await client.query(
+          `INSERT INTO outbox_events (id, topic, payload)
+           VALUES ($1, $2, $3)`,
+          [uuidv4(), 'entity.upsert', JSON.stringify({ id: rows[0].id, tenantId: rows[0].tenant_id })],
+        );
+
+        return rows[0];
+      },
+      { pool: this.pg }
+    );
+
+    if (!entity) {
+      return null;
+    }
 
     try {
-      await client.query('BEGIN');
-
-      const updateFields: string[] = [];
-      const params: any[] = [input.id];
-      let paramIndex = 2;
-
-      if (input.labels !== undefined) {
-        updateFields.push(`labels = $${paramIndex}`);
-        params.push(input.labels);
-        paramIndex++;
-      }
-
-      if (input.props !== undefined) {
-        updateFields.push(`props = $${paramIndex}`);
-        params.push(JSON.stringify(input.props));
-        paramIndex++;
-      }
-
-      updateFields.push(`updated_at = now()`);
-
-      const { rows } = await client.query<EntityRow>(
-        `UPDATE entities SET ${updateFields.join(', ')}
-         WHERE id = $1
-         RETURNING *`,
-        params,
+      await this.upsertNeo4jNode({
+        id: entity.id,
+        tenantId: entity.tenant_id,
+        kind: entity.kind,
+        labels: entity.labels,
+        props: entity.props,
+      });
+    } catch (neo4jError) {
+      repoLogger.warn(
+        { entityId: input.id, error: neo4jError },
+        'Neo4j update failed, will retry via outbox',
       );
-
-      if (rows.length === 0) {
-        await client.query('ROLLBACK');
-        return null;
-      }
-
-      const entity = rows[0];
-
-      // Outbox event for Neo4j sync
-      await client.query(
-        `INSERT INTO outbox_events (id, topic, payload)
-         VALUES ($1, $2, $3)`,
-        [uuidv4(), 'entity.upsert', JSON.stringify({ id: entity.id, tenantId: entity.tenant_id })],
-      );
-
-      await client.query('COMMIT');
-
-      // Best effort Neo4j update
-      try {
-        await this.upsertNeo4jNode({
-          id: entity.id,
-          tenantId: entity.tenant_id,
-          kind: entity.kind,
-          labels: entity.labels,
-          props: entity.props,
-        });
-      } catch (neo4jError) {
-        repoLogger.warn(
-          { entityId: input.id, error: neo4jError },
-          'Neo4j update failed, will retry via outbox',
-        );
-      }
-
-      return this.mapRow(entity);
-    } catch (error) {
-      await client.query('ROLLBACK');
-      throw error;
-    } finally {
-      client.release();
     }
+
+    return this.mapRow(entity);
   }
 
   /**
    * Delete entity with dual-write
    */
-  async delete(id: string): Promise<boolean> {
-    const client = await this.pg.connect();
+  async delete(id: string, tenantId: string): Promise<boolean> {
+    const deleted = await withTenantConnection(
+      tenantId,
+      async (client) => {
+        const { rowCount } = await client.query(`DELETE FROM entities WHERE id = $1`, [id]);
 
-    try {
-      await client.query('BEGIN');
-
-      const { rowCount } = await client.query(`DELETE FROM entities WHERE id = $1`, [id]);
-
-      if (rowCount && rowCount > 0) {
-        // Outbox event for Neo4j cleanup
-        await client.query(
-          `INSERT INTO outbox_events (id, topic, payload)
-           VALUES ($1, $2, $3)`,
-          [uuidv4(), 'entity.delete', JSON.stringify({ id })],
-        );
-
-        await client.query('COMMIT');
-
-        // Best effort Neo4j delete
-        try {
-          await this.deleteNeo4jNode(id);
-        } catch (neo4jError) {
-          repoLogger.warn(
-            { entityId: id, error: neo4jError },
-            'Neo4j delete failed, will retry via outbox',
+        if (rowCount && rowCount > 0) {
+          await client.query(
+            `INSERT INTO outbox_events (id, topic, payload)
+             VALUES ($1, $2, $3)`,
+            [uuidv4(), 'entity.delete', JSON.stringify({ id, tenantId })],
           );
+          return true;
         }
 
-        return true;
-      } else {
-        await client.query('ROLLBACK');
         return false;
-      }
-    } catch (error) {
-      await client.query('ROLLBACK');
-      throw error;
-    } finally {
-      client.release();
+      },
+      { pool: this.pg }
+    );
+
+    if (!deleted) {
+      return false;
     }
+
+    try {
+      await this.deleteNeo4jNode(id, tenantId);
+    } catch (neo4jError) {
+      repoLogger.warn(
+        { entityId: id, error: neo4jError },
+        'Neo4j delete failed, will retry via outbox',
+      );
+    }
+
+    return true;
   }
 
   /**
    * Find entity by ID
    */
-  async findById(id: string, tenantId?: string): Promise<Entity | null> {
-    const params = [id];
-    let query = `SELECT * FROM entities WHERE id = $1`;
+  async findById(id: string, tenantId: string): Promise<Entity | null> {
+    const row = await withTenantConnection(
+      tenantId,
+      async (client) => {
+        const { rows } = await client.query<EntityRow>(
+          `SELECT * FROM entities WHERE id = $1`,
+          [id],
+        );
+        return rows[0] ?? null;
+      },
+      { pool: this.pg }
+    );
 
-    if (tenantId) {
-      query += ` AND tenant_id = $2`;
-      params.push(tenantId);
-    }
-
-    const { rows } = await this.pg.query<EntityRow>(query, params);
-    return rows[0] ? this.mapRow(rows[0]) : null;
+    return row ? this.mapRow(row) : null;
   }
 
   /**
@@ -263,44 +249,55 @@ export class EntityRepo {
     limit?: number;
     offset?: number;
   }): Promise<Entity[]> {
-    const params: any[] = [tenantId];
-    let query = `SELECT * FROM entities WHERE tenant_id = $1`;
-    let paramIndex = 2;
+    const rows = await withTenantConnection(
+      tenantId,
+      async (client) => {
+        const params: any[] = [];
+        let query = `SELECT * FROM entities`;
+        const conditions: string[] = ['TRUE'];
 
-    if (kind) {
-      query += ` AND kind = $${paramIndex}`;
-      params.push(kind);
-      paramIndex++;
-    }
+        if (kind) {
+          params.push(kind);
+          conditions.push(`kind = $${params.length}`);
+        }
 
-    if (props) {
-      query += ` AND props @> $${paramIndex}::jsonb`;
-      params.push(JSON.stringify(props));
-      paramIndex++;
-    }
+        if (props) {
+          params.push(JSON.stringify(props));
+          conditions.push(`props @> $${params.length}::jsonb`);
+        }
 
-    query += ` ORDER BY created_at DESC LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`;
-    params.push(Math.min(limit, 1000), offset); // Cap at 1000 for safety
+        query += ` WHERE ${conditions.join(' AND ')}`;
+        params.push(Math.min(limit, 1000));
+        params.push(offset);
+        query += ` ORDER BY created_at DESC LIMIT $${params.length - 1} OFFSET $${params.length}`;
 
-    const { rows } = await this.pg.query<EntityRow>(query, params);
+        const { rows } = await client.query<EntityRow>(query, params);
+        return rows;
+      },
+      { pool: this.pg }
+    );
+
     return rows.map(this.mapRow);
   }
 
   /**
    * Batch load entities by IDs (for DataLoader)
    */
-  async batchByIds(ids: readonly string[], tenantId?: string): Promise<(Entity | null)[]> {
+  async batchByIds(ids: readonly string[], tenantId: string): Promise<(Entity | null)[]> {
     if (ids.length === 0) return [];
 
-    const params = [ids];
-    let query = `SELECT * FROM entities WHERE id = ANY($1)`;
+    const rows = await withTenantConnection(
+      tenantId,
+      async (client) => {
+        const { rows } = await client.query<EntityRow>(
+          `SELECT * FROM entities WHERE id = ANY($1)`,
+          [ids],
+        );
+        return rows;
+      },
+      { pool: this.pg }
+    );
 
-    if (tenantId) {
-      query += ` AND tenant_id = $2`;
-      params.push(tenantId);
-    }
-
-    const { rows } = await this.pg.query<EntityRow>(query, params);
     const entitiesMap = new Map(rows.map((row) => [row.id, this.mapRow(row)]));
 
     return ids.map((id) => entitiesMap.get(id) || null);
@@ -322,7 +319,8 @@ export class EntityRepo {
     labels: string[];
     props: any;
   }): Promise<void> {
-    const session = this.neo4j.session();
+    const database = await ensureTenantNamespace(this.neo4j, tenantId);
+    const session = this.neo4j.session({ database });
 
     try {
       await session.executeWrite(async (tx) => {
@@ -345,8 +343,9 @@ export class EntityRepo {
   /**
    * Delete entity node from Neo4j
    */
-  private async deleteNeo4jNode(id: string): Promise<void> {
-    const session = this.neo4j.session();
+  private async deleteNeo4jNode(id: string, tenantId: string): Promise<void> {
+    const database = await ensureTenantNamespace(this.neo4j, tenantId);
+    const session = this.neo4j.session({ database });
 
     try {
       await session.executeWrite(async (tx) => {


### PR DESCRIPTION
## Summary
- add PostgreSQL migration and helpers that provision per-tenant schemas and search_path isolation
- scope Neo4j sessions to tenant databases and enforce tenant-aware GraphQL access via JWT claims
- update persistence repos and GraphQL schema to require tenant identifiers and document testing steps

## Testing
- `npm run lint` *(fails: missing globals package in eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68d62cd643cc83338edc4c4524f50eeb