### PR TITLE
feat: add gds-backed graph analytics queries

### DIFF
--- a/server/db/migrations/neo4j/2025-09-01_graph_analytics_projection.cypher
+++ b/server/db/migrations/neo4j/2025-09-01_graph_analytics_projection.cypher
@@ -1,0 +1,29 @@
+// Summit Graph Analytics projection bootstrap
+// Ensures a reusable named graph exists for PageRank and community detection workloads
+
+CALL {
+  WITH 'summit_analytics_global' AS graphName
+  CALL gds.graph.exists(graphName)
+  YIELD exists
+  WITH graphName, exists
+  CALL apoc.do.when(
+    exists,
+    'CALL gds.graph.drop($graphName, false) YIELD graphName RETURN graphName',
+    'RETURN $graphName AS graphName',
+    { graphName: graphName }
+  ) YIELD value
+  RETURN graphName
+}
+CALL gds.graph.project.cypher(
+  'summit_analytics_global',
+  'MATCH (n:Entity)
+   RETURN id(n) AS id, labels(n) AS labels, { id: n.id, label: n.label, investigationId: n.investigation_id } AS properties',
+  'MATCH (n:Entity)-[r]->(m:Entity)
+   RETURN id(n) AS source, id(m) AS target, type(r) AS type',
+  {
+    validateRelationships: false,
+    batchSize: 100000
+  }
+)
+YIELD graphName
+RETURN graphName;

--- a/server/perf/k6-graph-analytics.js
+++ b/server/perf/k6-graph-analytics.js
@@ -1,0 +1,112 @@
+import http from 'k6/http';
+import { Trend } from 'k6/metrics';
+import { check, sleep } from 'k6';
+
+const GRAPHQL_URL = __ENV.GRAPHQL_URL || 'http://localhost:4000/graphql';
+const AUTH_TOKEN = __ENV.GRAPHQL_TOKEN || '';
+const HEADERS = {
+  'Content-Type': 'application/json',
+  ...(AUTH_TOKEN ? { Authorization: `Bearer ${AUTH_TOKEN}` } : {}),
+};
+
+const pagerankTrend = new Trend('graph_pagerank_duration_ms');
+const communityTrend = new Trend('graph_communities_duration_ms');
+
+const PAGE_RANK_QUERY = `
+  query PageRank($limit: Int, $force: Boolean) {
+    graphPageRank(limit: $limit, forceRefresh: $force) {
+      nodeId
+      score
+    }
+  }
+`;
+
+const COMMUNITIES_QUERY = `
+  query Communities($limit: Int, $algorithm: CommunityDetectionAlgorithm) {
+    graphCommunities(limit: $limit, algorithm: $algorithm) {
+      communityId
+      size
+      algorithm
+    }
+  }
+`;
+
+export const options = {
+  scenarios: {
+    pagerank: {
+      executor: 'constant-vus',
+      exec: 'runPageRank',
+      vus: Number(__ENV.K6_PAGERANK_VUS || 5),
+      duration: __ENV.K6_DURATION || '30s',
+    },
+    communities: {
+      executor: 'ramping-arrival-rate',
+      exec: 'runCommunities',
+      startRate: Number(__ENV.K6_COMMUNITIES_START_RATE || 5),
+      timeUnit: '1s',
+      preAllocatedVUs: Number(__ENV.K6_COMMUNITIES_VUS || 10),
+      stages: [
+        { target: Number(__ENV.K6_COMMUNITIES_PEAK_RATE || 25), duration: '30s' },
+        { target: Number(__ENV.K6_COMMUNITIES_PEAK_RATE || 25), duration: '30s' },
+        { target: Number(__ENV.K6_COMMUNITIES_END_RATE || 5), duration: '20s' },
+      ],
+    },
+  },
+  thresholds: {
+    graph_pagerank_duration_ms: ['p(95)<2000', 'avg<1000'],
+    graph_communities_duration_ms: ['p(95)<2500', 'avg<1200'],
+    http_req_failed: ['rate<0.01'],
+  },
+};
+
+function postGraphQL(query, variables = {}) {
+  const payload = JSON.stringify({ query, variables });
+  const res = http.post(GRAPHQL_URL, payload, { headers: HEADERS });
+  return res;
+}
+
+export function runPageRank() {
+  const res = postGraphQL(PAGE_RANK_QUERY, {
+    limit: Number(__ENV.K6_PAGERANK_LIMIT || 50),
+    force: false,
+  });
+
+  pagerankTrend.add(res.timings.duration);
+
+  check(res, {
+    'pagerank status 200': (r) => r.status === 200,
+    'pagerank has data': (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body?.data?.graphPageRank);
+      } catch (error) {
+        return false;
+      }
+    },
+  });
+
+  sleep(Number(__ENV.K6_SLEEP || 1));
+}
+
+export function runCommunities() {
+  const res = postGraphQL(COMMUNITIES_QUERY, {
+    limit: Number(__ENV.K6_COMMUNITIES_LIMIT || 20),
+    algorithm: __ENV.K6_COMMUNITIES_ALGO || 'LOUVAIN',
+  });
+
+  communityTrend.add(res.timings.duration);
+
+  check(res, {
+    'communities status 200': (r) => r.status === 200,
+    'communities has data': (r) => {
+      try {
+        const body = JSON.parse(r.body);
+        return Array.isArray(body?.data?.graphCommunities);
+      } catch (error) {
+        return false;
+      }
+    },
+  });
+
+  sleep(Number(__ENV.K6_SLEEP || 1));
+}

