### PR TITLE
feat: add role-based dashboards for RBAC personas

### DIFF
--- a/client/src/features/rbac/RoleBasedDashboard.stories.tsx
+++ b/client/src/features/rbac/RoleBasedDashboard.stories.tsx
@@ -1,0 +1,86 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Provider } from 'react-redux';
+import { configureStore } from '@reduxjs/toolkit';
+import { MockedProvider } from '@apollo/client/testing';
+import RoleBasedDashboard from './RoleBasedDashboard';
+import ui from '../../store/slices/ui';
+import rbac from '../../store/slices/rbacSlice';
+import { GET_RBAC_CONTEXT } from '../../graphql/rbac.gql.js';
+
+const baseUser = {
+  id: 'user-1',
+  displayName: 'Story User',
+  role: 'analyst',
+  primaryRole: 'analyst',
+  roles: ['analyst'],
+  personas: [],
+  permissions: [],
+  featureFlags: [],
+};
+
+function createStore() {
+  return configureStore({
+    reducer: {
+      ui,
+      rbac,
+    },
+  });
+}
+
+function withProviders(overrides: Partial<typeof baseUser>) {
+  const store = createStore();
+  const mocks = [
+    {
+      request: {
+        query: GET_RBAC_CONTEXT,
+      },
+      result: {
+        data: {
+          me: { ...baseUser, ...overrides },
+        },
+      },
+    },
+  ];
+
+  return (
+    <Provider store={store}>
+      <MockedProvider mocks={mocks}>
+        <RoleBasedDashboard />
+      </MockedProvider>
+    </Provider>
+  );
+}
+
+const meta: Meta<typeof RoleBasedDashboard> = {
+  title: 'Features/RBAC/RoleBasedDashboard',
+  component: RoleBasedDashboard,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RoleBasedDashboard>;
+
+export const Analyst: Story = {
+  render: () => withProviders({}),
+};
+
+export const Admin: Story = {
+  render: () =>
+    withProviders({
+      role: 'admin',
+      primaryRole: 'admin',
+      roles: ['admin'],
+    }),
+};
+
+export const MaestroConductor: Story = {
+  render: () =>
+    withProviders({
+      personas: ['maestro-conductor'],
+      permissions: ['ml:manage'],
+      featureFlags: [
+        { key: 'ml-tools', enabled: true },
+        { key: 'deployment-controls', enabled: false },
+      ],
+    }),
+};

--- a/client/src/features/rbac/RoleBasedDashboard.tsx
+++ b/client/src/features/rbac/RoleBasedDashboard.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useMemo } from 'react';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Alert from '@mui/material/Alert';
+import { useQuery } from '@apollo/client';
+import { useAppDispatch, useAppSelector } from '../../store';
+import { GET_RBAC_CONTEXT } from '../../graphql/rbac.gql.js';
+import { rbacFailed, rbacReceived, rbacRequested } from '../../store/slices/rbacSlice';
+import AnalystDashboardView from './views/AnalystDashboardView';
+import AdminDashboardView from './views/AdminDashboardView';
+import MaestroConductorDashboardView from './views/MaestroConductorDashboardView';
+
+function normalizePersonas(personas: Array<string | null | undefined> | null | undefined): string[] {
+  if (!personas) {
+    return [];
+  }
+  return personas.filter((persona): persona is string => Boolean(persona));
+}
+
+export const RoleBasedDashboard: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const { loading, error, primaryRole, roles, personas, permissions, featureFlags } = useAppSelector(
+    (state) => state.rbac,
+  );
+
+  const { loading: queryLoading } = useQuery(GET_RBAC_CONTEXT, {
+    onCompleted: (payload) => {
+      const me = payload?.me ?? {};
+      dispatch(
+        rbacReceived({
+          userId: me.id ?? null,
+          displayName: me.displayName ?? null,
+          primaryRole: me.primaryRole ?? me.role ?? null,
+          roles: Array.isArray(me.roles) && me.roles.length > 0 ? me.roles : me.role ? [me.role] : [],
+          personas: normalizePersonas(me.personas),
+          permissions: Array.isArray(me.permissions) ? me.permissions : [],
+          featureFlags: Array.isArray(me.featureFlags) ? me.featureFlags : [],
+        }),
+      );
+    },
+    onError: (apolloError) => {
+      dispatch(rbacFailed(apolloError.message));
+    },
+    fetchPolicy: 'cache-first',
+  });
+
+  useEffect(() => {
+    if (queryLoading) {
+      dispatch(rbacRequested());
+    }
+  }, [queryLoading, dispatch]);
+
+  const activeRole = useMemo(() => {
+    const normalizedPrimary = primaryRole?.toLowerCase();
+    if (normalizedPrimary) {
+      return normalizedPrimary;
+    }
+    const firstRole = roles.map((role) => role?.toLowerCase?.()).find(Boolean);
+    return firstRole ?? null;
+  }, [primaryRole, roles]);
+
+  const personaKey = useMemo(() => {
+    return personas
+      .map((persona) => persona.toLowerCase())
+      .find((persona) => persona.includes('maestro'))
+      ? 'maestro-conductor'
+      : null;
+  }, [personas]);
+
+  if (loading || queryLoading) {
+    return (
+      <Box display="flex" alignItems="center" justifyContent="center" minHeight="40vh">
+        <CircularProgress role="status" aria-label="Loading dashboards" />
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box p={2}>
+        <Alert severity="error" data-testid="rbac-error">
+          Failed to load RBAC context: {error}
+        </Alert>
+      </Box>
+    );
+  }
+
+  if (personaKey === 'maestro-conductor') {
+    return (
+      <MaestroConductorDashboardView
+        role={activeRole}
+        permissions={permissions}
+        featureFlags={featureFlags}
+      />
+    );
+  }
+
+  if (activeRole === 'admin') {
+    return <AdminDashboardView />;
+  }
+
+  if (roles.some((role) => role?.toLowerCase?.() === 'admin')) {
+    return <AdminDashboardView />;
+  }
+
+  return <AnalystDashboardView />;
+};
+
+export default RoleBasedDashboard;

