### PR TITLE
feat: implement data retention automation

### DIFF
--- a/docs/security/data-retention-compliance-guide.md
+++ b/docs/security/data-retention-compliance-guide.md
@@ -1,0 +1,118 @@
+# Summit Data Retention Compliance Guide
+
+## Overview
+
+Summit stores regulated customer telemetry in PostgreSQL and graph audit
+context in Neo4j. To maintain GDPR right-to-erasure guarantees and SOC 2
+control evidence, the platform now ships a unified retention toolchain:
+
+- **Metadata-driven SQL** for PostgreSQL (`server/db/retention/postgres_data_retention.sql`).
+- **APOC-enabled Cypher** for Neo4j (`server/db/retention/neo4j_data_retention.cypher`).
+- **Kubernetes CronJobs** that execute the retention logic on an audited
+  cadence (`infra/k8s/cronjobs/data-retention-cronjobs.yaml`).
+- **OPA policy** that blocks misconfigured CronJobs before deployment
+  (`policy/opa/retention.rego`).
+
+The solution separates *policy* (retention rules) from *execution*
+(CronJobs) so compliance teams can adjust retention horizons without code
+changes while SRE teams keep deterministic automation.
+
+## PostgreSQL retention workflow
+
+1. Deploy the metadata schema by running the SQL file once against the
+   production database:
+
+   ```bash
+   psql -f server/db/retention/postgres_data_retention.sql
+   ```
+
+2. Register retention rules in `compliance.retention_rules` for every
+   table that contains personal data. Each rule specifies:
+
+   - fully qualified table name (`table_fqn`)
+   - primary key and timestamp tracking columns
+   - retention window (for example `INTERVAL '365 days'`)
+   - action (`ARCHIVE` or `DELETE`)
+   - optional archive table (`archive_table_fqn`) and filter predicate
+
+3. Schedule `SELECT compliance.apply_retention();` via the Kubernetes
+   CronJob. The function archives eligible rows to the configured archive
+   table (creating it if necessary) or deletes them when GDPR erasure is
+   mandated.
+
+4. Audit trails land in `compliance.retention_audit_log`, providing
+   immutable evidence for SOC 2 CC7.2/CC7.3 and GDPR Article 30 records.
+
+## Neo4j retention workflow
+
+1. Ensure APOC is installed on the cluster (the script relies on
+   `apoc.periodic.iterate` and `apoc.do.when`).
+2. Label nodes that need retention with `RetentionManaged`, set
+   `retentionExpiresAt` (datetime) and optionally `retentionAction`
+   (`ARCHIVE` or `DELETE`).
+3. Execute the Cypher script using the CronJob or manually via
+   `cypher-shell -f server/db/retention/neo4j_data_retention.cypher`.
+4. The script snapshots archived payloads into `ArchivedSnapshot` nodes
+   and writes run metrics to a `RetentionAudit` node keyed by execution
+   UUID so auditors can verify coverage.
+
+## Kubernetes automation
+
+The `infra/k8s/cronjobs/data-retention-cronjobs.yaml` manifest delivers
+separate jobs for PostgreSQL and Neo4j. Key operational notes:
+
+- Create ConfigMaps that surface the latest scripts to the cluster:
+
+  ```bash
+  kubectl create configmap data-retention-postgres \
+    --from-file=postgres_data_retention.sql=server/db/retention/postgres_data_retention.sql
+
+  kubectl create configmap data-retention-neo4j \
+    --from-file=neo4j_data_retention.cypher=server/db/retention/neo4j_data_retention.cypher
+  ```
+
+- Provision the `data-retention` service account with least privilege
+  network and secret access.
+- Populate the `postgres-maintenance-credentials` and
+  `neo4j-maintenance-credentials` secrets with read/write credentials
+  dedicated to maintenance tasks (no application superuser keys).
+- Configure the optional `CONFIG_CHECKSUM` annotation via your CD system
+  to force Pod restarts whenever the scripts or secrets change.
+- The schedules stagger PostgreSQL (02:00 UTC) and Neo4j (02:30 UTC)
+  runs to avoid overlapping load.
+
+## OPA enforcement
+
+The `policy/opa/retention.rego` policy validates every CronJob labeled
+`app.kubernetes.io/name=data-retention` and denies deployment when:
+
+- the compliance label `summit.io/compliance-scope` is missing,
+- schedules attempt to run faster than hourly,
+- the concurrency policy is not `Forbid`,
+- resource limits, read-only filesystems, or script mounts are missing,
+- the manifest lacks the `checksum/config` change tracking annotation.
+
+Integrate the policy with Conftest, Gatekeeper, or CI to guarantee that
+retention jobs remain hardened before they reach production.
+
+## Monitoring and evidence collection
+
+- Stream `compliance.retention_audit_log` (PostgreSQL) and
+  `RetentionAudit` (Neo4j) into your SIEM for centralized evidence.
+- Alert when `status = 'ERROR'` in the PostgreSQL audit log or when the
+  Neo4j `errors` array is non-empty.
+- Record monthly review notes in SOC 2 binders referencing CronJob runs
+  and audit artifacts.
+
+## Incident response checklist
+
+1. Pause both CronJobs (`kubectl patch cronjob ... --type merge -p '{"spec":{"suspend":true}}'`).
+2. Investigate the offending rule or dataset. Roll back archive tables if
+   an incorrect delete occurred.
+3. Document the event in the incident tracker referencing the audit log
+   entry IDs.
+4. Resume the CronJobs once remediation is complete and update the
+   compliance calendar.
+
+Maintaining these steps keeps Summit aligned with GDPR retention
+principles and SOC 2 CC2.3 change-management expectations.

