### PR TITLE
Add automated security compliance checks to CI

### DIFF
--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -1,0 +1,131 @@
+name: Security Compliance Checks
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: security-compliance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conftest:
+    name: OPA policy evaluation
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+
+      - name: Install Conftest
+        run: |
+          set -euo pipefail
+          curl -L -o conftest.tar.gz https://github.com/open-policy-agent/conftest/releases/download/v0.46.0/conftest_0.46.0_Linux_x86_64.tar.gz
+          tar xzf conftest.tar.gz
+          sudo mv conftest /usr/local/bin/
+
+      - name: Evaluate policies against Helm charts
+        run: |
+          set -euo pipefail
+          if [ ! -d infra/helm ]; then
+            echo "infra/helm directory not found; skipping policy evaluation."
+            exit 0
+          fi
+
+          mapfile -t charts < <(find infra/helm -name Chart.yaml -print)
+          if [ ${#charts[@]} -eq 0 ]; then
+            echo "No Helm charts discovered under infra/helm; skipping policy evaluation."
+            exit 0
+          fi
+
+          for chart_file in "${charts[@]}"; do
+            chart_dir="$(dirname "${chart_file}")"
+            release_name="$(basename "${chart_dir}")"
+            echo "::group::Conftest ${release_name}"
+            helm dependency build "${chart_dir}" >/dev/null 2>&1 || true
+            manifest="$(mktemp)"
+            if helm template "${release_name}" "${chart_dir}" >"${manifest}"; then
+              conftest test "${manifest}" --policy policies/opa/kubernetes
+            else
+              echo "Failed to render Helm chart at ${chart_dir}" >&2
+              rm -f "${manifest}"
+              exit 1
+            fi
+            rm -f "${manifest}"
+            echo "::endgroup::"
+          done
+
+  trivy:
+    name: Trivy vulnerability scans
+    runs-on: ubuntu-22.04
+    needs: conftest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+
+      - name: Install Trivy
+        run: |
+          set -euo pipefail
+          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sudo sh -s -- -b /usr/local/bin v0.50.4
+
+      - name: Scan Helm charts with Trivy config
+        run: |
+          set -euo pipefail
+          if [ ! -d infra/helm ]; then
+            echo "infra/helm directory not found; skipping Helm config scan."
+          else
+            mapfile -t charts < <(find infra/helm -name Chart.yaml -print)
+            if [ ${#charts[@]} -eq 0 ]; then
+              echo "No Helm charts discovered under infra/helm; skipping Helm config scan."
+            else
+              for chart_file in "${charts[@]}"; do
+                chart_dir="$(dirname "${chart_file}")"
+                chart_name="$(basename "${chart_dir}")"
+                echo "::group::Trivy config ${chart_name}"
+                trivy config --exit-code 1 --severity HIGH,CRITICAL --helm-chart "${chart_dir}"
+                echo "::endgroup::"
+              done
+            fi
+          fi
+
+      - name: Build & scan Docker images with Trivy
+        env:
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          declare -A targets=(
+            ["platform-app"]="."
+            ["api-server"]="server"
+          )
+
+          for name in "${!targets[@]}"; do
+            context="${targets[$name]}"
+            dockerfile_path="${context}/Dockerfile"
+            if [ ! -f "${dockerfile_path}" ]; then
+              echo "Skipping ${name}; no Dockerfile at ${dockerfile_path}."
+              continue
+            fi
+
+            image_ref="ghcr.io/summit/${name}:ci-${IMAGE_TAG:0:12}"
+            echo "::group::Build ${image_ref}"
+            docker build --file "${dockerfile_path}" --tag "${image_ref}" "${context}"
+            echo "::endgroup::"
+
+            echo "::group::Trivy image ${image_ref}"
+            trivy image --exit-code 1 --severity HIGH,CRITICAL --ignore-unfixed "${image_ref}"
+            echo "::endgroup::"
+
+            docker image rm "${image_ref}" >/dev/null 2>&1 || true
+          done

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ tmp-sidecar-audit/
 # OPA binary downloads
 opa
 opa.exe
+!policies/opa/
+!policies/opa/**
 
 # Temporary files
 tmp/

--- a/docs/security/security-compliance-runbook.md
+++ b/docs/security/security-compliance-runbook.md
@@ -1,0 +1,87 @@
+# Security Compliance Runbook
+
+## Overview
+The **Security Compliance Checks** GitHub Actions workflow enforces automated
+policy and vulnerability controls whenever a pull request is opened or updated
+and on merges to `main`. The pipeline covers two layers:
+
+1. **OPA policy enforcement** – Helm charts are rendered and evaluated with
+   Conftest using the `kubernetes.compliance` policy package.
+2. **Trivy vulnerability scanning** – Helm charts are scanned for
+   misconfigurations and key Docker images are built and scanned for
+   vulnerabilities.
+
+Both stages must pass for merges protected by the workflow.
+
+## Workflow topology
+- **Location:** `.github/workflows/security-compliance.yml`
+- **Triggers:** `pull_request` (opened, synchronize, reopened,
+  ready_for_review) and `push` to `main`.
+- **Jobs:**
+  - `conftest` renders each Helm chart discovered under `infra/helm` and runs
+    `conftest test` with policies from `policies/opa/kubernetes`.
+  - `trivy` depends on `conftest`, installs Trivy, scans Helm charts with
+    `trivy config`, then builds two baseline Docker images (`.` and `server/`)
+    and executes `trivy image`.
+- **Concurrency:** A single workflow per ref via
+  `security-compliance-${{ github.ref }}` ensures the latest run wins.
+
+## Policy package
+- **Source:** `policies/opa/kubernetes/workload.rego`
+- **Rules enforced:**
+  - Containers must run as non-root (pod-level or per-container security
+    context).
+  - Containers must set `readOnlyRootFilesystem: true`.
+  - Container images must pin a tag or digest and may not use the `latest`
+    mutable tag.
+- **Extensibility:** Additional `deny` rules can be appended to the same
+  package. Each rule emits human-readable violation messages surfaced in the
+  workflow logs.
+
+## Trivy coverage
+- **Helm charts:** Every chart beneath `infra/helm` is scanned with
+  `trivy config --severity HIGH,CRITICAL --helm-chart <path>`.
+- **Docker images:** The workflow builds images for the repository root
+  `Dockerfile` and `server/Dockerfile`. Adjust the associative array in the
+  `Build & scan Docker images with Trivy` step to add more contexts. Images are
+  tagged `ghcr.io/summit/<name>:ci-<sha>` for isolation and removed after the
+  scan completes.
+
+## Responding to failures
+1. **Identify the failing job:** Open the workflow run and inspect the failing
+   step for the Conftest or Trivy job.
+2. **OPA violations:** Review the `deny` messages to determine which manifest
+   and container triggered the rule. Update the Helm values/templates to comply
+   or, if a temporary exception is required, discuss adding a scoped policy
+   override.
+3. **Trivy findings:**
+   - *Config scan:* Adjust the chart to remediate HIGH/CRITICAL
+     misconfigurations.
+   - *Image scan:* Upgrade dependencies in the Dockerfile or add fixed package
+     versions. Rebuild locally with `docker build` and re-run
+     `trivy image --severity HIGH,CRITICAL <image>` before pushing changes.
+4. **Re-run pipeline:** Push the remediation branch or trigger a rerun from the
+   GitHub UI after addressing issues.
+
+## Local testing
+- **Conftest:**
+  ```bash
+  # Render your chart and test locally
+  helm template myrelease infra/helm/mychart > /tmp/mychart.yaml
+  conftest test /tmp/mychart.yaml --policy policies/opa/kubernetes
+  ```
+- **Trivy config:**
+  ```bash
+  trivy config --severity HIGH,CRITICAL --helm-chart infra/helm/mychart
+  ```
+- **Trivy image:**
+  ```bash
+  docker build -f server/Dockerfile -t summit-server:dev server
+  trivy image --severity HIGH,CRITICAL summit-server:dev
+  ```
+
+## Maintenance checklist
+- Review Trivy release notes quarterly and bump the installer version in the
+  workflow.
+- Update the Docker image target list when new services are introduced.
+- Expand the OPA policy package as new baseline controls are required.

--- a/policies/opa/kubernetes/README.md
+++ b/policies/opa/kubernetes/README.md
@@ -1,0 +1,16 @@
+# Kubernetes Compliance Policies
+
+These Rego policies back the automated Conftest checks in the security compliance
+workflow. They enforce a minimal security baseline across rendered Helm
+manifests:
+
+- Containers must run as non-root, either via a pod-level security context or
+  container-specific settings.
+- Containers must set `readOnlyRootFilesystem: true` to harden the runtime
+  surface area.
+- Images must be pinned to a non-`latest` tag or digest to ensure immutability
+  and repeatable deployments.
+
+Extend this package with additional rules to meet workload-specific
+requirements. Every rule emits human-readable `deny` messages consumed by the CI
+pipeline.

--- a/policies/opa/kubernetes/workload.rego
+++ b/policies/opa/kubernetes/workload.rego
@@ -1,0 +1,106 @@
+package kubernetes.compliance
+
+import future.keywords.in
+
+workload_kinds := {"Deployment", "StatefulSet", "DaemonSet", "Job", "CronJob"}
+
+pod_spec(spec) {
+  input.kind == "CronJob"
+  spec := input.spec.jobTemplate.spec.template.spec
+}
+
+pod_spec(spec) {
+  input.kind != "CronJob"
+  spec := input.spec.template.spec
+}
+
+all_containers[container] {
+  pod_spec(spec)
+  spec.containers[_] = container
+}
+
+all_containers[container] {
+  pod_spec(spec)
+  spec.initContainers[_] = container
+}
+
+container_name(container) := name {
+  name := container.name
+}
+
+container_name(container) := "<unnamed>" {
+  not container.name
+}
+
+pod_run_as_non_root {
+  pod_spec(spec)
+  spec.securityContext.runAsNonRoot == true
+}
+
+container_run_as_non_root(container) {
+  container.securityContext.runAsNonRoot == true
+}
+
+container_read_only_root_fs(container) {
+  container.securityContext.readOnlyRootFilesystem == true
+}
+
+image_has_digest(image) {
+  re_match(".*@sha256:[0-9a-fA-F]{64}$", image)
+}
+
+image_last_segment(image, segment) {
+  parts := split(image, "/")
+  count(parts) > 0
+  segment := parts[count(parts) - 1]
+}
+
+image_tag(image, tag) {
+  not image_has_digest(image)
+  image_last_segment(image, segment)
+  pieces := split(segment, ":")
+  count(pieces) == 2
+  tag := pieces[1]
+}
+
+image_has_tag(image) {
+  image_tag(image, _)
+}
+
+deny[msg] {
+  input.kind in workload_kinds
+  pod_spec(_)
+  container := all_containers[_]
+  not pod_run_as_non_root
+  not container_run_as_non_root(container)
+  msg := sprintf("%s %q container %q must run as non-root", [input.kind, input.metadata.name, container_name(container)])
+}
+
+deny[msg] {
+  input.kind in workload_kinds
+  pod_spec(_)
+  container := all_containers[_]
+  not container_read_only_root_fs(container)
+  msg := sprintf("%s %q container %q must enable readOnlyRootFilesystem", [input.kind, input.metadata.name, container_name(container)])
+}
+
+deny[msg] {
+  input.kind in workload_kinds
+  pod_spec(_)
+  container := all_containers[_]
+  image := container.image
+  not image_has_digest(image)
+  not image_has_tag(image)
+  msg := sprintf("%s %q container %q image must pin a tag or digest", [input.kind, input.metadata.name, container_name(container)])
+}
+
+deny[msg] {
+  input.kind in workload_kinds
+  pod_spec(_)
+  container := all_containers[_]
+  image := container.image
+  not image_has_digest(image)
+  image_tag(image, tag)
+  lower(tag) == "latest"
+  msg := sprintf("%s %q container %q image tag must not be 'latest'", [input.kind, input.metadata.name, container_name(container)])
+}


### PR DESCRIPTION
## Summary
- add a security compliance workflow that runs Conftest and Trivy on PRs and main pushes
- introduce Kubernetes-focused OPA policies for container hardening
- document the workflow operation and response steps in a security runbook

## Testing
- not run (workflow updates)


------
https://chatgpt.com/codex/tasks/task_e_68d6d634134083339cc6a25eaa97a5ec