### PR TITLE
docs: add onboarding tutorial scripts and transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ open http://localhost:3000   # Web UI
 open http://localhost:4000   # API Gateway
 ```
 
+## 🎥 Onboarding Tutorials
+
+Accelerate team onboarding with short, script-backed walkthroughs. Recordings can be captured with Loom for rapid sharing or OBS Studio when you need multi-scene production. Each video includes a narrator script, transcript for captioning, and a placeholder link to swap once the final recording is available.
+
+- **Data Ingestion Wizard Onboarding** – [Script](docs/tutorials/data-ingestion-wizard-script.md) · [Transcript](docs/tutorials/data-ingestion-wizard-transcript.md) · [Recording placeholder](https://loom.com/share/TBD-data-ingestion-wizard)
+- **Graph Querying Essentials** – [Script](docs/tutorials/graph-querying-script.md) · [Transcript](docs/tutorials/graph-querying-transcript.md) · [Recording placeholder](https://loom.com/share/TBD-graph-querying)
+- **ML Integration Kickstart** – [Script](docs/tutorials/ml-integration-script.md) · [Transcript](docs/tutorials/ml-integration-transcript.md) · [Recording placeholder](https://loom.com/share/TBD-ml-integration)
+
 ## 📋 Prerequisites
 
 - **Node.js** 20+ 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,21 @@
+# Tutorial Video Library
+
+This directory hosts scripts, transcripts, and planning guides for IntelGraph onboarding videos. Use these resources to record short, high-impact walkthroughs for new team members.
+
+## Recording Checklist
+
+1. Review the script for your topic and adapt any environment details to match the target deployment.
+2. Use Loom for quick screen captures or OBS Studio when you need multiple scenes, webcam overlays, or advanced audio routing.
+3. Record at 1080p, 30fps with system audio. Capture microphone narration in a quiet space and monitor levels to avoid clipping.
+4. After recording, export captions from the matching transcript file to ensure accessibility compliance.
+5. Replace the placeholder Loom URL in each script and transcript once the final video is uploaded.
+
+## Available Tutorials
+
+| Topic | Script | Transcript | Placeholder Recording |
+|-------|--------|------------|-----------------------|
+| Data Ingestion Wizard Onboarding | [Script](./data-ingestion-wizard-script.md) | [Transcript](./data-ingestion-wizard-transcript.md) | https://loom.com/share/TBD-data-ingestion-wizard |
+| Graph Querying Essentials | [Script](./graph-querying-script.md) | [Transcript](./graph-querying-transcript.md) | https://loom.com/share/TBD-graph-querying |
+| ML Integration Kickstart | [Script](./ml-integration-script.md) | [Transcript](./ml-integration-transcript.md) | https://loom.com/share/TBD-ml-integration |
+
+Add new tutorials by duplicating the structure above and updating this table so the README remains the single source of truth.

--- a/docs/tutorials/data-ingestion-wizard-script.md
+++ b/docs/tutorials/data-ingestion-wizard-script.md
@@ -1,0 +1,35 @@
+# Video Script: Data Ingestion Wizard Onboarding
+
+**Goal:** Show new analysts how to import a CSV dataset into IntelGraph using the guided ingestion wizard and verify the pipeline kickoff.
+
+**Audience:** First-time IntelGraph data engineers and analysts.
+
+**Estimated runtime:** ~3 minutes.
+
+**Recommended recording tools:** Loom (quick sharing) or OBS Studio (higher production control). Capture at 1080p with system audio enabled.
+
+**Video placeholder:** https://loom.com/share/TBD-data-ingestion-wizard
+
+## Scene Breakdown
+
+| Timestamp | Visuals & Actions | Narration Script |
+|-----------|-------------------|------------------|
+| 00:00-00:20 | Title card with IntelGraph logo fades into the dashboard homepage. Cursor highlights the "Ingestion" module in the left nav. | "Welcome to IntelGraph! In this quick tour we'll use the Data Ingestion Wizard to bring a new dataset online in just a few clicks." |
+| 00:20-00:50 | Hover over the navigation, click **Data Ingestion** → **Launch Wizard**. Wizard modal opens showing source selection. | "From the dashboard, open the Data Ingestion area and launch the guided wizard. The wizard walks you through source setup, schema mapping, and validation." |
+| 00:50-01:20 | Select **CSV Upload**, click **Next**, drag in sample CSV, show preview pane auto-detecting columns. | "We'll ingest a CSV export of incident reports. Upload the file here and review the automatic schema detection. IntelGraph inspects headers and proposes data types." |
+| 01:20-01:45 | Switch to mapping step, map `incident_id` to key, `timestamp` to datetime, `threat_level` to enum. | "Confirm or adjust the column mappings. I'll set incident_id as the primary key, timestamp as a datetime, and flag threat_level as an enum so downstream analytics recognize the scale." |
+| 01:45-02:10 | Advance to validation step, show data quality checks (null counts, anomalies). Accept defaults. | "The wizard runs data quality checks automatically. Review null counts, anomaly alerts, and accepted thresholds. Everything looks good, so we'll accept the defaults." |
+| 02:10-02:40 | Final confirmation screen. Click **Start Ingestion**. Switch to pipeline activity page showing job status progressing from queued → running → completed. | "Submit the job to kick off ingestion. The activity view tracks progress in real time, so you can monitor the pipeline from queued to complete without leaving the wizard." |
+| 02:40-03:00 | Show success toast, navigate to data catalog entry, highlight sample records. End with outro card listing next steps. | "Once complete, the dataset is cataloged and ready for graph modeling. Explore the record preview, then continue to entity modeling or schedule recurring uploads. Thanks for onboarding!" |
+
+## On-Screen Callouts
+
+- Add lower-third text for each wizard step ("Select Source", "Map Schema", "Validate & Launch").
+- Use zoom/pan to emphasize the schema mapping dropdown and validation metrics.
+- Overlay keyboard shortcut tooltip when pressing `⌘+K`/`Ctrl+K` to search for existing ingestion jobs.
+
+## Post-Production Notes
+
+- Insert gentle background track at -18 LUFS; duck to -24 LUFS under narration.
+- Export MP4 and upload to Loom or the Summit video library; replace the placeholder link above with the final share URL.
+- Generate closed captions from the transcript file to ensure accessibility compliance.

--- a/docs/tutorials/data-ingestion-wizard-transcript.md
+++ b/docs/tutorials/data-ingestion-wizard-transcript.md
@@ -1,0 +1,35 @@
+# Transcript: Data Ingestion Wizard Onboarding
+
+**Recording placeholder:** https://loom.com/share/TBD-data-ingestion-wizard
+
+**Duration:** ~3 minutes
+
+---
+
+**00:00 – 00:10**  
+"Welcome to IntelGraph! In this quick tour, I'll show you how to bring a fresh dataset into the platform using the Data Ingestion Wizard."
+
+**00:10 – 00:25**  
+"From the main dashboard, head to the Data Ingestion area and launch the guided wizard. It's designed to walk you through source setup, schema mapping, and validation."
+
+**00:25 – 00:45**  
+"We'll work with a CSV export of incident reports. Upload the file, then review the automatic schema detection. IntelGraph inspects the headers and suggests data types so you start with a clean baseline."
+
+**00:45 – 01:05**  
+"Next, confirm the column mappings. I'll set `incident_id` as the primary key, map the `timestamp` column to a datetime field, and treat `threat_level` as an enum to drive downstream analytics."
+
+**01:05 – 01:25**  
+"The wizard automatically runs data quality checks. Scan the null counts and anomaly alerts. Everything looks good here, so we'll keep the defaults and continue."
+
+**01:25 – 01:50**  
+"On the final screen, review your configuration and press Start Ingestion. The activity feed shows the pipeline moving from queued to running so you always know what's happening."
+
+**01:50 – 02:20**  
+"Once the job completes, the dataset is cataloged instantly. Jump into the record preview to spot-check a few rows, then continue to build out your graph model or schedule recurring uploads."
+
+**02:20 – 03:00**  
+"And that's it! In under three minutes we've onboarded a new dataset with validated schema and quality checks. You're ready to model entities, create relationships, and power new insights." 
+
+---
+
+*Use this transcript to generate captions or localized subtitles. Update timestamps after the final recording if pacing changes.*

--- a/docs/tutorials/graph-querying-script.md
+++ b/docs/tutorials/graph-querying-script.md
@@ -1,0 +1,35 @@
+# Video Script: Graph Querying Essentials
+
+**Goal:** Demonstrate how analysts can explore graph data using the IntelGraph query console, execute template queries, and build custom Cypher statements.
+
+**Audience:** Intelligence analysts and data scientists onboarding to graph analytics.
+
+**Estimated runtime:** ~3 minutes.
+
+**Recommended recording tools:** Loom for rapid walkthroughs or OBS Studio for multi-scene edits. Record browser window plus optional webcam overlay.
+
+**Video placeholder:** https://loom.com/share/TBD-graph-querying
+
+## Scene Breakdown
+
+| Timestamp | Visuals & Actions | Narration Script |
+|-----------|-------------------|------------------|
+| 00:00-00:15 | Opening slide with "Graph Querying Essentials" title. Transition to IntelGraph workspace showing graph overview widget. | "Welcome back! In this session we'll get comfortable querying the IntelGraph knowledge graph using the built-in console." |
+| 00:15-00:40 | Navigate to **Analytics → Graph Console**. Show tabs for Templates and Custom Query. | "Open the Analytics section and launch the Graph Console. You'll see curated templates for common questions alongside a full Cypher editor." |
+| 00:40-01:05 | Select template "Find Related Threat Actors". Preview auto-generated Cypher, run query, show graph visualization and table results. | "Start with a template. Here I'm investigating related threat actors. The template preloads a Cypher query so you can run it instantly and inspect both graph and tabular results." |
+| 01:05-01:35 | Switch to Custom Query tab. Type `MATCH (a:Actor {name: $name})-[:ASSOCIATED_WITH]->(c:Campaign) RETURN a, c LIMIT 15;`. Use parameter panel to set `$name` to "Aurora Cell". | "To go deeper, hop into the custom tab. Draft Cypher or paste from your notebook, then set parameters without editing the query text. I'll search for campaigns linked to the Aurora Cell actor." |
+| 01:35-02:05 | Run query, highlight parameter badge, filter results in visualization (hide low confidence edges). | "Execute the query and refine the visualization. Filter by confidence, expand neighbors, and pin important nodes to build a reusable insight canvas." |
+| 02:05-02:35 | Save query as "Aurora Campaign Pivot", add description, toggle "Share with team". | "Save the query with a descriptive name and share it with your team so everyone starts from a vetted analytic pattern." |
+| 02:35-03:00 | Export results (CSV/PNG). Show closing slide with key takeaways and link to advanced docs. | "When you're ready to brief stakeholders, export the table to CSV or snapshot the graph. That's the core workflow for graph querying in IntelGraph." |
+
+## On-Screen Callouts
+
+- Highlight the Template Library icon and the "Run" button.
+- Use cursor emphasis to show the parameter sidebar appearing when using `$name`.
+- Display keyboard overlay when pressing `Shift+Enter` to execute queries.
+
+## Post-Production Notes
+
+- Insert quick zoom on the graph visualization to emphasize community clusters.
+- Add lower-third prompt: "Tip: Save queries to collaborate" at 02:05.
+- Replace the placeholder Loom URL once the final recording is uploaded and add it to the README embedding list.

--- a/docs/tutorials/graph-querying-transcript.md
+++ b/docs/tutorials/graph-querying-transcript.md
@@ -1,0 +1,35 @@
+# Transcript: Graph Querying Essentials
+
+**Recording placeholder:** https://loom.com/share/TBD-graph-querying
+
+**Duration:** ~3 minutes
+
+---
+
+**00:00 – 00:12**  
+"Welcome back! In this session we'll explore the IntelGraph knowledge graph using the built-in Graph Console."
+
+**00:12 – 00:28**  
+"Navigate to the Analytics area and open the console. Here you'll find curated templates for common investigative questions, plus a custom Cypher editor when you need full control."
+
+**00:28 – 00:48**  
+"I'll start with the 'Find Related Threat Actors' template. One click runs a pre-built Cypher query, returning both a force-directed visualization and a tabular list of connected actors."
+
+**00:48 – 01:10**  
+"To answer more specific questions, switch to the Custom Query tab. I'm pasting a Cypher pattern that looks for campaigns associated with a particular actor, then setting the name parameter to Aurora Cell."
+
+**01:10 – 01:32**  
+"Run the query with Shift plus Enter. The results appear instantly, and I can filter the graph by confidence, expand neighboring nodes, or pin key entities to craft the investigative story."
+
+**01:32 – 01:58**  
+"Happy with the outcome? Save the query as 'Aurora Campaign Pivot' and share it with your team so everyone benefits from a vetted analytic starting point."
+
+**01:58 – 02:35**  
+"When you need to brief stakeholders, export the table to CSV or download the visualization as a PNG snapshot. That's the end-to-end workflow for graph querying inside IntelGraph."
+
+**02:35 – 03:00**  
+"Thanks for watching! Jump into the advanced docs linked below to learn how to add algorithmic scoring or schedule recurring graph jobs."
+
+---
+
+*Use this transcript for captioning, translations, or knowledge base search indexing. Update timestamps after final recording if the pacing changes.*

--- a/docs/tutorials/ml-integration-script.md
+++ b/docs/tutorials/ml-integration-script.md
@@ -1,0 +1,36 @@
+# Video Script: ML Integration Kickstart
+
+**Goal:** Walk platform engineers through connecting an external ML model to IntelGraph, configuring feature streams, and validating inference output.
+
+**Audience:** Machine learning engineers and solution architects onboarding to IntelGraph's ML workspace.
+
+**Estimated runtime:** ~4 minutes.
+
+**Recommended recording tools:** OBS Studio for scene switching between browser and terminal, or Loom with screen + camera for a faster capture.
+
+**Video placeholder:** https://loom.com/share/TBD-ml-integration
+
+## Scene Breakdown
+
+| Timestamp | Visuals & Actions | Narration Script |
+|-----------|-------------------|------------------|
+| 00:00-00:20 | Intro slide "ML Integration Kickstart" with logos. Transition to IntelGraph ML Workspace overview page. | "In this tutorial we'll connect an external machine learning model to IntelGraph, wire up live features, and validate the inference results." |
+| 00:20-00:55 | Click **ML Workspace → Integrations**. Show available connectors (SageMaker, Vertex AI, Custom REST). Select **Custom REST Endpoint**. | "Navigate to the ML Workspace and open Integrations. You can choose from managed providers like SageMaker or Vertex AI, or define a custom REST endpoint. We'll use a custom model hosted in our cloud." |
+| 00:55-01:30 | Fill endpoint form: name "Threat Score API", base URL `https://ml.example.com/predict`, add auth header. | "Provide the model's metadata, the base URL for inference, and any authentication headers. IntelGraph stores credentials in the secure vault so your tokens never appear in logs." |
+| 01:30-02:05 | Configure feature stream: select dataset "Incident Ingestion", choose features `incident_id`, `threat_level`, `geo_hash`, `vector_embedding`. Show preview rows. | "Next, attach a feature stream. We'll reuse the incident ingestion dataset, selecting identifiers, categorical inputs, and the generated vector embedding. Preview the payload to ensure the JSON matches your model contract." |
+| 02:05-02:45 | Set output mapping: map response field `score` to `threat_score`, `explanations` to nested insights. Enable batching (size 50). | "Map the response fields back into IntelGraph. I'll route the numeric score into our threat_score attribute and capture explanations for analyst transparency. Enable batching to optimize throughput." |
+| 02:45-03:20 | Run test inference with sample payload, show success badge and returned JSON. | "Run a live test to confirm connectivity. The response looks good and returns scores with explanations, so we're ready to deploy." |
+| 03:20-03:50 | Deploy integration to staging, show monitoring dashboard with latency chart and error rate. | "Deploy to staging with a single click. The monitoring dashboard tracks latency, throughput, and error rates so you can validate model health before promoting to production." |
+| 03:50-04:10 | Highlight downstream usage: show rule builder referencing `threat_score`, mention alert pipeline. Outro card. | "Now that the integration is live, analysts can incorporate the threat score into rules, alerts, and graph analytics. Thanks for integrating your model with IntelGraph." |
+
+## On-Screen Callouts
+
+- Use annotation to emphasize secure credential storage and feature preview payload.
+- Show tooltip referencing docs/tutorials/advanced-pipeline-features.md for chaining ML outputs to pipelines.
+- Include quick terminal popover demonstrating `curl` health check (optional B-roll).
+
+## Post-Production Notes
+
+- Cut to webcam for 5 seconds during intro to personalize the tutorial.
+- Add lower-third text for each integration step to reinforce the workflow.
+- Replace the Loom placeholder link once uploaded; ensure README references the finalized URL.