--- a/infra/k8s/cronjobs/data-retention-cronjobs.yaml
+++ b/infra/k8s/cronjobs/data-retention-cronjobs.yaml
@@ -1,0 +1,151 @@
+apiVersion: v1
+kind: List
+metadata:
+  name: data-retention-cronjobs
+items:
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: postgres-data-retention
+      labels:
+        app.kubernetes.io/name: data-retention
+        app.kubernetes.io/component: scheduler
+        summit.io/compliance-scope: gdpr-soc2
+      annotations:
+        summit.io/policy-version: v1
+        opa.summit.io/profile: data-retention
+    spec:
+      schedule: "0 2 * * *"
+      concurrencyPolicy: Forbid
+      successfulJobsHistoryLimit: 1
+      failedJobsHistoryLimit: 3
+      suspend: false
+      jobTemplate:
+        spec:
+          backoffLimit: 2
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: data-retention
+                summit.io/compliance-scope: gdpr-soc2
+              annotations:
+                checksum/config: $(CONFIG_CHECKSUM)
+            spec:
+              serviceAccountName: data-retention
+              restartPolicy: Never
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: apply-postgres-retention
+                  image: bitnami/postgresql:16.3.0
+                  imagePullPolicy: IfNotPresent
+                  command: ["/bin/sh", "-c"]
+                  args:
+                    - |
+                      psql \
+                        --host="$PGHOST" \
+                        --port="$PGPORT" \
+                        --username="$PGUSER" \
+                        --dbname="$PGDATABASE" \
+                        --file="/policies/postgres_data_retention.sql"
+                  envFrom:
+                    - secretRef:
+                        name: postgres-maintenance-credentials
+                  resources:
+                    requests:
+                      cpu: "100m"
+                      memory: "128Mi"
+                    limits:
+                      cpu: "500m"
+                      memory: "512Mi"
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: true
+                  volumeMounts:
+                    - name: retention-sql
+                      mountPath: /policies/postgres_data_retention.sql
+                      subPath: postgres_data_retention.sql
+              volumes:
+                - name: retention-sql
+                  configMap:
+                    name: data-retention-postgres
+                    defaultMode: 0400
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: neo4j-data-retention
+      labels:
+        app.kubernetes.io/name: data-retention
+        app.kubernetes.io/component: scheduler
+        summit.io/compliance-scope: gdpr-soc2
+      annotations:
+        summit.io/policy-version: v1
+        opa.summit.io/profile: data-retention
+    spec:
+      schedule: "30 2 * * *"
+      concurrencyPolicy: Forbid
+      successfulJobsHistoryLimit: 1
+      failedJobsHistoryLimit: 3
+      suspend: false
+      jobTemplate:
+        spec:
+          backoffLimit: 2
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/name: data-retention
+                summit.io/compliance-scope: gdpr-soc2
+              annotations:
+                checksum/config: $(CONFIG_CHECKSUM)
+            spec:
+              serviceAccountName: data-retention
+              restartPolicy: Never
+              securityContext:
+                runAsNonRoot: true
+              containers:
+                - name: apply-neo4j-retention
+                  image: neo4j:5.20.0-community
+                  imagePullPolicy: IfNotPresent
+                  command: ["/bin/sh", "-c"]
+                  args:
+                    - |
+                      cypher-shell \
+                        --address "$NEO4J_URI" \
+                        --username "$NEO4J_USER" \
+                        --password "$NEO4J_PASSWORD" \
+                        --file "/policies/neo4j_data_retention.cypher"
+                  env:
+                    - name: NEO4J_URI
+                      valueFrom:
+                        secretKeyRef:
+                          name: neo4j-maintenance-credentials
+                          key: boltUri
+                    - name: NEO4J_USER
+                      valueFrom:
+                        secretKeyRef:
+                          name: neo4j-maintenance-credentials
+                          key: username
+                    - name: NEO4J_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: neo4j-maintenance-credentials
+                          key: password
+                  resources:
+                    requests:
+                      cpu: "100m"
+                      memory: "128Mi"
+                    limits:
+                      cpu: "500m"
+                      memory: "512Mi"
+                  securityContext:
+                    allowPrivilegeEscalation: false
+                    readOnlyRootFilesystem: true
+                  volumeMounts:
+                    - name: retention-cypher
+                      mountPath: /policies/neo4j_data_retention.cypher
+                      subPath: neo4j_data_retention.cypher
+              volumes:
+                - name: retention-cypher
+                  configMap:
+                    name: data-retention-neo4j
+                    defaultMode: 0400

