### PR TITLE
feat: automate database backups with CronJobs

### DIFF
--- a/ops/db/backup-jobs/cronjobs.yaml
+++ b/ops/db/backup-jobs/cronjobs.yaml
@@ -1,0 +1,103 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: postgres-daily-backup
+  namespace: data
+spec:
+  schedule: "0 2 * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: database-backup
+          restartPolicy: OnFailure
+          containers:
+            - name: postgres-backup
+              image: postgres:16
+              imagePullPolicy: IfNotPresent
+              envFrom:
+                - secretRef:
+                    name: postgres-backup-credentials
+                - secretRef:
+                    name: database-backup-storage
+              env:
+                - name: S3_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      name: database-backup-settings
+                      key: POSTGRES_S3_PREFIX
+              volumeMounts:
+                - name: backup-scripts
+                  mountPath: /opt/db-backups
+                - name: tmp
+                  mountPath: /tmp
+              command:
+                - /bin/bash
+                - -lc
+                - >-
+                  export DEBIAN_FRONTEND=noninteractive &&
+                  apt-get update && apt-get install -y --no-install-recommends awscli &&
+                  chmod +x /opt/db-backups/postgres-backup.sh &&
+                  /opt/db-backups/postgres-backup.sh
+          volumes:
+            - name: backup-scripts
+              configMap:
+                name: database-backup-scripts
+                defaultMode: 0755
+            - name: tmp
+              emptyDir: {}
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: neo4j-daily-backup
+  namespace: data
+spec:
+  schedule: "30 2 * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        spec:
+          serviceAccountName: database-backup
+          restartPolicy: OnFailure
+          containers:
+            - name: neo4j-backup
+              image: neo4j:5.19
+              imagePullPolicy: IfNotPresent
+              envFrom:
+                - secretRef:
+                    name: neo4j-backup-credentials
+                - secretRef:
+                    name: database-backup-storage
+              env:
+                - name: S3_PREFIX
+                  valueFrom:
+                    configMapKeyRef:
+                      name: database-backup-settings
+                      key: NEO4J_S3_PREFIX
+              volumeMounts:
+                - name: backup-scripts
+                  mountPath: /opt/db-backups
+                - name: tmp
+                  mountPath: /tmp
+              command:
+                - /bin/bash
+                - -lc
+                - >-
+                  export DEBIAN_FRONTEND=noninteractive &&
+                  apt-get update && apt-get install -y --no-install-recommends awscli &&
+                  chmod +x /opt/db-backups/neo4j-backup.sh &&
+                  /opt/db-backups/neo4j-backup.sh
+          volumes:
+            - name: backup-scripts
+              configMap:
+                name: database-backup-scripts
+                defaultMode: 0755
+            - name: tmp
+              emptyDir: {}

