### PR TITLE
feat: integrate external identity providers into auth flow

### DIFF
--- a/helm/server/values.yaml
+++ b/helm/server/values.yaml
@@ -53,6 +53,54 @@ env:
       secretKeyRef:
         name: server-secret
         key: jwt-refresh-secret
+  - name: AUTH_DEFAULT_TENANT
+    value: 'default'
+  - name: AUTH_PROVIDERS
+    value: 'oidc,okta,azure'
+  - name: AUTH_ROLE_MAPPINGS
+    value: '{"Okta-SOC-Admins":["ADMIN"],"azure-intelgraph-analyst":["ANALYST"]}'
+  - name: OIDC_AUDIENCE
+    value: ''
+  - name: OIDC_JWKS_URI
+    value: ''
+  - name: OIDC_GROUPS_CLAIM
+    value: 'groups'
+  - name: OKTA_ISSUER
+    value: ''
+  - name: OKTA_AUDIENCE
+    value: ''
+  - name: OKTA_JWKS_URI
+    value: ''
+  - name: OKTA_GROUPS_CLAIM
+    value: 'groups'
+  - name: AZURE_AD_TENANT_ID
+    value: ''
+  - name: AZURE_AD_CLIENT_ID
+    value: ''
+  - name: AZURE_AD_AUDIENCE
+    value: ''
+  - name: AZURE_AD_ISSUER
+    value: ''
+  - name: AZURE_AD_JWKS_URI
+    value: ''
+  - name: AZURE_AD_GROUPS_CLAIM
+    value: 'groups'
+  # Optional: uncomment and configure client secrets in a Kubernetes secret
+  # - name: OKTA_CLIENT_ID
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: server-secret
+  #       key: okta-client-id
+  # - name: OKTA_CLIENT_SECRET
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: server-secret
+  #       key: okta-client-secret
+  # - name: AZURE_AD_CLIENT_SECRET
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: server-secret
+  #       key: azure-client-secret
   - name: ALLOWED_ORIGINS
     value: 'https://app.intelgraph.com'
   - name: CORS_ORIGIN