--- a/policy/opa/retention.rego
+++ b/policy/opa/retention.rego
@@ -1,0 +1,71 @@
+package summit.retention
+
+import rego.v1
+
+is_retention_cronjob if {
+    input.kind == "CronJob"
+    input.metadata.labels["app.kubernetes.io/name"] == "data-retention"
+}
+
+required_label := "summit.io/compliance-scope"
+
+minute_field(schedule) := minute if {
+    cleaned := trim(schedule, " ")
+    fields := split(cleaned, " ")
+    count(fields) >= 1
+    minute := fields[0]
+}
+
+deny contains msg if {
+    is_retention_cronjob
+    not input.metadata.labels[required_label]
+    msg := sprintf("Data retention CronJobs must declare the %q label", [required_label])
+}
+
+deny contains msg if {
+    is_retention_cronjob
+    minute := minute_field(input.spec.schedule)
+    minute in ["*", "*/1", "*/2", "*/5", "*/10", "*/15"]
+    msg := "Data retention CronJobs must not run more frequently than once per hour"
+}
+
+deny contains msg if {
+    is_retention_cronjob
+    input.spec.concurrencyPolicy != "Forbid"
+    msg := "Data retention CronJobs must set concurrencyPolicy to Forbid"
+}
+
+deny contains msg if {
+    is_retention_cronjob
+    container := input.spec.jobTemplate.spec.template.spec.containers[_]
+    not container.securityContext.readOnlyRootFilesystem
+    msg := sprintf("Container %s must run with a read-only root filesystem", [container.name])
+}
+
+deny contains msg if {
+    is_retention_cronjob
+    not input.spec.jobTemplate.spec.template.spec.securityContext.runAsNonRoot
+    msg := "Data retention CronJobs must run as non-root"
+}
+
+deny contains msg if {
+    is_retention_cronjob
+    container := input.spec.jobTemplate.spec.template.spec.containers[_]
+    not container.resources.limits
+    msg := sprintf("Container %s must define resource limits", [container.name])
+}
+
+deny contains msg if {
+    is_retention_cronjob
+    container := input.spec.jobTemplate.spec.template.spec.containers[_]
+    not container.volumeMounts
+    msg := sprintf("Container %s must mount a policy bundle volume", [container.name])
+}
+
+deny contains msg if {
+    is_retention_cronjob
+    not input.spec.jobTemplate.spec.template.metadata.annotations["checksum/config"]
+    msg := "Data retention CronJobs must include a checksum/config annotation for change tracking"
+}
+
+allow if { not deny[_] }

