### PR TITLE
feat(feedback): add dashboard feedback workflows

### DIFF
--- a/client/src/components/dashboard/FeedbackDialog.tsx
+++ b/client/src/components/dashboard/FeedbackDialog.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Button,
+  TextField,
+  MenuItem,
+  Box,
+  Typography,
+  Alert,
+} from '@mui/material';
+import { useForm, Controller } from 'react-hook-form';
+import { useMutation } from '@apollo/client';
+import { useToastHelpers } from '../ToastContainer';
+import { SUBMIT_FEEDBACK_MUTATION } from '../../graphql/feedback';
+
+type FeedbackCategory = 'BUG' | 'FEATURE' | 'OTHER';
+
+interface FeedbackFormValues {
+  category: FeedbackCategory;
+  title: string;
+  description: string;
+  contact?: string;
+}
+
+interface FeedbackDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSubmitted?: () => void;
+}
+
+const categories: { value: FeedbackCategory; label: string; helper: string }[] = [
+  { value: 'BUG', label: 'Bug report', helper: 'Report defects, glitches, or broken flows.' },
+  { value: 'FEATURE', label: 'Feature request', helper: 'Suggest enhancements or new capabilities.' },
+  { value: 'OTHER', label: 'General feedback', helper: 'Share workflow notes or anything else.' },
+];
+
+export const FeedbackDialog: React.FC<FeedbackDialogProps> = ({ open, onClose, onSubmitted }) => {
+  const toast = useToastHelpers();
+  const [submitFeedback, { loading }] = useMutation(SUBMIT_FEEDBACK_MUTATION);
+  const [submissionError, setSubmissionError] = React.useState<string | null>(null);
+
+  const {
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FeedbackFormValues>({
+    defaultValues: {
+      category: 'BUG',
+      title: '',
+      description: '',
+      contact: '',
+    },
+  });
+
+  const handleClose = React.useCallback(() => {
+    if (!loading) {
+      reset();
+      setSubmissionError(null);
+      onClose();
+    }
+  }, [loading, onClose, reset]);
+
+  const onSubmit = async (values: FeedbackFormValues) => {
+    setSubmissionError(null);
+    try {
+      await submitFeedback({
+        variables: {
+          input: {
+            category: values.category,
+            title: values.title.trim(),
+            description: values.description.trim(),
+            contact: values.contact?.trim() || undefined,
+          },
+        },
+      });
+      toast.success('Feedback sent', 'Thanks! Our team will review your note.');
+      reset();
+      onSubmitted?.();
+      onClose();
+    } catch (error: any) {
+      setSubmissionError(error?.message || 'Failed to submit feedback.');
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={handleClose} aria-labelledby="feedback-dialog-title" fullWidth maxWidth="sm">
+      <DialogTitle id="feedback-dialog-title">Share product feedback</DialogTitle>
+      <DialogContent sx={{ pt: 1 }}>
+        <Typography variant="body2" color="text.secondary" mb={2}>
+          Tell us about a bug, request a capability, or leave general notes. We review every submission.
+        </Typography>
+
+        {submissionError && (
+          <Alert severity="error" sx={{ mb: 2 }} data-testid="feedback-error">
+            {submissionError}
+          </Alert>
+        )}
+
+        <Box component="form" id="feedback-form" onSubmit={handleSubmit(onSubmit)} noValidate>
+          <Controller
+            name="category"
+            control={control}
+            rules={{ required: 'Pick a category so we can triage quickly.' }}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                select
+                fullWidth
+                label="Category"
+                margin="dense"
+                helperText={errors.category?.message || categories.find((c) => c.value === field.value)?.helper}
+                error={!!errors.category}
+                data-testid="feedback-category"
+              >
+                {categories.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+            )}
+          />
+
+          <Controller
+            name="title"
+            control={control}
+            rules={{
+              required: 'Give your feedback a short title.',
+              minLength: { value: 4, message: 'Please add at least 4 characters.' },
+              maxLength: { value: 200, message: 'Keep titles under 200 characters.' },
+            }}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Title"
+                placeholder="Dashboard latency widget is empty"
+                fullWidth
+                margin="dense"
+                error={!!errors.title}
+                helperText={errors.title?.message || 'A concise summary helps us route the feedback.'}
+                inputProps={{ maxLength: 200 }}
+                data-testid="feedback-title"
+              />
+            )}
+          />
+
+          <Controller
+            name="description"
+            control={control}
+            rules={{
+              required: 'Please describe what happened or what you need.',
+              minLength: { value: 10, message: 'A little more detail will help us investigate.' },
+              maxLength: { value: 5000, message: 'Limit feedback to 5000 characters.' },
+            }}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Details"
+                placeholder="Include reproduction steps, expected behavior, or impact."
+                fullWidth
+                margin="dense"
+                multiline
+                minRows={4}
+                error={!!errors.description}
+                helperText={errors.description?.message || 'Provide context so the admin team can follow up.'}
+                inputProps={{ maxLength: 5000 }}
+                data-testid="feedback-description"
+              />
+            )}
+          />
+
+          <Controller
+            name="contact"
+            control={control}
+            rules={{
+              maxLength: { value: 320, message: 'Contact info should be under 320 characters.' },
+            }}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                label="Preferred contact (optional)"
+                placeholder="you@example.com or Slack handle"
+                fullWidth
+                margin="dense"
+                error={!!errors.contact}
+                helperText={
+                  errors.contact?.message || 'We will use this only if we need more information.'
+                }
+                inputProps={{ maxLength: 320 }}
+                data-testid="feedback-contact"
+              />
+            )}
+          />
+        </Box>
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 3 }}>
+        <Button onClick={handleClose} color="inherit" disabled={loading || isSubmitting}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          form="feedback-form"
+          variant="contained"
+          disabled={loading || isSubmitting}
+          data-testid="feedback-submit"
+        >
+          {loading || isSubmitting ? 'Sending…' : 'Send feedback'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default FeedbackDialog;

--- a/client/src/features/admin/AdminStudio.tsx
+++ b/client/src/features/admin/AdminStudio.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import OverridesPanel from './OverridesPanel';
 import CostExplorer from './CostExplorer';
+import FeedbackReview from './FeedbackReview';
 
 interface Config {
   MODEL_PROVIDER: string;
@@ -46,7 +47,9 @@ export default function AdminStudio() {
   const [bundleStatus, setBundleStatus] = React.useState<BundleStatus | null>(null);
   const [bundleSource, setBundleSource] = React.useState<BundleSource | null>(null);
   const [opaSince, setOpaSince] = React.useState<string | null>(null);
-  const [activeTab, setActiveTab] = React.useState<'config' | 'overrides' | 'cost-explorer' | 'help'>('config');
+  const [activeTab, setActiveTab] = React.useState<
+    'config' | 'overrides' | 'cost-explorer' | 'feedback' | 'help'
+  >('config');
   const [saveMessage, setSaveMessage] = React.useState<string>('');
   const [errors, setErrors] = React.useState<string[]>([]);
   const load = React.useCallback(async () => {
@@ -216,6 +219,8 @@ export default function AdminStudio() {
         return <OverridesPanel />;
       case 'cost-explorer':
         return <CostExplorer />;
+      case 'feedback':
+        return <FeedbackReview />;
       case 'help':
         return (
           <div style={{ padding: 24, maxWidth: 800 }}>
@@ -415,11 +420,14 @@ kubectl set env deployment/intelgraph-api PQ_BYPASS=1
           { key: 'config', label: 'Configuration' },
           { key: 'overrides', label: 'Overrides' },
           { key: 'cost-explorer', label: 'Cost Explorer' },
+          { key: 'feedback', label: 'Feedback' },
           { key: 'help', label: 'Help' }
         ].map(tab => (
           <button
             key={tab.key}
-            onClick={() => setActiveTab(tab.key as 'config' | 'overrides' | 'cost-explorer' | 'help')}
+            onClick={() =>
+              setActiveTab(tab.key as 'config' | 'overrides' | 'cost-explorer' | 'feedback' | 'help')
+            }
             style={{
               padding: '12px 24px',
               border: 'none',

--- a/client/src/features/admin/FeedbackReview.tsx
+++ b/client/src/features/admin/FeedbackReview.tsx
@@ -1,0 +1,265 @@
+import React from 'react';
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Stack,
+  MenuItem,
+  Select,
+  FormControl,
+  InputLabel,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TableContainer,
+  Chip,
+  IconButton,
+  Tooltip,
+  CircularProgress,
+  Alert,
+} from '@mui/material';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import DoneAllIcon from '@mui/icons-material/DoneAll';
+import PendingActionsIcon from '@mui/icons-material/PendingActions';
+import { useQuery, useMutation } from '@apollo/client';
+import {
+  FEEDBACK_SUBMISSIONS_QUERY,
+  UPDATE_FEEDBACK_STATUS_MUTATION,
+} from '../../graphql/feedback';
+import { useToastHelpers } from '../../components/ToastContainer';
+
+type FeedbackStatus = 'NEW' | 'IN_REVIEW' | 'RESOLVED' | 'ARCHIVED';
+type FeedbackCategory = 'BUG' | 'FEATURE' | 'OTHER';
+
+type FeedbackItem = {
+  id: string;
+  category: FeedbackCategory;
+  title: string;
+  description?: string | null;
+  status: FeedbackStatus;
+  userEmail?: string | null;
+  userId?: string | null;
+  createdAt: string;
+  metadata?: Record<string, any> | null;
+};
+
+const statusOptions: { value: FeedbackStatus | 'ALL'; label: string }[] = [
+  { value: 'ALL', label: 'All statuses' },
+  { value: 'NEW', label: 'New' },
+  { value: 'IN_REVIEW', label: 'In review' },
+  { value: 'RESOLVED', label: 'Resolved' },
+  { value: 'ARCHIVED', label: 'Archived' },
+];
+
+const categoryLabels: Record<FeedbackCategory, string> = {
+  BUG: 'Bug',
+  FEATURE: 'Feature request',
+  OTHER: 'Other',
+};
+
+const statusLabels: Record<FeedbackStatus, string> = {
+  NEW: 'New',
+  IN_REVIEW: 'In review',
+  RESOLVED: 'Resolved',
+  ARCHIVED: 'Archived',
+};
+
+const statusColors: Record<FeedbackStatus, 'default' | 'primary' | 'success' | 'warning' | 'info'> = {
+  NEW: 'warning',
+  IN_REVIEW: 'info',
+  RESOLVED: 'success',
+  ARCHIVED: 'default',
+};
+
+const formatDateTime = (value: string) => {
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    }).format(new Date(value));
+  } catch {
+    return value;
+  }
+};
+
+export const FeedbackReview: React.FC = () => {
+  const toast = useToastHelpers();
+  const [statusFilter, setStatusFilter] = React.useState<FeedbackStatus | 'ALL'>('NEW');
+
+  const { data, loading, error, refetch } = useQuery(FEEDBACK_SUBMISSIONS_QUERY, {
+    variables: {
+      filter: {
+        status: statusFilter === 'ALL' ? undefined : statusFilter,
+        limit: 50,
+      },
+    },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const [updateStatus, { loading: updating }] = useMutation(UPDATE_FEEDBACK_STATUS_MUTATION);
+
+  const submissions: FeedbackItem[] = data?.feedbackSubmissions?.items ?? [];
+  const total = data?.feedbackSubmissions?.total ?? 0;
+
+  const onRefresh = React.useCallback(() => {
+    refetch();
+  }, [refetch]);
+
+  const handleStatusChange = async (id: string, status: FeedbackStatus) => {
+    try {
+      await updateStatus({ variables: { input: { id, status } } });
+      toast.success('Feedback updated', `Marked submission as ${statusLabels[status]}.`);
+      await refetch();
+    } catch (err: any) {
+      toast.error('Update failed', err?.message || 'Could not update feedback status.');
+    }
+  };
+
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" spacing={2} mb={3}>
+          <Box>
+            <Typography variant="h5" gutterBottom>
+              User feedback inbox
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              Review feature requests and bug reports submitted from the dashboard.
+            </Typography>
+          </Box>
+          <Stack direction="row" spacing={2} alignItems="flex-end">
+            <FormControl size="small">
+              <InputLabel id="feedback-status-filter">Status</InputLabel>
+              <Select
+                labelId="feedback-status-filter"
+                label="Status"
+                value={statusFilter}
+                onChange={(event) => setStatusFilter(event.target.value as FeedbackStatus | 'ALL')}
+              >
+                {statusOptions.map((option) => (
+                  <MenuItem key={option.value} value={option.value}>
+                    {option.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <Tooltip title="Refresh">
+              <span>
+                <IconButton onClick={onRefresh} disabled={loading} aria-label="Refresh feedback list">
+                  <RefreshIcon />
+                </IconButton>
+              </span>
+            </Tooltip>
+          </Stack>
+        </Stack>
+
+        {error && (
+          <Alert severity="error" sx={{ mb: 2 }}>
+            Failed to load feedback: {error.message}
+          </Alert>
+        )}
+
+        <TableContainer>
+          <Table size="small" aria-label="Feedback submissions">
+            <TableHead>
+              <TableRow>
+                <TableCell>Category</TableCell>
+                <TableCell>Title</TableCell>
+                <TableCell>Description</TableCell>
+                <TableCell>Submitted by</TableCell>
+                <TableCell>Created</TableCell>
+                <TableCell align="right">Status</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {submissions.length === 0 && !loading ? (
+                <TableRow>
+                  <TableCell colSpan={6} align="center">
+                    <Typography variant="body2" color="text.secondary">
+                      No feedback found for this filter.
+                    </Typography>
+                  </TableCell>
+                </TableRow>
+              ) : (
+                submissions.map((item) => (
+                  <TableRow key={item.id} hover>
+                    <TableCell>
+                      <Chip label={categoryLabels[item.category]} size="small" />
+                    </TableCell>
+                    <TableCell width="20%">
+                      <Typography variant="subtitle2">{item.title}</Typography>
+                      {item.metadata?.contact && (
+                        <Typography variant="caption" color="text.secondary">
+                          Contact: {item.metadata.contact}
+                        </Typography>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>
+                        {item.description}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2">
+                        {item.userEmail || item.userId || 'Anonymous'}
+                      </Typography>
+                    </TableCell>
+                    <TableCell>
+                      <Typography variant="body2" color="text.secondary">
+                        {formatDateTime(item.createdAt)}
+                      </Typography>
+                    </TableCell>
+                    <TableCell align="right">
+                      <Stack direction="row" spacing={1} justifyContent="flex-end" alignItems="center">
+                        <Chip label={statusLabels[item.status]} color={statusColors[item.status]} size="small" />
+                        <Tooltip title="Mark in review">
+                          <span>
+                            <IconButton
+                              aria-label="Mark in review"
+                              size="small"
+                              onClick={() => handleStatusChange(item.id, 'IN_REVIEW')}
+                              disabled={updating || item.status === 'IN_REVIEW'}
+                            >
+                              <PendingActionsIcon fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                        <Tooltip title="Mark resolved">
+                          <span>
+                            <IconButton
+                              aria-label="Mark resolved"
+                              size="small"
+                              onClick={() => handleStatusChange(item.id, 'RESOLVED')}
+                              disabled={updating || item.status === 'RESOLVED'}
+                            >
+                              <DoneAllIcon fontSize="small" />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </Stack>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </TableContainer>
+
+        <Stack direction="row" justifyContent="space-between" alignItems="center" mt={2}>
+          <Typography variant="caption" color="text.secondary">
+            Showing {submissions.length} of {total} submissions.
+          </Typography>
+          {loading && <CircularProgress size={20} aria-label="Loading feedback" />}
+        </Stack>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default FeedbackReview;

--- a/client/src/graphql/feedback.ts
+++ b/client/src/graphql/feedback.ts
@@ -1,0 +1,43 @@
+import { gql } from '@apollo/client';
+
+export const SUBMIT_FEEDBACK_MUTATION = gql`
+  mutation SubmitFeedback($input: SubmitFeedbackInput!) {
+    submitFeedback(input: $input) {
+      id
+      status
+      category
+      title
+      description
+      createdAt
+    }
+  }
+`;
+
+export const FEEDBACK_SUBMISSIONS_QUERY = gql`
+  query FeedbackSubmissions($filter: FeedbackFilterInput) {
+    feedbackSubmissions(filter: $filter) {
+      total
+      items {
+        id
+        category
+        title
+        description
+        status
+        userEmail
+        userId
+        createdAt
+        metadata
+      }
+    }
+  }
+`;
+
+export const UPDATE_FEEDBACK_STATUS_MUTATION = gql`
+  mutation UpdateFeedbackStatus($input: UpdateFeedbackStatusInput!) {
+    updateFeedbackStatus(input: $input) {
+      id
+      status
+      updatedAt
+    }
+  }
+`;

--- a/client/src/pages/Dashboard/__tests__/Dashboard.test.tsx
+++ b/client/src/pages/Dashboard/__tests__/Dashboard.test.tsx
@@ -1,14 +1,34 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Provider } from 'react-redux';
+import { MockedProvider } from '@apollo/client/testing';
 import store from '../../../store/index';
 import Dashboard from '../index';
+import { ToastProvider } from '../../../components/ToastContainer';
+
+function renderDashboard() {
+  return render(
+    <MockedProvider mocks={[]} addTypename={false}>
+      <ToastProvider>
+        <Provider store={store}>
+          <Dashboard />
+        </Provider>
+      </ToastProvider>
+    </MockedProvider>,
+  );
+}
 
 test('renders dashboard skeletons then content', async () => {
-  render(
-    <Provider store={store}>
-      <Dashboard />
-    </Provider>,
-  );
+  renderDashboard();
   expect(screen.getByRole('status')).toBeInTheDocument();
+});
+
+test('opens feedback dialog from dashboard button', async () => {
+  renderDashboard();
+
+  const trigger = screen.getByRole('button', { name: /share feedback/i });
+  fireEvent.click(trigger);
+
+  expect(screen.getByRole('dialog', { name: /share product feedback/i })).toBeInTheDocument();
+  expect(screen.getByTestId('feedback-title')).toBeInTheDocument();
 });

--- a/client/src/pages/Dashboard/index.tsx
+++ b/client/src/pages/Dashboard/index.tsx
@@ -3,6 +3,8 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import FeedbackIcon from '@mui/icons-material/FeedbackOutlined';
 import StatsOverview from '../../components/dashboard/StatsOverview';
 import LatencyPanels from '../../components/dashboard/LatencyPanels';
 import ErrorPanels from '../../components/dashboard/ErrorPanels';
@@ -10,14 +12,28 @@ import ResolverTop5 from '../../components/dashboard/ResolverTop5';
 import GrafanaLinkCard from '../../components/dashboard/GrafanaLinkCard';
 import LiveActivityFeed from '../../components/dashboard/LiveActivityFeed';
 import { useDashboardPrefetch, useIntelligentPrefetch } from '../../hooks/usePrefetch';
+import FeedbackDialog from '../../components/dashboard/FeedbackDialog';
 
 export default function Dashboard() {
   // Prefetch critical dashboard data to eliminate panel pop-in
   useDashboardPrefetch();
   useIntelligentPrefetch();
 
+  const [isFeedbackOpen, setFeedbackOpen] = React.useState(false);
+
   return (
     <Box p={2} aria-live="polite">
+      <Box display="flex" justifyContent="flex-end" mb={2}>
+        <Button
+          variant="contained"
+          color="primary"
+          startIcon={<FeedbackIcon />}
+          onClick={() => setFeedbackOpen(true)}
+          data-testid="open-feedback-dialog"
+        >
+          Share feedback
+        </Button>
+      </Box>
       <Grid container spacing={2}>
         <Grid item xs={12} md={6}>
           <Paper elevation={1} sx={{ p: 2, borderRadius: 3 }}>
@@ -52,6 +68,8 @@ export default function Dashboard() {
           </Paper>
         </Grid>
       </Grid>
+
+      <FeedbackDialog open={isFeedbackOpen} onClose={() => setFeedbackOpen(false)} />
     </Box>
   );
 }

--- a/client/tests/e2e/feedback.spec.ts
+++ b/client/tests/e2e/feedback.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dashboard feedback flow', () => {
+  test('allows submitting feedback from dashboard', async ({ page }) => {
+    await page.route('**/graphql', async (route) => {
+      const request = route.request();
+      if (request.method() === 'POST') {
+        try {
+          const body = JSON.parse(request.postData() || '{}');
+          if (body?.operationName === 'SubmitFeedback') {
+            return route.fulfill({
+              status: 200,
+              contentType: 'application/json',
+              body: JSON.stringify({
+                data: {
+                  submitFeedback: {
+                    id: 'fb-test',
+                    status: 'NEW',
+                    category: body.variables.input.category,
+                    title: body.variables.input.title,
+                    description: body.variables.input.description,
+                    createdAt: new Date().toISOString(),
+                    __typename: 'FeedbackSubmission',
+                  },
+                },
+              }),
+            });
+          }
+        } catch (error) {
+          console.warn('Failed to parse GraphQL body', error);
+        }
+      }
+      return route.continue();
+    });
+
+    await page.goto('http://localhost:3001/dashboard');
+
+    await page.getByRole('button', { name: /share feedback/i }).click();
+    await page.getByTestId('feedback-title').fill('Observability widget offline');
+    await page.getByTestId('feedback-description').fill('Latency panel shows blank data after deploy.');
+    await page.getByTestId('feedback-contact').fill('sre@summit.test');
+
+    await page.getByTestId('feedback-submit').click();
+
+    await expect(page.getByText('Feedback sent')).toBeVisible();
+    await expect(page.getByRole('dialog', { name: /share product feedback/i })).toBeHidden();
+  });
+});

--- a/server/migrations/20250925000100-create-user-feedback.sql
+++ b/server/migrations/20250925000100-create-user-feedback.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS user_feedback (
+  id UUID PRIMARY KEY,
+  tenant_id TEXT,
+  user_id TEXT,
+  user_email TEXT,
+  category TEXT NOT NULL,
+  title TEXT NOT NULL,
+  description TEXT,
+  status TEXT NOT NULL DEFAULT 'NEW',
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS user_feedback_category_idx ON user_feedback (category);
+CREATE INDEX IF NOT EXISTS user_feedback_status_idx ON user_feedback (status);
+CREATE INDEX IF NOT EXISTS user_feedback_created_at_idx ON user_feedback (created_at DESC);
+
+CREATE OR REPLACE FUNCTION set_user_feedback_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS user_feedback_set_updated_at ON user_feedback;
+CREATE TRIGGER user_feedback_set_updated_at
+BEFORE UPDATE ON user_feedback
+FOR EACH ROW
+EXECUTE FUNCTION set_user_feedback_updated_at();

--- a/server/src/db/repositories/userFeedback.ts
+++ b/server/src/db/repositories/userFeedback.ts
@@ -1,0 +1,139 @@
+import { Pool } from 'pg';
+import { randomUUID } from 'crypto';
+import { getPostgresPool } from '../postgres.js';
+
+export type FeedbackCategory = 'BUG' | 'FEATURE' | 'OTHER';
+export type FeedbackStatus = 'NEW' | 'IN_REVIEW' | 'RESOLVED' | 'ARCHIVED';
+
+export interface CreateFeedbackInput {
+  tenantId?: string | null;
+  userId?: string | null;
+  userEmail?: string | null;
+  category: FeedbackCategory;
+  title: string;
+  description?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface FeedbackRecord {
+  id: string;
+  tenantId: string | null;
+  userId: string | null;
+  userEmail: string | null;
+  category: FeedbackCategory;
+  title: string;
+  description: string | null;
+  status: FeedbackStatus;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FeedbackListFilters {
+  status?: FeedbackStatus;
+  category?: FeedbackCategory;
+  limit?: number;
+  offset?: number;
+  tenantId?: string;
+}
+
+export class UserFeedbackRepository {
+  constructor(private pool: Pool = getPostgresPool()) {}
+
+  async createFeedback(input: CreateFeedbackInput): Promise<FeedbackRecord> {
+    const id = randomUUID();
+    const metadata = input.metadata ?? {};
+    const { rows } = await this.pool.query(
+      `INSERT INTO user_feedback (id, tenant_id, user_id, user_email, category, title, description, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+       RETURNING id, tenant_id AS "tenantId", user_id AS "userId", user_email AS "userEmail",
+                 category, title, description, status, metadata,
+                 created_at AS "createdAt", updated_at AS "updatedAt"`,
+      [
+        id,
+        input.tenantId ?? null,
+        input.userId ?? null,
+        input.userEmail ?? null,
+        input.category,
+        input.title,
+        input.description ?? null,
+        metadata,
+      ],
+    );
+
+    return rows[0];
+  }
+
+  async listFeedback(filters: FeedbackListFilters = {}): Promise<{ total: number; items: FeedbackRecord[] }> {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (filters.tenantId) {
+      params.push(filters.tenantId);
+      conditions.push(`tenant_id = $${params.length}`);
+    }
+
+    if (filters.status) {
+      params.push(filters.status);
+      conditions.push(`status = $${params.length}`);
+    }
+
+    if (filters.category) {
+      params.push(filters.category);
+      conditions.push(`category = $${params.length}`);
+    }
+
+    const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const limit = typeof filters.limit === 'number' ? Math.min(Math.max(filters.limit, 1), 200) : 50;
+    const offset = typeof filters.offset === 'number' ? Math.max(filters.offset, 0) : 0;
+
+    const countQuery = `SELECT COUNT(*)::int AS total FROM user_feedback ${whereClause}`;
+    const { rows: countRows } = await this.pool.query(countQuery, params);
+
+    params.push(limit);
+    params.push(offset);
+    const limitParam = `$${params.length - 1}`;
+    const offsetParam = `$${params.length}`;
+
+    const dataQuery = `
+      SELECT
+        id,
+        tenant_id AS "tenantId",
+        user_id AS "userId",
+        user_email AS "userEmail",
+        category,
+        title,
+        description,
+        status,
+        metadata,
+        created_at AS "createdAt",
+        updated_at AS "updatedAt"
+      FROM user_feedback
+      ${whereClause}
+      ORDER BY created_at DESC
+      LIMIT ${limitParam}
+      OFFSET ${offsetParam}
+    `;
+
+    const { rows } = await this.pool.query(dataQuery, params);
+
+    return { total: countRows[0]?.total ?? 0, items: rows };
+  }
+
+  async updateStatus(id: string, status: FeedbackStatus): Promise<FeedbackRecord | null> {
+    const { rows } = await this.pool.query(
+      `UPDATE user_feedback
+       SET status = $2
+       WHERE id = $1
+       RETURNING id, tenant_id AS "tenantId", user_id AS "userId", user_email AS "userEmail",
+                 category, title, description, status, metadata,
+                 created_at AS "createdAt", updated_at AS "updatedAt"`,
+      [id, status],
+    );
+
+    return rows[0] ?? null;
+  }
+}
+
+export const userFeedbackRepository = new UserFeedbackRepository();

--- a/server/src/graphql/resolvers/feedback.ts
+++ b/server/src/graphql/resolvers/feedback.ts
@@ -1,0 +1,137 @@
+import { z } from 'zod';
+import baseLogger from '../../config/logger.js';
+import { userFeedbackRepository, FeedbackStatus } from '../../db/repositories/userFeedback.js';
+import { getRedisClient } from '../../db/redis.js';
+
+const logger = baseLogger.child({ name: 'FeedbackResolver' });
+
+const SubmitFeedbackZ = z.object({
+  category: z.enum(['BUG', 'FEATURE', 'OTHER']),
+  title: z.string().min(4).max(200),
+  description: z.string().max(5000).optional(),
+  contact: z.string().max(320).optional(),
+  metadata: z.record(z.any()).optional(),
+});
+
+const FeedbackFilterZ = z
+  .object({
+    status: z.enum(['NEW', 'IN_REVIEW', 'RESOLVED', 'ARCHIVED']).optional(),
+    category: z.enum(['BUG', 'FEATURE', 'OTHER']).optional(),
+    limit: z.number().int().min(1).max(200).optional(),
+    offset: z.number().int().min(0).optional(),
+  })
+  .optional();
+
+const UpdateStatusZ = z.object({
+  id: z.string().uuid(),
+  status: z.enum(['NEW', 'IN_REVIEW', 'RESOLVED', 'ARCHIVED']),
+});
+
+const redis = (() => {
+  try {
+    return getRedisClient();
+  } catch (error) {
+    logger.warn('Redis unavailable for feedback notifications', { error });
+    return null;
+  }
+})();
+
+async function queueFeedbackNotification(feedback: any, contact?: string | null) {
+  const notifyTo = process.env.FEEDBACK_NOTIFICATION_EMAIL;
+  if (!notifyTo || !redis) {
+    return;
+  }
+
+  try {
+    const emailPayload = {
+      to: [notifyTo],
+      subject: `New ${feedback.category.toLowerCase()} feedback received`,
+      body: `A new piece of feedback was submitted.\n\nTitle: ${feedback.title}\nCategory: ${feedback.category}\nSubmitted By: ${
+        feedback.userEmail || feedback.userId || 'anonymous'
+      }\nContact: ${contact || 'not provided'}\n\nDetails:\n${feedback.description || 'n/a'}\n`,
+      metadata: {
+        feedbackId: feedback.id,
+        tenantId: feedback.tenantId,
+        status: feedback.status,
+      },
+    };
+    await redis.lpush('email_queue', JSON.stringify(emailPayload));
+  } catch (error) {
+    logger.warn('Failed to queue feedback notification', { error, feedbackId: feedback.id });
+  }
+}
+
+function requireAdmin(ctx: any) {
+  const role = ctx?.user?.role || 'VIEWER';
+  if (role !== 'ADMIN') {
+    throw new Error('forbidden');
+  }
+}
+
+function resolveTenantId(ctx: any): string | null {
+  return (
+    ctx?.user?.tenantId ||
+    ctx?.tenantId ||
+    ctx?.req?.headers?.['x-tenant-id'] ||
+    null
+  );
+}
+
+export const feedbackResolvers = {
+  Query: {
+    async feedbackSubmissions(_parent: unknown, args: { filter?: unknown }, ctx: any) {
+      requireAdmin(ctx);
+      const parsedFilter = FeedbackFilterZ.parse(args.filter);
+      const tenantId = resolveTenantId(ctx);
+
+      const result = await userFeedbackRepository.listFeedback({
+        ...(parsedFilter || {}),
+        tenantId: tenantId || undefined,
+      });
+
+      return {
+        total: result.total,
+        items: result.items,
+      };
+    },
+  },
+  Mutation: {
+    async submitFeedback(_parent: unknown, args: { input: unknown }, ctx: any) {
+      const parsed = SubmitFeedbackZ.parse(args.input);
+      const tenantId = resolveTenantId(ctx);
+      const userId = ctx?.user?.id || null;
+      const userEmail = ctx?.user?.email || null;
+
+      const metadata = {
+        ...(parsed.metadata || {}),
+        ...(parsed.contact ? { contact: parsed.contact } : {}),
+        submittedFrom: 'dashboard',
+      };
+
+      const record = await userFeedbackRepository.createFeedback({
+        tenantId: tenantId || null,
+        userId,
+        userEmail,
+        category: parsed.category,
+        title: parsed.title,
+        description: parsed.description,
+        metadata,
+      });
+
+      await queueFeedbackNotification(record, parsed.contact);
+
+      return record;
+    },
+    async updateFeedbackStatus(_parent: unknown, args: { input: unknown }, ctx: any) {
+      requireAdmin(ctx);
+      const parsed = UpdateStatusZ.parse(args.input);
+
+      const updated = await userFeedbackRepository.updateStatus(parsed.id, parsed.status as FeedbackStatus);
+      if (!updated) {
+        throw new Error('feedback not found');
+      }
+
+      return updated;
+    },
+  },
+};

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -12,6 +12,7 @@ import { triggerN8nFlow } from '../../integrations/n8n.js';
 import { checkN8nTriggerAllowed } from '../../integrations/n8n-policy.js';
 import { isEnabled as flagEnabled } from '../../featureFlags/flagsmith.js';
 import { doclingResolvers } from './docling.ts';
+import { feedbackResolvers } from './feedback.ts';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -25,6 +26,7 @@ const resolvers = {
     // Production core resolvers (PostgreSQL + Neo4j)
     ...coreResolvers.Query,
     ...doclingResolvers.Query,
+    ...feedbackResolvers.Query,
     async pipeline(_p: any, args: { id: string }) {
       const { getPipelineDef } = await import('../../db/repositories/pipelines.js');
       return await getPipelineDef(args.id);
@@ -63,6 +65,7 @@ const resolvers = {
     // Production core resolvers
     ...coreResolvers.Mutation,
     ...doclingResolvers.Mutation,
+    ...feedbackResolvers.Mutation,
 
     // Legacy resolvers (will be phased out)
     ...entityResolvers.Mutation,

--- a/server/src/graphql/schema.feedback.ts
+++ b/server/src/graphql/schema.feedback.ts
@@ -1,0 +1,66 @@
+import { gql } from 'graphql-tag';
+
+export const feedbackTypeDefs = gql`
+  enum FeedbackCategory {
+    BUG
+    FEATURE
+    OTHER
+  }
+
+  enum FeedbackStatus {
+    NEW
+    IN_REVIEW
+    RESOLVED
+    ARCHIVED
+  }
+
+  type FeedbackSubmission {
+    id: ID!
+    tenantId: String
+    userId: String
+    userEmail: String
+    category: FeedbackCategory!
+    title: String!
+    description: String
+    status: FeedbackStatus!
+    metadata: JSON
+    createdAt: DateTime!
+    updatedAt: DateTime!
+  }
+
+  type FeedbackConnection {
+    total: Int!
+    items: [FeedbackSubmission!]!
+  }
+
+  input SubmitFeedbackInput {
+    category: FeedbackCategory!
+    title: String!
+    description: String
+    contact: String
+    metadata: JSON
+  }
+
+  input FeedbackFilterInput {
+    status: FeedbackStatus
+    category: FeedbackCategory
+    limit: Int
+    offset: Int
+  }
+
+  input UpdateFeedbackStatusInput {
+    id: ID!
+    status: FeedbackStatus!
+  }
+
+  extend type Query {
+    feedbackSubmissions(filter: FeedbackFilterInput): FeedbackConnection!
+  }
+
+  extend type Mutation {
+    submitFeedback(input: SubmitFeedbackInput!): FeedbackSubmission!
+    updateFeedbackStatus(input: UpdateFeedbackStatusInput!): FeedbackSubmission!
+  }
+`;
+
+export default feedbackTypeDefs;

--- a/server/src/graphql/schema/index.ts
+++ b/server/src/graphql/schema/index.ts
@@ -6,6 +6,7 @@ import aiModule from '../schema.ai.js';
 import annotationsModule from '../schema.annotations.js';
 import graphragTypesModule from '../types/graphragTypes.js';
 import { crystalTypeDefs } from '../schema.crystal.js';
+import { feedbackTypeDefs } from '../schema.feedback.js';
 
 const { copilotTypeDefs } = copilotModule as { copilotTypeDefs: any };
 const { graphTypeDefs } = graphModule as { graphTypeDefs: any };
@@ -33,6 +34,7 @@ const base = gql`
 export const typeDefs = [
   base,
   coreTypeDefs,
+  feedbackTypeDefs,
   copilotTypeDefs,
   graphTypeDefs,
   graphragTypes,

--- a/server/src/tests/graphql/feedback.resolver.test.ts
+++ b/server/src/tests/graphql/feedback.resolver.test.ts
@@ -1,0 +1,104 @@
+import { jest } from '@jest/globals';
+import { feedbackResolvers } from '../../graphql/resolvers/feedback';
+import { userFeedbackRepository } from '../../db/repositories/userFeedback.js';
+import type { FeedbackRecord } from '../../db/repositories/userFeedback.js';
+
+const mockRedisClient = { lpush: jest.fn(() => Promise.resolve(1)) };
+
+jest.mock('../../db/redis.js', () => ({
+  getRedisClient: () => mockRedisClient,
+}));
+
+jest.mock('../../db/repositories/userFeedback.js', () => {
+  const actual = jest.requireActual('../../db/repositories/userFeedback.js');
+  return {
+    ...actual,
+    userFeedbackRepository: {
+      createFeedback: jest.fn(),
+      listFeedback: jest.fn(),
+      updateStatus: jest.fn(),
+    },
+  };
+});
+
+describe('feedbackResolvers', () => {
+  const mockRepo = userFeedbackRepository as jest.Mocked<typeof userFeedbackRepository>;
+  const sampleRecord: FeedbackRecord = {
+    id: 'fb-1',
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    userEmail: 'user@example.com',
+    category: 'BUG',
+    title: 'Broken panel',
+    description: 'The SLA widget never loads',
+    status: 'NEW',
+    metadata: { contact: 'ops@example.com' },
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.FEEDBACK_NOTIFICATION_EMAIL = 'product@summit.test';
+  });
+
+  afterEach(() => {
+    delete process.env.FEEDBACK_NOTIFICATION_EMAIL;
+  });
+
+  it('submits feedback and queues email notification', async () => {
+    mockRepo.createFeedback.mockResolvedValue(sampleRecord);
+
+    const result = await feedbackResolvers.Mutation.submitFeedback(
+      null,
+      { input: { category: 'BUG', title: 'Broken panel', description: 'details', contact: 'ops@example.com' } },
+      { user: { id: 'user-1', email: 'user@example.com', tenantId: 'tenant-1' } },
+    );
+
+    expect(mockRepo.createFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        userEmail: 'user@example.com',
+        category: 'BUG',
+        title: 'Broken panel',
+        description: 'details',
+      }),
+    );
+    expect(mockRedisClient.lpush).toHaveBeenCalledTimes(1);
+    expect(result.id).toEqual(sampleRecord.id);
+  });
+
+  it('throws for non-admin feedback listing', async () => {
+    await expect(
+      feedbackResolvers.Query.feedbackSubmissions(null, {}, { user: { role: 'VIEWER' } }),
+    ).rejects.toThrow('forbidden');
+  });
+
+  it('lists feedback with tenant scoping', async () => {
+    mockRepo.listFeedback.mockResolvedValue({ total: 1, items: [sampleRecord] });
+    const res = await feedbackResolvers.Query.feedbackSubmissions(
+      null,
+      { filter: { status: 'NEW' } },
+      { user: { role: 'ADMIN', tenantId: 'tenant-1' } },
+    );
+
+    expect(mockRepo.listFeedback).toHaveBeenCalledWith({ status: 'NEW', tenantId: 'tenant-1' });
+    expect(res.total).toBe(1);
+    expect(res.items[0].id).toBe(sampleRecord.id);
+  });
+
+  it('updates feedback status as admin', async () => {
+    const updated: FeedbackRecord = { ...sampleRecord, status: 'RESOLVED' };
+    mockRepo.updateStatus.mockResolvedValue(updated);
+
+    const res = await feedbackResolvers.Mutation.updateFeedbackStatus(
+      null,
+      { input: { id: sampleRecord.id, status: 'RESOLVED' } },
+      { user: { role: 'ADMIN' } },
+    );
+
+    expect(mockRepo.updateStatus).toHaveBeenCalledWith(sampleRecord.id, 'RESOLVED');
+    expect(res.status).toBe('RESOLVED');
+  });
+});


### PR DESCRIPTION
## Summary
- add a dashboard "Share feedback" dialog backed by a GraphQL mutation so users can submit bug reports or feature requests without leaving the UI
- create PostgreSQL persistence, GraphQL schema/resolvers, and an admin review tab for triaging feedback with status updates and optional email notifications
- cover the feature with unit, resolver, and Playwright E2E tests to validate the dialog flow and admin review logic

## Testing
- Not run (npm install fails with Unsupported URL Type "workspace:" when attempting to set up test dependencies)


------
https://chatgpt.com/codex/tasks/task_e_68d6cae56f248333b8b544961a8c23e9