### PR TITLE
feat: add visual graph query builder with validation

### DIFF
--- a/client/.storybook/main.ts
+++ b/client/.storybook/main.ts
@@ -1,0 +1,15 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  docs: {
+    autodocs: 'tag',
+  },
+};
+
+export default config;

--- a/client/.storybook/preview.ts
+++ b/client/.storybook/preview.ts
@@ -1,0 +1,16 @@
+import type { Preview } from '@storybook/react';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: {
+      expanded: true,
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/client/README.md
+++ b/client/README.md
@@ -62,3 +62,11 @@ npm i
 E2E_WS_URL=http://localhost:4000 E2E_REDIS_URL=redis://localhost:6379/1 \
   npm run test:e2e -- tests/e2e/analytics-bridge.spec.ts
 ```
+
+## Graph Query Builder
+
+- Navigate to `/graph/query-builder` to open the new visual query workspace. Drag nodes on the canvas to shape the pattern and connect them with AND/OR relationships.
+- Every edit is validated in real time via the `ValidateGraphQuery` GraphQL mutation; warnings and suggestions surface in the sidebar as you build.
+- Use the **Save** action to persist queries (client-side for now) and the **Share** action to copy the structured payload to your clipboard.
+- Storybook: `npm run storybook` serves an isolated playground (`Search/GraphQueryBuilder`) with mocked GraphQL responses for rapid UI iteration.
+- Playwright smoke: `npm run test:e2e -- tests/e2e/graph-query-builder.spec.ts` exercises the drag-and-drop builder and asserts live validation feedback.

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,9 @@
     "lint:fix": "eslint src --ext js,jsx,ts,tsx --fix",
     "format": "prettier --write .",
     "persist:queries": "pnpm exec graphql-codegen --config codegen.js",
-    "generate:persisted": "node scripts/generate-persisted-operations.js"
+    "generate:persisted": "node scripts/generate-persisted-operations.js",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@apollo/client": "^3.13.9",
@@ -87,6 +89,11 @@
     "@types/jest": "^30.0.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",
+    "@storybook/addon-essentials": "^8.2.9",
+    "@storybook/addon-interactions": "^8.2.9",
+    "@storybook/react": "^8.2.9",
+    "@storybook/react-vite": "^8.2.9",
+    "@storybook/test": "^8.2.9",
     "@typescript-eslint/eslint-plugin": "^8.44.0",
     "@typescript-eslint/parser": "^8.42.0",
     "@vitejs/plugin-react": "^5.0.3",
@@ -101,6 +108,7 @@
     "jest": "^30.0.5",
     "jest-junit": "^16.0.0",
     "prettier": "^3.3.3",
+    "storybook": "^8.2.9",
     "ts-jest": "^29.4.4",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.0.0",

--- a/client/src/App.router.jsx
+++ b/client/src/App.router.jsx
@@ -40,6 +40,7 @@ import {
   Map,
   Assessment,
   Settings,
+  FilterAlt,
 } from '@mui/icons-material';
 import { getIntelGraphTheme } from './theme/intelgraphTheme';
 import { store } from './store';
@@ -77,12 +78,14 @@ import ClaimsViewer from './features/conductor/ClaimsViewer';
 import RetractionQueue from './features/conductor/RetractionQueue';
 import CostAdvisor from './features/conductor/CostAdvisor';
 import RunSearch from './features/conductor/RunSearch';
+import GraphQueryBuilderPage from './pages/GraphQueryBuilder';
 
 // Navigation items
 const navigationItems = [
   { path: '/dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
   { path: '/investigations', label: 'Timeline', icon: <Search /> },
   { path: '/graph', label: 'Graph Explorer', icon: <Timeline /> },
+  { path: '/graph/query-builder', label: 'Query Builder', icon: <FilterAlt /> },
   { path: '/copilot', label: 'AI Copilot', icon: <Psychology /> },
   { path: '/conductor', label: 'Conductor Studio', icon: <Engineering /> },
   { path: '/conductor/approvals', label: 'Approvals', icon: <Engineering /> },
@@ -637,6 +640,7 @@ function MainLayout() {
             <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/investigations" element={<InvestigationsPage />} />
             <Route path="/graph" element={<GraphExplorerPage />} />
+            <Route path="/graph/query-builder" element={<GraphQueryBuilderPage />} />
             <Route path="/copilot" element={<CopilotPage />} />
             <Route path="/conductor" element={<ConductorStudio />} />
             <Route path="/conductor/approvals" element={<ApprovalsPanel />} />

--- a/client/src/components/search/GraphQueryBuilder.stories.tsx
+++ b/client/src/components/search/GraphQueryBuilder.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MockedProvider } from '@apollo/client/testing';
+import { GraphQueryBuilder, VALIDATE_GRAPH_QUERY } from './QueryChipBuilder';
+import type { GraphQuery } from '@/types/graphQuery';
+
+const sampleQuery: GraphQuery = {
+  nodes: [
+    {
+      id: 'node-1',
+      field: 'title',
+      operator: 'contains',
+      value: 'summit',
+      type: 'condition',
+    },
+    {
+      id: 'node-2',
+      field: 'status',
+      operator: 'equals',
+      value: 'active',
+      type: 'condition',
+    },
+  ],
+  edges: [
+    {
+      id: 'edge-1',
+      source: 'node-1',
+      target: 'node-2',
+      logicalOperator: 'AND',
+    },
+  ],
+  rootId: 'node-1',
+};
+
+const mocks = [
+  {
+    request: {
+      query: VALIDATE_GRAPH_QUERY,
+      variables: { query: sampleQuery },
+    },
+    result: {
+      data: {
+        validateGraphQuery: {
+          valid: true,
+          message: 'Query looks good',
+          errors: [],
+          suggestions: [],
+          normalized: JSON.stringify(sampleQuery),
+        },
+      },
+    },
+  },
+];
+
+const meta: Meta<typeof GraphQueryBuilder> = {
+  title: 'Search/GraphQueryBuilder',
+  component: GraphQueryBuilder,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <MockedProvider mocks={mocks} addTypename={false}>
+        <div style={{ height: 560 }}>
+          <Story />
+        </div>
+      </MockedProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GraphQueryBuilder>;
+
+export const Default: Story = {
+  args: {
+    initialQuery: sampleQuery,
+  },
+};
+
+export const EmptyState: Story = {
+  args: {},
+};

--- a/client/src/pages/GraphQueryBuilder.tsx
+++ b/client/src/pages/GraphQueryBuilder.tsx
@@ -1,0 +1,54 @@
+import React, { useCallback, useState } from 'react';
+import { Alert, Container, Stack, Typography } from '@mui/material';
+import { GraphQueryBuilder } from '@/components/search/QueryChipBuilder';
+import type { GraphQuery } from '@/types/graphQuery';
+
+export default function GraphQueryBuilderPage() {
+  const [query, setQuery] = useState<GraphQuery>({ nodes: [], edges: [] });
+  const [lastSaved, setLastSaved] = useState<string | null>(null);
+
+  const handleSave = useCallback((name: string, currentQuery: GraphQuery) => {
+    setLastSaved(name);
+    console.info('Saved graph query', name, currentQuery);
+  }, []);
+
+  const handleShare = useCallback((currentQuery: GraphQuery) => {
+    const payload = JSON.stringify(currentQuery, null, 2);
+    if (navigator?.clipboard?.writeText) {
+      navigator.clipboard.writeText(payload).catch(() => {
+        console.warn('Unable to copy graph query to clipboard');
+      });
+    }
+  }, []);
+
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Stack spacing={3}>
+        <Stack spacing={1}>
+          <Typography variant="h4" component="h1">
+            Graph Query Builder
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            Assemble graph patterns visually by connecting entity and relationship conditions.
+            The builder validates your query in real time using the GraphQL API so you can
+            confidently execute complex graph searches.
+          </Typography>
+        </Stack>
+
+        {lastSaved && (
+          <Alert severity="success" onClose={() => setLastSaved(null)}>
+            Saved query <strong>{lastSaved}</strong> locally. You can now reuse it in your
+            investigations.
+          </Alert>
+        )}
+
+        <GraphQueryBuilder
+          query={query}
+          onQueryChange={setQuery}
+          onSave={handleSave}
+          onShare={handleShare}
+        />
+      </Stack>
+    </Container>
+  );
+}

--- a/client/src/types/graphQuery.ts
+++ b/client/src/types/graphQuery.ts
@@ -1,0 +1,42 @@
+export type QueryValue = string | number | boolean | null | string[];
+
+export type GraphQueryNodeType = 'condition' | 'group';
+
+export interface QueryChip {
+  id: string;
+  field: string;
+  operator: string;
+  value: string;
+  type: 'filter' | 'term' | 'range' | 'exists';
+}
+
+export interface GraphQueryNode {
+  id: string;
+  field: string;
+  operator: string;
+  value: string;
+  type: GraphQueryNodeType;
+  description?: string;
+}
+
+export interface GraphQueryEdge {
+  id: string;
+  source: string;
+  target: string;
+  logicalOperator: 'AND' | 'OR';
+}
+
+export interface GraphQuery {
+  nodes: GraphQueryNode[];
+  edges: GraphQueryEdge[];
+  rootId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface GraphQueryValidationResult {
+  valid: boolean;
+  message?: string;
+  errors?: string[];
+  suggestions?: string[];
+  normalized?: string;
+}

--- a/client/tests/e2e/graph-query-builder.spec.ts
+++ b/client/tests/e2e/graph-query-builder.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Graph query builder', () => {
+  test('allows visual construction with validation feedback', async ({ page }) => {
+    const baseUrl = (process.env.E2E_BASE_URL || 'http://localhost:3000').replace(/\/$/, '');
+    let validateCalled = false;
+
+    await page.route('**/graphql', async (route) => {
+      const request = route.request();
+      if (request.method() === 'POST') {
+        try {
+          const body = request.postDataJSON?.();
+          const isValidation =
+            body?.operationName === 'ValidateGraphQuery' ||
+            (typeof body?.query === 'string' && body.query.includes('ValidateGraphQuery'));
+          if (isValidation) {
+            validateCalled = true;
+            await route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({
+                data: {
+                  validateGraphQuery: {
+                    valid: true,
+                    message: 'Query looks good',
+                    errors: [],
+                    suggestions: [],
+                    normalized: JSON.stringify(body?.variables?.query ?? {}),
+                  },
+                },
+              }),
+            });
+            return;
+          }
+        } catch (error) {
+          // Swallow JSON parse issues and continue
+        }
+      }
+
+      await route.continue();
+    });
+
+    await page.goto(`${baseUrl}/graph/query-builder`);
+    await page.getByTestId('graph-query-builder').waitFor();
+
+    await page.getByLabel('New node field').click();
+    await page.getByRole('option', { name: 'Title' }).click();
+    await page.getByLabel('New node operator').click();
+    await page.getByRole('option', { name: 'contains' }).click();
+    await page.getByLabel('New node value').fill('alpha network');
+    await page.getByTestId('add-condition').click();
+
+    await expect(page.getByTestId('graph-query-node')).toBeVisible();
+    await expect(page.getByText('Query looks good')).toBeVisible();
+    await expect.poll(() => validateCalled).toBeTruthy();
+  });
+});

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -6,7 +6,11 @@
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "bundler",
-    "strict": true
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "build"]


### PR DESCRIPTION
## Summary
- replace the chip-based query builder with a React Flow canvas that supports drag-and-drop nodes, logical edges, and GraphQL-backed validation feedback
- add strongly typed graph query models, expose the builder on a dedicated /graph/query-builder route, and provide Storybook coverage plus documentation updates
- extend client tooling with Storybook scripts and a Playwright e2e spec exercising the new builder workflow

## Testing
- npm run lint *(fails: missing package "globals" because workspace dependencies are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bb59b1dc8333aef77e6d5d02f658