--- a/server/src/graphql/resolvers.graphAnalytics.js
+++ b/server/src/graphql/resolvers.graphAnalytics.js
@@ -1,0 +1,111 @@
+const GraphAnalyticsService = require('../services/GraphAnalyticsService');
+const { getNeo4jDriver, getRedisClient } = require('../config/database');
+
+const DEFAULT_ALLOWED_ROLES = ['ANALYST', 'ADMIN'];
+
+function normalizeRole(role) {
+  return String(role || '').toUpperCase();
+}
+
+function ensureAuthorized(user, allowedRoles = DEFAULT_ALLOWED_ROLES) {
+  if (!user) {
+    const error = new Error('Not authenticated');
+    error.code = 'UNAUTHENTICATED';
+    throw error;
+  }
+
+  if (allowedRoles.length === 0) {
+    return true;
+  }
+
+  const userRole = normalizeRole(user.role);
+  if (!allowedRoles.includes(userRole)) {
+    const error = new Error('Forbidden');
+    error.code = 'FORBIDDEN';
+    throw error;
+  }
+
+  return true;
+}
+
+function getService(context) {
+  if (context?.services?.graphAnalytics) {
+    return context.services.graphAnalytics;
+  }
+
+  if (!context) {
+    context = {};
+  }
+
+  if (!context.__graphAnalyticsService) {
+    let driver;
+    let redis;
+    try {
+      driver = getNeo4jDriver();
+    } catch (error) {
+      context?.logger?.error?.('Graph analytics resolver failed to acquire Neo4j driver', error);
+    }
+
+    try {
+      redis = getRedisClient();
+    } catch (error) {
+      context?.logger?.warn?.('Graph analytics resolver failed to acquire Redis client', error);
+    }
+
+    context.__graphAnalyticsService = new GraphAnalyticsService({ driver, redis });
+  }
+
+  return context.__graphAnalyticsService;
+}
+
+const resolvers = {
+  Query: {
+    async graphPageRank(_, args, context) {
+      ensureAuthorized(context?.user);
+      const service = getService(context);
+
+      const results = await service.calculatePageRank({
+        investigationId: args?.investigationId ?? null,
+        limit: args?.limit,
+        maxIterations: args?.maxIterations,
+        dampingFactor: args?.dampingFactor,
+        concurrency: args?.concurrency,
+        forceRefresh: Boolean(args?.forceRefresh),
+      });
+
+      return results.map((node) => ({
+        nodeId: node.nodeId,
+        label: node.label,
+        score: node.score ?? node.pageRank,
+        pageRank: node.pageRank ?? node.score,
+      }));
+    },
+
+    async graphCommunities(_, args, context) {
+      ensureAuthorized(context?.user);
+      const service = getService(context);
+
+      const communities = await service.detectCommunities({
+        investigationId: args?.investigationId ?? null,
+        limit: args?.limit,
+        algorithm: args?.algorithm,
+        maxIterations: args?.maxIterations,
+        tolerance: args?.tolerance,
+        concurrency: args?.concurrency,
+        forceRefresh: Boolean(args?.forceRefresh),
+      });
+
+      return communities.map((community) => ({
+        communityId: community.communityId ?? community.id,
+        size: community.size,
+        algorithm: community.algorithm || 'LOUVAIN',
+        nodes: (community.nodes || []).map((node) => ({
+          nodeId: node.nodeId ?? node.id ?? node,
+          label: node.label ?? null,
+        })),
+      }));
+    },
+  },
+};
+
+module.exports = resolvers;