--- a/client/src/features/rbac/views/AdminDashboardView.tsx
+++ b/client/src/features/rbac/views/AdminDashboardView.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Divider from '@mui/material/Divider';
+import StatsOverview from '../../../components/dashboard/StatsOverview';
+import LatencyPanels from '../../../components/dashboard/LatencyPanels';
+import ErrorPanels from '../../../components/dashboard/ErrorPanels';
+import LiveActivityFeed from '../../../components/dashboard/LiveActivityFeed';
+
+const mlTools = [
+  { label: 'AutoML Model Registry', status: 'Healthy' },
+  { label: 'Feature Store', status: 'Syncing' },
+  { label: 'Inference Pipelines', status: 'Draining' },
+];
+
+const deploymentControls = [
+  'Blue/Green Deployment orchestration',
+  'Instant rollback with policy guardrails',
+  'Freeze windows for critical tenants',
+];
+
+export interface AdminDashboardViewProps {
+  showMlTools?: boolean;
+  showDeploymentControls?: boolean;
+}
+
+export const AdminDashboardView: React.FC<AdminDashboardViewProps> = ({
+  showMlTools = true,
+  showDeploymentControls = true,
+}) => {
+  return (
+    <Box p={2} data-testid="admin-dashboard">
+      <Typography variant="h4" component="h1" gutterBottom>
+        Admin Control Center
+      </Typography>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={6}>
+          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
+            <Typography variant="h6" gutterBottom>
+              Platform Telemetry
+            </Typography>
+            <StatsOverview />
+          </Paper>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <LiveActivityFeed />
+        </Grid>
+        <Grid item xs={12}>
+          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
+            <LatencyPanels />
+          </Paper>
+        </Grid>
+        <Grid item xs={12}>
+          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
+            <ErrorPanels />
+          </Paper>
+        </Grid>
+        {showMlTools && (
+          <Grid item xs={12} md={6}>
+            <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }} data-testid="ml-tools-panel">
+              <Typography variant="h6" gutterBottom>
+                ML Tooling
+              </Typography>
+              <List>
+                {mlTools.map((tool) => (
+                  <ListItem key={tool.label} disableGutters>
+                    <ListItemText primary={tool.label} secondary="Managed by Maestro" />
+                    <Chip label={tool.status} size="small" color={tool.status === 'Healthy' ? 'success' : 'warning'} />
+                  </ListItem>
+                ))}
+              </List>
+            </Paper>
+          </Grid>
+        )}
+        {showDeploymentControls && (
+          <Grid item xs={12} md={6}>
+            <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }} data-testid="deployment-controls-panel">
+              <Typography variant="h6" gutterBottom>
+                Deployment Controls
+              </Typography>
+              <Stack spacing={1} divider={<Divider flexItem />}>
+                {deploymentControls.map((control) => (
+                  <Typography key={control} variant="body2">
+                    {control}
+                  </Typography>
+                ))}
+              </Stack>
+            </Paper>
+          </Grid>
+        )}
+      </Grid>
+    </Box>
+  );
+};
+
+export default AdminDashboardView;

