### PR TITLE
feat: implement tenant theming engine

### DIFF
--- a/client/.storybook/main.ts
+++ b/client/.storybook/main.ts
@@ -1,0 +1,18 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(js|jsx|ts|tsx|mdx)'],
+  addons: ['@storybook/addon-essentials', '@storybook/addon-interactions'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  docs: {
+    autodocs: 'tag',
+  },
+  core: {
+    disableTelemetry: true,
+  },
+};
+
+export default config;

--- a/client/.storybook/preview.tsx
+++ b/client/.storybook/preview.tsx
@@ -1,0 +1,117 @@
+import type { Preview } from '@storybook/react';
+import React, { useEffect } from 'react';
+import TenantThemeProvider, { useTenantTheme } from '../src/theme/ThemeProvider.jsx';
+import '../src/styles/globals.css';
+
+const storybookTheme = {
+  tenantId: 'storybook',
+  name: 'Storybook Showcase',
+  light: {
+    primary: '#1D4ED8',
+    primaryContrast: '#FFFFFF',
+    secondary: '#7C3AED',
+    accent: '#F97316',
+    background: '#F5F7FF',
+    surface: '#FFFFFF',
+    surfaceMuted: '#E0E7FF',
+    border: '#CBD5F5',
+    text: '#111827',
+    textMuted: '#4B5563',
+    success: '#0EA5E9',
+    warning: '#D97706',
+    danger: '#DC2626',
+    focus: '#4338CA',
+    fontBody: "'Inter', 'Segoe UI', system-ui, sans-serif",
+    fontHeading: "'Plus Jakarta Sans', 'Inter', system-ui, sans-serif",
+    fontMono: "'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace",
+    shadowSm: '0 1px 3px rgba(29, 78, 216, 0.12)',
+    shadowMd: '0 12px 24px rgba(29, 78, 216, 0.12)',
+    shadowLg: '0 18px 40px rgba(79, 70, 229, 0.18)',
+    radiusSm: '6px',
+    radiusMd: '12px',
+    radiusLg: '20px',
+    radiusPill: '999px',
+  },
+  dark: {
+    primary: '#93C5FD',
+    primaryContrast: '#0B1220',
+    secondary: '#C4B5FD',
+    accent: '#FDBA74',
+    background: '#0B1220',
+    surface: '#111827',
+    surfaceMuted: '#1F2937',
+    border: '#1E3A8A',
+    text: '#E5E7EB',
+    textMuted: '#9CA3AF',
+    success: '#38BDF8',
+    warning: '#FBBF24',
+    danger: '#F87171',
+    focus: '#60A5FA',
+    fontBody: "'Inter', 'Segoe UI', system-ui, sans-serif",
+    fontHeading: "'Plus Jakarta Sans', 'Inter', system-ui, sans-serif",
+    fontMono: "'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace",
+    shadowSm: '0 1px 3px rgba(15, 23, 42, 0.45)',
+    shadowMd: '0 12px 24px rgba(15, 23, 42, 0.45)',
+    shadowLg: '0 18px 40px rgba(15, 23, 42, 0.5)',
+    radiusSm: '6px',
+    radiusMd: '12px',
+    radiusLg: '20px',
+    radiusPill: '999px',
+  },
+};
+
+const ThemeModeBridge: React.FC<{ mode: string; children: React.ReactNode }> = ({ mode, children }) => {
+  const { setMode } = useTenantTheme();
+
+  useEffect(() => {
+    if (mode) {
+      setMode(mode);
+    }
+  }, [mode, setMode]);
+
+  return <div style={{ minHeight: '100vh', padding: '1.5rem' }}>{children}</div>;
+};
+
+const preview: Preview = {
+  parameters: {
+    controls: { expanded: true },
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    backgrounds: {
+      default: 'surface',
+      values: [
+        { name: 'surface', value: '#F5F7FF' },
+        { name: 'contrast', value: '#0B1220' },
+      ],
+    },
+  },
+  globalTypes: {
+    themeMode: {
+      name: 'Theme Mode',
+      description: 'Switch between light, dark, and system modes',
+      defaultValue: 'light',
+      toolbar: {
+        icon: 'circlehollow',
+        items: [
+          { value: 'light', title: 'Light' },
+          { value: 'dark', title: 'Dark' },
+          { value: 'system', title: 'System' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => {
+      const mode = context.globals.themeMode as string;
+      return (
+        <TenantThemeProvider disableRemote initialTheme={storybookTheme}>
+          <ThemeModeBridge mode={mode}>
+            <Story />
+          </ThemeModeBridge>
+        </TenantThemeProvider>
+      );
+    },
+  ],
+};
+
+export default preview;

--- a/client/package.json
+++ b/client/package.json
@@ -19,7 +19,9 @@
     "lint:fix": "eslint src --ext js,jsx,ts,tsx --fix",
     "format": "prettier --write .",
     "persist:queries": "pnpm exec graphql-codegen --config codegen.js",
-    "generate:persisted": "node scripts/generate-persisted-operations.js"
+    "generate:persisted": "node scripts/generate-persisted-operations.js",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@apollo/client": "^3.13.9",
@@ -84,6 +86,10 @@
     "@testing-library/jest-dom": "^6.7.0",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@storybook/addon-essentials": "^8.4.1",
+    "@storybook/addon-interactions": "^8.4.1",
+    "@storybook/react-vite": "^8.4.1",
+    "@storybook/test": "^8.4.1",
     "@types/jest": "^30.0.0",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19.1.9",

--- a/client/src/App.router.jsx
+++ b/client/src/App.router.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect } from 'react';
 import {
   BrowserRouter as Router,
   Routes,
@@ -10,8 +10,6 @@ import {
 import { Provider } from 'react-redux';
 import { ApolloProvider } from '@apollo/client';
 import {
-  ThemeProvider,
-  CssBaseline,
   Container,
   Box,
   Card,
@@ -41,10 +39,9 @@ import {
   Assessment,
   Settings,
 } from '@mui/icons-material';
-import { getIntelGraphTheme } from './theme/intelgraphTheme';
+import TenantThemeProvider from './theme/ThemeProvider.jsx';
 import { store } from './store';
 import { apolloClient } from './services/apollo';
-import { useSelector } from 'react-redux';
 import { AuthProvider, useAuth } from './context/AuthContext.jsx';
 import ProtectedRoute from './components/common/ProtectedRoute.jsx';
 import LoginPage from './components/auth/LoginPage.jsx';
@@ -681,34 +678,33 @@ function MainLayout() {
 // Themed App Shell with Beautiful Background
 
 function ThemedAppShell({ children }) {
-  const mode = useSelector((state) => state.ui?.theme || 'light');
-  const theme = useMemo(() => getIntelGraphTheme(mode), [mode]);
+  const { user } = useAuth();
+  const tenantId = user?.tenantId || 'default';
 
   return (
-    <ThemeProvider theme={theme}>
-      <CssBaseline />
+    <TenantThemeProvider tenantId={tenantId}>
       <Box
         sx={{
-          background:
-            'linear-gradient(135deg, #e3f2fd 0%, #f5f5f5 25%, #eceff1 50%, #e8eaf6 75%, #e1f5fe 100%)',
           minHeight: '100vh',
           position: 'relative',
+          backgroundColor: 'var(--color-background)',
+          color: 'var(--color-text)',
+          transition: 'background-color 120ms ease, color 120ms ease',
           '&::before': {
             content: '""',
             position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
+            inset: 0,
             background:
-              'radial-gradient(circle at 20% 50%, rgba(33, 150, 243, 0.1) 0%, transparent 50%), radial-gradient(circle at 80% 20%, rgba(63, 81, 181, 0.1) 0%, transparent 50%), radial-gradient(circle at 40% 80%, rgba(3, 169, 244, 0.1) 0%, transparent 50%)',
+              'radial-gradient(circle at 20% 30%, rgba(20, 89, 255, 0.12) 0%, transparent 55%), radial-gradient(circle at 80% 20%, rgba(99, 102, 241, 0.16) 0%, transparent 60%), radial-gradient(circle at 30% 80%, rgba(192, 38, 211, 0.12) 0%, transparent 60%)',
             pointerEvents: 'none',
+            opacity: 0.4,
+            mixBlendMode: 'screen',
           },
         }}
       >
         <Box sx={{ position: 'relative', zIndex: 1 }}>{children}</Box>
       </Box>
-    </ThemeProvider>
+    </TenantThemeProvider>
   );
 }
 

--- a/client/src/graphql/theme.gql.js
+++ b/client/src/graphql/theme.gql.js
@@ -1,0 +1,125 @@
+import { gql } from '@apollo/client';
+
+export const GET_TENANT_THEME = gql`
+  query GetTenantTheme($tenantId: String) {
+    tenantTheme(tenantId: $tenantId) {
+      tenantId
+      name
+      updatedAt
+      light {
+        primary
+        primaryContrast
+        secondary
+        accent
+        background
+        surface
+        surfaceMuted
+        border
+        text
+        textMuted
+        success
+        warning
+        danger
+        focus
+        fontBody
+        fontHeading
+        fontMono
+        shadowSm
+        shadowMd
+        shadowLg
+        radiusSm
+        radiusMd
+        radiusLg
+        radiusPill
+      }
+      dark {
+        primary
+        primaryContrast
+        secondary
+        accent
+        background
+        surface
+        surfaceMuted
+        border
+        text
+        textMuted
+        success
+        warning
+        danger
+        focus
+        fontBody
+        fontHeading
+        fontMono
+        shadowSm
+        shadowMd
+        shadowLg
+        radiusSm
+        radiusMd
+        radiusLg
+        radiusPill
+      }
+    }
+  }
+`;
+
+export const UPSERT_TENANT_THEME = gql`
+  mutation UpsertTenantTheme($input: TenantThemeInput!) {
+    upsertTenantTheme(input: $input) {
+      tenantId
+      name
+      updatedAt
+      light {
+        primary
+        primaryContrast
+        secondary
+        accent
+        background
+        surface
+        surfaceMuted
+        border
+        text
+        textMuted
+        success
+        warning
+        danger
+        focus
+        fontBody
+        fontHeading
+        fontMono
+        shadowSm
+        shadowMd
+        shadowLg
+        radiusSm
+        radiusMd
+        radiusLg
+        radiusPill
+      }
+      dark {
+        primary
+        primaryContrast
+        secondary
+        accent
+        background
+        surface
+        surfaceMuted
+        border
+        text
+        textMuted
+        success
+        warning
+        danger
+        focus
+        fontBody
+        fontHeading
+        fontMono
+        shadowSm
+        shadowMd
+        shadowLg
+        radiusSm
+        radiusMd
+        radiusLg
+        radiusPill
+      }
+    }
+  }
+`;

--- a/client/src/stories/ThemePreview.stories.tsx
+++ b/client/src/stories/ThemePreview.stories.tsx
@@ -1,0 +1,177 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Chip from '@mui/material/Chip';
+import TextField from '@mui/material/TextField';
+import Avatar from '@mui/material/Avatar';
+import { useTenantTheme } from '../theme/ThemeProvider.jsx';
+
+const PaletteSwatches: React.FC = () => {
+  const { theme, mode } = useTenantTheme();
+  const tokens = mode === 'dark' ? theme.dark : theme.light;
+
+  const palette = [
+    { label: 'Primary', key: 'primary', textColor: tokens.primaryContrast },
+    { label: 'Secondary', key: 'secondary', textColor: tokens.primaryContrast },
+    { label: 'Accent', key: 'accent', textColor: tokens.primaryContrast },
+    { label: 'Background', key: 'background', textColor: tokens.text },
+    { label: 'Surface', key: 'surface', textColor: tokens.text },
+    { label: 'Surface Muted', key: 'surfaceMuted', textColor: tokens.text },
+    { label: 'Success', key: 'success', textColor: tokens.primaryContrast },
+    { label: 'Warning', key: 'warning', textColor: tokens.primaryContrast },
+    { label: 'Danger', key: 'danger', textColor: tokens.primaryContrast },
+  ];
+
+  return (
+    <Grid container spacing={3} sx={{ mt: 1 }}>
+      {palette.map((swatch) => (
+        <Grid item xs={12} sm={6} md={4} key={swatch.key}>
+          <Paper
+            elevation={0}
+            sx={{
+              p: 2,
+              borderRadius: 'var(--radius-lg)',
+              backgroundColor: tokens[swatch.key as keyof typeof tokens],
+              color: swatch.textColor,
+              boxShadow: 'var(--shadow-sm)',
+              border: '1px solid rgba(255,255,255,0.04)',
+            }}
+          >
+            <Typography variant="subtitle2" sx={{ opacity: 0.8 }}>
+              {swatch.label}
+            </Typography>
+            <Typography variant="h6" sx={{ fontWeight: 600 }}>
+              {tokens[swatch.key as keyof typeof tokens]}
+            </Typography>
+            <Typography variant="caption" sx={{ opacity: 0.75 }}>
+              CSS: var(--color-{swatch.key.replace(/([A-Z])/g, '-$1').toLowerCase()})
+            </Typography>
+          </Paper>
+        </Grid>
+      ))}
+    </Grid>
+  );
+};
+
+const ComponentShowcase: React.FC = () => {
+  const { theme, mode } = useTenantTheme();
+  const tokens = mode === 'dark' ? theme.dark : theme.light;
+
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 4,
+        display: 'grid',
+        gap: 3,
+        backgroundColor: 'var(--color-surface)',
+        borderRadius: 'var(--radius-lg)',
+        boxShadow: 'var(--shadow-md)',
+        border: '1px solid var(--color-border)',
+        color: 'var(--color-text)',
+      }}
+    >
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={3} alignItems="center" justifyContent="space-between">
+        <Stack spacing={1}>
+          <Typography variant="h4" sx={{ fontFamily: 'var(--font-heading)', fontWeight: 700 }}>
+            {theme.name}
+          </Typography>
+          <Typography variant="body1" sx={{ maxWidth: 480 }}>
+            This tenant theme uses {tokens.fontBody.split(',')[0].replace(/'/g, '')} for body text and{' '}
+            {tokens.fontHeading.split(',')[0].replace(/'/g, '')} for headings. Buttons, inputs, and badges below use
+            live CSS variables.
+          </Typography>
+        </Stack>
+        <Avatar sx={{ bgcolor: 'var(--color-primary)', width: 64, height: 64, fontWeight: 700 }}>IG</Avatar>
+      </Stack>
+
+      <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems="center">
+        <Button variant="contained" sx={{ bgcolor: 'var(--color-primary)' }}>
+          Primary Action
+        </Button>
+        <Button variant="outlined" sx={{ color: 'var(--color-primary)', borderColor: 'var(--color-border)' }}>
+          Secondary
+        </Button>
+        <Chip label="Tenant" color="primary" sx={{ bgcolor: 'var(--color-accent)', color: 'var(--color-primary-contrast)' }} />
+      </Stack>
+
+      <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+        <TextField
+          label="Search investigations"
+          placeholder="Type to filter"
+          fullWidth
+          InputProps={{
+            sx: {
+              borderRadius: 'var(--radius-md)',
+            },
+          }}
+        />
+        <TextField
+          label="Status"
+          select
+          SelectProps={{ native: true }}
+          fullWidth
+          InputProps={{
+            sx: {
+              borderRadius: 'var(--radius-md)',
+            },
+          }}
+        >
+          <option value="active">Active</option>
+          <option value="review">Review</option>
+          <option value="archived">Archived</option>
+        </TextField>
+      </Stack>
+    </Paper>
+  );
+};
+
+const ThemePreview: React.FC = () => (
+  <Stack spacing={4} sx={{ color: 'var(--color-text)' }}>
+    <Box>
+      <Typography variant="overline" sx={{ letterSpacing: '0.18em', opacity: 0.7 }}>
+        Tenant theming
+      </Typography>
+      <Typography variant="h3" sx={{ fontFamily: 'var(--font-heading)', fontWeight: 700 }}>
+        Palette tokens
+      </Typography>
+      <Typography variant="body2" sx={{ maxWidth: 520, mt: 1 }}>
+        Live preview of CSS variables delivered by the theming engine. Switch the global toolbar to inspect dark mode and
+        ensure contrast remains accessible.
+      </Typography>
+      <PaletteSwatches />
+    </Box>
+
+    <Box>
+      <Typography variant="h3" sx={{ fontFamily: 'var(--font-heading)', fontWeight: 700 }}>
+        Components
+      </Typography>
+      <Typography variant="body2" sx={{ maxWidth: 520, mt: 1 }}>
+        Buttons, form inputs, badges, and layout primitives inherit the active theme and remain WCAG AA compliant across
+        modes.
+      </Typography>
+      <ComponentShowcase />
+    </Box>
+  </Stack>
+);
+
+const meta: Meta<typeof ThemePreview> = {
+  title: 'Design System/Tenant Theme',
+  component: ThemePreview,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ThemePreview>;
+
+export const Overview: Story = {
+  render: () => <ThemePreview />,
+};

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -4,24 +4,52 @@
   box-sizing: border-box;
 }
 
+:root {
+  --color-primary: #1459ff;
+  --color-primary-contrast: #ffffff;
+  --color-secondary: #6366f1;
+  --color-accent: #c026d3;
+  --color-background: #f8fafc;
+  --color-surface: #ffffff;
+  --color-surface-muted: #e2e8f0;
+  --color-border: #cbd5f5;
+  --color-text: #0f172a;
+  --color-text-muted: #475569;
+  --color-success: #059669;
+  --color-warning: #d97706;
+  --color-danger: #dc2626;
+  --color-focus: #2563eb;
+  --font-body: 'Inter', 'Segoe UI', system-ui, sans-serif;
+  --font-heading: 'Work Sans', 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace;
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.08);
+  --shadow-md: 0 6px 18px rgba(15, 23, 42, 0.12);
+  --shadow-lg: 0 18px 48px rgba(15, 23, 42, 0.16);
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+  --radius-pill: 999px;
+  --motion-reduced: 0;
+  --contrast-high: 0;
+  --hairline: rgba(12, 13, 14, 0.08);
+}
+
 html,
 body,
 #root {
   height: 100%;
 }
+
 body {
-  font-family:
-    ui-sans-serif,
-    -apple-system,
-    Segoe UI,
-    Roboto,
-    Inter,
-    Helvetica,
-    Arial,
-    sans-serif;
+  font-family: var(--font-body);
   line-height: 1.55;
-  color: #0c0d0e;
-  background-color: #fafbfc;
+  color: var(--color-text);
+  background-color: var(--color-background);
+  transition: background-color 120ms ease, color 120ms ease;
+}
+
+html[data-theme-mode='dark'] body {
+  background-color: var(--color-background);
 }
 
 #root {
@@ -37,7 +65,7 @@ body {
 .graph-canvas {
   width: 100%;
   height: 100%;
-  background-color: #fafafa;
+  background-color: var(--color-surface-muted);
 }
 
 .loading-spinner {
@@ -48,36 +76,64 @@ body {
 }
 
 .error-message {
-  color: #d32f2f;
+  color: var(--color-danger);
   text-align: center;
   padding: 20px;
 }
 
-/* Tufte/Wright-inspired refinements */
-:root {
-  --hairline: rgba(12, 13, 14, 0.08);
-}
 .hairline {
   border-color: var(--hairline) !important;
 }
+
 .muted {
-  color: rgba(12, 13, 14, 0.56);
+  color: var(--color-text-muted);
 }
+
 .smallcaps {
   font-variant-caps: small-caps;
   letter-spacing: 0.06em;
 }
+
 .note {
-  color: rgba(12, 13, 14, 0.56);
+  color: var(--color-text-muted);
   font-size: 0.85rem;
 }
+
 .section-title {
   font-weight: 600;
   letter-spacing: 0.12rem;
   text-transform: none;
+  font-family: var(--font-heading);
 }
+
 .panel {
   border: 1px solid var(--hairline);
-  border-radius: 6px;
-  background: #fff;
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-sm);
+}
+
+a {
+  color: var(--color-primary);
+}
+
+a:focus-visible,
+button:focus-visible,
+[role='button']:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/client/src/theme/ThemeProvider.jsx
+++ b/client/src/theme/ThemeProvider.jsx
@@ -1,379 +1,345 @@
-import React, { createContext, useContext, useState, useEffect } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import {
   createTheme,
   ThemeProvider as MuiThemeProvider,
   useMediaQuery,
   CssBaseline,
 } from '@mui/material';
-import { useSelector, useDispatch } from 'react-redux';
-import { getIntelGraphTheme } from './intelgraphTheme'; // Import the new theme function
+import { useTheme as useMuiTheme } from '@mui/material/styles';
+import { useMutation, useQuery } from '@apollo/client';
+import { GET_TENANT_THEME, UPSERT_TENANT_THEME } from '../graphql/theme.gql.js';
 
-const ThemeContext = createContext();
+const ThemeContext = createContext(null);
 
-export const useTheme = () => {
+const DEFAULT_LIGHT = {
+  primary: '#1459FF',
+  primaryContrast: '#FFFFFF',
+  secondary: '#6366F1',
+  accent: '#C026D3',
+  background: '#F8FAFC',
+  surface: '#FFFFFF',
+  surfaceMuted: '#E2E8F0',
+  border: '#CBD5F5',
+  text: '#0F172A',
+  textMuted: '#475569',
+  success: '#059669',
+  warning: '#D97706',
+  danger: '#DC2626',
+  focus: '#2563EB',
+  fontBody: "'Inter', 'Segoe UI', system-ui, sans-serif",
+  fontHeading: "'Work Sans', 'Inter', system-ui, sans-serif",
+  fontMono: "'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace",
+  shadowSm: '0 1px 2px rgba(15, 23, 42, 0.08)',
+  shadowMd: '0 6px 18px rgba(15, 23, 42, 0.12)',
+  shadowLg: '0 18px 48px rgba(15, 23, 42, 0.16)',
+  radiusSm: '6px',
+  radiusMd: '10px',
+  radiusLg: '16px',
+  radiusPill: '999px',
+};
+
+const DEFAULT_DARK = {
+  primary: '#7C9DFF',
+  primaryContrast: '#0B1220',
+  secondary: '#A5B4FC',
+  accent: '#F472B6',
+  background: '#0B1220',
+  surface: '#111827',
+  surfaceMuted: '#1F2937',
+  border: '#27324A',
+  text: '#E2E8F0',
+  textMuted: '#94A3B8',
+  success: '#34D399',
+  warning: '#FBBF24',
+  danger: '#F87171',
+  focus: '#60A5FA',
+  fontBody: "'Inter', 'Segoe UI', system-ui, sans-serif",
+  fontHeading: "'Work Sans', 'Inter', system-ui, sans-serif",
+  fontMono: "'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace",
+  shadowSm: '0 1px 2px rgba(8, 47, 73, 0.6)',
+  shadowMd: '0 6px 18px rgba(8, 47, 73, 0.55)',
+  shadowLg: '0 18px 48px rgba(8, 47, 73, 0.5)',
+  radiusSm: '6px',
+  radiusMd: '10px',
+  radiusLg: '16px',
+  radiusPill: '999px',
+};
+
+const CSS_VARIABLE_MAP = {
+  '--color-primary': 'primary',
+  '--color-primary-contrast': 'primaryContrast',
+  '--color-secondary': 'secondary',
+  '--color-accent': 'accent',
+  '--color-background': 'background',
+  '--color-surface': 'surface',
+  '--color-surface-muted': 'surfaceMuted',
+  '--color-border': 'border',
+  '--color-text': 'text',
+  '--color-text-muted': 'textMuted',
+  '--color-success': 'success',
+  '--color-warning': 'warning',
+  '--color-danger': 'danger',
+  '--color-focus': 'focus',
+  '--font-body': 'fontBody',
+  '--font-heading': 'fontHeading',
+  '--font-mono': 'fontMono',
+  '--shadow-sm': 'shadowSm',
+  '--shadow-md': 'shadowMd',
+  '--shadow-lg': 'shadowLg',
+  '--radius-sm': 'radiusSm',
+  '--radius-md': 'radiusMd',
+  '--radius-lg': 'radiusLg',
+  '--radius-pill': 'radiusPill',
+};
+
+const ensureTokens = (theme) => {
+  if (!theme) {
+    return {
+      tenantId: 'default',
+      name: 'Summit Default',
+      light: { ...DEFAULT_LIGHT },
+      dark: { ...DEFAULT_DARK },
+    };
+  }
+
+  return {
+    tenantId: theme.tenantId ?? 'default',
+    name: theme.name ?? 'Summit Default',
+    light: { ...DEFAULT_LIGHT, ...(theme.light || {}) },
+    dark: { ...DEFAULT_DARK, ...(theme.dark || {}) },
+  };
+};
+
+const applyCssVariables = (mode, tokens, { highContrast, reducedMotion, tenantId }) => {
+  if (typeof document === 'undefined') return;
+  const root = document.documentElement;
+  root.setAttribute('data-theme-mode', mode);
+  root.setAttribute('data-tenant', tenantId);
+  Object.entries(CSS_VARIABLE_MAP).forEach(([cssVar, tokenKey]) => {
+    root.style.setProperty(cssVar, tokens[tokenKey]);
+  });
+  root.style.setProperty('--motion-reduced', reducedMotion ? '1' : '0');
+  root.style.setProperty('--contrast-high', highContrast ? '1' : '0');
+};
+
+const createMuiThemeFromTokens = (mode, tokens, { highContrast, reducedMotion }) => {
+  const numericRadius = Number.parseInt(tokens.radiusMd, 10) || 10;
+
+  const theme = createTheme({
+    palette: {
+      mode,
+      primary: { main: tokens.primary, contrastText: tokens.primaryContrast },
+      secondary: { main: tokens.secondary },
+      background: { default: tokens.background, paper: tokens.surface },
+      text: { primary: tokens.text, secondary: tokens.textMuted },
+      success: { main: tokens.success },
+      warning: { main: tokens.warning },
+      error: { main: tokens.danger },
+    },
+    typography: {
+      fontFamily: tokens.fontBody,
+      h1: { fontFamily: tokens.fontHeading, fontWeight: 600 },
+      h2: { fontFamily: tokens.fontHeading, fontWeight: 600 },
+      h3: { fontFamily: tokens.fontHeading, fontWeight: 600 },
+      button: { textTransform: 'none', fontWeight: 600 },
+      caption: { letterSpacing: '0.08em' },
+    },
+    shape: { borderRadius: numericRadius },
+    shadows: [
+      'none',
+      tokens.shadowSm,
+      tokens.shadowMd,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+      tokens.shadowLg,
+    ],
+    components: {
+      MuiCssBaseline: {
+        styleOverrides: {
+          '*, *::before, *::after': {
+            boxSizing: 'border-box',
+          },
+          body: {
+            backgroundColor: tokens.background,
+            color: tokens.text,
+            fontFamily: tokens.fontBody,
+            transition: 'background-color 120ms ease, color 120ms ease',
+          },
+          a: {
+            color: tokens.primary,
+          },
+          ':focus-visible': {
+            outline: `2px solid ${tokens.focus}`,
+            outlineOffset: '2px',
+          },
+        },
+      },
+    },
+  });
+
+  if (highContrast) {
+    theme.palette.text.primary = mode === 'dark' ? '#FFFFFF' : '#000000';
+    theme.palette.text.secondary = mode === 'dark' ? '#F8FAFC' : '#1F2937';
+  }
+
+  if (reducedMotion) {
+    theme.transitions = {
+      ...theme.transitions,
+      create: () => 'none',
+    };
+  }
+
+  return theme;
+};
+
+export const useTenantTheme = () => {
   const context = useContext(ThemeContext);
   if (!context) {
-    throw new Error('useTheme must be used within a ThemeProvider');
+    throw new Error('useTenantTheme must be used within a ThemeProvider');
   }
   return context;
 };
 
-// Enhanced theme configurations
-// Enhanced theme configurations
-const getThemeConfig = (mode) => {
-  // Removed colorScheme parameter
-  const isDark = mode === 'dark';
+export const useTheme = useTenantTheme;
 
-  const baseTheme = getIntelGraphTheme(mode); // Use the new theme function
-
-  // Merge custom components and mixins from the original getThemeConfig
-  // This ensures that existing custom styles and responsive helpers are preserved.
-  return {
-    ...baseTheme,
-    palette: {
-      ...baseTheme.palette,
-      // Custom colors for intelligence application (if still needed, otherwise remove)
-      threat: {
-        high: '#f44336',
-        medium: '#ff9800',
-        low: '#4caf50',
-        unknown: '#9e9e9e',
-      },
-      entity: {
-        person: '#4caf50',
-        organization: '#2196f3',
-        location: '#ff9800',
-        document: '#9c27b0',
-        event: '#f44336',
-        asset: '#795548',
-        communication: '#607d8b',
-      },
-    },
-    typography: {
-      ...baseTheme.typography,
-      // Override specific typography variants if needed, otherwise remove
-      fontFamily: [
-        'Inter',
-        '-apple-system',
-        'BlinkMacSystemFont',
-        '"Segoe UI"',
-        'Roboto',
-        '"Helvetica Neue"',
-        'Arial',
-        'sans-serif',
-      ].join(','),
-      h1: {
-        ...baseTheme.typography.h1,
-        fontSize: '2.125rem', // Keep existing h1 size if different from new theme
-      },
-      h2: {
-        ...baseTheme.typography.h2,
-        fontSize: '1.75rem',
-      },
-      h3: {
-        ...baseTheme.typography.h3,
-        fontSize: '1.5rem',
-      },
-      h4: {
-        ...baseTheme.typography.h4,
-        fontSize: '1.25rem',
-      },
-      h5: {
-        fontSize: '1.125rem',
-        fontWeight: 600,
-        lineHeight: 1.5,
-      },
-      h6: {
-        fontSize: '1rem',
-        fontWeight: 600,
-        lineHeight: 1.5,
-      },
-      body1: {
-        ...baseTheme.typography.body1,
-        fontSize: '0.875rem',
-      },
-      body2: {
-        ...baseTheme.typography.body2,
-        fontSize: '0.75rem',
-      },
-      caption: {
-        ...baseTheme.typography.caption,
-        fontSize: '0.6875rem',
-      },
-    },
-    components: {
-      ...baseTheme.components, // Preserve existing components overrides
-      MuiCssBaseline: {
-        styleOverrides: {
-          body: {
-            scrollbarColor: isDark ? '#6b6b6b #2b2b2b' : '#d4d4d4 #f1f1f1',
-            '&::-webkit-scrollbar, & *::-webkit-scrollbar': {
-              width: 8,
-              height: 8,
-            },
-            '&::-webkit-scrollbar-thumb, & *::-webkit-scrollbar-thumb': {
-              borderRadius: 8,
-              backgroundColor: isDark ? '#6b6b6b' : '#d4d4d4',
-              minHeight: 24,
-              '&:hover': {
-                backgroundColor: isDark ? '#8b8b8b' : '#b4b4b4',
-              },
-            },
-            '&::-webkit-scrollbar-track, & *::-webkit-scrollbar-track': {
-              borderRadius: 8,
-              backgroundColor: isDark ? '#2b2b2b' : '#f1f1f1',
-            },
-          },
-          '*': {
-            '&:focus-visible': {
-              outline: `2px solid ${baseTheme.palette.primary.main}`,
-              outlineOffset: 2,
-            },
-          },
-        },
-      },
-      MuiAppBar: {
-        styleOverrides: {
-          root: {
-            backgroundColor: isDark ? '#1e1e1e' : '#ffffff',
-            color: isDark ? '#ffffff' : '#212121',
-            boxShadow: isDark
-              ? '0px 2px 4px -1px rgba(0,0,0,0.4)'
-              : '0px 2px 4px -1px rgba(0,0,0,0.2)',
-          },
-        },
-      },
-      MuiDrawer: {
-        styleOverrides: {
-          paper: {
-            backgroundColor: isDark ? '#1e1e1e' : '#ffffff',
-            borderRight: `1px solid ${isDark ? '#333333' : '#e0e0e0'}`,
-          },
-        },
-      },
-      MuiCard: {
-        styleOverrides: {
-          root: {
-            backgroundColor: isDark ? '#1e1e1e' : '#ffffff',
-            borderRadius: 12,
-            boxShadow: isDark
-              ? '0px 4px 20px rgba(0, 0, 0, 0.3)'
-              : '0px 4px 20px rgba(0, 0, 0, 0.1)',
-            transition: 'box-shadow 0.3s ease-in-out, transform 0.2s ease-in-out',
-            '&:hover': {
-              boxShadow: isDark
-                ? '0px 8px 30px rgba(0, 0, 0, 0.4)'
-                : '0px 8px 30px rgba(0, 0, 0, 0.15)',
-              transform: 'translateY(-2px)',
-            },
-          },
-        },
-      },
-      MuiButton: {
-        styleOverrides: {
-          root: {
-            textTransform: 'none',
-            borderRadius: 8,
-            fontWeight: 600,
-            transition: 'all 0.2s ease-in-out',
-            '&:focus-visible': {
-              outline: `2px solid ${baseTheme.palette.primary.main}`,
-              outlineOffset: 2,
-            },
-          },
-          contained: {
-            boxShadow: 'none',
-            '&:hover': {
-              boxShadow: '0px 4px 12px rgba(0, 0, 0, 0.15)',
-              transform: 'translateY(-1px)',
-            },
-          },
-        },
-      },
-      MuiIconButton: {
-        styleOverrides: {
-          root: {
-            borderRadius: 8,
-            transition: 'all 0.2s ease-in-out',
-            '&:hover': {
-              backgroundColor: isDark ? 'rgba(255, 255, 255, 0.08)' : 'rgba(0, 0, 0, 0.04)',
-              transform: 'scale(1.05)',
-            },
-            '&:focus-visible': {
-              outline: `2px solid ${baseTheme.palette.primary.main}`,
-              outlineOffset: 2,
-            },
-          },
-        },
-      },
-      MuiTextField: {
-        styleOverrides: {
-          root: {
-            '& .MuiOutlinedInput-root': {
-              borderRadius: 8,
-              transition: 'all 0.2s ease-in-out',
-              '&:hover': {
-                transform: 'translateY(-1px)',
-              },
-              '&.Mui-focused': {
-                transform: 'translateY(-1px)',
-                boxShadow: `0px 4px 12px rgba(${baseTheme.palette.primary.main}, 0.2)`,
-              },
-            },
-          },
-        },
-      },
-      MuiChip: {
-        styleOverrides: {
-          root: {
-            borderRadius: 6,
-            fontWeight: 500,
-            transition: 'all 0.2s ease-in-out',
-            '&:hover': {
-              transform: 'scale(1.05)',
-            },
-          },
-        },
-      },
-      MuiTooltip: {
-        styleOverrides: {
-          tooltip: {
-            backgroundColor: isDark ? '#333333' : '#616161',
-            color: '#ffffff',
-            fontSize: '0.75rem',
-            borderRadius: 6,
-            padding: '8px 12px',
-          },
-        },
-      },
-      MuiListItem: {
-        styleOverrides: {
-          root: {
-            borderRadius: 8,
-            margin: '2px 0',
-            '&.Mui-selected': {
-              backgroundColor: isDark ? 'rgba(144, 202, 249, 0.08)' : 'rgba(25, 118, 210, 0.08)',
-              '&:hover': {
-                backgroundColor: isDark ? 'rgba(144, 202, 249, 0.12)' : 'rgba(25, 118, 210, 0.12)',
-              },
-            },
-            '&:hover': {
-              backgroundColor: isDark ? 'rgba(255, 255, 255, 0.04)' : 'rgba(0, 0, 0, 0.04)',
-              transform: 'translateX(4px)',
-            },
-          },
-        },
-      },
-      MuiAccordion: {
-        styleOverrides: {
-          root: {
-            borderRadius: 8,
-            marginBottom: 8,
-            '&:before': {
-              display: 'none',
-            },
-            '&.Mui-expanded': {
-              margin: '8px 0',
-            },
-          },
-        },
-      },
-    },
-    // Custom mixins for responsive design
-    mixins: {
-      toolbar: {
-        minHeight: 64,
-        '@media (max-width:599px)': {
-          minHeight: 56,
-        },
-      },
-      // Responsive breakpoints helpers
-      responsive: {
-        mobile: '@media (max-width: 599px)',
-        tablet: '@media (max-width: 899px)',
-        desktop: '@media (min-width: 900px)',
-        wide: '@media (min-width: 1200px)',
-      },
-    },
-  };
-};
-
-export function ThemeProvider({ children }) {
-  const dispatch = useDispatch();
-  const { darkMode, colorScheme } = useSelector(
-    (state) => state.ui || { darkMode: false, colorScheme: 'default' },
-  );
-
-  // System preference detection
-  const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
-  const [systemMode, setSystemMode] = useState(prefersDarkMode ? 'dark' : 'light');
-
-  // High contrast mode detection
-  const prefersHighContrast = useMediaQuery('(prefers-contrast: high)');
+export function ThemeProvider({
+  children,
+  tenantId,
+  initialTheme,
+  disableRemote = false,
+}) {
+  const resolvedTenantId = tenantId || initialTheme?.tenantId || 'default';
+  const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');
+  const prefersHighContrast = useMediaQuery('(prefers-contrast: more), (prefers-contrast: high)');
   const prefersReducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
 
+  const baseTokens = ensureTokens({ tenantId: resolvedTenantId, ...initialTheme });
+  const [themeState, setThemeState] = useState(baseTokens);
+  const [userMode, setUserMode] = useState(null);
+  const [mode, setMode] = useState(userMode ?? (prefersDark ? 'dark' : 'light'));
+
   useEffect(() => {
-    setSystemMode(prefersDarkMode ? 'dark' : 'light');
-  }, [prefersDarkMode]);
+    if (userMode === null) {
+      setMode(prefersDark ? 'dark' : 'light');
+    }
+  }, [prefersDark, userMode]);
 
-  // Auto mode uses system preference
-  const effectiveMode = darkMode === 'auto' ? systemMode : darkMode ? 'dark' : 'light';
+  const { data, loading, error, refetch } = useQuery(GET_TENANT_THEME, {
+    variables: { tenantId: resolvedTenantId },
+    skip: disableRemote,
+    fetchPolicy: 'cache-first',
+  });
 
-  const theme = React.useMemo(() => {
-    const baseTheme = getThemeConfig(effectiveMode, colorScheme);
+  const [upsertThemeMutation, { loading: saving }] = useMutation(UPSERT_TENANT_THEME, {
+    fetchPolicy: 'no-cache',
+  });
 
-    // Apply accessibility enhancements
-    if (prefersHighContrast) {
-      baseTheme.palette.text.primary = effectiveMode === 'dark' ? '#ffffff' : '#000000';
-      baseTheme.palette.text.secondary = effectiveMode === 'dark' ? '#e0e0e0' : '#424242';
+  useEffect(() => {
+    if (data?.tenantTheme) {
+      setThemeState(ensureTokens(data.tenantTheme));
+    }
+  }, [data]);
+
+  useEffect(() => {
+    const variant = mode === 'dark' ? themeState.dark : themeState.light;
+    applyCssVariables(mode, variant, {
+      highContrast: prefersHighContrast,
+      reducedMotion: prefersReducedMotion,
+      tenantId: themeState.tenantId,
+    });
+  }, [mode, themeState, prefersHighContrast, prefersReducedMotion]);
+
+  const muiTheme = useMemo(
+    () =>
+      createMuiThemeFromTokens(mode, mode === 'dark' ? themeState.dark : themeState.light, {
+        highContrast: prefersHighContrast,
+        reducedMotion: prefersReducedMotion,
+      }),
+    [mode, themeState, prefersHighContrast, prefersReducedMotion],
+  );
+
+  const setColorMode = (nextMode) => {
+    if (nextMode === 'system') {
+      setUserMode(null);
+      setMode(prefersDark ? 'dark' : 'light');
+      return;
     }
 
-    if (prefersReducedMotion) {
-      // Disable animations for users who prefer reduced motion
-      baseTheme.transitions = {
-        ...baseTheme.transitions,
-        create: () => 'none',
-      };
+    setUserMode(nextMode);
+    setMode(nextMode);
+  };
 
-      // Override component transition styles
-      Object.keys(baseTheme.components).forEach((component) => {
-        if (baseTheme.components[component].styleOverrides) {
-          const overrides = baseTheme.components[component].styleOverrides;
-          Object.keys(overrides).forEach((rule) => {
-            if (overrides[rule].transition) {
-              overrides[rule].transition = 'none';
-            }
-            if (overrides[rule]['&:hover'] && overrides[rule]['&:hover'].transform) {
-              overrides[rule]['&:hover'].transform = 'none';
-            }
-          });
-        }
-      });
+  const saveTheme = async (nextTheme) => {
+    const prepared = ensureTokens({
+      ...nextTheme,
+      tenantId: nextTheme?.tenantId || themeState.tenantId,
+      name: nextTheme?.name || themeState.name,
+    });
+
+    setThemeState(prepared);
+
+    if (disableRemote) {
+      return prepared;
     }
 
-    return baseTheme;
-  }, [effectiveMode, colorScheme, prefersHighContrast, prefersReducedMotion]);
+    const { data: mutationData } = await upsertThemeMutation({
+      variables: {
+        input: {
+          tenantId: prepared.tenantId,
+          name: prepared.name,
+          light: prepared.light,
+          dark: prepared.dark,
+        },
+      },
+    });
+
+    if (mutationData?.upsertTenantTheme) {
+      const ensured = ensureTokens(mutationData.upsertTenantTheme);
+      setThemeState(ensured);
+      return ensured;
+    }
+
+    return prepared;
+  };
 
   const contextValue = {
-    darkMode: effectiveMode === 'dark',
-    colorScheme,
-    systemMode,
-    prefersDarkMode,
+    tenantId: themeState.tenantId,
+    name: themeState.name,
+    mode,
+    setMode: setColorMode,
+    theme: themeState,
+    loading,
+    saving,
+    error,
+    prefersDarkMode: prefersDark,
     prefersHighContrast,
     prefersReducedMotion,
-    toggleDarkMode: () => {
-      // Implement dark mode toggle through Redux
-      // dispatch(toggleDarkMode());
-    },
-    setColorScheme: (scheme) => {
-      // Implement color scheme change through Redux
-      // dispatch(setColorScheme(scheme));
-    },
+    refresh: () => refetch?.({ tenantId: resolvedTenantId }),
+    saveTheme,
   };
 
   return (
     <ThemeContext.Provider value={contextValue}>
-      <MuiThemeProvider theme={theme}>
+      <MuiThemeProvider theme={muiTheme}>
         <CssBaseline />
         {children}
       </MuiThemeProvider>
@@ -381,9 +347,10 @@ export function ThemeProvider({ children }) {
   );
 }
 
-// Hook for responsive design
+export const TenantThemeProvider = ThemeProvider;
+
 export const useResponsive = () => {
-  const theme = useTheme();
+  const theme = useMuiTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const isTablet = useMediaQuery(theme.breakpoints.down('md'));
   const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
@@ -398,9 +365,8 @@ export const useResponsive = () => {
   };
 };
 
-// Hook for accessibility features
 export const useAccessibility = () => {
-  const { prefersHighContrast, prefersReducedMotion } = useTheme();
+  const { prefersHighContrast, prefersReducedMotion } = useTenantTheme();
   const [announcements, setAnnouncements] = useState([]);
 
   const announce = (message, priority = 'polite') => {
@@ -413,9 +379,8 @@ export const useAccessibility = () => {
 
     setAnnouncements((prev) => [...prev, announcement]);
 
-    // Remove announcement after it's been announced
     setTimeout(() => {
-      setAnnouncements((prev) => prev.filter((a) => a.id !== announcement.id));
+      setAnnouncements((prev) => prev.filter((item) => item.id !== announcement.id));
     }, 1000);
   };
 

--- a/client/tests/e2e/theme.spec.ts
+++ b/client/tests/e2e/theme.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect } from '@playwright/test';
+import { injectAxe, checkA11y } from '@axe-core/playwright';
+
+const buildThemeResponse = (overrides: Partial<Record<'light' | 'dark', Partial<Record<string, string>>>> = {}) => ({
+  data: {
+    tenantTheme: {
+      tenantId: 'playwright-tenant',
+      name: 'Playwright Preview',
+      updatedAt: new Date().toISOString(),
+      light: {
+        primary: '#0052A4',
+        primaryContrast: '#FFFFFF',
+        secondary: '#2481D7',
+        accent: '#F97316',
+        background: '#F5F7FF',
+        surface: '#FFFFFF',
+        surfaceMuted: '#E2E8F0',
+        border: '#CBD5F5',
+        text: '#102042',
+        textMuted: '#4B5563',
+        success: '#0EA5E9',
+        warning: '#D97706',
+        danger: '#DC2626',
+        focus: '#4338CA',
+        fontBody: "'Inter', 'Segoe UI', system-ui, sans-serif",
+        fontHeading: "'Plus Jakarta Sans', 'Inter', system-ui, sans-serif",
+        fontMono: "'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace",
+        shadowSm: '0 1px 3px rgba(29, 78, 216, 0.12)',
+        shadowMd: '0 12px 24px rgba(29, 78, 216, 0.12)',
+        shadowLg: '0 18px 40px rgba(79, 70, 229, 0.18)',
+        radiusSm: '6px',
+        radiusMd: '12px',
+        radiusLg: '20px',
+        radiusPill: '999px',
+        ...overrides.light,
+      },
+      dark: {
+        primary: '#8FB1FF',
+        primaryContrast: '#050914',
+        secondary: '#C4B5FD',
+        accent: '#FDBA74',
+        background: '#050914',
+        surface: '#10162A',
+        surfaceMuted: '#1B253F',
+        border: '#1E3A8A',
+        text: '#E5E7EB',
+        textMuted: '#9CA3AF',
+        success: '#38BDF8',
+        warning: '#FBBF24',
+        danger: '#F87171',
+        focus: '#60A5FA',
+        fontBody: "'Inter', 'Segoe UI', system-ui, sans-serif",
+        fontHeading: "'Plus Jakarta Sans', 'Inter', system-ui, sans-serif",
+        fontMono: "'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace",
+        shadowSm: '0 1px 3px rgba(8, 47, 73, 0.6)',
+        shadowMd: '0 12px 24px rgba(8, 47, 73, 0.55)',
+        shadowLg: '0 18px 40px rgba(8, 47, 73, 0.5)',
+        radiusSm: '6px',
+        radiusMd: '12px',
+        radiusLg: '20px',
+        radiusPill: '999px',
+        ...overrides.dark,
+      },
+    },
+  },
+});
+
+const interceptThemeQuery = async (page, themeOverrides = {}) => {
+  const response = buildThemeResponse(themeOverrides);
+  await page.route('**/graphql', async (route, request) => {
+    if (request.method() === 'POST') {
+      const body = request.postDataJSON() as { operationName?: string };
+      if (body?.operationName === 'GetTenantTheme') {
+        await route.fulfill({ json: response });
+        return;
+      }
+    }
+    await route.continue();
+  });
+};
+
+test.describe('Tenant theming engine', () => {
+  test('applies tenant CSS variables for light mode', async ({ page }) => {
+    await interceptThemeQuery(page);
+    await page.goto('/');
+    await page.waitForSelector('body');
+
+    const primary = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--color-primary').trim().toLowerCase(),
+    );
+    const background = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--color-background').trim().toLowerCase(),
+    );
+
+    expect(primary).toBe('#0052a4');
+    expect(background).toBe('#f5f7ff');
+
+    await injectAxe(page);
+    await checkA11y(page, undefined, {
+      detailedReport: true,
+      detailedReportOptions: { html: true },
+    });
+  });
+
+  test('respects prefers-color-scheme dark tokens', async ({ page }) => {
+    await interceptThemeQuery(page, {
+      dark: {
+        background: '#0b1220',
+        text: '#f8fafc',
+      },
+    });
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.goto('/');
+    await page.waitForTimeout(250);
+
+    const modeAttr = await page.evaluate(() => document.documentElement.getAttribute('data-theme-mode'));
+    const background = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--color-background').trim().toLowerCase(),
+    );
+    const textColor = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--color-text').trim().toLowerCase(),
+    );
+
+    expect(modeAttr).toBe('dark');
+    expect(background).toBe('#0b1220');
+    expect(textColor).toBe('#f8fafc');
+  });
+});

--- a/server/db/migrations/postgres/2025-09-01_tenant_themes.sql
+++ b/server/db/migrations/postgres/2025-09-01_tenant_themes.sql
@@ -1,0 +1,25 @@
+-- Tenant theming support
+CREATE TABLE IF NOT EXISTS tenant_themes (
+  tenant_id TEXT PRIMARY KEY,
+  name TEXT NOT NULL DEFAULT 'Summit Default',
+  light JSONB NOT NULL DEFAULT '{}'::jsonb,
+  dark JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS tenant_themes_updated_at_idx ON tenant_themes(updated_at DESC);
+
+CREATE OR REPLACE FUNCTION set_tenant_themes_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_tenant_themes_updated_at ON tenant_themes;
+CREATE TRIGGER trg_tenant_themes_updated_at
+BEFORE UPDATE ON tenant_themes
+FOR EACH ROW
+EXECUTE FUNCTION set_tenant_themes_updated_at();

--- a/server/src/graphql/schema.core.js
+++ b/server/src/graphql/schema.core.js
@@ -92,6 +92,41 @@ export const coreTypeDefs = gql`
     relationshipCount: Int!
   }
 
+  type ThemeVariant {
+    primary: String!
+    primaryContrast: String!
+    secondary: String!
+    accent: String!
+    background: String!
+    surface: String!
+    surfaceMuted: String!
+    border: String!
+    text: String!
+    textMuted: String!
+    success: String!
+    warning: String!
+    danger: String!
+    focus: String!
+    fontBody: String!
+    fontHeading: String!
+    fontMono: String!
+    shadowSm: String!
+    shadowMd: String!
+    shadowLg: String!
+    radiusSm: String!
+    radiusMd: String!
+    radiusLg: String!
+    radiusPill: String!
+  }
+
+  type TenantTheme {
+    tenantId: String!
+    name: String!
+    light: ThemeVariant!
+    dark: ThemeVariant!
+    updatedAt: DateTime!
+  }
+
   # Input types for mutations
   input EntityInput {
     tenantId: String!
@@ -130,6 +165,40 @@ export const coreTypeDefs = gql`
     description: String
     status: InvestigationStatus
     props: JSON
+  }
+
+  input ThemeVariantInput {
+    primary: String!
+    primaryContrast: String!
+    secondary: String!
+    accent: String!
+    background: String!
+    surface: String!
+    surfaceMuted: String!
+    border: String!
+    text: String!
+    textMuted: String!
+    success: String!
+    warning: String!
+    danger: String!
+    focus: String!
+    fontBody: String!
+    fontHeading: String!
+    fontMono: String!
+    shadowSm: String!
+    shadowMd: String!
+    shadowLg: String!
+    radiusSm: String!
+    radiusMd: String!
+    radiusLg: String!
+    radiusPill: String!
+  }
+
+  input TenantThemeInput {
+    tenantId: String
+    name: String!
+    light: ThemeVariantInput!
+    dark: ThemeVariantInput!
   }
 
   # Search and filter inputs
@@ -188,6 +257,9 @@ export const coreTypeDefs = gql`
       offset: Int = 0
     ): [Investigation!]!
 
+    # Tenant theme configuration
+    tenantTheme(tenantId: String): TenantTheme!
+
     # Graph operations
     graphNeighborhood(input: GraphTraversalInput!): GraphNeighborhood!
 
@@ -210,6 +282,9 @@ export const coreTypeDefs = gql`
     createInvestigation(input: InvestigationInput!): Investigation!
     updateInvestigation(input: InvestigationUpdateInput!): Investigation
     deleteInvestigation(id: ID!, tenantId: String!): Boolean!
+
+    # Theme management
+    upsertTenantTheme(input: TenantThemeInput!): TenantTheme!
 
     # Bulk operations
     createEntitiesBatch(inputs: [EntityInput!]!, tenantId: String!): [Entity!]!

--- a/server/src/repos/ThemeRepo.ts
+++ b/server/src/repos/ThemeRepo.ts
@@ -1,0 +1,188 @@
+import { Pool } from 'pg';
+import logger from '../config/logger.js';
+
+const themeLogger = logger.child({ name: 'ThemeRepo' });
+
+export interface ThemeVariantTokens {
+  primary: string;
+  primaryContrast: string;
+  secondary: string;
+  accent: string;
+  background: string;
+  surface: string;
+  surfaceMuted: string;
+  border: string;
+  text: string;
+  textMuted: string;
+  success: string;
+  warning: string;
+  danger: string;
+  focus: string;
+  fontBody: string;
+  fontHeading: string;
+  fontMono: string;
+  shadowSm: string;
+  shadowMd: string;
+  shadowLg: string;
+  radiusSm: string;
+  radiusMd: string;
+  radiusLg: string;
+  radiusPill: string;
+}
+
+export interface TenantTheme {
+  tenantId: string;
+  name: string;
+  light: ThemeVariantTokens;
+  dark: ThemeVariantTokens;
+  updatedAt: Date;
+  createdAt?: Date;
+}
+
+interface ThemeRow {
+  tenant_id: string;
+  name: string;
+  light: ThemeVariantTokens;
+  dark: ThemeVariantTokens;
+  created_at: Date;
+  updated_at: Date;
+}
+
+const DEFAULT_LIGHT: ThemeVariantTokens = {
+  primary: '#1459FF',
+  primaryContrast: '#FFFFFF',
+  secondary: '#6366F1',
+  accent: '#C026D3',
+  background: '#F8FAFC',
+  surface: '#FFFFFF',
+  surfaceMuted: '#E2E8F0',
+  border: '#CBD5F5',
+  text: '#0F172A',
+  textMuted: '#475569',
+  success: '#059669',
+  warning: '#D97706',
+  danger: '#DC2626',
+  focus: '#2563EB',
+  fontBody: "'Inter', 'Segoe UI', system-ui, sans-serif",
+  fontHeading: "'Work Sans', 'Inter', system-ui, sans-serif",
+  fontMono: "'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace",
+  shadowSm: '0 1px 2px rgba(15, 23, 42, 0.08)',
+  shadowMd: '0 6px 18px rgba(15, 23, 42, 0.12)',
+  shadowLg: '0 18px 48px rgba(15, 23, 42, 0.16)',
+  radiusSm: '6px',
+  radiusMd: '10px',
+  radiusLg: '16px',
+  radiusPill: '999px',
+};
+
+const DEFAULT_DARK: ThemeVariantTokens = {
+  primary: '#7C9DFF',
+  primaryContrast: '#0B1220',
+  secondary: '#A5B4FC',
+  accent: '#F472B6',
+  background: '#0B1220',
+  surface: '#111827',
+  surfaceMuted: '#1F2937',
+  border: '#27324A',
+  text: '#E2E8F0',
+  textMuted: '#94A3B8',
+  success: '#34D399',
+  warning: '#FBBF24',
+  danger: '#F87171',
+  focus: '#60A5FA',
+  fontBody: "'Inter', 'Segoe UI', system-ui, sans-serif",
+  fontHeading: "'Work Sans', 'Inter', system-ui, sans-serif",
+  fontMono: "'JetBrains Mono', 'SFMono-Regular', ui-monospace, monospace",
+  shadowSm: '0 1px 2px rgba(8, 47, 73, 0.6)',
+  shadowMd: '0 6px 18px rgba(8, 47, 73, 0.55)',
+  shadowLg: '0 18px 48px rgba(8, 47, 73, 0.5)',
+  radiusSm: '6px',
+  radiusMd: '10px',
+  radiusLg: '16px',
+  radiusPill: '999px',
+};
+
+const DEFAULT_THEME: Omit<TenantTheme, 'tenantId'> = {
+  name: 'Summit Default',
+  light: DEFAULT_LIGHT,
+  dark: DEFAULT_DARK,
+  updatedAt: new Date(0),
+  createdAt: new Date(0),
+};
+
+export class ThemeRepo {
+  constructor(private readonly pg: Pool) {}
+
+  private mergeWithDefaults(theme: TenantTheme): TenantTheme {
+    return {
+      ...theme,
+      light: { ...DEFAULT_LIGHT, ...theme.light },
+      dark: { ...DEFAULT_DARK, ...theme.dark },
+    };
+  }
+
+  private mapRow(row: ThemeRow): TenantTheme {
+    return this.mergeWithDefaults({
+      tenantId: row.tenant_id,
+      name: row.name,
+      light: row.light || DEFAULT_LIGHT,
+      dark: row.dark || DEFAULT_DARK,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    });
+  }
+
+  async getTheme(tenantId: string): Promise<TenantTheme> {
+    try {
+      const { rows } = await this.pg.query<ThemeRow>(
+        `SELECT tenant_id, name, light, dark, created_at, updated_at
+         FROM tenant_themes
+         WHERE tenant_id = $1`,
+        [tenantId],
+      );
+
+      if (rows.length === 0) {
+        themeLogger.debug({ tenantId }, 'No tenant theme found, using defaults');
+        return this.mergeWithDefaults({
+          tenantId,
+          ...DEFAULT_THEME,
+        });
+      }
+
+      return this.mapRow(rows[0]);
+    } catch (error) {
+      themeLogger.warn({ tenantId, error }, 'Failed to load tenant theme, falling back to defaults');
+      return this.mergeWithDefaults({
+        tenantId,
+        ...DEFAULT_THEME,
+      });
+    }
+  }
+
+  async upsertTheme(input: TenantTheme): Promise<TenantTheme> {
+    try {
+      const { rows } = await this.pg.query<ThemeRow>(
+        `INSERT INTO tenant_themes (tenant_id, name, light, dark)
+         VALUES ($1, $2, $3::jsonb, $4::jsonb)
+         ON CONFLICT (tenant_id)
+         DO UPDATE SET
+           name = EXCLUDED.name,
+           light = EXCLUDED.light,
+           dark = EXCLUDED.dark,
+           updated_at = now()
+         RETURNING tenant_id, name, light, dark, created_at, updated_at`,
+        [input.tenantId, input.name, JSON.stringify(input.light), JSON.stringify(input.dark)],
+      );
+
+      return this.mapRow(rows[0]);
+    } catch (error) {
+      themeLogger.error({ tenantId: input.tenantId, error }, 'Failed to upsert tenant theme');
+      throw error;
+    }
+  }
+}
+
+export const defaultTheme = (tenantId = 'default'): TenantTheme => ({
+  tenantId,
+  ...DEFAULT_THEME,
+});


### PR DESCRIPTION
## Summary
- add a tenant_themes Postgres table, repository, and GraphQL query/mutation for loading and updating branding tokens per tenant
- rebuild the React theme provider to consume the GraphQL data, emit CSS variables, and update the shell and global styles for light/dark accessibility
- add Storybook theming configuration, example story, client GraphQL documents, and Playwright coverage with new scripts for local storybook usage

## Testing
- npx playwright test tests/e2e/theme.spec.ts *(fails: @playwright/test missing in workspace environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bb97c7b48333be3efee7d2d75428