### PR TITLE
Add offline caching for dashboards and ingest wizard

### DIFF
--- a/client/public/service-worker.js
+++ b/client/public/service-worker.js
@@ -1,0 +1,301 @@
+const STATIC_CACHE = 'summit-static-v1';
+const GRAPHQL_PATH_SUFFIX = '/graphql';
+const PRECACHE_ROUTES = ['/', '/index.html', '/dashboard', '/graph', '/ingest/wizard'];
+
+const DB_NAME = 'summit-offline';
+const DB_VERSION = 1;
+const RESOURCE_STORE = 'resources';
+const MUTATION_STORE = 'mutations';
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(STATIC_CACHE);
+      await Promise.all(
+        PRECACHE_ROUTES.map(async (url) => {
+          try {
+            await cache.add(new Request(url, { cache: 'reload' }));
+          } catch (error) {
+            console.warn('[Offline] Failed to precache', url, error);
+          }
+        }),
+      );
+    })(),
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => key.startsWith('summit-static-') && key !== STATIC_CACHE)
+          .map((key) => caches.delete(key)),
+      );
+      await self.clients.claim();
+    })(),
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const url = new URL(request.url);
+
+  if (request.method === 'POST' && url.pathname.endsWith(GRAPHQL_PATH_SUFFIX)) {
+    event.respondWith(handleGraphQLRequest(request));
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(handleNavigationRequest(request));
+    return;
+  }
+
+  if (request.method === 'GET') {
+    event.respondWith(handleStaticRequest(request));
+  }
+});
+
+async function handleNavigationRequest(request) {
+  try {
+    const response = await fetch(request);
+    const cache = await caches.open(STATIC_CACHE);
+    cache.put(request, response.clone());
+    return response;
+  } catch (error) {
+    const cache = await caches.open(STATIC_CACHE);
+    return (await cache.match(request)) || (await cache.match('/index.html')) || Response.error();
+  }
+}
+
+async function handleStaticRequest(request) {
+  const cache = await caches.open(STATIC_CACHE);
+  const cached = await cache.match(request);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const response = await fetch(request);
+    cache.put(request, response.clone());
+    return response;
+  } catch (error) {
+    return Response.error();
+  }
+}
+
+async function handleGraphQLRequest(request) {
+  const body = await parseRequestBody(request.clone());
+  const cacheKey = body ? createCacheKey(body) : null;
+
+  try {
+    const response = await fetch(request);
+    if (cacheKey) {
+      const clone = response.clone();
+      const contentType = clone.headers.get('content-type') || '';
+      if (contentType.includes('application/json')) {
+        try {
+          const payload = await clone.json();
+          await putResource(cacheKey, payload);
+          broadcastMessage('OFFLINE_DATA_SYNCED', { key: cacheKey, updatedAt: Date.now() });
+        } catch (error) {
+          console.warn('[Offline] Failed to cache GraphQL payload', error);
+        }
+      }
+    }
+    return response;
+  } catch (networkError) {
+    if (body && isMutation(body)) {
+      const optimistic = createOptimisticResponse(body);
+      await queueMutation(body);
+      broadcastMessage('OFFLINE_MUTATION_QUEUED', { operationName: body.operationName });
+      return new Response(JSON.stringify({ data: optimistic, extensions: { offlineQueued: true } }), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Offline': 'true',
+        },
+      });
+    }
+
+    if (cacheKey) {
+      const cached = await getResource(cacheKey);
+      if (cached) {
+        return new Response(JSON.stringify(cached.data), {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Offline': 'true',
+          },
+        });
+      }
+    }
+
+    return new Response(
+      JSON.stringify({ errors: [{ message: 'Offline and no cached data available.' }] }),
+      {
+        status: 503,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Offline': 'true',
+        },
+      },
+    );
+  }
+}
+
+function parseRequestBody(request) {
+  return request
+    .text()
+    .then((text) => {
+      if (!text) return null;
+      try {
+        return JSON.parse(text);
+      } catch (error) {
+        console.warn('[Offline] Failed to parse request body', error);
+        return null;
+      }
+    })
+    .catch(() => null);
+}
+
+function isMutation(body) {
+  if (!body) return false;
+  if (typeof body.query === 'string' && body.query.trim().startsWith('mutation')) {
+    return true;
+  }
+  const knownMutations = new Set([
+    'CreateInvestigation',
+    'CreateEntity',
+    'CreateRelationship',
+    'StartCopilotRun',
+  ]);
+  return typeof body.operationName === 'string' && knownMutations.has(body.operationName);
+}
+
+function createCacheKey(body) {
+  const operationName =
+    body?.operationName || extractOperationName(body?.query) || body?.extensions?.persistedQuery?.sha256Hash || 'anonymous';
+  const variables = body?.variables ? JSON.stringify(body.variables) : '{}';
+  return `${operationName}:${variables}`;
+}
+
+function extractOperationName(query) {
+  if (typeof query !== 'string') return null;
+  const match = /(mutation|query)\s+(\w+)/.exec(query);
+  return match ? match[2] : null;
+}
+
+function createOptimisticResponse(body) {
+  const variables = body?.variables || {};
+  const now = Date.now();
+  switch (body?.operationName) {
+    case 'CreateInvestigation':
+      return {
+        createInvestigation: {
+          id: variables?.input?.id || `offline-investigation-${now}`,
+          name: variables?.input?.name || 'Offline Investigation',
+          description: variables?.input?.description || '',
+          status: 'OFFLINE_PENDING',
+          __offline: true,
+        },
+      };
+    case 'CreateEntity':
+      return {
+        createEntity: {
+          id: `offline-entity-${now}`,
+          type: variables?.input?.type || 'UNKNOWN',
+          name: variables?.input?.name || 'Offline Entity',
+          canonicalId: variables?.input?.canonicalId || '',
+          properties: variables?.input?.properties || {},
+          __offline: true,
+        },
+      };
+    case 'CreateRelationship':
+      return {
+        createRelationship: {
+          id: `offline-rel-${now}`,
+          type: variables?.input?.type || 'RELATED_TO',
+          fromEntityId: variables?.input?.fromEntityId || 'offline-source',
+          toEntityId: variables?.input?.toEntityId || 'offline-target',
+          __offline: true,
+        },
+      };
+    case 'StartCopilotRun':
+      return {
+        startCopilotRun: {
+          id: `offline-run-${now}`,
+          goalText: variables?.goalText || 'Offline goal',
+          status: 'QUEUED_OFFLINE',
+          __offline: true,
+        },
+      };
+    default:
+      return {};
+  }
+}
+
+let dbPromise;
+
+function getDb() {
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(RESOURCE_STORE)) {
+          db.createObjectStore(RESOURCE_STORE, { keyPath: 'key' });
+        }
+        if (!db.objectStoreNames.contains(MUTATION_STORE)) {
+          db.createObjectStore(MUTATION_STORE, { keyPath: 'id' });
+        }
+      };
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  }
+  return dbPromise;
+}
+
+async function putResource(key, data) {
+  const db = await getDb();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction(RESOURCE_STORE, 'readwrite');
+    tx.oncomplete = resolve;
+    tx.onabort = tx.onerror = () => reject(tx.error);
+    tx.objectStore(RESOURCE_STORE).put({ key, data, updatedAt: Date.now() });
+  });
+}
+
+async function getResource(key) {
+  const db = await getDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(RESOURCE_STORE, 'readonly');
+    const request = tx.objectStore(RESOURCE_STORE).get(key);
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+async function queueMutation(body) {
+  const db = await getDb();
+  await new Promise((resolve, reject) => {
+    const tx = db.transaction(MUTATION_STORE, 'readwrite');
+    tx.oncomplete = resolve;
+    tx.onabort = tx.onerror = () => reject(tx.error);
+    tx.objectStore(MUTATION_STORE).put({
+      id: self.crypto && self.crypto.randomUUID ? self.crypto.randomUUID() : `offline-mutation-${Date.now()}`,
+      body,
+      createdAt: Date.now(),
+      attempts: 0,
+    });
+  });
+}
+
+function broadcastMessage(type, payload) {
+  self.clients.matchAll({ includeUncontrolled: true }).then((clients) => {
+    clients.forEach((client) => client.postMessage({ type, payload }));
+  });
+}

--- a/client/src/components/offline/OfflineBanner.tsx
+++ b/client/src/components/offline/OfflineBanner.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { Alert, Button, Collapse, Stack, Typography } from '@mui/material';
+import { useOffline } from '../../context/OfflineContext';
+
+export default function OfflineBanner() {
+  const { isOffline, lastSync, pendingMutations, flushPending } = useOffline();
+
+  const formattedSync = lastSync ? new Date(lastSync).toLocaleString() : null;
+
+  if (!isOffline && pendingMutations === 0) {
+    return null;
+  }
+
+  return (
+    <Stack spacing={1} data-testid="offline-banner" sx={{ mb: 2 }}>
+      <Collapse in={isOffline} appear>
+        <Alert severity="warning" variant="outlined">
+          <Stack direction="column" spacing={0.5}>
+            <Typography variant="subtitle2">Offline mode</Typography>
+            <Typography variant="body2">
+              You're viewing cached data while the connection is unavailable.
+            </Typography>
+            {formattedSync && (
+              <Typography variant="caption" color="text.secondary">
+                Last successful sync: {formattedSync}
+              </Typography>
+            )}
+          </Stack>
+        </Alert>
+      </Collapse>
+
+      <Collapse in={pendingMutations > 0} appear>
+        <Alert
+          severity={isOffline ? 'info' : 'success'}
+          variant="outlined"
+          action={
+            !isOffline && (
+              <Button size="small" onClick={() => flushPending()} data-testid="offline-sync-button">
+                Sync now
+              </Button>
+            )
+          }
+          data-testid="offline-mutation-alert"
+        >
+          <Typography variant="body2">
+            {pendingMutations} change{pendingMutations === 1 ? '' : 's'} will sync once connectivity is restored.
+          </Typography>
+        </Alert>
+      </Collapse>
+    </Stack>
+  );
+}

--- a/client/src/context/OfflineContext.tsx
+++ b/client/src/context/OfflineContext.tsx
@@ -1,0 +1,102 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import {
+  flushQueuedMutations,
+  getPendingMutationCount,
+} from '../services/offline/mutations';
+import { registerOfflineServiceWorker } from '../services/offline/registerServiceWorker';
+
+export type OfflineContextValue = {
+  isOffline: boolean;
+  lastSync: number | null;
+  pendingMutations: number;
+  flushPending: () => Promise<void>;
+};
+
+const OfflineContext = createContext<OfflineContextValue | undefined>(undefined);
+
+export function OfflineProvider({ children }: { children: React.ReactNode }) {
+  const [isOffline, setIsOffline] = useState<boolean>(typeof navigator !== 'undefined' ? !navigator.onLine : false);
+  const [lastSync, setLastSync] = useState<number | null>(null);
+  const [pendingMutations, setPendingMutations] = useState<number>(0);
+
+  useEffect(() => {
+    let isMounted = true;
+    let messageHandler: ((event: MessageEvent) => void) | null = null;
+
+    const updatePending = async () => {
+      const count = await getPendingMutationCount();
+      if (isMounted) setPendingMutations(count);
+    };
+
+    registerOfflineServiceWorker().then((registration) => {
+      if (!registration || !isMounted) return;
+
+      messageHandler = (event: MessageEvent) => {
+        const { type } = (event.data ?? {}) as { type?: string };
+        if (type === 'OFFLINE_MUTATION_QUEUED' || type === 'OFFLINE_MUTATION_FLUSHED') {
+          void updatePending();
+        }
+        if (type === 'OFFLINE_DATA_SYNCED' && isMounted) {
+          setLastSync(Date.now());
+        }
+      };
+
+      navigator.serviceWorker.addEventListener('message', messageHandler);
+
+      void updatePending();
+    });
+
+    const handleOnline = async () => {
+      setIsOffline(false);
+      const result = await flushQueuedMutations();
+      setPendingMutations(result.remaining);
+      setLastSync(Date.now());
+    };
+
+    const handleOffline = () => {
+      setIsOffline(true);
+    };
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    if (typeof navigator !== 'undefined' && navigator.onLine) {
+      void handleOnline();
+    } else {
+      setIsOffline(true);
+      void updatePending();
+    }
+
+    return () => {
+      isMounted = false;
+      if (messageHandler) {
+        navigator.serviceWorker.removeEventListener('message', messageHandler);
+      }
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  const flushPending = async () => {
+    const result = await flushQueuedMutations();
+    setPendingMutations(result.remaining);
+    if (result.processed > 0) {
+      setLastSync(Date.now());
+    }
+  };
+
+  const value = useMemo(
+    () => ({ isOffline, lastSync, pendingMutations, flushPending }),
+    [isOffline, lastSync, pendingMutations],
+  );
+
+  return <OfflineContext.Provider value={value}>{children}</OfflineContext.Provider>;
+}
+
+export function useOffline(): OfflineContextValue {
+  const context = useContext(OfflineContext);
+  if (!context) {
+    throw new Error('useOffline must be used within an OfflineProvider');
+  }
+  return context;
+}

--- a/client/src/services/offline/indexedDb.ts
+++ b/client/src/services/offline/indexedDb.ts
@@ -1,0 +1,193 @@
+const DB_NAME = 'summit-offline';
+const DB_VERSION = 1;
+const RESOURCE_STORE = 'resources';
+const MUTATION_STORE = 'mutations';
+
+export type StoredResource<T = unknown> = {
+  key: string;
+  data: T;
+  updatedAt: number;
+};
+
+export type QueuedMutation = {
+  id: string;
+  body: unknown;
+  createdAt: number;
+  attempts: number;
+};
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+function hasIndexedDb(): boolean {
+  return typeof indexedDB !== 'undefined';
+}
+
+function getDb(): Promise<IDBDatabase> {
+  if (!hasIndexedDb()) {
+    return Promise.reject(new Error('IndexedDB is not available in this environment.'));
+  }
+
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+      request.onupgradeneeded = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains(RESOURCE_STORE)) {
+          db.createObjectStore(RESOURCE_STORE, { keyPath: 'key' });
+        }
+        if (!db.objectStoreNames.contains(MUTATION_STORE)) {
+          db.createObjectStore(MUTATION_STORE, { keyPath: 'id' });
+        }
+      };
+
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error ?? new Error('Failed to open offline database.'));
+    });
+  }
+
+  return dbPromise;
+}
+
+function runTransaction<T>(
+  storeName: string,
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => void,
+): Promise<T> {
+  if (!hasIndexedDb()) {
+    return Promise.resolve(undefined as T);
+  }
+
+  return getDb().then(
+    (db) =>
+      new Promise<T>((resolve, reject) => {
+        const transaction = db.transaction(storeName, mode);
+        const store = transaction.objectStore(storeName);
+
+        transaction.oncomplete = () => {
+          resolve(undefined as T);
+        };
+        transaction.onerror = () => {
+          reject(transaction.error ?? new Error('Offline transaction failed.'));
+        };
+
+        operation(store);
+      }),
+  );
+}
+
+export async function setCachedResource<T>(key: string, data: T): Promise<void> {
+  if (!hasIndexedDb()) return;
+
+  const record: StoredResource<T> = {
+    key,
+    data,
+    updatedAt: Date.now(),
+  };
+
+  await runTransaction<void>(RESOURCE_STORE, 'readwrite', (store) => {
+    store.put(record);
+  });
+}
+
+export async function getCachedResource<T>(key: string): Promise<StoredResource<T> | undefined> {
+  if (!hasIndexedDb()) return undefined;
+
+  const db = await getDb();
+  return new Promise<StoredResource<T> | undefined>((resolve, reject) => {
+    const transaction = db.transaction(RESOURCE_STORE, 'readonly');
+    const store = transaction.objectStore(RESOURCE_STORE);
+    const request = store.get(key);
+
+    request.onsuccess = () => {
+      resolve(request.result as StoredResource<T> | undefined);
+    };
+    request.onerror = () => reject(request.error ?? new Error('Failed to read offline cache.'));
+  });
+}
+
+export async function clearCachedResource(key: string): Promise<void> {
+  if (!hasIndexedDb()) return;
+
+  await runTransaction<void>(RESOURCE_STORE, 'readwrite', (store) => {
+    store.delete(key);
+  });
+}
+
+export async function queueMutation(body: unknown): Promise<QueuedMutation | undefined> {
+  if (!hasIndexedDb()) return undefined;
+
+  const record: QueuedMutation = {
+    id: typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : `offline-${Date.now()}`,
+    body,
+    createdAt: Date.now(),
+    attempts: 0,
+  };
+
+  await runTransaction<void>(MUTATION_STORE, 'readwrite', (store) => {
+    store.put(record);
+  });
+
+  return record;
+}
+
+export async function getQueuedMutations(): Promise<QueuedMutation[]> {
+  if (!hasIndexedDb()) return [];
+
+  const db = await getDb();
+  return new Promise<QueuedMutation[]>((resolve, reject) => {
+    const transaction = db.transaction(MUTATION_STORE, 'readonly');
+    const store = transaction.objectStore(MUTATION_STORE);
+    const request = store.getAll();
+
+    request.onsuccess = () => {
+      resolve((request.result as QueuedMutation[]) ?? []);
+    };
+    request.onerror = () => reject(request.error ?? new Error('Failed to read queued mutations.'));
+  });
+}
+
+export async function deleteQueuedMutation(id: string): Promise<void> {
+  if (!hasIndexedDb()) return;
+
+  await runTransaction<void>(MUTATION_STORE, 'readwrite', (store) => {
+    store.delete(id);
+  });
+}
+
+export async function incrementMutationAttempts(id: string): Promise<void> {
+  if (!hasIndexedDb()) return;
+
+  const db = await getDb();
+  await new Promise<void>((resolve, reject) => {
+    const transaction = db.transaction(MUTATION_STORE, 'readwrite');
+    const store = transaction.objectStore(MUTATION_STORE);
+    const request = store.get(id);
+
+    request.onsuccess = () => {
+      const existing = request.result as QueuedMutation | undefined;
+      if (existing) {
+        existing.attempts += 1;
+        store.put(existing);
+      }
+      resolve();
+    };
+    request.onerror = () => reject(request.error ?? new Error('Failed to update queued mutation.'));
+  });
+}
+
+export async function getQueuedMutationCount(): Promise<number> {
+  if (!hasIndexedDb()) return 0;
+
+  const db = await getDb();
+  return new Promise<number>((resolve, reject) => {
+    const transaction = db.transaction(MUTATION_STORE, 'readonly');
+    const store = transaction.objectStore(MUTATION_STORE);
+    const request = store.getAllKeys();
+
+    request.onsuccess = () => {
+      resolve((request.result as IDBValidKey[])?.length ?? 0);
+    };
+    request.onerror = () => reject(request.error ?? new Error('Failed to count queued mutations.'));
+  });
+}