--- a/client/src/features/rbac/views/AnalystDashboardView.tsx
+++ b/client/src/features/rbac/views/AnalystDashboardView.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import StatsOverview from '../../../components/dashboard/StatsOverview';
+import LatencyPanels from '../../../components/dashboard/LatencyPanels';
+import ErrorPanels from '../../../components/dashboard/ErrorPanels';
+import ResolverTop5 from '../../../components/dashboard/ResolverTop5';
+import GrafanaLinkCard from '../../../components/dashboard/GrafanaLinkCard';
+import LiveActivityFeed from '../../../components/dashboard/LiveActivityFeed';
+
+export const AnalystDashboardView: React.FC = () => {
+  return (
+    <Box p={2} aria-live="polite" data-testid="analyst-dashboard">
+      <Typography variant="h4" component="h1" gutterBottom>
+        Analyst Operations Overview
+      </Typography>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={6}>
+          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
+            <Typography variant="h6" gutterBottom>
+              Stats Overview
+            </Typography>
+            <StatsOverview />
+          </Paper>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <LiveActivityFeed />
+        </Grid>
+        <Grid item xs={12} md={4}>
+          <GrafanaLinkCard />
+        </Grid>
+        <Grid item xs={12}>
+          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
+            <LatencyPanels />
+          </Paper>
+        </Grid>
+        <Grid item xs={12}>
+          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
+            <ErrorPanels />
+          </Paper>
+        </Grid>
+        <Grid item xs={12}>
+          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
+            <ResolverTop5 />
+          </Paper>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default AnalystDashboardView;

--- a/client/src/features/rbac/views/MaestroConductorDashboardView.tsx
+++ b/client/src/features/rbac/views/MaestroConductorDashboardView.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import Paper from '@mui/material/Paper';
+import Typography from '@mui/material/Typography';
+import Alert from '@mui/material/Alert';
+import Stack from '@mui/material/Stack';
+import Chip from '@mui/material/Chip';
+import Divider from '@mui/material/Divider';
+
+export interface MaestroConductorDashboardViewProps {
+  role: string | null;
+  permissions: string[];
+  featureFlags: Record<string, boolean>;
+}
+
+const mlTasks = [
+  'Model drift detection alerts',
+  'Shadow deployment readiness checks',
+  'Feature parity validation',
+];
+
+const deploymentPipelines = [
+  { name: 'Aurora Risk Engine', status: 'Deploying', id: 'aurora-risk' },
+  { name: 'Realtime Watchtower', status: 'Canary', id: 'watchtower' },
+  { name: 'Narrative Synthesizer', status: 'Idle', id: 'narrative' },
+];
+
+export const MaestroConductorDashboardView: React.FC<MaestroConductorDashboardViewProps> = ({
+  role,
+  permissions,
+  featureFlags,
+}) => {
+  const canAccessMlTools = featureFlags['ml-tools'] || permissions.includes('ml:manage') || role === 'admin';
+  const canManageDeployments =
+    featureFlags['deployment-controls'] || permissions.includes('deploy:manage') || role === 'admin';
+
+  return (
+    <Box p={2} data-testid="maestro-dashboard">
+      <Typography variant="h4" component="h1" gutterBottom>
+        Maestro Conductor Mission Control
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+        Persona-aware orchestration for Maestro operators. Features are unsealed as RBAC capabilities arrive via GraphQL.
+      </Typography>
+      <Grid container spacing={2}>
+        <Grid item xs={12} md={6}>
+          {canAccessMlTools ? (
+            <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }} data-testid="maestro-ml-tools">
+              <Typography variant="h6" gutterBottom>
+                ML Operations Toolkit
+              </Typography>
+              <Stack spacing={1} divider={<Divider flexItem />}>
+                {mlTasks.map((task) => (
+                  <Typography key={task} variant="body2">
+                    {task}
+                  </Typography>
+                ))}
+              </Stack>
+            </Paper>
+          ) : (
+            <Alert severity="warning" data-testid="maestro-ml-locked">
+              ML tooling is hidden for the <strong>{role ?? 'unknown'}</strong> role. Request the <code>ml:manage</code> permission to
+              unlock experimentation features.
+            </Alert>
+          )}
+        </Grid>
+        <Grid item xs={12} md={6}>
+          {canManageDeployments ? (
+            <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }} data-testid="maestro-deploy-controls">
+              <Typography variant="h6" gutterBottom>
+                Deployment Controls
+              </Typography>
+              <Stack spacing={2}>
+                {deploymentPipelines.map((pipeline) => (
+                  <Stack
+                    key={pipeline.id}
+                    direction="row"
+                    alignItems="center"
+                    justifyContent="space-between"
+                    sx={{ border: '1px solid', borderColor: 'divider', borderRadius: 2, p: 1.5 }}
+                  >
+                    <div>
+                      <Typography variant="subtitle1">{pipeline.name}</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        pipeline/{pipeline.id}
+                      </Typography>
+                    </div>
+                    <Chip label={pipeline.status} color={pipeline.status === 'Deploying' ? 'primary' : 'default'} size="small" />
+                  </Stack>
+                ))}
+              </Stack>
+            </Paper>
+          ) : (
+            <Alert severity="info" data-testid="maestro-deploy-locked">
+              Deployment controls are hidden. Grant the <code>deploy:manage</code> capability to expose Maestro release tooling.
+            </Alert>
+          )}
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default MaestroConductorDashboardView;