--- a/server/src/graphql/resolvers.js
+++ b/server/src/graphql/resolvers.js
@@ -1,6 +1,7 @@
 // src/graphql/resolvers.js
 const copilotResolvers = require('./resolvers.copilot');
 const graphOpsResolvers = require('./resolvers.graphops');
+const graphAnalyticsResolvers = require('./resolvers.graphAnalytics');
 const aiResolvers = require('./resolvers.ai');
 const annotationsResolvers = require('./resolvers.annotations'); // My new resolvers
 
@@ -9,6 +10,7 @@ const resolvers = {
   Query: {
     ...(copilotResolvers.Query || {}),
     ...(graphOpsResolvers.Query || {}),
+    ...(graphAnalyticsResolvers.Query || {}),
     ...(aiResolvers.Query || {}),
     ...(annotationsResolvers.Query || {}), // Add annotations queries if any
   },

--- a/server/src/graphql/schema.core.js
+++ b/server/src/graphql/schema.core.js
@@ -48,6 +48,30 @@ export const coreTypeDefs = gql`
     destination: Entity!
   }
 
+  type PageRankNode {
+    nodeId: ID!
+    label: String
+    score: Float!
+    pageRank: Float!
+  }
+
+  type GraphCommunityNode {
+    nodeId: ID!
+    label: String
+  }
+
+  type GraphCommunity {
+    communityId: Int!
+    size: Int!
+    algorithm: CommunityDetectionAlgorithm!
+    nodes: [GraphCommunityNode!]!
+  }
+
+  enum CommunityDetectionAlgorithm {
+    LOUVAIN
+    LABEL_PROPAGATION
+  }
+
   type Investigation {
     id: ID!
     tenantId: String!
@@ -190,6 +214,25 @@ export const coreTypeDefs = gql`
 
     # Graph operations
     graphNeighborhood(input: GraphTraversalInput!): GraphNeighborhood!
+
+    graphPageRank(
+      investigationId: ID
+      limit: Int = 100
+      maxIterations: Int = 20
+      dampingFactor: Float = 0.85
+      concurrency: Int
+      forceRefresh: Boolean = false
+    ): [PageRankNode!]!
+
+    graphCommunities(
+      investigationId: ID
+      limit: Int = 25
+      algorithm: CommunityDetectionAlgorithm = LOUVAIN
+      maxIterations: Int = 20
+      tolerance: Float = 0.0001
+      concurrency: Int
+      forceRefresh: Boolean = false
+    ): [GraphCommunity!]!
 
     # Search across all entity types
     searchEntities(tenantId: String!, query: String!, kinds: [String!], limit: Int = 50): [Entity!]!

--- a/server/tests/graphAnalytics.resolvers.test.ts
+++ b/server/tests/graphAnalytics.resolvers.test.ts
@@ -1,0 +1,83 @@
+import graphAnalyticsResolvers = require('../src/graphql/resolvers.graphAnalytics');
+
+describe('graph analytics GraphQL resolvers', () => {
+  const baseUser = { id: 'analyst-1', role: 'ANALYST' };
+
+  it('delegates to the service for PageRank', async () => {
+    const calculatePageRank = jest.fn().mockResolvedValue([
+      { nodeId: 'n1', label: 'Node 1', score: 0.42 },
+    ]);
+    const context = {
+      user: baseUser,
+      services: {
+        graphAnalytics: {
+          calculatePageRank,
+          detectCommunities: jest.fn(),
+        },
+      },
+    } as any;
+
+    const result = await graphAnalyticsResolvers.Query.graphPageRank(
+      null,
+      { limit: 25, forceRefresh: true },
+      context,
+    );
+
+    expect(calculatePageRank).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 25, forceRefresh: true }),
+    );
+    expect(result).toEqual([
+      expect.objectContaining({ nodeId: 'n1', score: 0.42, pageRank: 0.42 }),
+    ]);
+  });
+
+  it('delegates to the service for community detection', async () => {
+    const detectCommunities = jest.fn().mockResolvedValue([
+      { communityId: 7, size: 12, algorithm: 'LOUVAIN', nodes: [{ nodeId: 'n1', label: 'Node 1' }] },
+    ]);
+    const context = {
+      user: baseUser,
+      services: {
+        graphAnalytics: {
+          calculatePageRank: jest.fn(),
+          detectCommunities,
+        },
+      },
+    } as any;
+
+    const result = await graphAnalyticsResolvers.Query.graphCommunities(
+      null,
+      { limit: 10, algorithm: 'LABEL_PROPAGATION' },
+      context,
+    );
+
+    expect(detectCommunities).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 10, algorithm: 'LABEL_PROPAGATION' }),
+    );
+    expect(result).toEqual([
+      expect.objectContaining({ communityId: 7, size: 12, nodes: [expect.any(Object)] }),
+    ]);
+  });
+
+  it('throws when the user is missing', async () => {
+    await expect(
+      graphAnalyticsResolvers.Query.graphPageRank(null, { limit: 5 }, { services: {} } as any),
+    ).rejects.toThrow('Not authenticated');
+  });
+
+  it('throws when the user lacks the required role', async () => {
+    const context = {
+      user: { id: 'viewer', role: 'VIEWER' },
+      services: {
+        graphAnalytics: {
+          calculatePageRank: jest.fn(),
+          detectCommunities: jest.fn(),
+        },
+      },
+    } as any;
+
+    await expect(
+      graphAnalyticsResolvers.Query.graphCommunities(null, { limit: 1 }, context),
+    ).rejects.toThrow('Forbidden');
+  });
+});

