### PR TITLE
feat: add customizable dashboards

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -56,6 +56,8 @@
     "lodash": "^4.17.21",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-dnd": "^16.0.1",
+    "react-dnd-html5-backend": "^16.0.1",
     "react-grid-layout": "^1.5.2",
     "react-hook-form": "^7.62.0",
     "react-leaflet": "^5.0.0",

--- a/client/src/features/maestro/components/DashboardBuilder.stories.tsx
+++ b/client/src/features/maestro/components/DashboardBuilder.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MockedProvider } from '@apollo/client/testing';
+import { Provider } from 'react-redux';
+import store from '../../../store/index';
+import DashboardBuilder from './DashboardBuilder';
+import {
+  DASHBOARD_CONFIGURATION_QUERY,
+  SAVE_DASHBOARD_CONFIGURATION_MUTATION,
+} from '../graphql/dashboardOperations';
+
+const mocks = [
+  {
+    request: {
+      query: DASHBOARD_CONFIGURATION_QUERY,
+      variables: {},
+    },
+    result: {
+      data: {
+        dashboardConfiguration: null,
+      },
+    },
+  },
+  {
+    request: {
+      query: SAVE_DASHBOARD_CONFIGURATION_MUTATION,
+      variables: {
+        input: {
+          id: null,
+          name: 'Command Center Dashboard',
+          layout: 'grid',
+          widgets: [],
+          settings: { version: 1 },
+        },
+      },
+    },
+    result: {
+      data: {
+        saveDashboardConfiguration: {
+          id: 'story-dashboard',
+          name: 'Command Center Dashboard',
+          description: null,
+          layout: 'grid',
+          settings: { version: 1 },
+          updatedAt: new Date().toISOString(),
+          widgets: [],
+        },
+      },
+    },
+  },
+];
+
+const meta: Meta<typeof DashboardBuilder> = {
+  title: 'Features/Maestro/DashboardBuilder',
+  component: DashboardBuilder,
+  decorators: [
+    (Story) => (
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <Provider store={store}>
+          <div style={{ padding: 24, background: '#020617', minHeight: '100vh' }}>
+            <Story />
+          </div>
+        </Provider>
+      </MockedProvider>
+    ),
+  ],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DashboardBuilder>;
+
+export const Default: Story = {};

--- a/client/src/features/maestro/components/DashboardBuilder.tsx
+++ b/client/src/features/maestro/components/DashboardBuilder.tsx
@@ -1,0 +1,599 @@
+import React from 'react';
+import { useQuery, useMutation } from '@apollo/client';
+import { DndProvider, useDrag, useDrop } from 'react-dnd';
+import { HTML5Backend } from 'react-dnd-html5-backend';
+import {
+  addWidget,
+  initializeDashboard,
+  markSaved,
+  moveWidget as moveWidgetAction,
+  removeWidget,
+  setLayout,
+  setName,
+  type DashboardWidget,
+  type DashboardWidgetPosition,
+} from '../../../store/slices/dashboard';
+import { useAppDispatch, useAppSelector } from '../../../store/index';
+import StatsOverview from '../../../components/dashboard/StatsOverview';
+import LatencyPanels from '../../../components/dashboard/LatencyPanels';
+import ErrorPanels from '../../../components/dashboard/ErrorPanels';
+import ResolverTop5 from '../../../components/dashboard/ResolverTop5';
+import LiveActivityFeed from '../../../components/dashboard/LiveActivityFeed';
+import GrafanaLinkCard from '../../../components/dashboard/GrafanaLinkCard';
+import {
+  DASHBOARD_CONFIGURATION_QUERY,
+  SAVE_DASHBOARD_CONFIGURATION_MUTATION,
+  mapDashboardResponseToState,
+  mapStateWidgetToInput,
+  type MaestroDashboardConfigurationQuery,
+  type MaestroDashboardConfigurationQueryVariables,
+  type SaveDashboardConfigurationMutation,
+  type SaveDashboardConfigurationMutationVariables,
+  type SaveDashboardConfigurationInput,
+} from '../graphql/dashboardOperations';
+
+type PaletteItem = {
+  type: string;
+  title: string;
+  description: string;
+  icon: string;
+  defaults?: Partial<DashboardWidget>;
+};
+
+const AVAILABLE_WIDGETS: PaletteItem[] = [
+  {
+    type: 'graph-summary',
+    title: 'Graph Summary',
+    description: 'Key metrics for the current knowledge graph.',
+    icon: '📈',
+    defaults: { refreshInterval: 60 },
+  },
+  {
+    type: 'query-results',
+    title: 'Query Results',
+    description: 'Showcase curated investigations or saved queries.',
+    icon: '🧮',
+    defaults: {
+      config: {
+        rows: [
+          { label: 'High-Risk Entities', value: 5 },
+          { label: 'Pending Reviews', value: 12 },
+        ],
+      },
+    },
+  },
+  {
+    type: 'ml-insight',
+    title: 'ML Insights',
+    description: 'Surface predicted hotspots and anomaly warnings.',
+    icon: '🤖',
+    defaults: {
+      config: {
+        insights: [
+          {
+            title: 'Supply Chain Weak Signal',
+            confidence: 0.82,
+            summary: 'Supplier “Northwind Advanced” trending towards SLA breach.',
+          },
+        ],
+      },
+    },
+  },
+  {
+    type: 'latency',
+    title: 'Latency Trends',
+    description: 'Track p95 latency across orchestrations.',
+    icon: '⏱️',
+  },
+  {
+    type: 'error-budget',
+    title: 'Error Budgets',
+    description: 'Monitor burn rate and failure classes in real time.',
+    icon: '🔥',
+  },
+];
+
+const DEFAULT_WIDGETS: DashboardWidget[] = [
+  {
+    id: 'default-graph-summary',
+    type: 'graph-summary',
+    title: 'Graph Summary',
+    position: { x: 0, y: 0, w: 4, h: 4 },
+    config: null,
+    dataSource: null,
+    refreshInterval: 60,
+  },
+  {
+    id: 'default-query-results',
+    type: 'query-results',
+    title: 'Latest Queries',
+    position: { x: 0, y: 4, w: 4, h: 4 },
+    config: {
+      rows: [
+        { label: 'Policies requiring attention', value: 3 },
+        { label: 'Pending enrichment jobs', value: 5 },
+      ],
+    },
+    dataSource: null,
+    refreshInterval: null,
+  },
+  {
+    id: 'default-ml-insight',
+    type: 'ml-insight',
+    title: 'Predictive Insights',
+    position: { x: 0, y: 8, w: 4, h: 4 },
+    config: {
+      insights: [
+        {
+          title: 'Anomaly cluster detected',
+          confidence: 0.76,
+          summary: 'Emerging cluster in executive comms requires review.',
+        },
+      ],
+    },
+    dataSource: null,
+    refreshInterval: 120,
+  },
+];
+
+type DraggedWidget = { id: string; index: number };
+type PaletteDragItem = { widgetType: string };
+
+function createWidgetFromPalette(item: PaletteItem): Omit<DashboardWidget, 'id' | 'position'> {
+  const shared: Omit<DashboardWidget, 'id' | 'position'> = {
+    type: item.type,
+    title: item.title,
+    config: (item.defaults?.config ?? null) as Record<string, unknown> | null,
+    dataSource: item.defaults?.dataSource ?? null,
+    refreshInterval: item.defaults?.refreshInterval ?? null,
+  };
+
+  switch (item.type) {
+    case 'graph-summary':
+      return shared;
+    case 'query-results':
+      return {
+        ...shared,
+        config:
+          shared.config ?? {
+            rows: [
+              { label: 'Investigations Completed', value: 18 },
+              { label: 'SSE Alerts Open', value: 4 },
+            ],
+          },
+      };
+    case 'ml-insight':
+      return {
+        ...shared,
+        config:
+          shared.config ?? {
+            insights: [
+              {
+                title: 'Model drift warning',
+                confidence: 0.71,
+                summary: 'Embedding divergence detected for analyst classifier.',
+              },
+            ],
+          },
+      };
+    case 'latency':
+      return { ...shared, title: 'Latency Performance' };
+    case 'error-budget':
+      return { ...shared, title: 'Error Budget Health' };
+    default:
+      return shared;
+  }
+}
+
+function WidgetPalette({ onAdd }: { onAdd: (type: string) => void }) {
+  return (
+    <div className="rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4" aria-label="Widget palette">
+      <h2 className="text-sm font-semibold text-slate-200">Available widgets</h2>
+      <p className="mt-1 text-xs text-slate-500">Drag to the canvas or click to add.</p>
+      <ul className="mt-4 space-y-3">
+        {AVAILABLE_WIDGETS.map((widget) => (
+          <PaletteWidget key={widget.type} item={widget} onAdd={onAdd} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function PaletteWidget({ item, onAdd }: { item: PaletteItem; onAdd: (type: string) => void }) {
+  const [{ isDragging }, drag] = useDrag(() => ({
+    type: 'palette-widget',
+    item: { widgetType: item.type } satisfies PaletteDragItem,
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+  }));
+
+  return (
+    <li
+      ref={drag}
+      data-testid={`palette-item-${item.type}`}
+      onClick={() => onAdd(item.type)}
+      className={`cursor-move rounded-xl border border-slate-800 bg-slate-900/80 p-3 transition hover:border-emerald-500 hover:shadow-lg ${
+        isDragging ? 'opacity-50' : ''
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <span className="text-xl" aria-hidden>
+          {item.icon}
+        </span>
+        <div>
+          <p className="text-sm font-semibold text-slate-100">{item.title}</p>
+          <p className="mt-1 text-xs text-slate-400">{item.description}</p>
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function DashboardCanvas({
+  children,
+  onAddWidget,
+}: {
+  children: React.ReactNode;
+  onAddWidget: (type: string) => void;
+}) {
+  const [{ isOver, canDrop }, drop] = useDrop(() => ({
+    accept: 'palette-widget',
+    drop: (item: PaletteDragItem) => {
+      onAddWidget(item.widgetType);
+    },
+    collect: (monitor) => ({ isOver: monitor.isOver(), canDrop: monitor.canDrop() }),
+  }));
+
+  return (
+    <div
+      ref={drop}
+      data-testid="dashboard-canvas"
+      className={`min-h-[360px] rounded-2xl border border-dashed border-slate-800 bg-slate-950/40 p-4 transition ${
+        isOver && canDrop ? 'border-emerald-400 bg-emerald-950/20' : ''
+      }`}
+      aria-label="Dashboard canvas"
+    >
+      {children}
+    </div>
+  );
+}
+
+function DashboardWidgetCard({
+  widget,
+  index,
+  onMove,
+  onRemove,
+}: {
+  widget: DashboardWidget;
+  index: number;
+  onMove: (from: number, to: number) => void;
+  onRemove: (id: string) => void;
+}) {
+  const ref = React.useRef<HTMLDivElement | null>(null);
+
+  const [, drop] = useDrop<DraggedWidget>({
+    accept: 'dashboard-widget',
+    hover(item, monitor) {
+      if (!ref.current) return;
+      if (item.index === index) return;
+      const bounding = ref.current.getBoundingClientRect();
+      const hoverMiddleY = (bounding.bottom - bounding.top) / 2;
+      const clientOffset = monitor.getClientOffset();
+      if (!clientOffset) return;
+      const hoverClientY = clientOffset.y - bounding.top;
+      if (item.index < index && hoverClientY < hoverMiddleY) return;
+      if (item.index > index && hoverClientY > hoverMiddleY) return;
+      onMove(item.index, index);
+      item.index = index;
+    },
+  });
+
+  const [{ isDragging }, drag] = useDrag(() => ({
+    type: 'dashboard-widget',
+    item: { id: widget.id, index } satisfies DraggedWidget,
+    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+  }));
+
+  drag(drop(ref));
+
+  return (
+    <div
+      ref={ref}
+      data-testid={`dashboard-widget-${widget.id}`}
+      className={`mb-3 rounded-2xl border border-slate-800 bg-slate-900/70 p-4 shadow-lg transition ${
+        isDragging ? 'opacity-40' : ''
+      }`}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-slate-100">{widget.title}</h3>
+        <button
+          type="button"
+          onClick={() => onRemove(widget.id)}
+          className="rounded-md border border-transparent px-2 py-1 text-xs text-slate-400 hover:border-rose-500 hover:text-rose-300"
+          aria-label={`Remove ${widget.title}`}
+        >
+          Remove
+        </button>
+      </div>
+      <div className="mt-3 text-sm text-slate-300">
+        <WidgetRenderer widget={widget} />
+      </div>
+    </div>
+  );
+}
+
+function QueryResultsWidget({ config }: { config?: Record<string, unknown> | null }) {
+  const rows = (config?.rows as Array<{ label: string; value: number }> | undefined) ?? [
+    { label: 'No data available', value: 0 },
+  ];
+
+  return (
+    <table className="w-full table-fixed" aria-label="Query results">
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.label} className="border-b border-slate-800/60 last:border-b-0">
+            <td className="py-1 text-slate-400">{row.label}</td>
+            <td className="py-1 text-right font-semibold text-emerald-300">{row.value}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+function MlInsightsWidget({ config }: { config?: Record<string, unknown> | null }) {
+  const insights = (config?.insights as Array<{ title: string; summary: string; confidence?: number }> | undefined) ?? [
+    { title: 'No ML insight available', summary: 'Connect data sources to unlock insights.' },
+  ];
+
+  return (
+    <ul className="space-y-2" aria-label="ML insights">
+      {insights.map((insight) => (
+        <li key={insight.title} className="rounded-xl border border-emerald-500/20 bg-emerald-500/5 p-3">
+          <p className="text-sm font-semibold text-emerald-200">{insight.title}</p>
+          <p className="mt-1 text-xs text-slate-300">{insight.summary}</p>
+          {typeof insight.confidence === 'number' ? (
+            <p className="mt-1 text-xs text-emerald-400">Confidence {(insight.confidence * 100).toFixed(0)}%</p>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function WidgetRenderer({ widget }: { widget: DashboardWidget }) {
+  switch (widget.type) {
+    case 'graph-summary':
+      return <StatsOverview />;
+    case 'query-results':
+      return <QueryResultsWidget config={widget.config} />;
+    case 'ml-insight':
+      return <MlInsightsWidget config={widget.config} />;
+    case 'latency':
+      return <LatencyPanels />;
+    case 'error-budget':
+      return <ErrorPanels />;
+    case 'resolver-top':
+      return <ResolverTop5 />;
+    case 'activity-feed':
+      return <LiveActivityFeed />;
+    case 'grafana-link':
+      return <GrafanaLinkCard />;
+    default:
+      return <p className="text-xs text-slate-500">Widget renderer not implemented.</p>;
+  }
+}
+
+export function DashboardBuilder({ dashboardId }: { dashboardId?: string | null }) {
+  const dispatch = useAppDispatch();
+  const widgets = useAppSelector((state) => state.dashboard.widgets);
+  const layout = useAppSelector((state) => state.dashboard.layout);
+  const name = useAppSelector((state) => state.dashboard.name);
+  const dirty = useAppSelector((state) => state.dashboard.dirty);
+  const persistedId = useAppSelector((state) => state.dashboard.persistedId);
+  const lastSavedAt = useAppSelector((state) => state.dashboard.lastSavedAt);
+
+  const hasInitialized = React.useRef(false);
+  const [feedback, setFeedback] = React.useState<string | null>(null);
+
+  const queryResult = useQuery<
+    MaestroDashboardConfigurationQuery,
+    MaestroDashboardConfigurationQueryVariables
+  >(DASHBOARD_CONFIGURATION_QUERY, {
+    variables: dashboardId ? { id: dashboardId } : {},
+    fetchPolicy: 'cache-first',
+  });
+
+  const [saveDashboard, saveState] = useMutation<
+    SaveDashboardConfigurationMutation,
+    SaveDashboardConfigurationMutationVariables
+  >(SAVE_DASHBOARD_CONFIGURATION_MUTATION);
+
+  React.useEffect(() => {
+    if (hasInitialized.current) return;
+    if (queryResult.loading) return;
+    if (queryResult.data?.dashboardConfiguration) {
+      dispatch(initializeDashboard(mapDashboardResponseToState(queryResult.data.dashboardConfiguration)));
+      hasInitialized.current = true;
+    } else if (!queryResult.loading && !queryResult.error) {
+      dispatch(
+        initializeDashboard({
+          id: dashboardId ?? null,
+          name: 'Command Center Dashboard',
+          description: 'Adaptive workspace with analyst context.',
+          layout: 'grid',
+          widgets: DEFAULT_WIDGETS,
+          settings: { version: 1 },
+          updatedAt: null,
+        }),
+      );
+      hasInitialized.current = true;
+    }
+  }, [dashboardId, dispatch, queryResult.data, queryResult.error, queryResult.loading]);
+
+  React.useEffect(() => {
+    if (!queryResult.error || hasInitialized.current) {
+      return;
+    }
+    dispatch(
+      initializeDashboard({
+        id: dashboardId ?? null,
+        name: 'Command Center Dashboard',
+        description: 'Adaptive workspace with analyst context.',
+        layout: 'grid',
+        widgets: DEFAULT_WIDGETS,
+        settings: { version: 1 },
+        updatedAt: null,
+      }),
+    );
+    hasInitialized.current = true;
+    setFeedback('Loaded default dashboard layout');
+  }, [dashboardId, dispatch, queryResult.error]);
+
+  const handleAddWidget = React.useCallback(
+    (type: string) => {
+      const palette = AVAILABLE_WIDGETS.find((item) => item.type === type);
+      const widgetDefaults = palette ? createWidgetFromPalette(palette) : { type, title: type };
+      dispatch(
+        addWidget({
+          ...widgetDefaults,
+          position: { w: 4, h: 4 },
+        }),
+      );
+    },
+    [dispatch],
+  );
+
+  const handleMoveWidget = React.useCallback(
+    (from: number, to: number) => {
+      dispatch(moveWidgetAction({ fromIndex: from, toIndex: to }));
+    },
+    [dispatch],
+  );
+
+  const handleRemoveWidget = React.useCallback(
+    (id: string) => {
+      dispatch(removeWidget(id));
+    },
+    [dispatch],
+  );
+
+  const handleSave = React.useCallback(async () => {
+    const payload: SaveDashboardConfigurationInput = {
+      id: persistedId ?? dashboardId ?? null,
+      name,
+      layout,
+      widgets: widgets.map(mapStateWidgetToInput),
+      settings: {
+        version: 1,
+        updatedAt: new Date().toISOString(),
+      },
+    };
+
+    const result = await saveDashboard({
+      variables: {
+        input: payload,
+      },
+    });
+
+    if (result.data?.saveDashboardConfiguration) {
+      dispatch(
+        markSaved({
+          id: result.data.saveDashboardConfiguration.id,
+          updatedAt: result.data.saveDashboardConfiguration.updatedAt,
+          settings: result.data.saveDashboardConfiguration.settings ?? null,
+        }),
+      );
+      setFeedback('Layout saved');
+      setTimeout(() => setFeedback(null), 2500);
+    }
+  }, [dashboardId, dispatch, layout, name, persistedId, saveDashboard, widgets]);
+
+  const handleNameChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    dispatch(setName(event.target.value));
+  };
+
+  const handleLayoutChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    dispatch(setLayout(event.target.value as 'grid' | 'freeform'));
+  };
+
+  const loading = queryResult.loading && !hasInitialized.current;
+
+  return (
+    <DndProvider backend={HTML5Backend}>
+      <div className="space-y-4" aria-busy={loading}>
+        <header className="flex flex-col gap-3 rounded-2xl border border-slate-800/60 bg-slate-950/60 p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex-1">
+            <label className="block text-xs font-semibold uppercase tracking-wide text-slate-400" htmlFor="dashboard-name">
+              Dashboard name
+            </label>
+            <input
+              id="dashboard-name"
+              data-testid="dashboard-name-input"
+              value={name}
+              onChange={handleNameChange}
+              className="mt-1 w-full rounded-xl border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+            />
+            <div className="mt-2 text-xs text-slate-500">
+              {dirty ? (
+                <span className="text-amber-400">Unsaved changes</span>
+              ) : lastSavedAt ? (
+                <span>Last saved {new Date(lastSavedAt).toLocaleTimeString()}</span>
+              ) : (
+                <span>Personalize your analyst workspace</span>
+              )}
+              {feedback ? <span className="ml-2 text-emerald-300">{feedback}</span> : null}
+            </div>
+          </div>
+          <div className="flex items-center gap-3">
+            <label className="text-xs text-slate-400" htmlFor="dashboard-layout">
+              Layout
+            </label>
+            <select
+              id="dashboard-layout"
+              value={layout}
+              onChange={handleLayoutChange}
+              className="rounded-lg border border-slate-700 bg-slate-900 px-2 py-1 text-xs text-slate-100 focus:border-emerald-500"
+            >
+              <option value="grid">Grid</option>
+              <option value="freeform">Freeform</option>
+            </select>
+            <button
+              type="button"
+              data-testid="dashboard-save"
+              onClick={handleSave}
+              disabled={!dirty || saveState.loading}
+              className={`rounded-lg px-3 py-1 text-xs font-semibold transition ${
+                dirty && !saveState.loading
+                  ? 'bg-emerald-500 text-slate-950 hover:bg-emerald-400'
+                  : 'bg-slate-800 text-slate-400'
+              }`}
+            >
+              {saveState.loading ? 'Saving…' : 'Save layout'}
+            </button>
+          </div>
+        </header>
+
+        <div className="grid gap-4 lg:grid-cols-[280px,1fr]">
+          <WidgetPalette onAdd={handleAddWidget} />
+          <DashboardCanvas onAddWidget={handleAddWidget}>
+            {widgets.length === 0 ? (
+              <p className="text-sm text-slate-400">Drag widgets from the palette to begin building.</p>
+            ) : (
+              widgets.map((widget, index) => (
+                <DashboardWidgetCard
+                  key={widget.id}
+                  widget={widget}
+                  index={index}
+                  onMove={handleMoveWidget}
+                  onRemove={handleRemoveWidget}
+                />
+              ))
+            )}
+          </DashboardCanvas>
+        </div>
+      </div>
+    </DndProvider>
+  );
+}
+
+export default DashboardBuilder;

--- a/client/src/features/maestro/graphql/dashboardOperations.ts
+++ b/client/src/features/maestro/graphql/dashboardOperations.ts
@@ -1,0 +1,153 @@
+import { gql } from '@apollo/client';
+import type {
+  DashboardInitializePayload,
+  DashboardWidget,
+  DashboardWidgetPosition,
+} from '../../../store/slices/dashboard';
+
+export interface DashboardWidgetGraphQL {
+  id: string;
+  type: string;
+  title: string;
+  position: DashboardWidgetPosition;
+  config?: Record<string, unknown> | null;
+  dataSource?: Record<string, unknown> | null;
+  refreshInterval?: number | null;
+}
+
+export interface DashboardConfigurationGraphQL {
+  id: string;
+  name: string;
+  description?: string | null;
+  layout: 'grid' | 'freeform';
+  settings?: Record<string, unknown> | null;
+  updatedAt: string;
+  widgets: DashboardWidgetGraphQL[];
+}
+
+export interface MaestroDashboardConfigurationQuery {
+  dashboardConfiguration: DashboardConfigurationGraphQL | null;
+}
+
+export interface MaestroDashboardConfigurationQueryVariables {
+  id?: string | null;
+}
+
+export interface SaveDashboardWidgetInput {
+  id?: string | null;
+  type: string;
+  title: string;
+  position: DashboardWidgetPosition;
+  config?: Record<string, unknown> | null;
+  dataSource?: Record<string, unknown> | null;
+  refreshInterval?: number | null;
+}
+
+export interface SaveDashboardConfigurationInput {
+  id?: string | null;
+  name: string;
+  description?: string | null;
+  layout: 'grid' | 'freeform';
+  settings?: Record<string, unknown> | null;
+  widgets: SaveDashboardWidgetInput[];
+}
+
+export interface SaveDashboardConfigurationMutation {
+  saveDashboardConfiguration: DashboardConfigurationGraphQL;
+}
+
+export interface SaveDashboardConfigurationMutationVariables {
+  input: SaveDashboardConfigurationInput;
+}
+
+export const DASHBOARD_CONFIGURATION_QUERY = gql`
+  query MaestroDashboardConfiguration($id: ID) {
+    dashboardConfiguration(id: $id) {
+      id
+      name
+      description
+      layout
+      settings
+      updatedAt
+      widgets {
+        id
+        type
+        title
+        position {
+          x
+          y
+          w
+          h
+        }
+        config
+        dataSource
+        refreshInterval
+      }
+    }
+  }
+`;
+
+export const SAVE_DASHBOARD_CONFIGURATION_MUTATION = gql`
+  mutation SaveDashboardConfiguration($input: SaveDashboardConfigurationInput!) {
+    saveDashboardConfiguration(input: $input) {
+      id
+      name
+      description
+      layout
+      settings
+      updatedAt
+      widgets {
+        id
+        type
+        title
+        position {
+          x
+          y
+          w
+          h
+        }
+        config
+        dataSource
+        refreshInterval
+      }
+    }
+  }
+`;
+
+export function mapGraphQLWidgetToState(widget: DashboardWidgetGraphQL): DashboardWidget {
+  return {
+    id: widget.id,
+    type: widget.type,
+    title: widget.title,
+    position: widget.position,
+    config: widget.config ?? null,
+    dataSource: widget.dataSource ?? null,
+    refreshInterval: widget.refreshInterval ?? null,
+  };
+}
+
+export function mapDashboardResponseToState(
+  config: DashboardConfigurationGraphQL,
+): DashboardInitializePayload {
+  return {
+    id: config.id,
+    name: config.name,
+    description: config.description ?? null,
+    layout: config.layout,
+    widgets: config.widgets.map(mapGraphQLWidgetToState),
+    settings: config.settings ?? null,
+    updatedAt: config.updatedAt,
+  };
+}
+
+export function mapStateWidgetToInput(widget: DashboardWidget): SaveDashboardWidgetInput {
+  return {
+    id: widget.id,
+    type: widget.type,
+    title: widget.title,
+    position: widget.position,
+    config: widget.config ?? null,
+    dataSource: widget.dataSource ?? null,
+    refreshInterval: widget.refreshInterval ?? null,
+  };
+}

--- a/client/src/features/maestro/pages/Dashboard.tsx
+++ b/client/src/features/maestro/pages/Dashboard.tsx
@@ -1,124 +1,17 @@
 import React from 'react';
-import { pipelineRecords, policyDenials, queueDepthHistory, sloSnapshots } from '../mockData';
-
-function StatCard({ label, value, helper }: { label: string; value: string; helper: string }) {
-  return (
-    <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 shadow-lg">
-      <p className="text-sm uppercase tracking-wide text-slate-400">{label}</p>
-      <p className="mt-2 text-2xl font-semibold text-white">{value}</p>
-      <p className="mt-1 text-xs text-slate-400">{helper}</p>
-    </div>
-  );
-}
-
-function QueueDepthChart() {
-  return (
-    <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
-      <div className="flex items-center justify-between">
-        <p className="text-sm font-semibold text-slate-200">Queue Depth (last 12h)</p>
-        <span className="text-xs text-slate-400">p95 target: 12</span>
-      </div>
-      <div className="mt-4 flex items-end gap-1">
-        {queueDepthHistory.map((point) => (
-          <div
-            key={point.hour}
-            className="flex-1 rounded-t-lg bg-emerald-500/70"
-            style={{ height: `${point.depth * 4}px` }}
-            aria-label={`Hour ${point.hour}, depth ${point.depth}`}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-function PolicyDenialsCard() {
-  return (
-    <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
-      <p className="text-sm font-semibold text-slate-200">Policy Denials</p>
-      <ul className="mt-3 space-y-3 text-sm text-slate-300">
-        {policyDenials.map((denial) => (
-          <li key={denial.id} className="rounded-xl border border-slate-800/60 bg-slate-950/60 p-3">
-            <p className="font-semibold text-emerald-300">{denial.tenant}</p>
-            <p className="mt-1 text-slate-100">{denial.reason}</p>
-            <p className="mt-1 text-xs text-slate-500">{new Date(denial.occurredAt).toLocaleTimeString()}</p>
-          </li>
-        ))}
-      </ul>
-    </div>
-  );
-}
-
-function SloWidget() {
-  return (
-    <div className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4">
-      <p className="text-sm font-semibold text-slate-200">SLO Summary</p>
-      <table className="mt-3 w-full text-sm text-slate-300">
-        <thead className="text-xs uppercase text-slate-500">
-          <tr>
-            <th className="py-2 text-left">Service</th>
-            <th className="text-left">p95</th>
-            <th className="text-left">Error</th>
-            <th className="text-left">Saturation</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sloSnapshots.map((snapshot) => (
-            <tr key={snapshot.service} className="border-t border-slate-800/70">
-              <td className="py-2 text-slate-200">{snapshot.service}</td>
-              <td>{snapshot.latencyP95Ms}ms</td>
-              <td>{(snapshot.errorRate * 100).toFixed(2)}%</td>
-              <td>{(snapshot.saturation * 100).toFixed(1)}%</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      <a
-        href="/runs/run-1?filter=slo"
-        className="mt-3 inline-flex items-center text-xs font-semibold text-emerald-400 hover:text-emerald-300"
-      >
-        View impacted runs →
-      </a>
-    </div>
-  );
-}
+import DashboardBuilder from '../components/DashboardBuilder';
 
 export function DashboardPage() {
-  const totalPipelines = pipelineRecords.length;
-  const healthy = pipelineRecords.filter((pipeline) => pipeline.status === 'healthy').length;
-  const degraded = pipelineRecords.filter((pipeline) => pipeline.status === 'degraded').length;
-
-  const longestLeadTime = pipelineRecords.reduce((max, pipeline) => Math.max(max, pipeline.leadTimeMinutes), 0);
-  const averageChangeFailure =
-    pipelineRecords.reduce((total, pipeline) => total + pipeline.dora.changeFailureRate, 0) / totalPipelines;
-
   return (
     <div className="space-y-6">
-      <header>
-        <h1 className="text-2xl font-semibold text-white">Dashboard</h1>
-        <p className="mt-1 text-sm text-slate-400">p95 load &lt; 1.5s with 2k pipelines — this view hydrates from cached telemetry.</p>
-      </header>
-      <section className="grid gap-4 md:grid-cols-4">
-        <StatCard label="Pipelines" value={`${totalPipelines}`} helper="Total managed pipelines" />
-        <StatCard label="Healthy" value={`${healthy}`} helper="Passing policy + SLO" />
-        <StatCard label="Degraded" value={`${degraded}`} helper="Requires triage" />
-        <StatCard label="Longest critical path" value={`${longestLeadTime}m`} helper="Lead time to prod" />
-      </section>
-      <section className="grid gap-4 xl:grid-cols-[2fr,1fr]">
-        <QueueDepthChart />
-        <div className="space-y-4">
-          <PolicyDenialsCard />
-          <SloWidget />
-        </div>
-      </section>
-      <section className="rounded-2xl border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-300">
-        <h2 className="text-lg font-semibold text-slate-100">Change risk</h2>
-        <p className="mt-2">
-          Average change failure rate:{' '}
-          <span className="font-semibold text-emerald-300">{averageChangeFailure.toFixed(1)}%</span>. Auto retry reasons and
-          policy denials stream into this widget every 30 seconds via SSE.
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-white">Custom Maestro Dashboard</h1>
+        <p className="max-w-3xl text-sm text-slate-400">
+          Compose the widgets your operators rely on—drag intelligence summaries, live query feeds, and ML insights into a
+          layout tailored to your mission. Layouts persist to Maestro&apos;s control plane for every authenticated analyst.
         </p>
-      </section>
+      </header>
+      <DashboardBuilder />
     </div>
   );
 }

--- a/client/src/graphql/dashboard.graphql
+++ b/client/src/graphql/dashboard.graphql
@@ -25,3 +25,53 @@ query DB_Investigations {
     edgeCount
   }
 }
+
+query MaestroDashboardConfiguration($id: ID) {
+  dashboardConfiguration(id: $id) {
+    id
+    name
+    description
+    layout
+    settings
+    updatedAt
+    widgets {
+      id
+      type
+      title
+      position {
+        x
+        y
+        w
+        h
+      }
+      config
+      dataSource
+      refreshInterval
+    }
+  }
+}
+
+mutation SaveDashboardConfiguration($input: SaveDashboardConfigurationInput!) {
+  saveDashboardConfiguration(input: $input) {
+    id
+    name
+    description
+    layout
+    settings
+    updatedAt
+    widgets {
+      id
+      type
+      title
+      position {
+        x
+        y
+        w
+        h
+      }
+      config
+      dataSource
+      refreshInterval
+    }
+  }
+}

--- a/client/src/pages/Dashboard/index.tsx
+++ b/client/src/pages/Dashboard/index.tsx
@@ -1,15 +1,8 @@
 import React from 'react';
 import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
-import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import StatsOverview from '../../components/dashboard/StatsOverview';
-import LatencyPanels from '../../components/dashboard/LatencyPanels';
-import ErrorPanels from '../../components/dashboard/ErrorPanels';
-import ResolverTop5 from '../../components/dashboard/ResolverTop5';
-import GrafanaLinkCard from '../../components/dashboard/GrafanaLinkCard';
-import LiveActivityFeed from '../../components/dashboard/LiveActivityFeed';
 import { useDashboardPrefetch, useIntelligentPrefetch } from '../../hooks/usePrefetch';
+import DashboardBuilder from '../../features/maestro/components/DashboardBuilder';
 
 export default function Dashboard() {
   // Prefetch critical dashboard data to eliminate panel pop-in
@@ -18,40 +11,16 @@ export default function Dashboard() {
 
   return (
     <Box p={2} aria-live="polite">
-      <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
-          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
-            <Typography variant="h6" gutterBottom>
-              Stats Overview
-            </Typography>
-            <StatsOverview />
-          </Paper>
-        </Grid>
-        <Grid item xs={12} md={6}>
-          <LiveActivityFeed />
-        </Grid>
-        <Grid item xs={12} md={4}>
-          <GrafanaLinkCard />
-        </Grid>
-
-        <Grid item xs={12}>
-          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
-            <LatencyPanels />
-          </Paper>
-        </Grid>
-
-        <Grid item xs={12}>
-          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
-            <ErrorPanels />
-          </Paper>
-        </Grid>
-
-        <Grid item xs={12}>
-          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
-            <ResolverTop5 />
-          </Paper>
-        </Grid>
-      </Grid>
+      <Box mb={3}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Adaptive Intelligence Dashboard
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Drag cards from the palette to curate the view your mission needs. Changes are saved to the Maestro control plane via
+          GraphQL so every analyst logs in to a workspace that matches their role.
+        </Typography>
+      </Box>
+      <DashboardBuilder />
     </Box>
   );
 }

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,9 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import ui from './slices/ui';
+import dashboard from './slices/dashboard';
 
 const store = configureStore({
-  reducer: { ui },
+  reducer: { ui, dashboard },
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/client/src/store/slices/dashboard.ts
+++ b/client/src/store/slices/dashboard.ts
@@ -1,0 +1,187 @@
+import { createSlice, nanoid, PayloadAction } from '@reduxjs/toolkit';
+
+export type DashboardLayout = 'grid' | 'freeform';
+
+export interface DashboardWidgetPosition {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface DashboardWidget {
+  id: string;
+  type: string;
+  title: string;
+  config?: Record<string, unknown> | null;
+  dataSource?: Record<string, unknown> | null;
+  position: DashboardWidgetPosition;
+  refreshInterval?: number | null;
+}
+
+export interface DashboardInitializePayload {
+  id?: string | null;
+  name: string;
+  description?: string | null;
+  layout: DashboardLayout;
+  widgets: DashboardWidget[];
+  settings?: Record<string, unknown> | null;
+  updatedAt?: string | null;
+}
+
+export interface DashboardState {
+  persistedId: string | null;
+  name: string;
+  description: string | null;
+  layout: DashboardLayout;
+  widgets: DashboardWidget[];
+  dirty: boolean;
+  lastSavedAt: string | null;
+  settings: Record<string, unknown> | null;
+}
+
+const initialState: DashboardState = {
+  persistedId: null,
+  name: 'Command Center Dashboard',
+  description: null,
+  layout: 'grid',
+  widgets: [],
+  dirty: false,
+  lastSavedAt: null,
+  settings: null,
+};
+
+function reindexWidgets(state: DashboardState) {
+  state.widgets.forEach((widget, index) => {
+    widget.position = {
+      ...widget.position,
+      x: 0,
+      y: index * Math.max(1, widget.position.h),
+    };
+  });
+}
+
+const dashboardSlice = createSlice({
+  name: 'dashboard',
+  initialState,
+  reducers: {
+    initializeDashboard(state, action: PayloadAction<DashboardInitializePayload>) {
+      const { id, name, description, layout, widgets, settings, updatedAt } = action.payload;
+      state.persistedId = id ?? null;
+      state.name = name;
+      state.description = description ?? null;
+      state.layout = layout;
+      state.widgets = widgets.map((widget, index) => ({
+        ...widget,
+        position: {
+          ...widget.position,
+          x: 0,
+          y: index * Math.max(1, widget.position.h),
+        },
+      }));
+      state.settings = settings ?? null;
+      state.lastSavedAt = updatedAt ?? null;
+      state.dirty = false;
+    },
+    addWidget(
+      state,
+      action: PayloadAction<
+        Omit<DashboardWidget, 'id' | 'position'> & { id?: string; position?: Partial<DashboardWidgetPosition> }
+      >,
+    ) {
+      const { id, position, ...rest } = action.payload;
+      const widget: DashboardWidget = {
+        id: id ?? nanoid(),
+        position: {
+          x: 0,
+          y: state.widgets.length * 4,
+          w: position?.w ?? 4,
+          h: position?.h ?? 4,
+        },
+        ...rest,
+      };
+      state.widgets.push(widget);
+      reindexWidgets(state);
+      state.dirty = true;
+    },
+    removeWidget(state, action: PayloadAction<string>) {
+      state.widgets = state.widgets.filter((widget) => widget.id !== action.payload);
+      reindexWidgets(state);
+      state.dirty = true;
+    },
+    moveWidget(state, action: PayloadAction<{ fromIndex: number; toIndex: number }>) {
+      const { fromIndex, toIndex } = action.payload;
+      if (fromIndex === toIndex || fromIndex < 0 || toIndex < 0) {
+        return;
+      }
+      const [moved] = state.widgets.splice(fromIndex, 1);
+      if (!moved) {
+        return;
+      }
+      state.widgets.splice(toIndex, 0, moved);
+      reindexWidgets(state);
+      state.dirty = true;
+    },
+    updateWidget(state, action: PayloadAction<{ id: string; changes: Partial<DashboardWidget> }>) {
+      const widget = state.widgets.find((item) => item.id === action.payload.id);
+      if (!widget) {
+        return;
+      }
+      Object.assign(widget, action.payload.changes);
+      if (action.payload.changes.position) {
+        widget.position = {
+          ...widget.position,
+          ...action.payload.changes.position,
+        } as DashboardWidgetPosition;
+      }
+      state.dirty = true;
+    },
+    setLayout(state, action: PayloadAction<DashboardLayout>) {
+      state.layout = action.payload;
+      state.dirty = true;
+    },
+    setName(state, action: PayloadAction<string>) {
+      state.name = action.payload;
+      state.dirty = true;
+    },
+    setDescription(state, action: PayloadAction<string | null>) {
+      state.description = action.payload;
+      state.dirty = true;
+    },
+    markSaved(
+      state,
+      action: PayloadAction<{ id: string; updatedAt: string; settings?: Record<string, unknown> | null }>,
+    ) {
+      state.persistedId = action.payload.id;
+      state.lastSavedAt = action.payload.updatedAt;
+      if (typeof action.payload.settings !== 'undefined') {
+        state.settings = action.payload.settings;
+      }
+      state.dirty = false;
+    },
+    resetDashboard(state) {
+      state.persistedId = null;
+      state.widgets = [];
+      state.layout = 'grid';
+      state.description = null;
+      state.lastSavedAt = null;
+      state.settings = null;
+      state.dirty = false;
+    },
+  },
+});
+
+export const {
+  initializeDashboard,
+  addWidget,
+  removeWidget,
+  moveWidget,
+  updateWidget,
+  setLayout,
+  setName,
+  setDescription,
+  markSaved,
+  resetDashboard,
+} = dashboardSlice.actions;
+
+export default dashboardSlice.reducer;

--- a/client/tests/e2e/dashboard-customization.spec.ts
+++ b/client/tests/e2e/dashboard-customization.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Custom dashboard builder', () => {
+  test('allows adding latency widget and persists layout', async ({ page }) => {
+    const mutationPayloads: any[] = [];
+
+    await page.route('**/graphql**', async (route, request) => {
+      const respond = (data: unknown) =>
+        route.fulfill({
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ data }),
+        });
+
+      const url = new URL(request.url());
+      const operationName = url.searchParams.get('operationName');
+
+      if (request.method() === 'GET' && operationName === 'MaestroDashboardConfiguration') {
+        return respond({ dashboardConfiguration: null });
+      }
+
+      if (request.method() === 'GET' && operationName === 'SaveDashboardConfiguration') {
+        return respond({
+          saveDashboardConfiguration: {
+            id: 'persisted-dashboard',
+            name: 'Adaptive Intelligence Dashboard',
+            description: null,
+            layout: 'grid',
+            settings: { version: 1 },
+            updatedAt: new Date().toISOString(),
+            widgets: [],
+          },
+        });
+      }
+
+      if (request.method() === 'POST') {
+        try {
+          const payload = request.postDataJSON();
+          if (payload?.operationName === 'MaestroDashboardConfiguration') {
+            return respond({ dashboardConfiguration: null });
+          }
+          if (payload?.operationName === 'SaveDashboardConfiguration') {
+            mutationPayloads.push(payload.variables.input);
+            return respond({
+              saveDashboardConfiguration: {
+                id: 'persisted-dashboard',
+                name: payload.variables.input.name,
+                description: payload.variables.input.description ?? null,
+                layout: payload.variables.input.layout,
+                settings: payload.variables.input.settings ?? {},
+                updatedAt: new Date().toISOString(),
+                widgets: payload.variables.input.widgets.map((widget: any, index: number) => ({
+                  ...widget,
+                  id: widget.id ?? `widget-${index}`,
+                })),
+              },
+            });
+          }
+        } catch (error) {
+          // Fall through to network if the payload isn't JSON
+        }
+      }
+
+      return route.continue();
+    });
+
+    await page.goto('/dashboard');
+
+    await expect(page.getByTestId('dashboard-name-input')).toBeVisible();
+
+    const paletteItem = page.getByTestId('palette-item-latency');
+    await expect(paletteItem).toBeVisible();
+    await paletteItem.dragTo(page.getByTestId('dashboard-canvas'));
+
+    await expect(page.getByText(/p95 Latency/)).toBeVisible();
+
+    await page.getByTestId('dashboard-save').click();
+
+    await expect.poll(() => mutationPayloads.length).toBeGreaterThan(0);
+    const saved = mutationPayloads.pop();
+    expect(saved.widgets.some((widget: any) => widget.type === 'latency')).toBeTruthy();
+  });
+});

--- a/server/src/db/repositories/dashboardConfigs.ts
+++ b/server/src/db/repositories/dashboardConfigs.ts
@@ -1,0 +1,221 @@
+import { randomUUID } from 'crypto';
+import type { PoolClient } from 'pg';
+import { getPostgresPool } from '../../db/postgres.js';
+import logger from '../../config/logger.js';
+
+const log = logger.child({ name: 'dashboard-repository' });
+
+export interface DashboardWidgetRecord {
+  id: string;
+  type: string;
+  title: string;
+  position: { x: number; y: number; w: number; h: number };
+  config: Record<string, unknown> | null;
+  dataSource: Record<string, unknown> | null;
+  refreshInterval: number | null;
+}
+
+export interface DashboardConfigurationRecord {
+  id: string;
+  name: string;
+  description: string | null;
+  layout: string;
+  settings: Record<string, unknown> | null;
+  updatedAt: Date;
+  widgets: DashboardWidgetRecord[];
+}
+
+export interface SaveDashboardWidget {
+  id?: string | null;
+  type: string;
+  title: string;
+  position: { x: number; y: number; w: number; h: number };
+  config?: Record<string, unknown> | null;
+  dataSource?: Record<string, unknown> | null;
+  refreshInterval?: number | null;
+}
+
+export interface SaveDashboardConfiguration {
+  id?: string | null;
+  userId: string;
+  name: string;
+  description?: string | null;
+  layout: string;
+  settings?: Record<string, unknown> | null;
+  widgets: SaveDashboardWidget[];
+}
+
+const pool = getPostgresPool();
+
+function isUuid(value: string | null | undefined): value is string {
+  if (!value) return false;
+  return /^[0-9a-fA-F-]{36}$/.test(value);
+}
+
+async function mapDashboardRow(
+  row: any,
+  client: PoolClient | null,
+): Promise<DashboardConfigurationRecord | null> {
+  if (!row) return null;
+  const executor = client ?? pool;
+  const widgetResult = await executor.query(
+    `SELECT id, type, title, config, data_source, position, refresh_interval
+     FROM dashboard_widgets
+     WHERE dashboard_id = $1
+     ORDER BY (position->>'y')::int ASC, (position->>'x')::int ASC`,
+    [row.id],
+  );
+
+  const widgets: DashboardWidgetRecord[] = widgetResult.rows.map((widget: any) => ({
+    id: widget.id,
+    type: widget.type,
+    title: widget.title,
+    position:
+      typeof widget.position === 'string'
+        ? JSON.parse(widget.position)
+        : widget.position ?? { x: 0, y: 0, w: 4, h: 4 },
+    config:
+      typeof widget.config === 'string'
+        ? (JSON.parse(widget.config) as Record<string, unknown>)
+        : widget.config ?? null,
+    dataSource:
+      typeof widget.data_source === 'string'
+        ? (JSON.parse(widget.data_source) as Record<string, unknown>)
+        : widget.data_source ?? null,
+    refreshInterval: widget.refresh_interval ?? null,
+  }));
+
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? null,
+    layout: row.layout,
+    settings:
+      typeof row.settings === 'string'
+        ? (JSON.parse(row.settings) as Record<string, unknown>)
+        : row.settings ?? null,
+    updatedAt: row.updated_at,
+    widgets,
+  };
+}
+
+export async function fetchDashboardConfiguration(
+  options: { id?: string | null; userId: string },
+): Promise<DashboardConfigurationRecord | null> {
+  const { id, userId } = options;
+  if (id && !isUuid(id)) {
+    log.warn({ id }, 'Ignoring non-uuid dashboard id');
+  }
+
+  if (id && isUuid(id)) {
+    const result = await pool.query(
+      `SELECT id, name, description, layout, settings, updated_at
+       FROM dashboards
+       WHERE id = $1 AND (created_by = $2 OR is_public IS TRUE)
+       LIMIT 1`,
+      [id, userId],
+    );
+    if (result.rowCount === 0) {
+      return null;
+    }
+    return await mapDashboardRow(result.rows[0], null);
+  }
+
+  const latest = await pool.query(
+    `SELECT id, name, description, layout, settings, updated_at
+     FROM dashboards
+     WHERE created_by = $1
+     ORDER BY updated_at DESC
+     LIMIT 1`,
+    [userId],
+  );
+
+  if (latest.rowCount === 0) {
+    return null;
+  }
+
+  return await mapDashboardRow(latest.rows[0], null);
+}
+
+export async function saveDashboardConfiguration(
+  input: SaveDashboardConfiguration,
+): Promise<DashboardConfigurationRecord> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    const normalizedSettings = input.settings ?? {};
+    const normalizedDescription = input.description ?? null;
+    const layout = input.layout || 'grid';
+
+    let dashboardId: string;
+
+    if (input.id && isUuid(input.id)) {
+      const updateResult = await client.query(
+        `UPDATE dashboards
+         SET name = $1,
+             description = $2,
+             layout = $3,
+             settings = $4,
+             updated_at = NOW()
+         WHERE id = $5 AND created_by = $6
+         RETURNING id, name, description, layout, settings, updated_at`,
+        [
+          input.name,
+          normalizedDescription,
+          layout,
+          JSON.stringify(normalizedSettings),
+          input.id,
+          input.userId,
+        ],
+      );
+
+      if (updateResult.rowCount === 0) {
+        throw new Error('Dashboard not found or access denied');
+      }
+      dashboardId = updateResult.rows[0].id;
+    } else {
+      const insertResult = await client.query(
+        `INSERT INTO dashboards (name, description, layout, settings, created_by)
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING id`,
+        [input.name, normalizedDescription, layout, JSON.stringify(normalizedSettings), input.userId],
+      );
+      dashboardId = insertResult.rows[0].id;
+    }
+
+    await client.query('DELETE FROM dashboard_widgets WHERE dashboard_id = $1', [dashboardId]);
+
+    for (const widget of input.widgets) {
+      const widgetId = widget.id && isUuid(widget.id) ? widget.id : randomUUID();
+      await client.query(
+        `INSERT INTO dashboard_widgets
+         (id, dashboard_id, type, title, config, data_source, position, refresh_interval, is_visible)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE)`,
+        [
+          widgetId,
+          dashboardId,
+          widget.type,
+          widget.title,
+          JSON.stringify(widget.config ?? {}),
+          JSON.stringify(widget.dataSource ?? {}),
+          JSON.stringify(widget.position),
+          widget.refreshInterval ?? null,
+        ],
+      );
+    }
+
+    await client.query('COMMIT');
+    const refreshed = await fetchDashboardConfiguration({ id: dashboardId, userId: input.userId });
+    if (!refreshed) {
+      throw new Error('Failed to load dashboard after save');
+    }
+    return refreshed;
+  } catch (error) {
+    await client.query('ROLLBACK');
+    log.error({ err: error instanceof Error ? error.message : error }, 'Failed to save dashboard configuration');
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/server/src/graphql/resolvers/dashboard.ts
+++ b/server/src/graphql/resolvers/dashboard.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+import { requireAuth } from '../../lib/auth.js';
+import {
+  fetchDashboardConfiguration,
+  saveDashboardConfiguration,
+  type DashboardConfigurationRecord,
+  type SaveDashboardConfiguration,
+} from '../../db/repositories/dashboardConfigs.js';
+
+const positionSchema = z.object({
+  x: z.number().int(),
+  y: z.number().int(),
+  w: z.number().int().positive(),
+  h: z.number().int().positive(),
+});
+
+const widgetSchema = z.object({
+  id: z.string().uuid().optional(),
+  type: z.string().min(1),
+  title: z.string().min(1),
+  position: positionSchema,
+  config: z.any().optional(),
+  dataSource: z.any().optional(),
+  refreshInterval: z.number().int().nullable().optional(),
+});
+
+const saveSchema = z.object({
+  id: z.string().uuid().optional(),
+  name: z.string().min(1),
+  description: z.string().nullable().optional(),
+  layout: z.enum(['grid', 'freeform']).default('grid'),
+  settings: z.any().optional(),
+  widgets: z.array(widgetSchema),
+});
+
+function toGraphQL(record: DashboardConfigurationRecord) {
+  return {
+    id: record.id,
+    name: record.name,
+    description: record.description,
+    layout: record.layout,
+    settings: record.settings,
+    updatedAt:
+      record.updatedAt instanceof Date ? record.updatedAt.toISOString() : String(record.updatedAt),
+    widgets: record.widgets.map((widget) => ({
+      id: widget.id,
+      type: widget.type,
+      title: widget.title,
+      position: widget.position,
+      config: widget.config,
+      dataSource: widget.dataSource,
+      refreshInterval: widget.refreshInterval,
+    })),
+  };
+}
+
+export const dashboardResolvers = {
+  Query: {
+    async dashboardConfiguration(_parent: unknown, args: { id?: string | null }, context: any) {
+      const user = requireAuth(context);
+      const record = await fetchDashboardConfiguration({ id: args?.id ?? null, userId: user.id });
+      return record ? toGraphQL(record) : null;
+    },
+  },
+  Mutation: {
+    async saveDashboardConfiguration(
+      _parent: unknown,
+      args: { input: Omit<SaveDashboardConfiguration, 'userId'> },
+      context: any,
+    ) {
+      const user = requireAuth(context);
+      const parsed = saveSchema.parse(args.input);
+      const record = await saveDashboardConfiguration({ ...parsed, userId: user.id });
+      return toGraphQL(record);
+    },
+  },
+};
+
+export default dashboardResolvers;

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -12,6 +12,7 @@ import { triggerN8nFlow } from '../../integrations/n8n.js';
 import { checkN8nTriggerAllowed } from '../../integrations/n8n-policy.js';
 import { isEnabled as flagEnabled } from '../../featureFlags/flagsmith.js';
 import { doclingResolvers } from './docling.ts';
+import { dashboardResolvers } from './dashboard.ts';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -25,6 +26,7 @@ const resolvers = {
     // Production core resolvers (PostgreSQL + Neo4j)
     ...coreResolvers.Query,
     ...doclingResolvers.Query,
+    ...dashboardResolvers.Query,
     async pipeline(_p: any, args: { id: string }) {
       const { getPipelineDef } = await import('../../db/repositories/pipelines.js');
       return await getPipelineDef(args.id);
@@ -63,6 +65,7 @@ const resolvers = {
     // Production core resolvers
     ...coreResolvers.Mutation,
     ...doclingResolvers.Mutation,
+    ...dashboardResolvers.Mutation,
 
     // Legacy resolvers (will be phased out)
     ...entityResolvers.Mutation,

--- a/server/src/graphql/schema/dashboard.ts
+++ b/server/src/graphql/schema/dashboard.ts
@@ -1,0 +1,66 @@
+import { gql } from 'graphql-tag';
+
+export const dashboardTypeDefs = gql`
+  extend type Query {
+    dashboardConfiguration(id: ID): DashboardConfiguration
+  }
+
+  type DashboardConfiguration {
+    id: ID!
+    name: String!
+    description: String
+    layout: String!
+    settings: JSON
+    updatedAt: DateTime!
+    widgets: [DashboardWidget!]!
+  }
+
+  type DashboardWidget {
+    id: ID!
+    type: String!
+    title: String!
+    position: DashboardWidgetPosition!
+    config: JSON
+    dataSource: JSON
+    refreshInterval: Int
+  }
+
+  type DashboardWidgetPosition {
+    x: Int!
+    y: Int!
+    w: Int!
+    h: Int!
+  }
+
+  input DashboardWidgetPositionInput {
+    x: Int!
+    y: Int!
+    w: Int!
+    h: Int!
+  }
+
+  input DashboardWidgetInput {
+    id: ID
+    type: String!
+    title: String!
+    position: DashboardWidgetPositionInput!
+    config: JSON
+    dataSource: JSON
+    refreshInterval: Int
+  }
+
+  input SaveDashboardConfigurationInput {
+    id: ID
+    name: String!
+    description: String
+    layout: String! = "grid"
+    settings: JSON
+    widgets: [DashboardWidgetInput!]!
+  }
+
+  extend type Mutation {
+    saveDashboardConfiguration(input: SaveDashboardConfigurationInput!): DashboardConfiguration!
+  }
+`;
+
+export default dashboardTypeDefs;

--- a/server/src/graphql/schema/index.ts
+++ b/server/src/graphql/schema/index.ts
@@ -6,6 +6,7 @@ import aiModule from '../schema.ai.js';
 import annotationsModule from '../schema.annotations.js';
 import graphragTypesModule from '../types/graphragTypes.js';
 import { crystalTypeDefs } from '../schema.crystal.js';
+import { dashboardTypeDefs } from './dashboard.js';
 
 const { copilotTypeDefs } = copilotModule as { copilotTypeDefs: any };
 const { graphTypeDefs } = graphModule as { graphTypeDefs: any };
@@ -39,6 +40,7 @@ export const typeDefs = [
   aiTypeDefs,
   annotationsTypeDefs,
   crystalTypeDefs,
+  dashboardTypeDefs,
 ];
 
 export default typeDefs;


### PR DESCRIPTION
## Summary
- add a React DnD based dashboard builder that syncs with the new dashboard slice and persisted GraphQL queries
- persist customizable dashboard layouts via new server schema, resolver, and Postgres repository
- document widgets in Storybook and guard the flow with an end-to-end Playwright test

## Testing
- npm run lint *(fails: missing dependency `globals` in lint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b4d70d14833388b959790c39bab7