--- a/ops/db/backup-jobs/scripts/neo4j-backup.sh
+++ b/ops/db/backup-jobs/scripts/neo4j-backup.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${NEO4J_HOST:?NEO4J_HOST is required}"
+: "${NEO4J_BOLT_PORT:=7687}"
+: "${NEO4J_DATABASE:=neo4j}"
+: "${NEO4J_USERNAME:?NEO4J_USERNAME is required}"
+: "${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}"
+: "${S3_BUCKET:?S3_BUCKET is required}"
+: "${NEO4J_HOME:=/var/lib/neo4j}"
+
+export NEO4J_HOME
+export PATH="${NEO4J_HOME}/bin:${PATH}"
+BACKUP_PREFIX="${S3_PREFIX:-neo4j/}"
+BACKUP_TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP_BASENAME="${NEO4J_DATABASE}-${BACKUP_TIMESTAMP}.backup.tar.gz"
+BACKUP_DIR="$(mktemp -d /tmp/neo4j-backup.XXXXXX)"
+ARCHIVE_PATH="/tmp/${BACKUP_BASENAME}"
+BACKUP_MODE="${NEO4J_BACKUP_MODE:-full}" # full or incremental
+
+trap 'rm -rf "${BACKUP_DIR}" "${ARCHIVE_PATH}"' EXIT
+
+NEO4J_FROM="${NEO4J_FROM:-bolt://${NEO4J_HOST}:${NEO4J_BOLT_PORT}}"
+
+neo4j-admin database backup \
+  --from="${NEO4J_FROM}" \
+  --database="${NEO4J_DATABASE}" \
+  --backup-dir="${BACKUP_DIR}" \
+  --type="${BACKUP_MODE}" \
+  --user="${NEO4J_USERNAME}" \
+  --password="${NEO4J_PASSWORD}" \
+  --overwrite-destination=true
+
+# The backup command produces files inside ${BACKUP_DIR}/${NEO4J_DATABASE}
+
+tar -C "${BACKUP_DIR}" -czf "${ARCHIVE_PATH}" .
+
+echo "Backup archived to ${ARCHIVE_PATH}" >&2
+
+S3_URI="s3://${S3_BUCKET}/${BACKUP_PREFIX%/}/${BACKUP_BASENAME}"
+UPLOAD_ARGS=("s3" "cp" "${ARCHIVE_PATH}" "${S3_URI}")
+if [[ -n "${AWS_ENDPOINT_URL:-}" ]]; then
+  UPLOAD_ARGS+=("--endpoint-url" "${AWS_ENDPOINT_URL}")
+fi
+
+aws "${UPLOAD_ARGS[@]}"
+
+echo "Uploaded backup to ${S3_URI}" >&2

--- a/ops/db/backup-jobs/scripts/neo4j-restore.sh
+++ b/ops/db/backup-jobs/scripts/neo4j-restore.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RESTORE_S3_URI:?RESTORE_S3_URI is required}"
+: "${NEO4J_DATABASE:=neo4j}"
+: "${NEO4J_HOME:=/var/lib/neo4j}"
+
+export NEO4J_HOME
+export PATH="${NEO4J_HOME}/bin:${PATH}"
+TMP_ARCHIVE="$(mktemp /tmp/neo4j-restore.XXXXXX.tar.gz)"
+RESTORE_DIR="$(mktemp -d /tmp/neo4j-restore.XXXXXX)"
+
+trap 'rm -f "${TMP_ARCHIVE}"; rm -rf "${RESTORE_DIR}"' EXIT
+
+echo "Downloading ${RESTORE_S3_URI} to ${TMP_ARCHIVE}" >&2
+
+DOWNLOAD_ARGS=("s3" "cp" "${RESTORE_S3_URI}" "${TMP_ARCHIVE}")
+if [[ -n "${AWS_ENDPOINT_URL:-}" ]]; then
+  DOWNLOAD_ARGS+=("--endpoint-url" "${AWS_ENDPOINT_URL}")
+fi
+
+aws "${DOWNLOAD_ARGS[@]}"
+
+tar -xzf "${TMP_ARCHIVE}" -C "${RESTORE_DIR}"
+
+echo "Loading backup into ${NEO4J_HOME}" >&2
+
+neo4j-admin database load \
+  --from-path="${RESTORE_DIR}" \
+  --database="${NEO4J_DATABASE}" \
+  --overwrite-destination=true
+
+echo "Restore completed for ${NEO4J_DATABASE}" >&2

