### PR TITLE
feat: add milvus vector search support

### DIFF
--- a/server/perf/vector-search-benchmark.ts
+++ b/server/perf/vector-search-benchmark.ts
@@ -1,0 +1,28 @@
+import { vectorSearchBridge } from '../src/services/vectorSearchBridge';
+
+function buildRandomVector(dimension: number): number[] {
+  return Array.from({ length: dimension }, () => Math.random());
+}
+
+async function main() {
+  if (!vectorSearchBridge.isEnabled()) {
+    console.error('Vector search bridge is not configured. Set MILVUS_HOST or VECTOR_DB_ENABLED=true.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const dimension = Number(process.env.EMBEDDING_DIMENSION || '1536');
+  const vector = buildRandomVector(dimension);
+  const warmup = Number(process.env.VECTOR_BENCH_WARMUP || '3');
+  const runs = Number(process.env.VECTOR_BENCH_RUNS || '10');
+
+  try {
+    const metrics = await vectorSearchBridge.benchmark(vector, warmup, runs);
+    console.log('Vector similarity search latency (ms):', metrics);
+  } catch (error) {
+    console.error('Failed to benchmark vector search:', error);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/server/python/vector/milvus_store.py
+++ b/server/python/vector/milvus_store.py
@@ -1,0 +1,221 @@
+"""Milvus vector store integration for Summit ML engine.
+
+This module provides a small wrapper around pymilvus so the
+TensorFlow/PyTorch pipelines can persist and query embeddings that are
+later consumed by the GraphQL API.  The design favors clarity over
+cleverness so it can run both in notebooks and production workers.
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from pymilvus import (Collection, CollectionSchema, DataType, FieldSchema,
+                      connections, utility)
+
+
+@dataclass
+class EmbeddingRecord:
+    """Represents one embedding destined for Milvus."""
+
+    id: str
+    vector: List[float]
+    tenant_id: str
+    node_id: str
+    embedding_model: Optional[str] = None
+    metadata: Optional[dict] = None
+
+
+class MilvusVectorStore:
+    """Thin convenience wrapper around a Milvus collection."""
+
+    def __init__(
+        self,
+        collection_name: str = "summit_embeddings",
+        dim: Optional[int] = None,
+        host: Optional[str] = None,
+        port: int = 19530,
+        token: Optional[str] = None,
+        alias: str = "default",
+    ) -> None:
+        self.collection_name = collection_name
+        self.alias = alias
+        self.dim = dim
+
+        address = host or "127.0.0.1"
+        uri = f"http://{address}:{port}" if not address.startswith("http") else address
+
+        connections.connect(alias=alias, uri=uri, token=token)
+
+        if not utility.has_collection(collection_name, using=alias):
+            if dim is None:
+                raise ValueError(
+                    "Embedding dimension must be provided when creating a new collection"
+                )
+            self._create_collection(dim)
+        else:
+            collection = Collection(collection_name, using=alias)
+            if dim is None:
+                dim = next(
+                    field.params.get("dim")
+                    for field in collection.schema.fields
+                    if field.name == "embedding"
+                )
+            self.collection = collection
+            self.dim = dim
+            return
+
+        self.collection = Collection(collection_name, using=alias)
+
+        # Lazy load indexes to avoid startup penalties
+        if not self.collection.has_index(index_name="embeddings_hnsw"):
+            self.collection.create_index(
+                field_name="embedding",
+                index_params={
+                    "index_type": "HNSW",
+                    "metric_type": "COSINE",
+                    "params": {"M": 16, "efConstruction": 200},
+                },
+                index_name="embeddings_hnsw",
+            )
+        self.collection.load()
+
+    def _create_collection(self, dim: int) -> None:
+        fields = [
+            FieldSchema(
+                name="id",
+                dtype=DataType.VARCHAR,
+                is_primary=True,
+                max_length=128,
+                auto_id=False,
+            ),
+            FieldSchema(
+                name="tenant_id",
+                dtype=DataType.VARCHAR,
+                max_length=64,
+            ),
+            FieldSchema(
+                name="node_id",
+                dtype=DataType.VARCHAR,
+                max_length=128,
+            ),
+            FieldSchema(
+                name="embedding_model",
+                dtype=DataType.VARCHAR,
+                max_length=128,
+            ),
+            FieldSchema(
+                name="metadata",
+                dtype=DataType.VARCHAR,
+                max_length=2048,
+            ),
+            FieldSchema(
+                name="embedding",
+                dtype=DataType.FLOAT_VECTOR,
+                dim=dim,
+            ),
+        ]
+        schema = CollectionSchema(fields, description="Summit entity embeddings")
+        Collection(self.collection_name, schema, using=self.alias)
+        self.dim = dim
+
+    def upsert(self, records: Iterable[EmbeddingRecord]) -> None:
+        records = list(records)
+        if not records:
+            return
+
+        first_dim = len(records[0].vector)
+        if self.dim and first_dim != self.dim:
+            raise ValueError(f"Embedding dimension mismatch: expected {self.dim}, got {first_dim}")
+
+        ids = [rec.id for rec in records]
+        expr = f'id in [{",".join(f"\"{_id}\"" for _id in ids)}]'
+        self.collection.delete(expr)
+
+        data = [
+            ids,
+            [rec.tenant_id for rec in records],
+            [rec.node_id for rec in records],
+            [rec.embedding_model or "unknown" for rec in records],
+            [json.dumps(rec.metadata or {}) for rec in records],
+            [rec.vector for rec in records],
+        ]
+        self.collection.insert(data)
+        self.collection.flush()
+
+    def similarity_search(
+        self,
+        vector: List[float],
+        top_k: int = 10,
+        tenant_id: Optional[str] = None,
+        node_ids: Optional[Iterable[str]] = None,
+        embedding_model: Optional[str] = None,
+        search_params: Optional[dict] = None,
+    ) -> List[dict]:
+        if self.dim and len(vector) != self.dim:
+            raise ValueError(f"Query vector dimension mismatch: expected {self.dim}, got {len(vector)}")
+
+        filters = []
+        if tenant_id:
+            filters.append(f"tenant_id == '{tenant_id}'")
+        if embedding_model:
+            filters.append(f"embedding_model == '{embedding_model}'")
+        if node_ids:
+            node_list = ",".join(f"'{node}'" for node in node_ids)
+            filters.append(f"node_id in [{node_list}]")
+
+        expr = " and ".join(filters) if filters else ""
+
+        params = {
+            "metric_type": "COSINE",
+            "params": {"ef": 200},
+        }
+        if search_params:
+            params.update(search_params)
+
+        results = self.collection.search(  # type: ignore[arg-type]
+            data=[vector],
+            anns_field="embedding",
+            param=params,
+            limit=top_k,
+            expr=expr or None,
+            output_fields=["tenant_id", "node_id", "embedding_model", "metadata"],
+        )
+
+        formatted: List[dict] = []
+        hits = results[0] if results else []
+        for hit in hits:
+            payload = {
+                "id": hit.id,
+                "score": float(hit.distance),
+                "tenant_id": hit.entity.get("tenant_id"),
+                "node_id": hit.entity.get("node_id"),
+                "embedding_model": hit.entity.get("embedding_model"),
+                "metadata": json.loads(hit.entity.get("metadata") or "{}"),
+            }
+            formatted.append(payload)
+        return formatted
+
+    def benchmark_search(self, vector: List[float], warmup: int = 3, runs: int = 10) -> dict:
+        # Warm-up
+        for _ in range(warmup):
+            self.similarity_search(vector, top_k=1)
+
+        latencies: List[float] = []
+        for _ in range(runs):
+            start = time.perf_counter()
+            self.similarity_search(vector, top_k=5)
+            latencies.append((time.perf_counter() - start) * 1000.0)
+
+        latencies.sort()
+        return {
+            "runs": runs,
+            "p50_ms": latencies[len(latencies) // 2],
+            "p95_ms": latencies[max(int(runs * 0.95) - 1, 0)],
+            "avg_ms": sum(latencies) / runs,
+        }
+
+
+__all__ = ["MilvusVectorStore", "EmbeddingRecord"]

--- a/server/python/vector/runner.py
+++ b/server/python/vector/runner.py
@@ -1,0 +1,56 @@
+"""Simple JSON-over-stdin runner for vector database operations."""
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Dict
+
+from .milvus_store import EmbeddingRecord, MilvusVectorStore
+
+
+def main() -> None:
+    try:
+        payload: Dict[str, Any] = json.load(sys.stdin)
+    except Exception as exc:  # pragma: no cover - defensive
+        json.dump({"status": "error", "error": f"invalid input: {exc}"}, sys.stdout)
+        return
+
+    action = payload.get("action")
+    config = payload.get("config", {})
+
+    try:
+        store = MilvusVectorStore(**config)
+    except Exception as exc:
+        json.dump({"status": "error", "error": str(exc)}, sys.stdout)
+        return
+
+    try:
+        if action == "upsert":
+            records = [EmbeddingRecord(**record) for record in payload.get("records", [])]
+            store.upsert(records)
+            json.dump({"status": "ok", "count": len(records)}, sys.stdout)
+        elif action == "search":
+            results = store.similarity_search(
+                vector=payload["vector"],
+                top_k=payload.get("top_k", 10),
+                tenant_id=payload.get("tenant_id"),
+                node_ids=payload.get("node_ids"),
+                embedding_model=payload.get("embedding_model"),
+                search_params=payload.get("search_params"),
+            )
+            json.dump({"status": "ok", "results": results}, sys.stdout)
+        elif action == "benchmark":
+            metrics = store.benchmark_search(
+                payload["vector"],
+                warmup=payload.get("warmup", 3),
+                runs=payload.get("runs", 10),
+            )
+            json.dump({"status": "ok", "metrics": metrics}, sys.stdout)
+        else:
+            json.dump({"status": "error", "error": f"unsupported action '{action}'"}, sys.stdout)
+    except Exception as exc:
+        json.dump({"status": "error", "error": str(exc)}, sys.stdout)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/python/vector/setup_milvus_collection.py
+++ b/server/python/vector/setup_milvus_collection.py
@@ -1,0 +1,37 @@
+"""CLI utility for preparing the Milvus collection used by Summit."""
+
+from __future__ import annotations
+
+import argparse
+
+from .milvus_store import MilvusVectorStore
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Create or update the Milvus embedding collection")
+    parser.add_argument("--collection", default="summit_embeddings", help="Collection name")
+    parser.add_argument("--dim", type=int, default=None, help="Embedding dimension (required if collection does not exist)")
+    parser.add_argument("--host", default=None, help="Milvus host or URI")
+    parser.add_argument("--port", type=int, default=19530, help="Milvus port")
+    parser.add_argument("--token", default=None, help="Milvus auth token")
+    parser.add_argument("--alias", default="default", help="Connection alias")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    kwargs = {
+        "collection_name": args.collection,
+        "dim": args.dim,
+        "host": args.host,
+        "port": args.port,
+        "token": args.token,
+        "alias": args.alias,
+    }
+    store = MilvusVectorStore(**kwargs)
+    store.collection.load()
+    print(f"Collection '{args.collection}' ready with dim={store.dim}")
+
+
+if __name__ == "__main__":
+    main()

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -55,6 +55,7 @@ faiss-cpu==1.12.0
 annoy==1.17.3
 hnswlib==0.8.0
 chromadb==1.0.21
+pymilvus==2.4.8
 
 # Deep Learning Frameworks
 tensorflow==2.20.0

--- a/server/src/graphql/schema.core.js
+++ b/server/src/graphql/schema.core.js
@@ -152,6 +152,27 @@ export const coreTypeDefs = gql`
     offset: Int = 0
   }
 
+  input VectorSimilarityFilter {
+    nodeIds: [ID!]
+    embeddingModel: String
+  }
+
+  input VectorSimilarityInput {
+    tenantId: String!
+    vector: [Float!]!
+    topK: Int = 10
+    filter: VectorSimilarityFilter
+  }
+
+  type VectorSimilarityMatch {
+    nodeId: ID
+    tenantId: String!
+    score: Float!
+    embeddingModel: String
+    entity: Entity
+    metadata: JSON
+  }
+
   # Graph traversal types
   type GraphNeighborhood {
     center: Entity!
@@ -193,6 +214,9 @@ export const coreTypeDefs = gql`
 
     # Search across all entity types
     searchEntities(tenantId: String!, query: String!, kinds: [String!], limit: Int = 50): [Entity!]!
+
+    # Vector similarity search bridging Milvus and Neo4j
+    vectorSimilaritySearch(input: VectorSimilarityInput!): [VectorSimilarityMatch!]!
   }
 
   # Extended Mutation operations

--- a/server/src/services/vectorSearchBridge.ts
+++ b/server/src/services/vectorSearchBridge.ts
@@ -1,0 +1,204 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import logger from '../utils/logger';
+
+export interface VectorRecord {
+  id: string;
+  vector: number[];
+  tenantId: string;
+  nodeId?: string;
+  embeddingModel?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface VectorSearchFilter {
+  nodeIds?: string[];
+  embeddingModel?: string;
+}
+
+export interface VectorSearchResult {
+  id: string;
+  nodeId?: string;
+  tenantId?: string;
+  score: number;
+  embeddingModel?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface PythonResponse<T> {
+  status: 'ok' | 'error';
+  error?: string;
+  results?: T;
+  count?: number;
+  metrics?: Record<string, number>;
+}
+
+export class VectorSearchBridge {
+  private readonly pythonModule = 'server.python.vector.runner';
+  private readonly pythonBin = process.env.PYTHON_BIN || 'python3';
+  private readonly pythonPath: string;
+  private readonly cwd: string;
+  private readonly config: Record<string, unknown>;
+  private readonly enabled: boolean;
+
+  constructor() {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = path.dirname(__filename);
+    this.cwd = path.resolve(__dirname, '..', '..');
+    this.pythonPath = path.resolve(__dirname, '..', '..', 'python');
+
+    const host = process.env.MILVUS_HOST || process.env.MILVUS_ADDRESS || undefined;
+    const port = process.env.MILVUS_PORT ? Number(process.env.MILVUS_PORT) : undefined;
+    const dim = process.env.EMBEDDING_DIMENSION ? Number(process.env.EMBEDDING_DIMENSION) : undefined;
+
+    this.config = {
+      collection_name: process.env.MILVUS_COLLECTION || 'summit_embeddings',
+      dim,
+      host,
+      port,
+      token: process.env.MILVUS_TOKEN,
+      alias: process.env.MILVUS_ALIAS || 'default',
+    };
+
+    this.enabled = Boolean(host || process.env.VECTOR_DB_ENABLED === 'true');
+
+    if (!this.enabled) {
+      logger.debug('Vector search bridge disabled (no host configured)');
+    }
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  async upsertEmbeddings(records: VectorRecord[]): Promise<void> {
+    if (!this.enabled || records.length === 0) {
+      return;
+    }
+
+    const payloadRecords = records.map((record) => ({
+      id: record.id,
+      vector: record.vector,
+      tenant_id: record.tenantId,
+      node_id: record.nodeId || '',
+      embedding_model: record.embeddingModel,
+      metadata: record.metadata || {},
+    }));
+
+    const response = await this.runPython<PythonResponse<unknown>>({
+      action: 'upsert',
+      records: payloadRecords,
+    });
+
+    if (response.status !== 'ok') {
+      throw new Error(response.error || 'Failed to upsert embeddings');
+    }
+  }
+
+  async searchSimilar(
+    vector: number[],
+    tenantId: string,
+    topK = 10,
+    filter?: VectorSearchFilter,
+  ): Promise<VectorSearchResult[]> {
+    if (!this.enabled) {
+      return [];
+    }
+
+    const response = await this.runPython<PythonResponse<any>>({
+      action: 'search',
+      vector,
+      top_k: topK,
+      tenant_id: tenantId,
+      node_ids: filter?.nodeIds,
+      embedding_model: filter?.embeddingModel,
+    });
+
+    if (response.status !== 'ok') {
+      throw new Error(response.error || 'Vector similarity search failed');
+    }
+
+    const results = (response.results || []) as Array<Record<string, unknown>>;
+    return results.map((result) => ({
+      id: String(result.id ?? ''),
+      nodeId: result.node_id ? String(result.node_id) : undefined,
+      tenantId: result.tenant_id ? String(result.tenant_id) : undefined,
+      score: typeof result.score === 'number' ? result.score : Number(result.score ?? 0),
+      embeddingModel: result.embedding_model ? String(result.embedding_model) : undefined,
+      metadata: (result.metadata as Record<string, unknown>) || undefined,
+    }));
+  }
+
+  async benchmark(vector: number[], warmup = 3, runs = 10): Promise<Record<string, number>> {
+    if (!this.enabled) {
+      return {};
+    }
+
+    const response = await this.runPython<PythonResponse<Record<string, number>>>({
+      action: 'benchmark',
+      vector,
+      warmup,
+      runs,
+    });
+
+    if (response.status !== 'ok' || !response.metrics) {
+      throw new Error(response.error || 'Benchmark failed');
+    }
+
+    return response.metrics;
+  }
+
+  private runPython<T>(payload: Record<string, unknown>): Promise<T> {
+    return new Promise((resolve, reject) => {
+      const child = spawn(this.pythonBin, ['-m', this.pythonModule], {
+        cwd: this.cwd,
+        env: {
+          ...process.env,
+          PYTHONPATH: this.buildPythonPath(),
+        },
+      });
+
+      let stdout = '';
+      let stderr = '';
+
+      child.stdout.on('data', (chunk) => {
+        stdout += chunk.toString();
+      });
+
+      child.stderr.on('data', (chunk) => {
+        stderr += chunk.toString();
+      });
+
+      child.on('error', (error) => {
+        logger.error('Failed to start python vector bridge', { error });
+        reject(error);
+      });
+
+      child.on('close', (code) => {
+        if (code !== 0) {
+          logger.error('Python vector bridge exited with error', { code, stderr });
+          return reject(new Error(stderr || `Python process exited with code ${code}`));
+        }
+
+        try {
+          const parsed = JSON.parse(stdout || '{}');
+          resolve(parsed as T);
+        } catch (error) {
+          logger.error('Failed to parse python vector bridge output', { stdout, error });
+          reject(error);
+        }
+      });
+
+      child.stdin.write(JSON.stringify({ ...payload, config: this.config }));
+      child.stdin.end();
+    });
+  }
+
+  private buildPythonPath(): string {
+    const existing = process.env.PYTHONPATH ? `${path.delimiter}${process.env.PYTHONPATH}` : '';
+    return `${this.pythonPath}${existing}`;
+  }
+}
+
+export const vectorSearchBridge = new VectorSearchBridge();


### PR DESCRIPTION
## Summary
- add a Milvus-backed vector store module for the Python ML engine plus setup and runner utilities
- create a Node bridge that shells out to the Python runner, extend ingest to persist embeddings, and add a latency benchmark script
- expose a GraphQL vectorSimilaritySearch query wired to Neo4j entities and include pymilvus in the server requirements

## Testing
- npm run lint -- src/ingest/http.ts src/graphql/resolvers.ts src/services/vectorSearchBridge.ts *(fails: missing eslint dependency `globals`)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b2de78808333a2763cf7421a2700