--- a/client/src/graphql/rbac.gql.js
+++ b/client/src/graphql/rbac.gql.js
@@ -1,0 +1,19 @@
+import { gql } from '@apollo/client';
+
+export const GET_RBAC_CONTEXT = gql`
+  query GetRbacContext {
+    me {
+      id
+      displayName
+      role
+      primaryRole
+      roles
+      personas
+      permissions
+      featureFlags {
+        key
+        enabled
+      }
+    }
+  }
+`;

--- a/client/src/pages/Dashboard/__tests__/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard/__tests__/Dashboard.test.tsx
@@ -1,14 +1,76 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import store from '../../../store/index';
+import { MockedProvider } from '@apollo/client/testing';
+import { configureStore } from '@reduxjs/toolkit';
+import ui from '../../../store/slices/ui';
+import rbac from '../../../store/slices/rbacSlice';
+import { GET_RBAC_CONTEXT } from '../../../graphql/rbac.gql.js';
 import Dashboard from '../index';
 
-test('renders dashboard skeletons then content', async () => {
+const createStore = () =>
+  configureStore({
+    reducer: {
+      ui,
+      rbac,
+    },
+  });
+
+const baseMock = {
+  id: 'user-1',
+  displayName: 'Test User',
+  role: 'analyst',
+  primaryRole: 'analyst',
+  roles: ['analyst'],
+  personas: [],
+  permissions: [],
+  featureFlags: [],
+};
+
+function renderDashboard(mockOverrides: Partial<typeof baseMock> = {}) {
+  const store = createStore();
+  const mock = {
+    request: {
+      query: GET_RBAC_CONTEXT,
+    },
+    result: {
+      data: {
+        me: { ...baseMock, ...mockOverrides },
+      },
+    },
+  };
+
   render(
     <Provider store={store}>
-      <Dashboard />
+      <MockedProvider mocks={[mock]}>
+        <Dashboard />
+      </MockedProvider>
     </Provider>,
   );
+}
+
+test('renders analyst dashboard by default', async () => {
+  renderDashboard();
   expect(screen.getByRole('status')).toBeInTheDocument();
+  await waitFor(() => screen.getByTestId('analyst-dashboard'));
+});
+
+test('renders admin controls when user has admin role', async () => {
+  renderDashboard({ role: 'admin', primaryRole: 'admin', roles: ['analyst', 'admin'] });
+  await waitFor(() => screen.getByTestId('admin-dashboard'));
+  expect(screen.getByTestId('ml-tools-panel')).toBeInTheDocument();
+});
+
+test('renders maestro persona view and hides locked features', async () => {
+  renderDashboard({
+    role: 'analyst',
+    primaryRole: 'analyst',
+    personas: ['maestro-conductor'],
+    permissions: ['ml:manage'],
+    featureFlags: [{ key: 'ml-tools', enabled: true }],
+  });
+
+  await waitFor(() => screen.getByTestId('maestro-dashboard'));
+  expect(screen.getByTestId('maestro-ml-tools')).toBeInTheDocument();
+  expect(screen.getByTestId('maestro-deploy-locked')).toBeInTheDocument();
 });

--- a/client/src/pages/Dashboard/index.tsx
+++ b/client/src/pages/Dashboard/index.tsx
@@ -1,57 +1,10 @@
 import React from 'react';
-import Box from '@mui/material/Box';
-import Grid from '@mui/material/Grid';
-import Paper from '@mui/material/Paper';
-import Typography from '@mui/material/Typography';
-import StatsOverview from '../../components/dashboard/StatsOverview';
-import LatencyPanels from '../../components/dashboard/LatencyPanels';
-import ErrorPanels from '../../components/dashboard/ErrorPanels';
-import ResolverTop5 from '../../components/dashboard/ResolverTop5';
-import GrafanaLinkCard from '../../components/dashboard/GrafanaLinkCard';
-import LiveActivityFeed from '../../components/dashboard/LiveActivityFeed';
 import { useDashboardPrefetch, useIntelligentPrefetch } from '../../hooks/usePrefetch';
+import RoleBasedDashboard from '../../features/rbac/RoleBasedDashboard';
 
 export default function Dashboard() {
-  // Prefetch critical dashboard data to eliminate panel pop-in
   useDashboardPrefetch();
   useIntelligentPrefetch();
 
-  return (
-    <Box p={2} aria-live="polite">
-      <Grid container spacing={2}>
-        <Grid item xs={12} md={6}>
-          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
-            <Typography variant="h6" gutterBottom>
-              Stats Overview
-            </Typography>
-            <StatsOverview />
-          </Paper>
-        </Grid>
-        <Grid item xs={12} md={6}>
-          <LiveActivityFeed />
-        </Grid>
-        <Grid item xs={12} md={4}>
-          <GrafanaLinkCard />
-        </Grid>
-
-        <Grid item xs={12}>
-          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
-            <LatencyPanels />
-          </Paper>
-        </Grid>
-
-        <Grid item xs={12}>
-          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
-            <ErrorPanels />
-          </Paper>
-        </Grid>
-
-        <Grid item xs={12}>
-          <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
-            <ResolverTop5 />
-          </Paper>
-        </Grid>
-      </Grid>
-    </Box>
-  );
+  return <RoleBasedDashboard />;
 }

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -8,6 +8,7 @@ import aiInsightsReducer from './slices/aiInsightsSlice'; // Import the new aiIn
 import timelineReducer from './slices/timelineSlice';
 import graphData from './graphSlice';
 import socket from './socketSlice';
+import rbac from './slices/rbacSlice';
 
 export const store = configureStore({
   reducer: {
@@ -20,6 +21,7 @@ export const store = configureStore({
     aiInsights: aiInsightsReducer, // Add the new aiInsightsReducer
     graphData,
     socket,
+    rbac,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,9 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import ui from './slices/ui';
+import rbac from './slices/rbacSlice';
 
 const store = configureStore({
-  reducer: { ui },
+  reducer: { ui, rbac },
 });
 
 export type RootState = ReturnType<typeof store.getState>;

--- a/client/src/store/slices/rbacSlice.ts
+++ b/client/src/store/slices/rbacSlice.ts
@@ -1,0 +1,89 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+export interface FeatureFlagState {
+  key: string;
+  enabled: boolean;
+}
+
+export interface RbacState {
+  loading: boolean;
+  error: string | null;
+  userId: string | null;
+  displayName: string | null;
+  primaryRole: string | null;
+  roles: string[];
+  personas: string[];
+  permissions: string[];
+  featureFlags: Record<string, boolean>;
+}
+
+export interface RbacPayload {
+  userId?: string | null;
+  displayName?: string | null;
+  primaryRole?: string | null;
+  roles?: string[] | null;
+  personas?: string[] | null;
+  permissions?: string[] | null;
+  featureFlags?: FeatureFlagState[] | null;
+}
+
+const initialState: RbacState = {
+  loading: false,
+  error: null,
+  userId: null,
+  displayName: null,
+  primaryRole: null,
+  roles: [],
+  personas: [],
+  permissions: [],
+  featureFlags: {},
+};
+
+function normalizeFeatureFlags(flags: FeatureFlagState[] | null | undefined): Record<string, boolean> {
+  if (!flags) {
+    return {};
+  }
+
+  return flags.reduce<Record<string, boolean>>((acc, flag) => {
+    if (flag?.key) {
+      acc[flag.key] = Boolean(flag.enabled);
+    }
+    return acc;
+  }, {});
+}
+
+const rbacSlice = createSlice({
+  name: 'rbac',
+  initialState,
+  reducers: {
+    rbacRequested(state) {
+      state.loading = true;
+      state.error = null;
+    },
+    rbacReceived(state, action: PayloadAction<RbacPayload>) {
+      const { userId, displayName, primaryRole, roles, personas, permissions, featureFlags } = action.payload;
+      state.loading = false;
+      state.error = null;
+      state.userId = userId ?? state.userId;
+      state.displayName = displayName ?? state.displayName;
+      state.primaryRole = primaryRole ?? state.primaryRole;
+      state.roles = roles ?? state.roles;
+      state.personas = personas ?? state.personas;
+      state.permissions = permissions ?? state.permissions;
+      state.featureFlags = {
+        ...state.featureFlags,
+        ...normalizeFeatureFlags(featureFlags),
+      };
+    },
+    rbacFailed(state, action: PayloadAction<string | undefined>) {
+      state.loading = false;
+      state.error = action.payload ?? 'Unable to load RBAC context';
+    },
+    setFeatureFlag(state, action: PayloadAction<{ key: string; enabled: boolean }>) {
+      state.featureFlags[action.payload.key] = action.payload.enabled;
+    },
+  },
+});
+
+export const { rbacRequested, rbacReceived, rbacFailed, setFeatureFlag } = rbacSlice.actions;
+export default rbacSlice.reducer;

--- a/client/tests/e2e/ui/role-based-dashboard.spec.ts
+++ b/client/tests/e2e/ui/role-based-dashboard.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, Page, Route, Request } from '@playwright/test';
+
+type RbacOverride = Partial<{
+  id: string;
+  displayName: string;
+  role: string;
+  primaryRole: string;
+  roles: string[];
+  personas: string[];
+  permissions: string[];
+  featureFlags: Array<{ key: string; enabled: boolean }>;
+}>;
+
+const baseUser = {
+  id: 'user-e2e',
+  displayName: 'E2E User',
+  role: 'analyst',
+  primaryRole: 'analyst',
+  roles: ['analyst'],
+  personas: [] as string[],
+  permissions: [] as string[],
+  featureFlags: [] as Array<{ key: string; enabled: boolean }>,
+};
+
+async function interceptRbac(page: Page, overrides: RbacOverride) {
+  const payload = { ...baseUser, ...overrides };
+  await page.route('**/graphql*', async (route: Route, request: Request) => {
+    const method = request.method();
+    const postData = request.postData();
+    const url = request.url();
+
+    const requestContainsRbacQuery = () => {
+      if (postData) {
+        return postData.includes('GetRbacContext');
+      }
+      return url.includes('GetRbacContext');
+    };
+
+    if (requestContainsRbacQuery()) {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: { me: payload } }),
+      });
+      return;
+    }
+
+    if (method === 'OPTIONS') {
+      await route.fulfill({ status: 200, body: 'OK' });
+      return;
+    }
+
+    await route.continue();
+  });
+}
+
+test.describe('Role-based dashboard RBAC rendering', () => {
+  test('shows analyst dashboard by default', async ({ page }) => {
+    await interceptRbac(page, {});
+    await page.goto('/dashboard');
+    await expect(page.getByTestId('analyst-dashboard')).toBeVisible();
+  });
+
+  test('shows admin controls for admin role', async ({ page }) => {
+    await interceptRbac(page, { role: 'admin', primaryRole: 'admin', roles: ['admin'] });
+    await page.goto('/dashboard');
+    await expect(page.getByTestId('admin-dashboard')).toBeVisible();
+    await expect(page.getByTestId('ml-tools-panel')).toBeVisible();
+  });
+
+  test('locks deployment controls when maestro persona lacks permission', async ({ page }) => {
+    await interceptRbac(page, {
+      personas: ['maestro-conductor'],
+      permissions: ['ml:manage'],
+      featureFlags: [
+        { key: 'ml-tools', enabled: true },
+        { key: 'deployment-controls', enabled: false },
+      ],
+    });
+    await page.goto('/dashboard');
+    await expect(page.getByTestId('maestro-dashboard')).toBeVisible();
+    await expect(page.getByTestId('maestro-ml-tools')).toBeVisible();
+    await expect(page.getByTestId('maestro-deploy-locked')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a Redux RBAC slice and GraphQL query to hydrate role and persona data from the API
- route the dashboard page through a new RoleBasedDashboard component that renders analyst, admin, or Maestro Conductor views with conditional features
- document scenarios with Storybook stories, unit tests, and a Playwright e2e spec for role-specific dashboard behavior

## Testing
- `npm run test -- Dashboard`


------
https://chatgpt.com/codex/tasks/task_e_68d6bbbd20608333951370c23f00e90e