### PR TITLE
Add GDPR anonymization tooling and mutation

### DIFF
--- a/docs/compliance/data-anonymization.md
+++ b/docs/compliance/data-anonymization.md
@@ -1,0 +1,112 @@
+# Summit Data Anonymization Compliance Guide
+
+This guide explains how Summit masks personally identifiable information (PII) in both PostgreSQL and Neo4j to support GDPR requests such as the right to erasure and data minimization.
+
+## Overview
+
+The anonymization workflow consists of four coordinated components:
+
+1. **Database schema extensions** to track anonymization runs and annotate masked records.
+2. **A Python anonymizer** (`server/scripts/data_anonymizer.py`) that rewrites sensitive values using the [`faker`](https://faker.readthedocs.io/) library.
+3. **GraphQL orchestration** via the `triggerAnonymization` mutation for on-demand execution.
+4. **Audit artefacts** persisted in PostgreSQL (`anonymization_runs` table) and Neo4j (`AnonymizationRun` nodes and run metadata on `Person` nodes).
+
+The run metadata captures scope, timestamps, dry-run flags, row/node counts, and user attribution so compliance teams can prove when masking occurred.
+
+## Database Changes
+
+### PostgreSQL
+
+* New table `anonymization_runs` stores run metadata (`id`, `triggered_by`, `scope`, `status`, counters, timestamps, notes).
+* `users` and `entities` tables now include `anonymized_at` and `anonymization_run_id` columns to tag affected records.
+* Indices on `anonymization_runs.started_at` and `completed_at` support chronological reporting.
+
+### Neo4j
+
+* Constraint `anonymization_run_id_unique` enforces unique run identifiers on `AnonymizationRun` nodes.
+* Indexes on `Person.anonymizationRunId` and `Person.anonymized` accelerate lookup of masked data for attestations.
+
+These schema updates should be deployed through the existing migration pipeline (`npm run db:migrate`).
+
+## Running the Python Anonymizer
+
+The script can be run standalone or triggered via GraphQL.
+
+```bash
+# Install dependencies (once)
+pip install -r server/requirements.txt
+
+# Execute against both databases
+python3 server/scripts/data_anonymizer.py --postgres --neo4j --triggered-by <user-id>
+
+# Preview changes without committing
+python3 server/scripts/data_anonymizer.py --postgres --neo4j --dry-run
+```
+
+Environment variables determine connectivity:
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `DATABASE_URL` *or* (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`, `DB_SSLMODE`) | PostgreSQL connection info | `localhost:5432` (Summit) |
+| `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`, `NEO4J_DATABASE` | Neo4j connection info | `bolt://localhost:7687` |
+
+The script logs operational details to `stderr` and prints a JSON summary to `stdout`:
+
+```json
+{
+  "run_id": "cc1df2b7-...",
+  "status": "COMPLETED",
+  "dry_run": false,
+  "scope": ["POSTGRES", "NEO4J"],
+  "started_at": "2025-09-30T17:15:20Z",
+  "completed_at": "2025-09-30T17:15:55Z",
+  "masked_postgres": 42,
+  "masked_neo4j": 16,
+  "notes": "Anonymized 42 PostgreSQL records and 16 Neo4j nodes."
+}
+```
+
+## GraphQL Trigger
+
+The `triggerAnonymization` mutation executes the Python script from the server tier. Example request:
+
+```graphql
+mutation RunAnonymizer {
+  triggerAnonymization(
+    input: {
+      targets: [POSTGRES, NEO4J]
+      dryRun: false
+      requestedBy: "user-1234"
+    }
+  ) {
+    runId
+    status
+    dryRun
+    scope
+    startedAt
+    completedAt
+    maskedPostgres
+    maskedNeo4j
+    notes
+  }
+}
+```
+
+Responses mirror the JSON payload shown above. The server resolves `requestedBy` automatically from the authenticated context if omitted.
+
+## Operational Checklist
+
+1. **Schedule maintenance**: anonymization rewrites PII in place; run during low-traffic windows or via dry-run first.
+2. **Document approvals**: record change tickets referencing the run identifier.
+3. **Verify results**: query `anonymization_runs` for the latest status and compare before/after row counts.
+4. **Retain artefacts**: export run summaries and attach to GDPR case files.
+5. **Repeat as needed**: rerun for additional tenants or data sets; subsequent runs overwrite PII with new masked values.
+
+## Compliance Considerations
+
+* **Data Minimization**: anonymized fields no longer contain live PII but maintain referential integrity for analytics.
+* **Auditability**: run metadata and indexes provide traceability for regulators.
+* **Access Control**: restrict GraphQL mutation execution to privileged compliance roles.
+* **Incident Response**: in the event of failure, the script records a `FAILED` status with diagnostic notes for rapid remediation.
+
+For further automation, integrate the mutation into GDPR case workflows so case managers can trigger masking directly from the Summit UI.

--- a/server/db/migrations/neo4j/2025-09-30_anonymization_constraints.cypher
+++ b/server/db/migrations/neo4j/2025-09-30_anonymization_constraints.cypher
@@ -1,0 +1,12 @@
+// Indexes and constraints to support data anonymization tracking
+CREATE CONSTRAINT anonymization_run_id_unique IF NOT EXISTS
+FOR (run:AnonymizationRun)
+REQUIRE run.id IS UNIQUE;
+
+CREATE INDEX person_anonymization_run_idx IF NOT EXISTS
+FOR (p:Person)
+ON (p.anonymizationRunId);
+
+CREATE INDEX person_anonymized_flag_idx IF NOT EXISTS
+FOR (p:Person)
+ON (p.anonymized);

--- a/server/db/migrations/postgres/2025-09-30_anonymization_support.sql
+++ b/server/db/migrations/postgres/2025-09-30_anonymization_support.sql
@@ -1,0 +1,26 @@
+-- Add anonymization tracking metadata for GDPR compliance
+CREATE TABLE IF NOT EXISTS anonymization_runs (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  triggered_by UUID REFERENCES users(id),
+  scope TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  dry_run BOOLEAN NOT NULL DEFAULT FALSE,
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ,
+  masked_postgres INTEGER NOT NULL DEFAULT 0,
+  masked_neo4j INTEGER NOT NULL DEFAULT 0,
+  notes TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS anonymization_runs_started_idx ON anonymization_runs(started_at);
+CREATE INDEX IF NOT EXISTS anonymization_runs_completed_idx ON anonymization_runs(completed_at);
+
+ALTER TABLE users
+  ADD COLUMN IF NOT EXISTS anonymized_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS anonymization_run_id UUID REFERENCES anonymization_runs(id);
+
+ALTER TABLE entities
+  ADD COLUMN IF NOT EXISTS anonymized_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS anonymization_run_id UUID REFERENCES anonymization_runs(id);
+

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -90,6 +90,9 @@ requests==2.32.5
 python-dotenv==1.1.1
 pyyaml==6.0.2
 psutil==7.0.0
+Faker==33.1.0
+psycopg2-binary==2.9.9
+neo4j==5.27.0
 
 # Language Detection
 langdetect==1.0.9

--- a/server/scripts/data_anonymizer.py
+++ b/server/scripts/data_anonymizer.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Utility for anonymizing Summit data across PostgreSQL and Neo4j.
+
+This script masks personally identifiable information (PII) to help satisfy
+GDPR erasure and minimization requests. It can be invoked directly or via the
+GraphQL anonymization mutation.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional
+
+from faker import Faker
+
+try:
+    import psycopg2
+    from psycopg2.extras import Json
+except ImportError as exc:  # pragma: no cover - runtime dependency validation
+    raise SystemExit(
+        "psycopg2 is required to run the anonymizer. Install with `pip install psycopg2-binary`."
+    ) from exc
+
+try:
+    from neo4j import GraphDatabase
+except ImportError as exc:  # pragma: no cover - runtime dependency validation
+    raise SystemExit(
+        "neo4j-driver is required to run the anonymizer. Install with `pip install neo4j`."
+    ) from exc
+
+
+def log(message: str) -> None:
+    """Emit operational logging to stderr so stdout can remain structured JSON."""
+    timestamp = datetime.utcnow().isoformat(timespec="seconds")
+    print(f"[{timestamp}] {message}", file=sys.stderr)
+
+
+PII_PROPERTY_KEYS = {
+    "email",
+    "primaryEmail",
+    "secondaryEmail",
+    "name",
+    "firstName",
+    "lastName",
+    "fullName",
+    "phone",
+    "phoneNumber",
+    "mobile",
+    "address",
+}
+
+
+@dataclass
+class RunSummary:
+    run_id: str
+    scope: List[str]
+    dry_run: bool
+    status: str = "PENDING"
+    started_at: datetime = field(default_factory=lambda: datetime.utcnow())
+    completed_at: Optional[datetime] = None
+    masked_postgres: int = 0
+    masked_neo4j: int = 0
+    notes: Optional[str] = None
+
+    def as_json(self) -> Dict[str, object]:
+        return {
+            "run_id": self.run_id,
+            "status": self.status,
+            "dry_run": self.dry_run,
+            "scope": self.scope,
+            "started_at": self.started_at.replace(tzinfo=None).isoformat() + "Z",
+            "completed_at": self.completed_at.replace(tzinfo=None).isoformat() + "Z"
+            if self.completed_at
+            else None,
+            "masked_postgres": self.masked_postgres,
+            "masked_neo4j": self.masked_neo4j,
+            "notes": self.notes,
+        }
+
+
+class AnonymizationRunner:
+    def __init__(
+        self,
+        scope: Iterable[str],
+        dry_run: bool,
+        triggered_by: Optional[str],
+        run_id: Optional[str] = None,
+    ) -> None:
+        unique_scope = list(dict.fromkeys(scope)) or ["POSTGRES", "NEO4J"]
+        self.summary = RunSummary(
+            run_id=run_id or str(uuid.uuid4()),
+            scope=unique_scope,
+            dry_run=dry_run,
+        )
+        self.triggered_by = triggered_by
+        self.faker = Faker()
+        self._pg_conn = None
+
+    # ---- PostgreSQL helpers -------------------------------------------------
+    def _pg_connect(self):
+        dsn = os.getenv("DATABASE_URL")
+        if dsn:
+            return psycopg2.connect(dsn)
+        host = os.getenv("DB_HOST", "localhost")
+        port = int(os.getenv("DB_PORT", "5432"))
+        user = os.getenv("DB_USER")
+        password = os.getenv("DB_PASSWORD")
+        dbname = os.getenv("DB_NAME", "summit")
+        sslmode = os.getenv("DB_SSLMODE", "prefer")
+        return psycopg2.connect(
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            dbname=dbname,
+            sslmode=sslmode,
+        )
+
+    @contextmanager
+    def pg_cursor(self):
+        if not self._pg_conn:
+            self._pg_conn = self._pg_connect()
+            self._pg_conn.autocommit = False
+        cursor = self._pg_conn.cursor()
+        try:
+            yield cursor
+        finally:
+            cursor.close()
+
+    def prepare_run(self) -> None:
+        log(f"Initializing anonymization run {self.summary.run_id} for scope {self.summary.scope}")
+        with self.pg_cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO anonymization_runs (id, triggered_by, scope, dry_run, status, started_at)
+                VALUES (%s, %s, %s, %s, 'RUNNING', now())
+                ON CONFLICT (id)
+                DO UPDATE SET scope = EXCLUDED.scope, dry_run = EXCLUDED.dry_run, status = 'RUNNING', started_at = now()
+                """,
+                (
+                    self.summary.run_id,
+                    self.triggered_by,
+                    list(self.summary.scope),
+                    self.summary.dry_run,
+                ),
+            )
+        self._pg_conn.commit()
+
+    def anonymize_postgres(self) -> None:
+        log("Scanning PostgreSQL for sensitive records")
+        total_updated = 0
+        entity_updates = 0
+
+        with self.pg_cursor() as cur:
+            # Users table
+            cur.execute("SELECT id FROM users")
+            users = [row[0] for row in cur.fetchall()]
+            log(f"Found {len(users)} user records for anonymization")
+            self.faker.unique.clear()
+            for user_id in users:
+                fake_email = self.faker.unique.email()
+                fake_name = self.faker.name()
+                cur.execute(
+                    """
+                    UPDATE users
+                    SET email = %s,
+                        display_name = %s,
+                        anonymized_at = now(),
+                        anonymization_run_id = %s
+                    WHERE id = %s
+                    """,
+                    (fake_email, fake_name, self.summary.run_id, user_id),
+                )
+            total_updated += len(users)
+
+            # Entities table
+            cur.execute("SELECT id, type, name, properties FROM entities")
+            rows = cur.fetchall()
+            log(f"Evaluating {len(rows)} entity records for anonymization")
+            self.faker.unique.clear()
+            for entity_id, entity_type, entity_name, properties in rows:
+                props = properties or {}
+                if isinstance(props, str):
+                    props = json.loads(props)
+                updated = False
+
+                if entity_name:
+                    entity_name = self.faker.name()
+                    updated = True
+
+                if entity_type and entity_type.lower() == "person" and not entity_name:
+                    entity_name = self.faker.name()
+                    updated = True
+
+                for key in list(props.keys()):
+                    if key in PII_PROPERTY_KEYS:
+                        props[key] = self._fake_value_for_key(key)
+                        updated = True
+
+                if updated:
+                    cur.execute(
+                        """
+                        UPDATE entities
+                        SET name = %s,
+                            properties = %s,
+                            anonymized_at = now(),
+                            anonymization_run_id = %s
+                        WHERE id = %s
+                        """,
+                        (
+                            entity_name,
+                            Json(props),
+                            self.summary.run_id,
+                            entity_id,
+                        ),
+                    )
+                    entity_updates += 1
+
+        if self.summary.dry_run:
+            self._pg_conn.rollback()
+        else:
+            self._pg_conn.commit()
+        self.summary.masked_postgres = total_updated + entity_updates
+        log(
+            f"PostgreSQL anonymization {'simulated' if self.summary.dry_run else 'completed'} for "
+            f"{self.summary.masked_postgres} records"
+        )
+
+    def finalize_postgres_status(self, status: str, notes: Optional[str]) -> None:
+        if not self._pg_conn:
+            return
+        with self.pg_cursor() as cur:
+            cur.execute(
+                """
+                UPDATE anonymization_runs
+                SET status = %s,
+                    completed_at = now(),
+                    masked_postgres = %s,
+                    masked_neo4j = %s,
+                    notes = %s
+                WHERE id = %s
+                """,
+                (
+                    status,
+                    self.summary.masked_postgres,
+                    self.summary.masked_neo4j,
+                    notes,
+                    self.summary.run_id,
+                ),
+            )
+        self._pg_conn.commit()
+
+    def close(self) -> None:
+        if self._pg_conn:
+            self._pg_conn.close()
+            self._pg_conn = None
+
+    # ---- Neo4j helpers -----------------------------------------------------
+    def anonymize_neo4j(self) -> None:
+        uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+        user = os.getenv("NEO4J_USER")
+        password = os.getenv("NEO4J_PASSWORD")
+        database = os.getenv("NEO4J_DATABASE")
+        auth = None
+        if user and password:
+            auth = (user, password)
+
+        log("Connecting to Neo4j for anonymization")
+        driver = GraphDatabase.driver(uri, auth=auth)
+        try:
+            def execute_mask(tx):
+                self.faker.unique.clear()
+                records = list(
+                    tx.run(
+                        "MATCH (p:Person) RETURN elementId(p) AS element_id, p.name AS name, p.email AS email, p.phone AS phone"
+                    )
+                )
+                updated = 0
+                for record in records:
+                    element_id = record["element_id"]
+                    tx.run(
+                        """
+                        MATCH (p) WHERE elementId(p) = $element_id
+                        SET p.name = $name,
+                            p.email = $email,
+                            p.phone = $phone,
+                            p.anonymized = true,
+                            p.anonymizedAt = datetime(),
+                            p.anonymizationRunId = $run_id
+                        """,
+                        {
+                            "element_id": element_id,
+                            "name": self.faker.name(),
+                            "email": self.faker.unique.email(),
+                            "phone": self.faker.phone_number(),
+                            "run_id": self.summary.run_id,
+                        },
+                    )
+                    updated += 1
+                return updated
+
+            def count_candidates(tx):
+                result = tx.run("MATCH (p:Person) RETURN count(p) AS count")
+                value = result.single()["count"]
+                return int(value or 0)
+
+            with driver.session(database=database) as session:
+                if self.summary.dry_run:
+                    self.summary.masked_neo4j = session.execute_read(count_candidates)
+                else:
+                    self.summary.masked_neo4j = session.execute_write(execute_mask)
+                    session.run(
+                        """
+                        MERGE (run:AnonymizationRun {id: $run_id})
+                        SET run.completedAt = datetime(),
+                            run.startedAt = coalesce(run.startedAt, datetime()),
+                            run.scope = $scope,
+                            run.maskedNodes = $masked_nodes
+                        """,
+                        {
+                            "run_id": self.summary.run_id,
+                            "scope": list(self.summary.scope),
+                            "masked_nodes": self.summary.masked_neo4j,
+                        },
+                    )
+        finally:
+            driver.close()
+        log(
+            f"Neo4j anonymization {'simulated' if self.summary.dry_run else 'completed'} for "
+            f"{self.summary.masked_neo4j} nodes"
+        )
+
+    # ---- Utility helpers ---------------------------------------------------
+    def _fake_value_for_key(self, key: str):
+        lowered = key.lower()
+        if "email" in lowered:
+            return self.faker.unique.email()
+        if "phone" in lowered or "mobile" in lowered:
+            return self.faker.phone_number()
+        if "first" in lowered:
+            return self.faker.first_name()
+        if "last" in lowered:
+            return self.faker.last_name()
+        if "name" in lowered:
+            return self.faker.name()
+        if "address" in lowered:
+            return self.faker.address()
+        return self.faker.word()
+
+
+def parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Anonymize Summit data for GDPR compliance")
+    parser.add_argument("--run-id", help="Existing anonymization run identifier")
+    parser.add_argument("--triggered-by", help="User identifier that initiated the run")
+    parser.add_argument(
+        "--postgres",
+        dest="postgres",
+        action="store_true",
+        help="Anonymize PostgreSQL data",
+    )
+    parser.add_argument(
+        "--neo4j",
+        dest="neo4j",
+        action="store_true",
+        help="Anonymize Neo4j data",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview changes without committing them",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = parse_args(argv)
+    scope: List[str] = []
+    if args.postgres:
+        scope.append("POSTGRES")
+    if args.neo4j:
+        scope.append("NEO4J")
+
+    runner = AnonymizationRunner(scope=scope, dry_run=args.dry_run, triggered_by=args.triggered_by, run_id=args.run_id)
+
+    try:
+        runner.prepare_run()
+        notes: Optional[str] = None
+
+        if "POSTGRES" in runner.summary.scope:
+            runner.anonymize_postgres()
+        if "NEO4J" in runner.summary.scope:
+            runner.anonymize_neo4j()
+
+        runner.summary.completed_at = datetime.utcnow()
+        if runner.summary.dry_run:
+            runner.summary.status = "DRY_RUN"
+            notes = "Dry run completed. No changes were committed."
+        else:
+            runner.summary.status = "COMPLETED"
+            notes = (
+                f"Anonymized {runner.summary.masked_postgres} PostgreSQL records and "
+                f"{runner.summary.masked_neo4j} Neo4j nodes."
+            )
+        runner.summary.notes = notes
+        runner.finalize_postgres_status(runner.summary.status, notes)
+        print(json.dumps(runner.summary.as_json()))
+        return 0
+    except Exception as exc:  # pragma: no cover - defensive logging
+        log(f"Anonymization failed: {exc}")
+        runner.summary.status = "FAILED"
+        runner.summary.notes = str(exc)
+        runner.summary.completed_at = datetime.utcnow()
+        runner.finalize_postgres_status("FAILED", runner.summary.notes)
+        return 1
+    finally:
+        runner.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server/src/graphql/modules/core/resolvers.ts
+++ b/server/src/graphql/modules/core/resolvers.ts
@@ -1,9 +1,16 @@
-import type { GraphStore, AIService } from '../services-types';
+import type {
+  GraphStore,
+  AIService,
+  AnonymizationService,
+  AnonymizationTarget,
+} from '../services-types';
 import { createGraphStore } from './services/graph-store';
 import { createAIService } from './services/ai';
+import { createAnonymizationService } from './services/anonymization';
 
 const store: GraphStore = createGraphStore();
 const ai: AIService = createAIService();
+const anonymizer: AnonymizationService = createAnonymizationService();
 
 export const Query = {
   entities: (_: unknown, { filters }: { filters: any }) => store.getEntities(filters || {}),
@@ -15,5 +22,22 @@ export const Mutation = {
   upsertEntity: async (_: unknown, { input }: { input: any }) => {
     const enriched = await ai.enrichEntity(input);
     return store.upsertEntity(enriched);
+  },
+  triggerAnonymization: async (
+    _: unknown,
+    { input }: { input: { targets?: AnonymizationTarget[]; dryRun?: boolean; requestedBy?: string } },
+    context?: { user?: { id?: string } } & Record<string, any>,
+  ) => {
+    const normalizedScope = Array.isArray(input?.targets) && input.targets?.length
+      ? (Array.from(new Set(input.targets)) as AnonymizationTarget[])
+      : (['POSTGRES', 'NEO4J'] as AnonymizationTarget[]);
+
+    const triggeredBy = input?.requestedBy ?? context?.user?.id ?? context?.actorId;
+
+    return anonymizer.triggerRun({
+      scope: normalizedScope,
+      dryRun: Boolean(input?.dryRun),
+      triggeredBy: triggeredBy ?? undefined,
+    });
   },
 };

--- a/server/src/graphql/modules/core/services/anonymization.ts
+++ b/server/src/graphql/modules/core/services/anonymization.ts
@@ -1,0 +1,136 @@
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+
+import type {
+  AnonymizationRun,
+  AnonymizationService,
+  AnonymizationTarget,
+  TriggerAnonymizationOptions,
+} from '../../services-types';
+
+interface ScriptPayload {
+  run_id: string;
+  status: string;
+  dry_run: boolean;
+  scope: string[];
+  started_at: string;
+  completed_at?: string | null;
+  masked_postgres?: number;
+  masked_neo4j?: number;
+  notes?: string | null;
+}
+
+const DEFAULT_SCOPE: AnonymizationTarget[] = ['POSTGRES', 'NEO4J'];
+
+function runPythonScript(pythonExecutable: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(pythonExecutable, args, {
+      env: { ...process.env },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        const error = new Error(
+          `Anonymization script exited with code ${code}${stderr ? `: ${stderr.trim()}` : ''}`,
+        );
+        reject(error);
+        return;
+      }
+      resolve(stdout.trim());
+    });
+  });
+}
+
+function toAnonymizationRun(payload: ScriptPayload): AnonymizationRun {
+  const scope = Array.isArray(payload.scope) && payload.scope.length > 0 ? payload.scope : DEFAULT_SCOPE;
+  const status = payload.status ?? (payload.dry_run ? 'DRY_RUN' : 'COMPLETED');
+  return {
+    runId: payload.run_id,
+    status,
+    dryRun: Boolean(payload.dry_run),
+    scope: scope as AnonymizationTarget[],
+    startedAt: payload.started_at ?? new Date().toISOString(),
+    completedAt: payload.completed_at ?? null,
+    maskedPostgres: payload.masked_postgres ?? 0,
+    maskedNeo4j: payload.masked_neo4j ?? 0,
+    notes: payload.notes ?? null,
+  };
+}
+
+export function createAnonymizationService(): AnonymizationService {
+  const scriptPath = path.join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    '..',
+    '..',
+    'scripts',
+    'data_anonymizer.py',
+  );
+
+  return {
+    async triggerRun(options: TriggerAnonymizationOptions): Promise<AnonymizationRun> {
+      const runId = randomUUID();
+      const normalizedScope = options.scope && options.scope.length > 0 ? Array.from(new Set(options.scope)) : DEFAULT_SCOPE;
+      const pythonExecutable = process.env.ANONYMIZER_PYTHON || process.env.PYTHON || 'python3';
+
+      const args = [scriptPath, '--run-id', runId];
+
+      if (normalizedScope.includes('POSTGRES')) {
+        args.push('--postgres');
+      }
+      if (normalizedScope.includes('NEO4J')) {
+        args.push('--neo4j');
+      }
+      if (options.dryRun) {
+        args.push('--dry-run');
+      }
+      if (options.triggeredBy) {
+        args.push('--triggered-by', options.triggeredBy);
+      }
+
+      const rawOutput = await runPythonScript(pythonExecutable, args);
+      if (!rawOutput) {
+        throw new Error('Anonymization script returned no output');
+      }
+
+      let parsed: ScriptPayload;
+      try {
+        parsed = JSON.parse(rawOutput) as ScriptPayload;
+      } catch (error) {
+        throw new Error(`Failed to parse anonymization output: ${(error as Error).message}`);
+      }
+
+      // Ensure the run id from the script is propagated even if it generated its own.
+      if (!parsed.run_id) {
+        parsed.run_id = runId;
+      }
+      if (!parsed.scope || parsed.scope.length === 0) {
+        parsed.scope = normalizedScope;
+      }
+      if (typeof parsed.dry_run !== 'boolean') {
+        parsed.dry_run = Boolean(options.dryRun);
+      }
+
+      return toAnonymizationRun(parsed);
+    },
+  };
+}

--- a/server/src/graphql/modules/core/typeDefs.ts
+++ b/server/src/graphql/modules/core/typeDefs.ts
@@ -44,7 +44,31 @@ export default gql`
     properties: JSON
   }
 
+  enum AnonymizationTarget {
+    POSTGRES
+    NEO4J
+  }
+
+  input TriggerAnonymizationInput {
+    targets: [AnonymizationTarget!]
+    dryRun: Boolean
+    requestedBy: ID
+  }
+
+  type AnonymizationRun {
+    runId: ID!
+    status: String!
+    dryRun: Boolean!
+    scope: [AnonymizationTarget!]!
+    startedAt: String!
+    completedAt: String
+    maskedPostgres: Int!
+    maskedNeo4j: Int!
+    notes: String
+  }
+
   type Mutation {
     upsertEntity(input: UpsertEntityInput!): Entity!
+    triggerAnonymization(input: TriggerAnonymizationInput!): AnonymizationRun!
   }
 `;

--- a/server/src/graphql/modules/services-types.ts
+++ b/server/src/graphql/modules/services-types.ts
@@ -7,3 +7,27 @@ export interface GraphStore {
 export interface AIService {
   enrichEntity(input: Record<string, any>): Promise<Record<string, any>>;
 }
+
+export type AnonymizationTarget = 'POSTGRES' | 'NEO4J';
+
+export interface TriggerAnonymizationOptions {
+  scope: AnonymizationTarget[];
+  dryRun?: boolean;
+  triggeredBy?: string;
+}
+
+export interface AnonymizationRun {
+  runId: string;
+  status: string;
+  dryRun: boolean;
+  scope: AnonymizationTarget[];
+  startedAt: string;
+  completedAt?: string | null;
+  maskedPostgres: number;
+  maskedNeo4j: number;
+  notes?: string | null;
+}
+
+export interface AnonymizationService {
+  triggerRun(options: TriggerAnonymizationOptions): Promise<AnonymizationRun>;
+}


### PR DESCRIPTION
## Summary
- add GDPR-focused migrations to track anonymization runs in Postgres and Neo4j
- provide a Python-based data anonymizer and GraphQL mutation to invoke it on demand
- document the end-to-end compliance workflow and add supporting dependencies

## Testing
- npm run lint *(fails: turbo not found in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b203e3c083338f7bbe289abcb79c