--- a/client/src/services/offline/mutations.ts
+++ b/client/src/services/offline/mutations.ts
@@ -1,0 +1,67 @@
+import {
+  deleteQueuedMutation,
+  getQueuedMutations,
+  getQueuedMutationCount,
+  incrementMutationAttempts,
+  queueMutation,
+  type QueuedMutation,
+} from './indexedDb';
+
+const GRAPHQL_ENDPOINT = import.meta.env.VITE_API_URL || 'http://localhost:4001/graphql';
+const TENANT = import.meta.env.VITE_TENANT_ID || 'dev';
+
+export async function flushQueuedMutations(): Promise<{ processed: number; remaining: number }> {
+  const queued = await getQueuedMutations();
+  if (!queued.length) {
+    return { processed: 0, remaining: 0 };
+  }
+
+  if (typeof navigator !== 'undefined' && !navigator.onLine) {
+    return { processed: 0, remaining: queued.length };
+  }
+
+  let processed = 0;
+
+  for (const mutation of queued) {
+    try {
+      const token = typeof localStorage !== 'undefined' ? localStorage.getItem('token') : undefined;
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'x-tenant-id': TENANT,
+      };
+
+      if (token) {
+        headers.authorization = `Bearer ${token}`;
+      }
+
+      const response = await fetch(GRAPHQL_ENDPOINT, {
+        method: 'POST',
+        headers,
+        credentials: 'include',
+        body: JSON.stringify(mutation.body),
+      });
+
+      if (response.ok) {
+        await deleteQueuedMutation(mutation.id);
+        processed += 1;
+      } else {
+        await incrementMutationAttempts(mutation.id);
+      }
+    } catch (error) {
+      void error;
+      await incrementMutationAttempts(mutation.id);
+      break;
+    }
+  }
+
+  const remaining = await getQueuedMutationCount();
+  return { processed, remaining };
+}
+
+export async function queueOfflineMutation(body: unknown): Promise<QueuedMutation | undefined> {
+  return queueMutation(body);
+}
+
+export async function getPendingMutationCount(): Promise<number> {
+  return getQueuedMutationCount();
+}