--- a/server/src/config/secrets.ts
+++ b/server/src/config/secrets.ts
@@ -41,6 +41,29 @@ const EnvSchema = z.object({
   OIDC_CLIENT_ID: z.string().optional(),
   OIDC_CLIENT_SECRET: z.string().optional(),
   OIDC_REDIRECT_URI: z.string().url().optional(),
+  OIDC_AUDIENCE: z.string().optional(),
+  OIDC_JWKS_URI: z.string().url().optional(),
+  OIDC_GROUPS_CLAIM: z.string().optional(),
+
+  // External Identity Providers
+  AUTH_PROVIDERS: z.string().optional(),
+  AUTH_DEFAULT_TENANT: z.string().optional(),
+  AUTH_ROLE_MAPPINGS: z.string().optional(),
+
+  OKTA_ISSUER: z.string().url().optional(),
+  OKTA_CLIENT_ID: z.string().optional(),
+  OKTA_CLIENT_SECRET: z.string().optional(),
+  OKTA_AUDIENCE: z.string().optional(),
+  OKTA_JWKS_URI: z.string().url().optional(),
+  OKTA_GROUPS_CLAIM: z.string().optional(),
+
+  AZURE_AD_ISSUER: z.string().url().optional(),
+  AZURE_AD_TENANT_ID: z.string().optional(),
+  AZURE_AD_CLIENT_ID: z.string().optional(),
+  AZURE_AD_CLIENT_SECRET: z.string().optional(),
+  AZURE_AD_AUDIENCE: z.string().optional(),
+  AZURE_AD_JWKS_URI: z.string().url().optional(),
+  AZURE_AD_GROUPS_CLAIM: z.string().optional(),
 
   // CORS
   CORS_ORIGIN: z.string().default('http://localhost:3000'),
@@ -205,6 +228,27 @@ ENCRYPTION_KEY=${secrets.ENCRYPTION_KEY}
 # OIDC_CLIENT_ID=your-client-id
 # OIDC_CLIENT_SECRET=your-client-secret
 # OIDC_REDIRECT_URI=http://localhost:8080/auth/callback
+# OIDC_AUDIENCE=api://intelgraph-dev
+# OIDC_JWKS_URI=https://your-oidc-provider.com/.well-known/jwks.json
+# OIDC_GROUPS_CLAIM=groups
+
+# External Auth Providers (configure as needed)
+# AUTH_PROVIDERS=oidc,okta,azure
+AUTH_DEFAULT_TENANT=default
+# AUTH_ROLE_MAPPINGS={"Okta-SOC-Admins":["ADMIN"],"azure-intelgraph-analyst":["ANALYST"]}
+# OKTA_ISSUER=https://your-okta-domain.okta.com/oauth2/default
+# OKTA_CLIENT_ID=your-okta-client-id
+# OKTA_CLIENT_SECRET=your-okta-client-secret
+# OKTA_AUDIENCE=api://default
+# OKTA_JWKS_URI=https://your-okta-domain.okta.com/oauth2/v1/keys
+# OKTA_GROUPS_CLAIM=groups
+# AZURE_AD_TENANT_ID=00000000-0000-0000-0000-000000000000
+# AZURE_AD_CLIENT_ID=00000000-0000-0000-0000-000000000000
+# AZURE_AD_CLIENT_SECRET=your-azure-secret
+# AZURE_AD_AUDIENCE=api://intelgraph-dev
+# AZURE_AD_ISSUER=https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/v2.0
+# AZURE_AD_JWKS_URI=https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/discovery/v2.0/keys
+# AZURE_AD_GROUPS_CLAIM=groups
 
 # CORS
 CORS_ORIGIN=http://localhost:3000

--- a/server/src/security/externalAuth.ts
+++ b/server/src/security/externalAuth.ts
@@ -1,0 +1,379 @@
+import axios from 'axios';
+import { createPublicKey, randomUUID } from 'crypto';
+import { decode, JwtHeader, JwtPayload, verify } from 'jsonwebtoken';
+import logger from '../utils/logger.js';
+
+export interface AuthProviderConfig {
+  id: string;
+  name: string;
+  issuer: string;
+  jwksUri: string;
+  audiences: string[];
+  clientId?: string;
+  groupsClaim?: string;
+  defaultTenant?: string;
+}
+
+export interface ExternalAuthUser {
+  id: string;
+  email?: string;
+  name?: string;
+  firstName?: string;
+  lastName?: string;
+  providerId: string;
+  providerName: string;
+  tenant: string;
+  roles: string[];
+  groups: string[];
+  scopes: string[];
+  residency: string;
+  issuedAt?: number;
+  expiresAt?: number;
+  claims: Record<string, any>;
+}
+
+interface CachedJWKS {
+  keys: any[];
+  expiresAt: number;
+}
+
+const DEFAULT_ROLE_MAPPINGS: Record<string, string[]> = {
+  'IntelGraph-Admins': ['ADMIN'],
+  'IntelGraph-Analysts': ['ANALYST'],
+  'IntelGraph-Operators': ['OPERATOR'],
+  'IntelGraph-Viewers': ['VIEWER'],
+  'Okta-SOC-Admins': ['ADMIN'],
+  'Okta-SOC-Analysts': ['ANALYST'],
+  'Okta-SOC-Operators': ['OPERATOR'],
+  'Okta-SOC-Viewers': ['VIEWER'],
+  'azure-intelgraph-admin': ['ADMIN'],
+  'azure-intelgraph-analyst': ['ANALYST'],
+  'azure-intelgraph-operator': ['OPERATOR'],
+  'azure-intelgraph-viewer': ['VIEWER'],
+};
+
+const SUPPORTED_ALGS = ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512'];
+
+let singletonManager: ExternalAuthManager | null = null;
+
+export function getExternalAuthManager(): ExternalAuthManager {
+  if (!singletonManager) {
+    singletonManager = new ExternalAuthManager(loadAuthProviders(), loadRoleMappings());
+  }
+  return singletonManager;
+}
+
+export function resetExternalAuthManager(): void {
+  singletonManager = null;
+}
+
+function loadRoleMappings(): Record<string, string[]> {
+  try {
+    const raw = process.env.AUTH_ROLE_MAPPINGS;
+    if (!raw) {
+      return DEFAULT_ROLE_MAPPINGS;
+    }
+    const parsed = JSON.parse(raw);
+    return {
+      ...DEFAULT_ROLE_MAPPINGS,
+      ...parsed,
+    };
+  } catch (error) {
+    logger.warn('Failed to parse AUTH_ROLE_MAPPINGS. Falling back to defaults.', {
+      error: (error as Error).message,
+    });
+    return DEFAULT_ROLE_MAPPINGS;
+  }
+}
+
+function loadAuthProviders(): AuthProviderConfig[] {
+  const requested = (process.env.AUTH_PROVIDERS || '')
+    .split(',')
+    .map((p) => p.trim().toLowerCase())
+    .filter(Boolean);
+
+  const providers: AuthProviderConfig[] = [];
+  const include = (id: string) => requested.length === 0 || requested.includes(id);
+  const defaultTenant = process.env.AUTH_DEFAULT_TENANT || 'default';
+
+  if (include('oidc') && process.env.OIDC_ISSUER) {
+    const issuer = process.env.OIDC_ISSUER;
+    const jwksUri = process.env.OIDC_JWKS_URI || `${issuer.replace(/\/$/, '')}/.well-known/jwks.json`;
+    const audience = process.env.OIDC_AUDIENCE || process.env.OIDC_CLIENT_ID;
+
+    providers.push({
+      id: 'oidc',
+      name: 'OIDC',
+      issuer,
+      jwksUri,
+      audiences: audience ? [audience] : [],
+      clientId: process.env.OIDC_CLIENT_ID,
+      groupsClaim: process.env.OIDC_GROUPS_CLAIM || 'groups',
+      defaultTenant,
+    });
+  }
+
+  if (include('okta') && process.env.OKTA_ISSUER) {
+    const issuer = process.env.OKTA_ISSUER.replace(/\/$/, '');
+    const jwksUri = process.env.OKTA_JWKS_URI || `${issuer}/v1/keys`;
+    const audience = process.env.OKTA_AUDIENCE || process.env.OKTA_CLIENT_ID;
+
+    providers.push({
+      id: 'okta',
+      name: 'Okta',
+      issuer,
+      jwksUri,
+      audiences: audience ? [audience] : [],
+      clientId: process.env.OKTA_CLIENT_ID,
+      groupsClaim: process.env.OKTA_GROUPS_CLAIM || 'groups',
+      defaultTenant,
+    });
+  }
+
+  if (include('azure') && (process.env.AZURE_AD_ISSUER || process.env.AZURE_AD_TENANT_ID)) {
+    const tenantId = process.env.AZURE_AD_TENANT_ID;
+    const issuer = process.env.AZURE_AD_ISSUER || (tenantId ? `https://login.microsoftonline.com/${tenantId}/v2.0` : undefined);
+    if (issuer) {
+      const normalizedIssuer = issuer.replace(/\/$/, '');
+      const jwksUri = process.env.AZURE_AD_JWKS_URI || `${normalizedIssuer.replace(/\/v2\.0$/, '')}/discovery/v2.0/keys`;
+      const audience = process.env.AZURE_AD_AUDIENCE || process.env.AZURE_AD_CLIENT_ID;
+
+      providers.push({
+        id: 'azure',
+        name: 'Azure AD',
+        issuer: normalizedIssuer,
+        jwksUri,
+        audiences: audience ? [audience] : [],
+        clientId: process.env.AZURE_AD_CLIENT_ID,
+        groupsClaim: process.env.AZURE_AD_GROUPS_CLAIM || 'groups',
+        defaultTenant: tenantId || defaultTenant,
+      });
+    }
+  }
+
+  if (providers.length === 0) {
+    logger.warn('No external auth providers configured. Only internal JWT authentication will be available.');
+  } else {
+    logger.info('Configured external authentication providers', {
+      providers: providers.map((provider) => provider.id),
+    });
+  }
+
+  return providers;
+}
+
+export class ExternalAuthManager {
+  private providers: AuthProviderConfig[];
+  private jwksCache: Map<string, CachedJWKS> = new Map();
+  private roleMappings: Record<string, string[]>;
+  private defaultTenant: string;
+
+  constructor(providers: AuthProviderConfig[], roleMappings: Record<string, string[]>) {
+    this.providers = providers;
+    this.roleMappings = roleMappings;
+    this.defaultTenant = process.env.AUTH_DEFAULT_TENANT || 'default';
+  }
+
+  async verify(token: string): Promise<ExternalAuthUser | null> {
+    if (!token) {
+      return null;
+    }
+
+    const decoded = decode(token, { complete: true });
+    if (!decoded || typeof decoded === 'string') {
+      return null;
+    }
+
+    const header = decoded.header as JwtHeader;
+    const payload = decoded.payload as JwtPayload & Record<string, any>;
+
+    const provider = this.resolveProvider(payload);
+    if (!provider) {
+      logger.debug('Token issuer not mapped to a configured provider', {
+        issuer: payload.iss,
+        audience: payload.aud,
+      });
+      return null;
+    }
+
+    try {
+      const publicKey = await this.getSigningKey(provider, header);
+      const verified = verify(token, publicKey, {
+        algorithms: header.alg && SUPPORTED_ALGS.includes(header.alg) ? [header.alg] : SUPPORTED_ALGS,
+        issuer: provider.issuer,
+        audience: provider.audiences.length > 0 ? provider.audiences : undefined,
+      }) as JwtPayload & Record<string, any>;
+
+      return this.mapToUser(provider, header, verified);
+    } catch (error) {
+      logger.warn('External token verification failed', {
+        provider: provider.id,
+        error: (error as Error).message,
+      });
+      return null;
+    }
+  }
+
+  private resolveProvider(payload: JwtPayload & Record<string, any>): AuthProviderConfig | undefined {
+    const issuer = (payload.iss as string | undefined)?.replace(/\/$/, '');
+    const audClaim = payload.aud;
+    const audiences: string[] = Array.isArray(audClaim)
+      ? audClaim.map((value) => String(value))
+      : audClaim
+        ? [String(audClaim)]
+        : [];
+
+    return this.providers.find((provider) => {
+      if (issuer && provider.issuer === issuer) {
+        return true;
+      }
+      if (audiences.length > 0 && provider.audiences.some((aud) => audiences.includes(aud))) {
+        return true;
+      }
+      return false;
+    });
+  }
+
+  private async getSigningKey(provider: AuthProviderConfig, header: JwtHeader): Promise<string> {
+    if (!header.kid) {
+      throw new Error('Token missing kid header');
+    }
+
+    const jwks = await this.loadJWKS(provider);
+    const key = jwks.keys.find((candidate) => candidate.kid === header.kid);
+    if (!key) {
+      throw new Error(`Unable to find signing key for kid ${header.kid}`);
+    }
+
+    const keyObject = createPublicKey({
+      key,
+      format: 'jwk',
+    });
+    return keyObject.export({ type: 'spki', format: 'pem' }).toString();
+  }
+
+  private async loadJWKS(provider: AuthProviderConfig): Promise<{ keys: any[] }> {
+    const cached = this.jwksCache.get(provider.id);
+    const now = Date.now();
+
+    if (cached && cached.expiresAt > now) {
+      return { keys: cached.keys };
+    }
+
+    const response = await axios.get(provider.jwksUri, {
+      timeout: 5000,
+    });
+    const data = response.data;
+    if (!data || !Array.isArray(data.keys)) {
+      throw new Error(`JWKS endpoint ${provider.jwksUri} did not return keys`);
+    }
+
+    this.jwksCache.set(provider.id, {
+      keys: data.keys,
+      expiresAt: now + 10 * 60 * 1000,
+    });
+
+    return { keys: data.keys };
+  }
+
+  private mapToUser(
+    provider: AuthProviderConfig,
+    header: JwtHeader,
+    payload: JwtPayload & Record<string, any>,
+  ): ExternalAuthUser {
+    const groupsClaim = provider.groupsClaim || 'groups';
+    const groups = this.extractGroups(payload, groupsClaim);
+    const roles = this.mapGroupsToRoles(groups);
+    const scopes = this.extractScopes(payload);
+    const tenant = this.resolveTenant(payload, provider);
+
+    const name = payload.name as string | undefined;
+    const givenName = (payload.given_name || payload.firstName) as string | undefined;
+    const familyName = (payload.family_name || payload.lastName) as string | undefined;
+
+    return {
+      id: (payload.sub as string) || randomUUID(),
+      email: (payload.email as string) || (payload.preferred_username as string),
+      name,
+      firstName: givenName,
+      lastName: familyName,
+      providerId: provider.id,
+      providerName: provider.name,
+      tenant,
+      roles,
+      groups,
+      scopes,
+      residency: (payload.residency as string) || (payload.country as string) || 'unknown',
+      issuedAt: payload.iat,
+      expiresAt: payload.exp,
+      claims: {
+        ...payload,
+        alg: header.alg,
+      },
+    };
+  }
+
+  private extractGroups(payload: Record<string, any>, claim: string): string[] {
+    const raw = payload[claim];
+    if (!raw) {
+      return [];
+    }
+    if (Array.isArray(raw)) {
+      return raw.map((value) => String(value));
+    }
+    if (typeof raw === 'string') {
+      return raw.split(',').map((value) => value.trim()).filter(Boolean);
+    }
+    return [];
+  }
+
+  private mapGroupsToRoles(groups: string[]): string[] {
+    const roles = new Set<string>();
+    for (const group of groups) {
+      const mapped = this.roleMappings[group];
+      if (mapped) {
+        mapped.forEach((role) => roles.add(role));
+      }
+    }
+
+    if (roles.size === 0) {
+      roles.add('VIEWER');
+    }
+
+    return Array.from(roles);
+  }
+
+  private extractScopes(payload: Record<string, any>): string[] {
+    if (Array.isArray(payload.scope)) {
+      return payload.scope.map((value: any) => String(value));
+    }
+
+    if (typeof payload.scope === 'string') {
+      return payload.scope.split(' ').map((value) => value.trim()).filter(Boolean);
+    }
+
+    if (Array.isArray(payload.scp)) {
+      return payload.scp.map((value: any) => String(value));
+    }
+
+    if (typeof payload.scp === 'string') {
+      return payload.scp.split(' ').map((value) => value.trim()).filter(Boolean);
+    }
+
+    if (Array.isArray(payload.roles)) {
+      return payload.roles.map((value: any) => `role:${value}`);
+    }
+
+    return [];
+  }
+
+  private resolveTenant(payload: Record<string, any>, provider: AuthProviderConfig): string {
+    return (
+      (payload.tenant as string) ||
+      (payload.tid as string) ||
+      provider.defaultTenant ||
+      this.defaultTenant ||
+      'default'
+    );
+  }
+}

--- a/server/tests/e2e/auth.providers.test.ts
+++ b/server/tests/e2e/auth.providers.test.ts
@@ -1,0 +1,212 @@
+/**
+ * E2E tests for external authentication providers
+ */
+
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import { generateKeyPairSync } from 'crypto';
+import jwt from 'jsonwebtoken';
+import { AuthenticationError, ForbiddenError } from 'apollo-server-express';
+import { validateOIDCToken, opaAuthzMiddleware } from '../../src/middleware/opa-abac';
+import { resetExternalAuthManager } from '../../src/security/externalAuth';
+import type { OPAClient } from '../../src/graphql/intelgraph/types';
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+  },
+}));
+
+import axios from 'axios';
+
+const mockedAxios = axios as unknown as {
+  get: jest.Mock;
+};
+
+const oktaIssuer = 'https://okta.example.com/oauth2/default';
+const oktaJwksUri = `${oktaIssuer}/v1/keys`;
+const azureTenant = '00000000-1111-2222-3333-444455556666';
+const azureIssuer = `https://login.microsoftonline.com/${azureTenant}/v2.0`;
+const azureJwksUri = `https://login.microsoftonline.com/${azureTenant}/discovery/v2.0/keys`;
+
+const oktaKeys = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const oktaPrivateKey = oktaKeys.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+const oktaPublicJwk = oktaKeys.publicKey.export({ format: 'jwk' }) as Record<string, any>;
+oktaPublicJwk.kid = 'okta-key-1';
+oktaPublicJwk.alg = 'RS256';
+oktaPublicJwk.use = 'sig';
+
+const azureKeys = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const azurePrivateKey = azureKeys.privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+const azurePublicJwk = azureKeys.publicKey.export({ format: 'jwk' }) as Record<string, any>;
+azurePublicJwk.kid = 'azure-key-1';
+azurePublicJwk.alg = 'RS256';
+azurePublicJwk.use = 'sig';
+
+describe('External identity provider integration', () => {
+  let app: express.Express;
+  let opaClient: OPAClient & { evaluate: jest.Mock };
+
+  beforeEach(() => {
+    process.env.AUTH_PROVIDERS = 'okta,azure';
+    process.env.AUTH_DEFAULT_TENANT = 'global-tenant';
+    process.env.AUTH_ROLE_MAPPINGS = JSON.stringify({
+      'Okta-SOC-Admins': ['ADMIN'],
+      'azure-intelgraph-analyst': ['ANALYST'],
+    });
+
+    process.env.OKTA_ISSUER = oktaIssuer;
+    process.env.OKTA_AUDIENCE = 'api://default';
+    process.env.OKTA_JWKS_URI = oktaJwksUri;
+    process.env.OKTA_GROUPS_CLAIM = 'groups';
+
+    process.env.AZURE_AD_ISSUER = azureIssuer;
+    process.env.AZURE_AD_AUDIENCE = 'api://intelgraph';
+    process.env.AZURE_AD_JWKS_URI = azureJwksUri;
+    process.env.AZURE_AD_GROUPS_CLAIM = 'groups';
+
+    mockedAxios.get.mockImplementation((url: string) => {
+      if (url === oktaJwksUri) {
+        return Promise.resolve({ data: { keys: [oktaPublicJwk] } });
+      }
+      if (url === azureJwksUri) {
+        return Promise.resolve({ data: { keys: [azurePublicJwk] } });
+      }
+      return Promise.reject(new Error(`Unexpected JWKS URL: ${url}`));
+    });
+
+    resetExternalAuthManager();
+
+    opaClient = {
+      evaluate: jest.fn().mockResolvedValue(true),
+    } as unknown as OPAClient & { evaluate: jest.Mock };
+
+    app = express();
+    app.get(
+      '/secure',
+      (req: Request, res: Response, next: NextFunction) => validateOIDCToken(req, res, next),
+      opaAuthzMiddleware(opaClient),
+      (req: Request, res: Response) => {
+        res.json({ user: (req as any).user });
+      },
+    );
+
+    app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+      if (err instanceof AuthenticationError) {
+        return res.status(401).json({ error: 'unauthorized' });
+      }
+      if (err instanceof ForbiddenError) {
+        return res.status(403).json({ error: 'forbidden' });
+      }
+      return res.status(500).json({ error: err.message });
+    });
+  });
+
+  afterEach(() => {
+    mockedAxios.get.mockReset();
+    resetExternalAuthManager();
+    delete process.env.AUTH_PROVIDERS;
+    delete process.env.AUTH_DEFAULT_TENANT;
+    delete process.env.AUTH_ROLE_MAPPINGS;
+    delete process.env.OKTA_ISSUER;
+    delete process.env.OKTA_AUDIENCE;
+    delete process.env.OKTA_JWKS_URI;
+    delete process.env.OKTA_GROUPS_CLAIM;
+    delete process.env.AZURE_AD_ISSUER;
+    delete process.env.AZURE_AD_AUDIENCE;
+    delete process.env.AZURE_AD_JWKS_URI;
+    delete process.env.AZURE_AD_GROUPS_CLAIM;
+  });
+
+  test('accepts Okta JWTs and populates RBAC roles for OPA', async () => {
+    const token = jwt.sign(
+      {
+        iss: oktaIssuer,
+        aud: 'api://default',
+        sub: 'user-okta-123',
+        email: 'alice.okta@example.com',
+        name: 'Alice Okta',
+        groups: ['Okta-SOC-Admins'],
+        tenant: 'okta-enterprise',
+      },
+      oktaPrivateKey,
+      { algorithm: 'RS256', expiresIn: '1h', header: { kid: oktaPublicJwk.kid } },
+    );
+
+    const response = await request(app)
+      .get('/secure')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(response.body.user).toMatchObject({
+      roles: ['ADMIN'],
+      tenant: 'okta-enterprise',
+      email: 'alice.okta@example.com',
+    });
+
+    expect(opaClient.evaluate).toHaveBeenCalledWith(
+      'intelgraph.abac.allow',
+      expect.objectContaining({
+        user: expect.objectContaining({
+          roles: ['ADMIN'],
+          tenant: 'okta-enterprise',
+        }),
+      }),
+    );
+  });
+
+  test('accepts Azure AD JWTs and derives tenant from tid claim', async () => {
+    const token = jwt.sign(
+      {
+        iss: azureIssuer,
+        aud: 'api://intelgraph',
+        sub: 'azure-user-456',
+        email: 'bob.azure@example.com',
+        name: 'Bob Azure',
+        groups: ['azure-intelgraph-analyst'],
+        tid: azureTenant,
+      },
+      azurePrivateKey,
+      { algorithm: 'RS256', expiresIn: '1h', header: { kid: azurePublicJwk.kid } },
+    );
+
+    const response = await request(app)
+      .get('/secure')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(response.body.user).toMatchObject({
+      roles: ['ANALYST'],
+      tenant: azureTenant,
+      email: 'bob.azure@example.com',
+    });
+
+    expect(opaClient.evaluate).toHaveBeenCalledWith(
+      'intelgraph.abac.allow',
+      expect.objectContaining({
+        user: expect.objectContaining({
+          roles: ['ANALYST'],
+          tenant: azureTenant,
+        }),
+      }),
+    );
+  });
+
+  test('rejects tokens from unknown issuers', async () => {
+    const token = jwt.sign(
+      {
+        iss: 'https://malicious.example.com',
+        aud: 'api://default',
+        sub: 'malicious-user',
+      },
+      oktaPrivateKey,
+      { algorithm: 'RS256', expiresIn: '1h', header: { kid: oktaPublicJwk.kid } },
+    );
+
+    await request(app)
+      .get('/secure')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(401);
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable external auth manager that validates Okta, Azure AD, and generic OIDC JWTs with JWKS caching
- update express middleware to hydrate OPA/RBAC context from external identities and expose new provider configuration in secrets and Helm values
- add end-to-end coverage that exercises Okta and Azure AD JWT flows against the authorization middleware

## Testing
- npm test -- auth.providers *(fails: jest binary is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b327dc0c8333b2bb3b679567b45b