--- a/docs/tutorials/ml-integration-transcript.md
+++ b/docs/tutorials/ml-integration-transcript.md
@@ -1,0 +1,38 @@
+# Transcript: ML Integration Kickstart
+
+**Recording placeholder:** https://loom.com/share/TBD-ml-integration
+
+**Duration:** ~4 minutes
+
+---
+
+**00:00 – 00:18**  
+"Welcome to the ML Integration Kickstart. In the next few minutes we'll connect an external inference endpoint to IntelGraph and make its scores available across the platform."
+
+**00:18 – 00:40**  
+"From the ML Workspace, open Integrations. IntelGraph supports managed providers such as SageMaker and Vertex AI, but today we're wiring up a custom REST endpoint for maximum flexibility."
+
+**00:40 – 01:05**  
+"I'll name this integration 'Threat Score API,' paste in the base URL, and add the bearer token header. Credentials are stored in the secure vault, so they never appear in logs or exports."
+
+**01:05 – 01:32**  
+"Next we attach a feature stream. I'm selecting the incident ingestion dataset and including the incident identifier, the analyst-assigned threat level, a geospatial hash, and the pre-computed vector embedding. The preview shows the JSON payload exactly as the model will receive it."
+
+**01:32 – 01:58**  
+"Now map the response. The model returns a numeric score and an explanations array. I'll store the score in our threat_score attribute and keep the explanations so analysts can see why the model responded the way it did. I'll also enable batching with a size of fifty to keep throughput high."
+
+**01:58 – 02:30**  
+"Time for a live test. IntelGraph sends a sample payload, and we get back a 200 response with the expected JSON. The green badge confirms that the endpoint is healthy."
+
+**02:30 – 03:05**  
+"Deploy the integration to staging. The monitoring dashboard starts collecting latency, throughput, and error metrics right away, so you can observe the model before promoting it to production."
+
+**03:05 – 03:45**  
+"With the integration live, analysts can use the threat_score in alert rules, pipelines, and even graph queries. It's a seamless way to blend ML insights into your investigative workflows."
+
+**03:45 – 04:10**  
+"Thanks for watching! Follow the linked documentation to automate retraining hooks or connect additional models when you're ready."
+
+---
+
+*Repurpose this transcript for captions, localized overdubs, or searchable knowledge base articles. Update timestamps after the final edit if pacing shifts.*


### PR DESCRIPTION
## Summary
- add onboarding tutorial scripts and transcripts for the data ingestion wizard, graph querying, and ML integration flows
- create a tutorials README with a recording checklist and placeholder Loom links
- surface the new tutorial resources in the root README for easier onboarding discovery

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d6bb73061083338c07e07cbcb364ae