--- a/client/src/services/offline/registerServiceWorker.ts
+++ b/client/src/services/offline/registerServiceWorker.ts
@@ -1,0 +1,26 @@
+let registrationPromise: Promise<ServiceWorkerRegistration> | null = null;
+
+export function registerOfflineServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) {
+    return Promise.resolve(null);
+  }
+
+  if (registrationPromise) {
+    return registrationPromise;
+  }
+
+  registrationPromise = navigator.serviceWorker
+    .register('/service-worker.js', { scope: '/' })
+    .then((registration) => {
+      if (import.meta.env.DEV) {
+        console.info('[Offline] Service worker registered:', registration.scope);
+      }
+      return registration;
+    })
+    .catch((error: Error) => {
+      console.warn('[Offline] Service worker registration failed:', error);
+      return null;
+    });
+
+  return registrationPromise;
+}

--- a/client/tests/e2e/offline-mode.spec.ts
+++ b/client/tests/e2e/offline-mode.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+async function waitForServiceWorker(page) {
+  await page.waitForFunction(() => navigator.serviceWorker?.ready);
+}
+
+test.describe('Offline mode experience', () => {
+  test('dashboard surfaces cached data when offline', async ({ page, context }) => {
+    await page.goto('/dashboard');
+    await waitForServiceWorker(page);
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText('📊 Intelligence Command Center')).toBeVisible();
+
+    await context.setOffline(true);
+    await page.reload();
+
+    await expect(page.getByTestId('offline-banner')).toBeVisible();
+    await expect(page.getByTestId('dashboard-offline-indicator')).toBeVisible();
+    await expect(page.getByText('📊 Intelligence Command Center')).toBeVisible();
+
+    await context.setOffline(false);
+  });
+
+  test('ingest wizard progress persists during offline usage', async ({ page, context }) => {
+    await page.goto('/ingest/wizard');
+    await waitForServiceWorker(page);
+
+    await expect(page.getByText('Data Ingest Wizard')).toBeVisible();
+
+    await page.getByLabel('Investigation Name').fill('Offline Case Study');
+    await page.getByLabel('Description').fill('Testing offline ingest wizard resilience.');
+    await page.getByRole('button', { name: 'Create Investigation' }).click();
+
+    await expect(page.getByText('Now let\'s add some entities', { exact: false })).toBeVisible();
+
+    await context.setOffline(true);
+    await page.reload();
+
+    await expect(page.getByTestId('wizard-offline-alert')).toBeVisible();
+    await expect(page.getByText('Now let\'s add some entities', { exact: false })).toBeVisible();
+    await expect(page.getByLabel('Entity Name')).toBeVisible();
+
+    await context.setOffline(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add an offline context/provider with UI banner, register the new service worker, and persist dashboard metrics when disconnected
- persist graph explorer state plus ingest wizard progress with IndexedDB-backed helpers for offline resiliency
- add a dedicated service worker implementation and Playwright coverage for offline dashboard and ingest workflows

## Testing
- npm run lint *(fails: Cannot find package 'globals' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b21d56488333afa0b9b9445eb3b4