### PR TITLE
feat: add summit CLI for local development

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,90 @@
+# Summit CLI
+
+The Summit CLI streamlines local development by wrapping the most common Docker, Kubernetes, and workspace commands behind a single entrypoint.
+
+## Installation
+
+From the repository root install dependencies and link the CLI globally:
+
+```bash
+npm run cli:install
+npm run cli:link
+```
+
+Once linked, the `summit` command is available on your PATH.
+
+Alternatively, you can run the CLI without linking:
+
+```bash
+node cli/bin/summit.js <command>
+```
+
+## Commands
+
+### `summit up`
+
+Start the local stack.
+
+| Option | Description |
+| --- | --- |
+| `--compose-file <path>` | Compose file to use (default: `docker-compose.yml`). |
+| `--services <names>` | Comma separated services to start (defaults to all). |
+| `--no-detach` | Keep Docker containers in the foreground. |
+| `--build` | Force a build before starting containers. |
+| `--k8s` | Apply Kubernetes manifests instead of Docker Compose. |
+| `--kube-manifest <path>` | File or directory of Kubernetes manifests (default: `deploy/k8s`). |
+| `--namespace <name>` | Kubernetes namespace (default: `summit-dev`). |
+| `--context <name>` | Kubernetes context to use with kubectl. |
+
+Examples:
+
+```bash
+summit up
+summit up --compose-file ops/docker-compose.yml --services api,worker
+summit up --k8s --kube-manifest infra/k8s --namespace summit-dev
+```
+
+### `summit test`
+
+Run repo tests with your preferred package manager.
+
+| Option | Description |
+| --- | --- |
+| `--scope <name>` | `all`, `server`, or `client` (defaults to `all`). |
+| `--package-manager <pm>` | Override package manager detection (`pnpm`, `npm`, `yarn`). |
+| `--watch` | Append `--watch` to the test command. |
+| `--` | Pass additional flags directly to the underlying test runner. |
+
+Examples:
+
+```bash
+summit test
+summit test --scope server
+summit test -- --runInBand
+```
+
+### `summit seed`
+
+Seed databases using the existing workspace scripts.
+
+| Option | Description |
+| --- | --- |
+| `--package-manager <pm>` | Override package manager detection. |
+| `--dry-run` | Print the seed command without executing it. |
+
+Examples:
+
+```bash
+summit seed
+summit seed --dry-run
+```
+
+## Package manager detection
+
+The CLI inspects lockfiles in the repository root (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`) to determine which package manager to use. You can always override this with the `--package-manager` option.
+
+## Troubleshooting
+
+- Ensure Docker or Kubernetes CLIs are installed locally.
+- For Kubernetes workflows set the correct context with `--context`.
+- When running without `npm run cli:link`, use `node cli/bin/summit.js` to avoid PATH issues.

--- a/cli/bin/summit.js
+++ b/cli/bin/summit.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import('../src/index.js');

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@summit/cli",
+  "version": "0.1.0",
+  "description": "Summit local development toolkit",
+  "type": "module",
+  "bin": {
+    "summit": "./bin/summit.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "commander": "^12.1.0"
+  }
+}

--- a/cli/src/commands/seed.js
+++ b/cli/src/commands/seed.js
@@ -1,0 +1,16 @@
+import { runCommand } from '../utils/exec.js';
+import { detectPackageManager, buildRunCommand } from '../utils/package-manager.js';
+
+export async function runSeed(options) {
+  const packageManager = detectPackageManager(options.packageManager);
+  const commandConfig = buildRunCommand(packageManager, 'db:seed');
+  const commandPreview = `${commandConfig.command} ${commandConfig.args.join(' ')}`.trim();
+
+  if (options.dryRun) {
+    console.log(`[dry-run] ${commandPreview}`);
+    return;
+  }
+
+  console.log(`Seeding databases using ${commandPreview}`);
+  await runCommand(commandConfig.command, commandConfig.args, { shell: false });
+}

--- a/cli/src/commands/test.js
+++ b/cli/src/commands/test.js
@@ -1,0 +1,27 @@
+import { runCommand } from '../utils/exec.js';
+import { detectPackageManager, buildRunCommand } from '../utils/package-manager.js';
+
+const SUPPORTED_SCOPES = ['all', 'server', 'client'];
+
+export async function runTest(options) {
+  const scope = options.scope ?? 'all';
+  if (scope && !SUPPORTED_SCOPES.includes(scope)) {
+    console.warn(`Unknown scope "${scope}". Falling back to workspace name matching.`);
+  }
+
+  const packageManager = detectPackageManager(options.packageManager);
+  const extraArgs = [...(options.passthrough ?? [])];
+
+  if (options.watch && !extraArgs.includes('--watch')) {
+    extraArgs.push('--watch');
+  }
+
+  const commandConfig = buildRunCommand(packageManager, 'test', {
+    scope: scope === 'all' ? undefined : scope,
+    args: extraArgs
+  });
+
+  const scopeLabel = scope === 'all' ? 'all scopes' : scope || 'all scopes';
+  console.log(`Running tests with ${packageManager} (${scopeLabel})`);
+  await runCommand(commandConfig.command, commandConfig.args, { shell: false });
+}

--- a/cli/src/commands/up.js
+++ b/cli/src/commands/up.js
@@ -1,0 +1,78 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { runCommand, commandExists } from '../utils/exec.js';
+
+async function resolveDockerCompose() {
+  if (await commandExists('docker')) {
+    return { command: 'docker', args: ['compose'] };
+  }
+
+  if (await commandExists('docker-compose')) {
+    return { command: 'docker-compose', args: [] };
+  }
+
+  throw new Error('Docker CLI not found. Please install Docker to use this command.');
+}
+
+async function ensureKubectl() {
+  if (!(await commandExists('kubectl'))) {
+    throw new Error('kubectl not found. Install Kubernetes tooling or pass --k8s=false to use Docker.');
+  }
+}
+
+export async function runUp(options) {
+  if (options.k8s) {
+    await ensureKubectl();
+    const manifestPath = path.resolve(process.cwd(), options.kubeManifest ?? 'deploy/k8s');
+
+    if (!existsSync(manifestPath)) {
+      throw new Error(`Kubernetes manifest not found at ${manifestPath}`);
+    }
+
+    const args = [];
+    if (options.context) {
+      args.push('--context', options.context);
+    }
+    args.push('apply', '-f', manifestPath);
+    if (options.namespace) {
+      args.push('-n', options.namespace);
+    }
+
+    console.log(`Applying Kubernetes manifests from ${manifestPath}`);
+    await runCommand('kubectl', args);
+    console.log('Kubernetes resources applied successfully.');
+    return;
+  }
+
+  const composeFile = path.resolve(process.cwd(), options.composeFile ?? 'docker-compose.yml');
+
+  if (!existsSync(composeFile)) {
+    throw new Error(`Docker compose file not found at ${composeFile}`);
+  }
+
+  const services = (options.services ?? '')
+    .split(',')
+    .map((service) => service.trim())
+    .filter(Boolean);
+
+  const detach = options.detach !== false;
+
+  const { command, args: baseArgs } = await resolveDockerCompose();
+  const args = [...baseArgs, '-f', composeFile, 'up'];
+
+  if (options.build) {
+    args.push('--build');
+  }
+
+  if (detach) {
+    args.push('-d');
+  }
+
+  if (services.length > 0) {
+    args.push(...services);
+  }
+
+  console.log(`Starting Docker Compose stack using ${composeFile}`);
+  await runCommand(command, args);
+  console.log('Docker Compose stack started successfully.');
+}

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -1,0 +1,55 @@
+import { Command } from 'commander';
+import { runUp } from './commands/up.js';
+import { runTest } from './commands/test.js';
+import { runSeed } from './commands/seed.js';
+
+const program = new Command();
+
+program
+  .name('summit')
+  .description('Summit local development CLI')
+  .version('0.1.0');
+
+program.enablePositionalOptions(true);
+
+program
+  .command('up')
+  .description('Start local development infrastructure')
+  .option('--compose-file <path>', 'Path to docker compose file', 'docker-compose.yml')
+  .option('--services <names>', 'Comma separated list of services to start')
+  .option('--no-detach', 'Run docker compose in the foreground')
+  .option('--build', 'Force build before starting containers', false)
+  .option('--k8s', 'Apply Kubernetes manifests instead of Docker Compose', false)
+  .option('--kube-manifest <path>', 'Path to Kubernetes manifest file or directory', 'deploy/k8s')
+  .option('--namespace <name>', 'Kubernetes namespace to target', 'summit-dev')
+  .option('--context <name>', 'Kubernetes context to use')
+  .action(async (options) => {
+    await runUp(options);
+  });
+
+program
+  .command('test')
+  .description('Run Summit test suites')
+  .option('--scope <name>', 'Scope to run (all, server, client)', 'all')
+  .option('--package-manager <pm>', 'Package manager to use (pnpm|npm|yarn)')
+  .option('--watch', 'Run tests in watch mode')
+  .allowExcessArguments(true)
+  .passThroughOptions()
+  .action(async (options, command) => {
+    const passthrough = command.args ?? [];
+    await runTest({ ...options, passthrough });
+  });
+
+program
+  .command('seed')
+  .description('Seed local databases with test data')
+  .option('--package-manager <pm>', 'Package manager to use (pnpm|npm|yarn)')
+  .option('--dry-run', 'Print the seed command without executing it', false)
+  .action(async (options) => {
+    await runSeed(options);
+  });
+
+program.parseAsync(process.argv).catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/cli/src/utils/exec.js
+++ b/cli/src/utils/exec.js
@@ -1,0 +1,38 @@
+import { spawn } from 'node:child_process';
+
+export function runCommand(command, args = [], options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: options.stdio ?? 'inherit',
+      cwd: options.cwd ?? process.cwd(),
+      env: { ...process.env, ...options.env },
+      shell: options.shell ?? false
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(code);
+      } else {
+        const error = new Error(`Command failed: ${command} ${args.join(' ')}`);
+        error.exitCode = code;
+        reject(error);
+      }
+    });
+  });
+}
+
+export function commandExists(command) {
+  return new Promise((resolve) => {
+    const checker = spawn('sh', ['-c', `command -v "${command}"`], { stdio: 'ignore' });
+    checker.on('close', (code) => {
+      resolve(code === 0);
+    });
+    checker.on('error', () => {
+      resolve(false);
+    });
+  });
+}

--- a/cli/src/utils/package-manager.js
+++ b/cli/src/utils/package-manager.js
@@ -1,0 +1,54 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+const PACKAGE_MANAGER_PRIORITY = ['pnpm', 'npm', 'yarn'];
+
+export function detectPackageManager(preferred) {
+  if (preferred && PACKAGE_MANAGER_PRIORITY.includes(preferred)) {
+    return preferred;
+  }
+
+  const root = process.cwd();
+
+  if (existsSync(path.join(root, 'pnpm-lock.yaml'))) {
+    return 'pnpm';
+  }
+
+  if (existsSync(path.join(root, 'package-lock.json'))) {
+    return 'npm';
+  }
+
+  if (existsSync(path.join(root, 'yarn.lock'))) {
+    return 'yarn';
+  }
+
+  return PACKAGE_MANAGER_PRIORITY[0];
+}
+
+export function buildRunCommand(packageManager, script, options = {}) {
+  const scope = options.scope;
+  const args = options.args ?? [];
+
+  switch (packageManager) {
+    case 'pnpm': {
+      const base = scope ? ['--filter', scope, 'run', script] : ['run', script];
+      const extras = args.length > 0 ? ['--', ...args] : [];
+      return { command: 'pnpm', args: [...base, ...extras] };
+    }
+    case 'yarn': {
+      const base = scope && scope !== 'all'
+        ? ['workspace', scope, 'run', script]
+        : ['run', script];
+      return { command: 'yarn', args: [...base, ...args] };
+    }
+    case 'npm':
+    default: {
+      const base = ['run', script];
+      if (scope && scope !== 'all') {
+        base.push('--workspace', scope);
+      }
+      const extras = args.length > 0 ? ['--', ...args] : [];
+      return { command: 'npm', args: [...base, ...extras] };
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -95,7 +95,10 @@
     "policy:bundle": "opa build -b policies/opa -o composer-policy-bundle.tar.gz",
     "codegen": "echo skip-graphql-codegen",
     "docs:build": "echo docs build skipped",
-    "docusaurus": "echo docusaurus not configured"
+    "docusaurus": "echo docusaurus not configured",
+    "cli:install": "cd cli && npm install",
+    "cli:link": "cd cli && npm link",
+    "cli:run": "node cli/bin/summit.js"
   },
   "keywords": [
     "intelgraph",


### PR DESCRIPTION
## Summary
- add a Node.js-based Summit CLI package for local development workflows
- support docker compose, kubernetes, testing, and database seeding commands from a single entrypoint
- document installation and wire repo scripts for installing, linking, and invoking the CLI

## Testing
- node cli/bin/summit.js --help
- node cli/bin/summit.js up --help
- node cli/bin/summit.js test --help
- node cli/bin/summit.js seed --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d6b160bc348333a33016a6f28123d5