--- a/server/db/retention/neo4j_data_retention.cypher
+++ b/server/db/retention/neo4j_data_retention.cypher
@@ -1,0 +1,61 @@
+// Summit Data Retention Automation for Neo4j
+//
+// This Cypher script archives or deletes nodes that have exceeded their
+// approved retention window. Nodes must be labeled RetentionManaged and
+// provide a `retentionExpiresAt` datetime property. An optional
+// `retentionAction` property can override the global default of ARCHIVE.
+//
+// The workflow mirrors the PostgreSQL implementation:
+//  * Expired nodes are streamed in deterministic batches.
+//  * ARCHIVE moves the node payload into an ArchivedSnapshot node for
+//    long-term storage before deleting the original node.
+//  * DELETE removes the node immediately when GDPR's right-to-be-forgotten
+//    obligations apply.
+//  * Each execution appends metrics to a RetentionAudit node so auditors
+//    can verify when retention processing occurred.
+
+WITH datetime() AS startedAt, apoc.create.uuid() AS runId
+CALL apoc.periodic.iterate(
+    'MATCH (n:RetentionManaged)
+     WHERE n.retentionExpiresAt <= datetime()
+     RETURN n, coalesce(n.retentionAction, $defaultAction) AS action',
+    'CALL apoc.do.when(
+         action = "ARCHIVE",
+         "MERGE (archive:ArchivedSnapshot {sourceNodeId: id(n)})\n"
+         "SET archive += properties(n),\n"
+         "    archive.archivedAt = datetime(),\n"
+         "    archive.sourceLabels = labels(n)\n"
+         "WITH archive, n\n"
+         "MERGE (audit:RetentionAudit {runId: $runId})\n"
+         "ON CREATE SET audit.startedAt = $startedAt\n"
+         "SET audit.lastUpdated = datetime(),\n"
+         "    audit.totalProcessed = coalesce(audit.totalProcessed, 0) + 1,\n"
+         "    audit.archived = coalesce(audit.archived, 0) + 1\n"
+         "DETACH DELETE n\n"
+         "RETURN archive",
+         'MERGE (audit:RetentionAudit {runId: $runId})\n'
+         'ON CREATE SET audit.startedAt = $startedAt\n'
+         'SET audit.lastUpdated = datetime(),\n'
+         '    audit.totalProcessed = coalesce(audit.totalProcessed, 0) + 1,\n'
+         '    audit.deleted = coalesce(audit.deleted, 0) + 1\n'
+         'DETACH DELETE n',
+         {n: n, runId: $runId, startedAt: $startedAt}
+     ) YIELD value
+     RETURN value',
+    {
+        batchSize: 500,
+        parallel: false,
+        params: {
+            defaultAction: 'ARCHIVE',
+            runId: runId,
+            startedAt: startedAt
+        }
+    }
+) YIELD batches, total, errorMessages
+RETURN {
+    runId: runId,
+    startedAt: startedAt,
+    batches: batches,
+    totalProcessed: total,
+    errors: errorMessages
+} AS retentionSummary;