--- a/ops/db/backup-jobs/scripts/postgres-backup.sh
+++ b/ops/db/backup-jobs/scripts/postgres-backup.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${POSTGRES_HOST:?POSTGRES_HOST is required}"
+: "${POSTGRES_PORT:=5432}"
+: "${POSTGRES_DATABASE:?POSTGRES_DATABASE is required}"
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+: "${S3_BUCKET:?S3_BUCKET is required}"
+
+BACKUP_PREFIX="${S3_PREFIX:-postgres/}"
+BACKUP_TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+BACKUP_BASENAME="${POSTGRES_DATABASE}-${BACKUP_TIMESTAMP}.sql.gz"
+BACKUP_PATH="/tmp/${BACKUP_BASENAME}"
+
+export PGPASSWORD="${POSTGRES_PASSWORD}"
+
+pg_dump \
+  --host="${POSTGRES_HOST}" \
+  --port="${POSTGRES_PORT}" \
+  --username="${POSTGRES_USER}" \
+  --format=plain \
+  --no-owner \
+  "${POSTGRES_DATABASE}" \
+  | gzip > "${BACKUP_PATH}"
+
+echo "Backup written to ${BACKUP_PATH}" >&2
+
+S3_URI="s3://${S3_BUCKET}/${BACKUP_PREFIX%/}/${BACKUP_BASENAME}"
+
+UPLOAD_ARGS=("s3" "cp" "${BACKUP_PATH}" "${S3_URI}")
+if [[ -n "${AWS_ENDPOINT_URL:-}" ]]; then
+  UPLOAD_ARGS+=("--endpoint-url" "${AWS_ENDPOINT_URL}")
+fi
+
+aws "${UPLOAD_ARGS[@]}"
+
+echo "Uploaded backup to ${S3_URI}" >&2
+
+rm -f "${BACKUP_PATH}"

--- a/ops/db/backup-jobs/scripts/postgres-restore.sh
+++ b/ops/db/backup-jobs/scripts/postgres-restore.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${RESTORE_S3_URI:?RESTORE_S3_URI is required}"
+: "${POSTGRES_HOST:?POSTGRES_HOST is required}"
+: "${POSTGRES_PORT:=5432}"
+: "${POSTGRES_DATABASE:?POSTGRES_DATABASE is required}"
+: "${POSTGRES_USER:?POSTGRES_USER is required}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}"
+
+TMP_FILE="$(mktemp /tmp/postgres-restore.XXXXXX.sql.gz)"
+CLEAN_TARGET="${CLEAN_TARGET:-false}"
+
+echo "Downloading ${RESTORE_S3_URI} to ${TMP_FILE}" >&2
+
+DOWNLOAD_ARGS=("s3" "cp" "${RESTORE_S3_URI}" "${TMP_FILE}")
+if [[ -n "${AWS_ENDPOINT_URL:-}" ]]; then
+  DOWNLOAD_ARGS+=("--endpoint-url" "${AWS_ENDPOINT_URL}")
+fi
+
+aws "${DOWNLOAD_ARGS[@]}"
+
+export PGPASSWORD="${POSTGRES_PASSWORD}"
+
+if [[ "${CLEAN_TARGET}" == "true" ]]; then
+  echo "Dropping existing objects from ${POSTGRES_DATABASE}" >&2
+  psql \
+    --host="${POSTGRES_HOST}" \
+    --port="${POSTGRES_PORT}" \
+    --username="${POSTGRES_USER}" \
+    --dbname="${POSTGRES_DATABASE}" \
+    --command="DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+fi
+
+gunzip -c "${TMP_FILE}" | psql \
+  --host="${POSTGRES_HOST}" \
+  --port="${POSTGRES_PORT}" \
+  --username="${POSTGRES_USER}" \
+  --dbname="${POSTGRES_DATABASE}"
+
+echo "Restore completed for ${POSTGRES_DATABASE}" >&2
+
+rm -f "${TMP_FILE}"