--- a/server/tests/graphAnalytics.service.test.ts
+++ b/server/tests/graphAnalytics.service.test.ts
@@ -1,0 +1,56 @@
+import GraphAnalyticsService = require('../src/services/GraphAnalyticsService');
+
+describe('GraphAnalyticsService caching', () => {
+  const createRedisStub = () => {
+    const store = new Map<string, string>();
+    return {
+      get: jest.fn(async (key: string) => store.get(key) ?? null),
+      set: jest.fn(async (key: string, value: string) => {
+        store.set(key, value);
+        return 'OK';
+      }),
+      del: jest.fn(async (key: string) => {
+        store.delete(key);
+        return 1;
+      }),
+    };
+  };
+
+  it('returns cached PageRank results on subsequent calls', async () => {
+    const redis = createRedisStub();
+    const service = new GraphAnalyticsService({
+      driver: { session: jest.fn() } as any,
+      redis,
+      cacheTtl: 10,
+    });
+
+    jest.spyOn(service as any, 'ensureGraphProjection').mockResolvedValue(undefined);
+    const execute = jest.spyOn(service as any, 'executePageRank').mockResolvedValue([
+      { nodeId: 'n1', label: 'Node', score: 0.5 },
+    ]);
+
+    const first = await service.calculatePageRank({ investigationId: 'inv-1', limit: 5 });
+    const second = await service.calculatePageRank({ investigationId: 'inv-1', limit: 5 });
+
+    expect(first).toEqual(second);
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(redis.get).toHaveBeenCalled();
+    expect(redis.set).toHaveBeenCalled();
+  });
+
+  it('bypasses the cache when forceRefresh is true', async () => {
+    const redis = createRedisStub();
+    const service = new GraphAnalyticsService({ driver: { session: jest.fn() } as any, redis });
+
+    jest.spyOn(service as any, 'ensureGraphProjection').mockResolvedValue(undefined);
+    jest.spyOn(service as any, 'dropGraphProjection').mockResolvedValue(undefined);
+    const execute = jest.spyOn(service as any, 'executePageRank').mockResolvedValue([
+      { nodeId: 'n1', label: 'Node', score: 0.5 },
+    ]);
+
+    await service.calculatePageRank({ investigationId: 'inv-2', limit: 10, forceRefresh: true });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(redis.del).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- integrate Neo4j Graph Data Science PageRank and community detection with Redis caching in the graph analytics service
- expose graphPageRank and graphCommunities GraphQL queries with schema and resolver wiring
- add a reusable Neo4j projection migration, k6 benchmark script, and Jest coverage for the analytics entrypoints

## Testing
- npm test -- graphAnalytics *(fails: npm cannot install workspace:* dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bb8b863c8333a705b7604520c0bc