--- a/server/db/retention/postgres_data_retention.sql
+++ b/server/db/retention/postgres_data_retention.sql
@@ -1,0 +1,221 @@
+-- Summit Data Retention Automation for PostgreSQL
+--
+-- This script provides reusable primitives for archiving or deleting
+-- data that has exceeded an approved retention period. The rules are
+-- intentionally metadata-driven so that compliance teams can register
+-- policies without shipping new application code.
+--
+-- Key concepts
+--  * compliance.retention_rules describes which tables are governed,
+--    how long records must be kept, and which action to take.
+--  * compliance.apply_retention() executes the rules, writing an audit
+--    trail to compliance.retention_audit_log so SOC 2 and GDPR reviews
+--    have tamper-evident evidence of enforcement.
+--  * The script is idempotent and safe to run from scheduled jobs.
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS compliance;
+
+CREATE TABLE IF NOT EXISTS compliance.retention_rules (
+    id                     BIGSERIAL PRIMARY KEY,
+    table_fqn              TEXT        NOT NULL,
+    primary_key_column     TEXT        NOT NULL,
+    timestamp_column       TEXT        NOT NULL,
+    retention_period       INTERVAL    NOT NULL,
+    action                 TEXT        NOT NULL CHECK (action IN ('ARCHIVE', 'DELETE')),
+    archive_table_fqn      TEXT,
+    filter_predicate       TEXT        NOT NULL DEFAULT 'TRUE',
+    enabled                BOOLEAN     NOT NULL DEFAULT TRUE,
+    last_run_at            TIMESTAMPTZ,
+    last_run_rows          BIGINT,
+    created_at             TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS compliance.retention_audit_log (
+    id              BIGSERIAL PRIMARY KEY,
+    rule_id         BIGINT      NOT NULL REFERENCES compliance.retention_rules(id) ON DELETE CASCADE,
+    action          TEXT        NOT NULL,
+    executed_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    rows_affected   BIGINT      NOT NULL DEFAULT 0,
+    status          TEXT        NOT NULL,
+    message         TEXT,
+    details         JSONB       DEFAULT '{}'::JSONB
+);
+
+CREATE OR REPLACE FUNCTION compliance.touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at := NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger
+        WHERE tgname = 'retention_rules_set_updated_at'
+    ) THEN
+        CREATE TRIGGER retention_rules_set_updated_at
+        BEFORE UPDATE ON compliance.retention_rules
+        FOR EACH ROW EXECUTE FUNCTION compliance.touch_updated_at();
+    END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION compliance.quote_fqn(fqn TEXT)
+RETURNS TEXT
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+    parts TEXT[];
+    quoted TEXT;
+BEGIN
+    parts := string_to_array(fqn, '.');
+    IF array_length(parts, 1) = 2 THEN
+        quoted := quote_ident(parts[1]) || '.' || quote_ident(parts[2]);
+    ELSE
+        quoted := quote_ident(fqn);
+    END IF;
+    RETURN quoted;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION compliance.apply_retention()
+RETURNS VOID
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    r                       compliance.retention_rules%ROWTYPE;
+    cutoff                  TIMESTAMPTZ;
+    quoted_table            TEXT;
+    quoted_archive          TEXT;
+    quoted_timestamp        TEXT;
+    inserted_count          BIGINT;
+    deleted_count           BIGINT;
+    status_text             TEXT;
+    message_text            TEXT;
+BEGIN
+    FOR r IN
+        SELECT * FROM compliance.retention_rules
+        WHERE enabled = TRUE
+        ORDER BY id
+    LOOP
+        inserted_count := 0;
+        deleted_count := 0;
+        status_text := 'SUCCESS';
+        message_text := NULL;
+        cutoff := NOW() - r.retention_period;
+        quoted_table := compliance.quote_fqn(r.table_fqn);
+        quoted_timestamp := quote_ident(r.timestamp_column);
+
+        BEGIN
+            IF r.action = 'ARCHIVE' THEN
+                IF r.archive_table_fqn IS NULL THEN
+                    RAISE EXCEPTION 'Archive action selected but archive_table_fqn is NULL for rule %', r.id;
+                END IF;
+
+                quoted_archive := compliance.quote_fqn(r.archive_table_fqn);
+
+                EXECUTE format('CREATE TABLE IF NOT EXISTS %s (LIKE %s INCLUDING ALL);', quoted_archive, quoted_table);
+
+                EXECUTE format(
+                    'INSERT INTO %1$s
+                     SELECT * FROM %2$s
+                     WHERE %3$s <= $1 AND (%4$s);',
+                    quoted_archive,
+                    quoted_table,
+                    quoted_timestamp,
+                    r.filter_predicate
+                ) USING cutoff;
+                GET DIAGNOSTICS inserted_count = ROW_COUNT;
+
+                EXECUTE format(
+                    'DELETE FROM %1$s
+                     WHERE %2$s <= $1 AND (%3$s);',
+                    quoted_table,
+                    quoted_timestamp,
+                    r.filter_predicate
+                ) USING cutoff;
+                GET DIAGNOSTICS deleted_count = ROW_COUNT;
+
+                message_text := format('Archived %s rows from %s to %s (rule %s).', inserted_count, r.table_fqn, r.archive_table_fqn, r.id);
+            ELSE
+                EXECUTE format(
+                    'DELETE FROM %1$s
+                     WHERE %2$s <= $1 AND (%3$s);',
+                    quoted_table,
+                    quoted_timestamp,
+                    r.filter_predicate
+                ) USING cutoff;
+                GET DIAGNOSTICS deleted_count = ROW_COUNT;
+                message_text := format('Deleted %s rows from %s (rule %s).', deleted_count, r.table_fqn, r.id);
+            END IF;
+        EXCEPTION
+            WHEN OTHERS THEN
+                status_text := 'ERROR';
+                message_text := format('Rule %s failed: %s', r.id, SQLERRM);
+        END;
+
+        UPDATE compliance.retention_rules
+        SET last_run_at = NOW(),
+            last_run_rows = COALESCE(deleted_count, 0)
+        WHERE id = r.id;
+
+        INSERT INTO compliance.retention_audit_log (
+            rule_id,
+            action,
+            executed_at,
+            rows_affected,
+            status,
+            message,
+            details
+        )
+        VALUES (
+            r.id,
+            r.action,
+            NOW(),
+            COALESCE(CASE WHEN r.action = 'ARCHIVE' THEN inserted_count ELSE deleted_count END, 0),
+            status_text,
+            message_text,
+            jsonb_build_object(
+                'table', r.table_fqn,
+                'archive_table', r.archive_table_fqn,
+                'cutoff', cutoff,
+                'filter', r.filter_predicate,
+                'rows_archived', inserted_count,
+                'rows_deleted', deleted_count
+            )
+        );
+    END LOOP;
+END;
+$$;
+
+COMMIT;
+
+-- Example rule registration (disabled by default):
+-- INSERT INTO compliance.retention_rules (
+--     table_fqn,
+--     primary_key_column,
+--     timestamp_column,
+--     retention_period,
+--     action,
+--     archive_table_fqn,
+--     filter_predicate,
+--     enabled
+-- ) VALUES (
+--     'public.audit_events',
+--     'id',
+--     'occurred_at',
+--     INTERVAL '730 days',
+--     'ARCHIVE',
+--     'archive.audit_events',
+--     'severity != ''critical''',
+--     TRUE
+-- );
+
+-- To run manually:
+-- SELECT compliance.apply_retention();


### PR DESCRIPTION
## Summary
- add PostgreSQL and Neo4j retention scripts that archive or delete expired records with full auditing
- schedule database enforcement via Kubernetes CronJobs labeled for GDPR/SOC2 compliance
- gate retention workloads with an OPA policy and document the operating guide in docs/security

## Testing
- not run (infrastructure-as-code change)


------
https://chatgpt.com/codex/tasks/task_e_68d6d61c6ad08333936778480bd910a3