--- a/ops/runbooks/database-backup-and-restore.md
+++ b/ops/runbooks/database-backup-and-restore.md
@@ -1,0 +1,153 @@
+# Database Backup and Restore Automation Runbook
+
+## Overview
+This runbook describes how to deploy the automated PostgreSQL and Neo4j backup processes, verify the resulting artifacts, and execute a controlled restore during a disaster recovery (DR) event.
+
+## Prerequisites
+- Kubernetes cluster access with permissions to create `CronJob`, `ConfigMap`, `Secret`, and `ServiceAccount` resources in the `data` namespace (or update the manifests to match your namespace).
+- AWS S3 bucket (or S3-compatible object storage) and access keys dedicated to database backups.
+- `kubectl`, `aws` CLI, `psql`, and `neo4j-admin` binaries available on the workstation used for validation and restores.
+- Network connectivity from the backup jobs to the database services.
+
+## Configuration
+1. **Create AWS credential secret**
+   ```bash
+   kubectl create secret generic database-backup-storage \
+     --namespace data \
+     --from-literal=S3_BUCKET=<bucket-name> \
+     --from-literal=AWS_DEFAULT_REGION=<region> \
+     --from-literal=AWS_ACCESS_KEY_ID=<key> \
+     --from-literal=AWS_SECRET_ACCESS_KEY=<secret>
+  ```
+   Include `--from-literal=AWS_ENDPOINT_URL=<url>` when using an S3-compatible provider.
+2. **Create database credential secrets**
+   ```bash
+   kubectl create secret generic postgres-backup-credentials \
+     --namespace data \
+     --from-literal=POSTGRES_HOST=<hostname> \
+     --from-literal=POSTGRES_PORT=5432 \
+     --from-literal=POSTGRES_DATABASE=<database> \
+     --from-literal=POSTGRES_USER=<user> \
+     --from-literal=POSTGRES_PASSWORD=<password>
+
+   kubectl create secret generic neo4j-backup-credentials \
+     --namespace data \
+     --from-literal=NEO4J_HOST=<hostname> \
+     --from-literal=NEO4J_BOLT_PORT=7687 \
+     --from-literal=NEO4J_DATABASE=<database> \
+     --from-literal=NEO4J_USERNAME=<user> \
+     --from-literal=NEO4J_PASSWORD=<password>
+   ```
+3. **Create configuration map for S3 prefixes**
+   ```bash
+   kubectl create configmap database-backup-settings \
+     --namespace data \
+     --from-literal=POSTGRES_S3_PREFIX=postgres/ \
+     --from-literal=NEO4J_S3_PREFIX=neo4j/
+   ```
+4. **Publish the backup scripts as a ConfigMap**
+   ```bash
+   kubectl create configmap database-backup-scripts \
+     --namespace data \
+     --from-file=postgres-backup.sh=ops/db/backup-jobs/scripts/postgres-backup.sh \
+     --from-file=neo4j-backup.sh=ops/db/backup-jobs/scripts/neo4j-backup.sh
+   ```
+   Re-run the command with `--dry-run=client -o yaml | kubectl apply -f -` to update the ConfigMap after script changes.
+5. **Service account (optional)**
+   ```bash
+   kubectl create serviceaccount database-backup --namespace data
+   ```
+
+## Deploying the CronJobs
+Apply the CronJob manifest after preparing the supporting resources:
+```bash
+kubectl apply -f ops/db/backup-jobs/cronjobs.yaml
+```
+The PostgreSQL job runs daily at 02:00 UTC, while the Neo4j job runs daily at 02:30 UTC. Adjust the `schedule` fields to match your maintenance window.
+
+## Synthetic Data Test Plan
+Perform this validation when first enabling the jobs and after significant database upgrades.
+
+### PostgreSQL
+1. Seed the database with synthetic data:
+   ```bash
+   psql "postgresql://<user>:<password>@<host>:<port>/<database>" \
+     --command="CREATE TABLE IF NOT EXISTS backup_validation(id SERIAL PRIMARY KEY, note TEXT);"
+   psql "postgresql://<user>:<password>@<host>:<port>/<database>" \
+     --command="INSERT INTO backup_validation(note) VALUES('$(date -u +%FT%TZ) synthetic check');"
+   ```
+2. Trigger the CronJob manually:
+   ```bash
+   kubectl create job --from=cronjob/postgres-daily-backup postgres-backup-test --namespace data
+   ```
+3. Confirm the S3 object exists and contains the new entry:
+   ```bash
+   aws s3 ls s3://<bucket>/postgres/
+   aws s3 cp s3://<bucket>/postgres/<latest-backup>.sql.gz - | gunzip | grep backup_validation
+   ```
+4. Delete the ad-hoc job after completion:
+   ```bash
+   kubectl delete job postgres-backup-test --namespace data
+   ```
+
+### Neo4j
+1. Insert synthetic data (example using cypher-shell):
+   ```bash
+   cypher-shell -a neo4j+s://<host>:<port> -u <user> -p <password> \
+     "MERGE (n:BackupValidation {id: 'synthetic'}) SET n.checkedAt = datetime()"
+   ```
+2. Trigger the CronJob manually:
+   ```bash
+   kubectl create job --from=cronjob/neo4j-daily-backup neo4j-backup-test --namespace data
+   ```
+3. Validate the archive:
+   ```bash
+   aws s3 ls s3://<bucket>/neo4j/
+   aws s3 cp s3://<bucket>/neo4j/<latest-backup>.backup.tar.gz - | tar -tzf - | head
+   ```
+4. Delete the ad-hoc job:
+   ```bash
+   kubectl delete job neo4j-backup-test --namespace data
+   ```
+
+## Restore Procedures
+
+### PostgreSQL Restore
+1. Identify the desired backup object and export its URI, for example:
+   ```bash
+   export RESTORE_S3_URI=s3://<bucket>/postgres/<timestamp>.sql.gz
+   ```
+2. Stop application writes or enable maintenance mode.
+3. Run the restore script from a bastion host or Kubernetes job:
+   ```bash
+   AWS_ACCESS_KEY_ID=<key> AWS_SECRET_ACCESS_KEY=<secret> \
+   POSTGRES_HOST=<host> POSTGRES_PORT=5432 POSTGRES_DATABASE=<database> \
+   POSTGRES_USER=<user> POSTGRES_PASSWORD=<password> \
+   RESTORE_S3_URI=${RESTORE_S3_URI} CLEAN_TARGET=true \
+   bash ops/db/backup-jobs/scripts/postgres-restore.sh
+   ```
+4. Validate the restored data using targeted queries.
+
+### Neo4j Restore
+> **Note:** Neo4j must be stopped prior to running `neo4j-admin database load`.
+
+1. Export the backup URI and stop the cluster member.
+2. Run the restore script on the host that owns the data directory:
+   ```bash
+   AWS_ACCESS_KEY_ID=<key> AWS_SECRET_ACCESS_KEY=<secret> \
+   RESTORE_S3_URI=s3://<bucket>/neo4j/<timestamp>.backup.tar.gz \
+   NEO4J_DATABASE=<database> NEO4J_HOME=/var/lib/neo4j \
+   bash ops/db/backup-jobs/scripts/neo4j-restore.sh
+   ```
+3. Start Neo4j and verify cluster health with `neo4j status` and targeted Cypher queries.
+
+## Disaster Recovery Validation
+- Restore to an isolated environment quarterly using the latest backups.
+- Execute smoke tests against critical application queries.
+- Document recovery time objective (RTO) and recovery point objective (RPO) metrics after each drill.
+
+## Troubleshooting
+- **`aws` command not found** – ensure the CronJob image installs `awscli` (included in the manifest via `apt-get`) and that validation hosts have the AWS CLI available.
+- **Permission denied** – confirm the service account has IAM permissions (`s3:PutObject`, `s3:GetObject`, `s3:ListBucket`).
+- **Neo4j backup failures** – verify that the `backup` role is enabled on the target server and that the configured port is reachable.
+- **Slow backups** – adjust schedules or use incremental backups by setting the `NEO4J_BACKUP_MODE` environment variable to `incremental` in the CronJob or ad-hoc job.


### PR DESCRIPTION
## Summary
- add Kubernetes CronJobs to execute daily PostgreSQL and Neo4j backups to object storage
- include backup and restore shell scripts that upload to S3 and support disaster recovery restores
- document configuration, validation, and recovery workflow in a database backup runbook

## Testing
- pre-commit run --files ops/db/backup-jobs/cronjobs.yaml ops/db/backup-jobs/scripts/postgres-backup.sh ops/db/backup-jobs/scripts/postgres-restore.sh ops/db/backup-jobs/scripts/neo4j-backup.sh ops/db/backup-jobs/scripts/neo4j-restore.sh ops/runbooks/database-backup-and-restore.md *(fails: InvalidConfigError in repository pre-commit configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b1868b8483338c113844975951dd