### PR TITLE
Add Neo4j graph ingestion validation framework

### DIFF
--- a/docs/ingestion/graph-validation.md
+++ b/docs/ingestion/graph-validation.md
@@ -1,0 +1,135 @@
+# Graph Ingestion Validation Framework
+
+This document describes the validation pipeline that must be executed before Neo4j ingestion. The framework combines JSON Schema checks, custom Cypher rule execution, and OpenTelemetry instrumentation so that invalid payloads are surfaced to operators and observability backends before any writes occur.
+
+## Components
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| JSON Schema validator | `server/src/graph/validation/GraphValidationService.ts` | Enforces structural and property requirements for nodes and relationships. |
+| Cypher rule catalog | `server/src/graph/validation/cypherRules.ts` | Runs rule-oriented Cypher snippets against the payload (using `UNWIND`) to detect disallowed patterns prior to ingestion. |
+| GraphQL mutation | `server/src/graphql/schema.graph-validation.ts`, `server/src/graphql/resolvers/graphValidation.ts` | Provides an API for callers to preflight graph data. |
+| Neo4j constraints | `server/db/migrations/neo4j/2025-10-05_graph_validation_rules.cypher` | Hardens the database so server-side constraints mirror the application policy. |
+| Tests | `server/src/tests/GraphValidationService.test.ts`, `server/src/graphql/resolvers/__tests__/graphValidation.test.ts` | Guardrail coverage for the validator and resolver. |
+
+## JSON Schema coverage
+
+The validator ships with embedded JSON Schema definitions for the ingestion payload:
+
+```ts
+const nodeSchema = {
+  type: 'object',
+  required: ['id', 'labels', 'properties'],
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string', minLength: 1 },
+    labels: { type: 'array', minItems: 1, items: { type: 'string', minLength: 1 } },
+    properties: { type: 'object', additionalProperties: true }
+  }
+};
+```
+
+The service executes a lightweight schema walker that supports the subset of JSON Schema features we rely on (type checking, `required`, `minLength`, `pattern`, and `additionalProperties`). JSON Schema violations are returned with `code=SCHEMA_VALIDATION_FAILED` (or more specific codes for type and enum mismatches) and surfaced via OpenTelemetry events on the `graph.validation` span.
+
+## Cypher rule execution
+
+`GraphValidationService` can evaluate arbitrary Cypher rules before ingesting. The default rules live in `server/src/graph/validation/cypherRules.ts` and currently cover:
+
+* Ensuring node `tenantId` matches the payload tenant.
+* Restricting relationship types to the allow list (`ASSOCIATED_WITH`, `MENTIONS`, `COMMUNICATED_WITH`, `LOCATED_AT`).
+* Verifying every relationship endpoint exists in the submitted node set.
+
+Rules are executed with parameters derived from the payload, for example:
+
+```cypher
+UNWIND $relationships AS rel
+WITH rel
+WHERE NOT rel.type IN $allowedRelationshipTypes
+RETURN collect({
+  id: coalesce(rel.id, rel.sourceId + '->' + rel.targetId),
+  type: rel.type,
+  sourceId: rel.sourceId,
+  targetId: rel.targetId
+}) AS violations
+```
+
+Each rule contributes its own `GraphValidationError` objects when violations are returned. Execution failures are downgraded to warnings so ingestion clients receive actionable feedback instead of 500s.
+
+## GraphQL mutation
+
+Extend your GraphQL client with the `validateGraphData` mutation:
+
+```graphql
+mutation ValidateGraph($input: GraphValidationInput!) {
+  validateGraphData(input: $input) {
+    valid
+    warnings
+    appliedRules
+    errors {
+      code
+      message
+      path
+      rule
+      severity
+    }
+  }
+}
+```
+
+Example variables:
+
+```json
+{
+  "input": {
+    "tenantId": "tenant-1",
+    "nodes": [
+      {
+        "id": "node-1",
+        "labels": ["Entity"],
+        "properties": {
+          "tenantId": "tenant-1",
+          "kind": "PERSON",
+          "name": "Alice"
+        }
+      }
+    ],
+    "relationships": []
+  }
+}
+```
+
+The resolver enforces tenant isolation through `TenantValidator` and attaches validation telemetry via the OpenTelemetry tracer (`graph-validation`).
+
+## Telemetry
+
+Every validation request is wrapped in a span named `graph.validation` with the following events:
+
+* `graph.validation.rule` – emitted for each rule with the violation count.
+* `graph.validation.error` – emitted per error with code, path, and rule metadata.
+* `graph.validation.warning` – emitted when rule execution is skipped or degraded.
+* Span status set to `ERROR` when any validation errors are present.
+
+These signals let dashboards and alerts detect ingestion problems before data is persisted.
+
+## Database constraints
+
+The Cypher script `2025-10-05_graph_validation_rules.cypher` installs property existence constraints so the same invariants are enforced inside Neo4j. Run the script after deploying the application:
+
+```bash
+cypher-shell -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" \
+  -f server/db/migrations/neo4j/2025-10-05_graph_validation_rules.cypher
+```
+
+The script also includes a helper query to surface any relationship types that fall outside the application allow list. Update the allow list in both the script and `GraphValidationService` when onboarding new relationship semantics.
+
+## Test coverage
+
+Run the focused test suites from the repository root:
+
+```bash
+cd server
+npm test -- GraphValidationService
+npm test -- graphValidationResolvers
+```
+
+The first suite exercises schema and Cypher-based rule enforcement; the second verifies the GraphQL entry point and tenant guardrail logic.

--- a/server/db/migrations/neo4j/2025-10-05_graph_validation_rules.cypher
+++ b/server/db/migrations/neo4j/2025-10-05_graph_validation_rules.cypher
@@ -1,0 +1,23 @@
+// Graph validation constraints for ingestion hardening
+// Apply with: cypher-shell -u $NEO4J_USER -p $NEO4J_PASSWORD -f 2025-10-05_graph_validation_rules.cypher
+
+// Ensure all Entity nodes include tenant and classification data
+CREATE CONSTRAINT entity_requires_tenant IF NOT EXISTS FOR (e:Entity)
+REQUIRE e.tenantId IS NOT NULL;
+
+CREATE CONSTRAINT entity_requires_kind IF NOT EXISTS FOR (e:Entity)
+REQUIRE e.kind IS NOT NULL;
+
+CREATE CONSTRAINT entity_requires_name IF NOT EXISTS FOR (e:Entity)
+REQUIRE e.name IS NOT NULL;
+
+// Ensure relationships carry tenant ownership metadata
+CREATE CONSTRAINT relationship_requires_tenant IF NOT EXISTS FOR ()-[r]-()
+REQUIRE r.tenantId IS NOT NULL;
+
+// Optional validation query: flag relationships using disallowed types
+// Adjust the allow list to match the application configuration.
+WITH ['ASSOCIATED_WITH', 'MENTIONS', 'COMMUNICATED_WITH', 'LOCATED_AT'] AS allowedTypes
+MATCH ()-[r]-()
+WHERE NOT type(r) IN allowedTypes
+RETURN DISTINCT type(r) AS disallowedRelationshipTypes;

--- a/server/src/graph/validation/GraphValidationService.ts
+++ b/server/src/graph/validation/GraphValidationService.ts
@@ -1,0 +1,425 @@
+import { trace, SpanStatusCode } from '@opentelemetry/api';
+import {
+  CypherExecutor,
+  GraphCypherRule,
+  GraphNodePayload,
+  GraphRelationshipPayload,
+  GraphValidationError,
+  GraphValidationOptions,
+  GraphValidationPayload,
+  GraphValidationResult,
+} from './types.js';
+
+const tracer = trace.getTracer('graph-validation', '1.0.0');
+
+const DEFAULT_NODE_PROPERTIES = ['tenantId', 'kind', 'name'];
+const DEFAULT_RELATIONSHIP_PROPERTIES = ['tenantId'];
+const DEFAULT_RELATIONSHIP_TYPES = [
+  'ASSOCIATED_WITH',
+  'MENTIONS',
+  'COMMUNICATED_WITH',
+  'LOCATED_AT',
+];
+
+type JsonSchema = {
+  type?: 'object' | 'array' | 'string' | 'number' | 'integer' | 'boolean';
+  properties?: Record<string, JsonSchema>;
+  required?: string[];
+  additionalProperties?: boolean;
+  items?: JsonSchema;
+  minItems?: number;
+  minLength?: number;
+  pattern?: string;
+  enum?: string[];
+};
+
+const nodeSchema: JsonSchema = {
+  type: 'object',
+  required: ['id', 'labels', 'properties'],
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string', minLength: 1 },
+    labels: {
+      type: 'array',
+      minItems: 1,
+      items: { type: 'string', minLength: 1 },
+    },
+    properties: {
+      type: 'object',
+      additionalProperties: true,
+    },
+  },
+};
+
+const relationshipSchema: JsonSchema = {
+  type: 'object',
+  required: ['type', 'sourceId', 'targetId'],
+  additionalProperties: false,
+  properties: {
+    id: { type: 'string', minLength: 1 },
+    type: { type: 'string', minLength: 1, pattern: '^[A-Z_]+$' },
+    sourceId: { type: 'string', minLength: 1 },
+    targetId: { type: 'string', minLength: 1 },
+    properties: {
+      type: 'object',
+      additionalProperties: true,
+    },
+  },
+};
+
+const payloadSchema: JsonSchema = {
+  type: 'object',
+  required: ['tenantId', 'nodes', 'relationships'],
+  additionalProperties: false,
+  properties: {
+    tenantId: { type: 'string', minLength: 1 },
+    nodes: {
+      type: 'array',
+      minItems: 1,
+      items: nodeSchema,
+    },
+    relationships: {
+      type: 'array',
+      minItems: 0,
+      items: relationshipSchema,
+    },
+  },
+};
+
+function joinPath(base: string, addition: string): string {
+  if (!base) return addition;
+  if (addition.startsWith('[')) {
+    return `${base}${addition}`;
+  }
+  return `${base}.${addition}`;
+}
+
+function schemaError(path: string, message: string, code = 'SCHEMA_VALIDATION_FAILED'): GraphValidationError {
+  return {
+    code,
+    message,
+    path,
+    rule: 'json-schema',
+    severity: 'ERROR',
+  };
+}
+
+function validateSchema(schema: JsonSchema, value: unknown, path: string, errors: GraphValidationError[]) {
+  if (!schema) return;
+
+  switch (schema.type) {
+    case 'object': {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        errors.push(schemaError(path, `Expected object but received ${Array.isArray(value) ? 'array' : typeof value}.`, 'TYPE_MISMATCH'));
+        return;
+      }
+      const record = value as Record<string, unknown>;
+      if (schema.required) {
+        for (const prop of schema.required) {
+          if (!(prop in record)) {
+            errors.push(schemaError(joinPath(path, prop), `Property '${prop}' is required.`));
+          }
+        }
+      }
+      if (schema.properties) {
+        for (const [prop, childSchema] of Object.entries(schema.properties)) {
+          if (prop in record) {
+            validateSchema(childSchema, record[prop], joinPath(path, prop), errors);
+          }
+        }
+      }
+      if (schema.additionalProperties === false && schema.properties) {
+        for (const key of Object.keys(record)) {
+          if (!schema.properties[key]) {
+            errors.push(schemaError(joinPath(path, key), `Unexpected property '${key}'.`, 'ADDITIONAL_PROPERTY_NOT_ALLOWED'));
+          }
+        }
+      }
+      break;
+    }
+    case 'array': {
+      if (!Array.isArray(value)) {
+        errors.push(schemaError(path, `Expected array but received ${typeof value}.`, 'TYPE_MISMATCH'));
+        return;
+      }
+      if (typeof schema.minItems === 'number' && value.length < schema.minItems) {
+        errors.push(schemaError(path, `Array must contain at least ${schema.minItems} item(s).`, 'ARRAY_LENGTH_TOO_SMALL'));
+      }
+      if (schema.items) {
+        value.forEach((item, index) => {
+          validateSchema(schema.items as JsonSchema, item, joinPath(path, `[${index}]`), errors);
+        });
+      }
+      break;
+    }
+    case 'string': {
+      if (typeof value !== 'string') {
+        errors.push(schemaError(path, `Expected string but received ${typeof value}.`, 'TYPE_MISMATCH'));
+        return;
+      }
+      if (typeof schema.minLength === 'number' && value.length < schema.minLength) {
+        errors.push(schemaError(path, `String must be at least ${schema.minLength} character(s).`, 'STRING_TOO_SHORT'));
+      }
+      if (schema.pattern) {
+        const regex = new RegExp(schema.pattern);
+        if (!regex.test(value)) {
+          errors.push(schemaError(path, `Value '${value}' does not match pattern ${schema.pattern}.`, 'PATTERN_MISMATCH'));
+        }
+      }
+      if (schema.enum && !schema.enum.includes(value)) {
+        errors.push(schemaError(path, `Value must be one of: ${schema.enum.join(', ')}.`, 'ENUM_MISMATCH'));
+      }
+      break;
+    }
+    case 'number': {
+      if (typeof value !== 'number' || Number.isNaN(value)) {
+        errors.push(schemaError(path, `Expected number but received ${typeof value}.`, 'TYPE_MISMATCH'));
+      }
+      break;
+    }
+    case 'integer': {
+      if (typeof value !== 'number' || !Number.isInteger(value)) {
+        errors.push(schemaError(path, `Expected integer but received ${typeof value}.`, 'TYPE_MISMATCH'));
+      }
+      break;
+    }
+    case 'boolean': {
+      if (typeof value !== 'boolean') {
+        errors.push(schemaError(path, `Expected boolean but received ${typeof value}.`, 'TYPE_MISMATCH'));
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+function ensureRule(appliedRules: string[], rule: string) {
+  if (!appliedRules.includes(rule)) {
+    appliedRules.push(rule);
+  }
+}
+
+export class GraphValidationService {
+  private readonly requiredNodeProperties: string[];
+  private readonly requiredRelationshipProperties: string[];
+  private readonly allowedRelationshipTypes: string[];
+  private readonly cypherRules: GraphCypherRule[];
+  private readonly cypherExecutor?: CypherExecutor;
+
+  constructor(options: GraphValidationOptions = {}) {
+    this.requiredNodeProperties = options.requiredNodeProperties ?? DEFAULT_NODE_PROPERTIES;
+    this.requiredRelationshipProperties =
+      options.requiredRelationshipProperties ?? DEFAULT_RELATIONSHIP_PROPERTIES;
+    this.allowedRelationshipTypes = options.allowedRelationshipTypes ?? DEFAULT_RELATIONSHIP_TYPES;
+    this.cypherRules = options.cypherRules ?? [];
+    this.cypherExecutor = options.cypherExecutor;
+  }
+
+  async validate(payload: GraphValidationPayload): Promise<GraphValidationResult> {
+    return tracer.startActiveSpan('graph.validation', async (span) => {
+      const errors: GraphValidationError[] = [];
+      const warnings: string[] = [];
+      const appliedRules: string[] = [];
+
+      try {
+        ensureRule(appliedRules, 'json-schema');
+        validateSchema(payloadSchema, payload, 'input', errors);
+
+        const nodes: GraphNodePayload[] = Array.isArray(payload.nodes) ? payload.nodes : [];
+        const relationships: GraphRelationshipPayload[] = Array.isArray(payload.relationships)
+          ? payload.relationships
+          : [];
+
+        ensureRule(appliedRules, 'node-required-properties');
+        const nodeIds = new Set<string>();
+
+        nodes.forEach((node, index) => {
+          const nodePath = `nodes[${index}]`;
+          if (nodeIds.has(node.id)) {
+            errors.push({
+              code: 'DUPLICATE_NODE_ID',
+              message: `Duplicate node id '${node.id}' detected.`,
+              path: `${nodePath}.id`,
+              rule: 'node-required-properties',
+              severity: 'ERROR',
+            });
+          } else {
+            nodeIds.add(node.id);
+          }
+
+          const props = (node && typeof node === 'object' ? node.properties : undefined) as
+            | Record<string, unknown>
+            | undefined;
+
+          for (const property of this.requiredNodeProperties) {
+            const propertyValue = props?.[property];
+            if (propertyValue === undefined || propertyValue === null || propertyValue === '') {
+              errors.push({
+                code: 'NODE_PROPERTY_REQUIRED',
+                message: `Node '${node.id}' is missing required property '${property}'.`,
+                path: `${nodePath}.properties.${property}`,
+                rule: 'node-required-properties',
+                severity: 'ERROR',
+              });
+            }
+          }
+
+          const tenantId = props?.tenantId;
+          if (tenantId !== undefined && tenantId !== payload.tenantId) {
+            errors.push({
+              code: 'TENANT_ID_MISMATCH',
+              message: `Node '${node.id}' tenantId '${tenantId}' does not match payload tenant '${payload.tenantId}'.`,
+              path: `${nodePath}.properties.tenantId`,
+              rule: 'node-required-properties',
+              severity: 'ERROR',
+            });
+          }
+        });
+
+        ensureRule(appliedRules, 'relationship-structure');
+        const allowedTypes = new Set(this.allowedRelationshipTypes);
+
+        relationships.forEach((relationship, index) => {
+          const relationshipPath = `relationships[${index}]`;
+
+          if (!allowedTypes.has(relationship.type)) {
+            errors.push({
+              code: 'RELATIONSHIP_TYPE_NOT_ALLOWED',
+              message: `Relationship '${relationship.type}' is not permitted.`,
+              path: `${relationshipPath}.type`,
+              rule: 'relationship-structure',
+              severity: 'ERROR',
+            });
+          }
+
+          for (const property of this.requiredRelationshipProperties) {
+            const value = relationship.properties?.[property];
+            if (value === undefined || value === null || value === '') {
+              errors.push({
+                code: 'RELATIONSHIP_PROPERTY_REQUIRED',
+                message: `Relationship '${relationship.type}' is missing required property '${property}'.`,
+                path: `${relationshipPath}.properties.${property}`,
+                rule: 'relationship-structure',
+                severity: 'ERROR',
+              });
+            }
+            if (property === 'tenantId' && value !== undefined && value !== payload.tenantId) {
+              errors.push({
+                code: 'TENANT_ID_MISMATCH',
+                message: `Relationship tenantId '${value}' does not match payload tenant '${payload.tenantId}'.`,
+                path: `${relationshipPath}.properties.tenantId`,
+                rule: 'relationship-structure',
+                severity: 'ERROR',
+              });
+            }
+          }
+
+          if (!nodeIds.has(relationship.sourceId)) {
+            errors.push({
+              code: 'RELATIONSHIP_SOURCE_NOT_FOUND',
+              message: `Source node '${relationship.sourceId}' not present in payload nodes.`,
+              path: `${relationshipPath}.sourceId`,
+              rule: 'relationship-structure',
+              severity: 'ERROR',
+            });
+          }
+
+          if (!nodeIds.has(relationship.targetId)) {
+            errors.push({
+              code: 'RELATIONSHIP_TARGET_NOT_FOUND',
+              message: `Target node '${relationship.targetId}' not present in payload nodes.`,
+              path: `${relationshipPath}.targetId`,
+              rule: 'relationship-structure',
+              severity: 'ERROR',
+            });
+          }
+
+          if (relationship.sourceId === relationship.targetId) {
+            errors.push({
+              code: 'RELATIONSHIP_SELF_REFERENCE',
+              message: `Self-referential relationship on node '${relationship.sourceId}' is not allowed.`,
+              path: relationshipPath,
+              rule: 'relationship-structure',
+              severity: 'ERROR',
+            });
+          }
+        });
+
+        if (this.cypherRules.length > 0) {
+          if (!this.cypherExecutor) {
+            warnings.push('Cypher rules configured but no executor was provided; skipped rule evaluation.');
+          } else {
+            const params = {
+              tenantId: payload.tenantId,
+              nodes,
+              relationships,
+              allowedRelationshipTypes: this.allowedRelationshipTypes,
+            };
+
+            for (const rule of this.cypherRules) {
+              ensureRule(appliedRules, rule.name);
+              try {
+                const result = await this.cypherExecutor.run(rule.statement, params);
+                const record = result.records[0] as Record<string, any> | undefined;
+                const violations = Array.isArray(record?.violations) ? record?.violations : [];
+
+                span.addEvent('graph.validation.rule', {
+                  rule: rule.name,
+                  violations: violations.length,
+                });
+
+                if (violations.length > 0) {
+                  for (const violation of violations) {
+                    const error = rule.buildError(violation, payload);
+                    error.rule = error.rule ?? rule.name;
+                    error.code = error.code || rule.errorCode;
+                    error.severity = error.severity ?? rule.severity ?? 'ERROR';
+                    errors.push(error);
+                  }
+                }
+              } catch (error) {
+                const message = (error as Error).message;
+                span.addEvent('graph.validation.rule_error', { rule: rule.name, message });
+                warnings.push(`Rule '${rule.name}' execution failed: ${message}`);
+              }
+            }
+          }
+        }
+
+        warnings.forEach((warning) => {
+          span.addEvent('graph.validation.warning', { message: warning });
+        });
+
+        if (errors.length > 0) {
+          errors.forEach((error) => {
+            span.addEvent('graph.validation.error', {
+              code: error.code,
+              message: error.message,
+              path: error.path,
+              rule: error.rule ?? 'unknown',
+            });
+          });
+          span.setStatus({ code: SpanStatusCode.ERROR, message: 'Graph validation failed' });
+        } else {
+          span.setStatus({ code: SpanStatusCode.OK });
+        }
+
+        return {
+          valid: errors.length === 0,
+          errors,
+          warnings,
+          appliedRules,
+        };
+      } catch (error) {
+        span.recordException(error as Error);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: (error as Error).message });
+        throw error;
+      } finally {
+        span.end();
+      }
+    });
+  }
+}
+
+export default GraphValidationService;

--- a/server/src/graph/validation/cypherRules.ts
+++ b/server/src/graph/validation/cypherRules.ts
@@ -1,0 +1,128 @@
+import type { Driver, QueryResult } from 'neo4j-driver';
+import {
+  CypherExecutor,
+  CypherQueryResult,
+  GraphCypherRule,
+  GraphValidationError,
+  GraphValidationPayload,
+} from './types.js';
+
+function recordToObject(record: any): Record<string, unknown> {
+  if (!record) return {};
+  if (typeof record.toObject === 'function') {
+    return record.toObject();
+  }
+  return record as Record<string, unknown>;
+}
+
+export function createCypherExecutorFromDriver(driver: Driver): CypherExecutor {
+  return {
+    async run<T = any>(statement: string, params: Record<string, unknown> = {}): Promise<CypherQueryResult<T>> {
+      if (typeof (driver as any).executeQuery === 'function') {
+        const result: QueryResult = await (driver as any).executeQuery(statement, params);
+        return {
+          records: (result.records || []).map((record: any) => recordToObject(record)) as T[],
+        };
+      }
+
+      const session = driver.session();
+      try {
+        const result = await session.run(statement, params);
+        return {
+          records: result.records.map((record: any) => recordToObject(record)) as T[],
+        };
+      } finally {
+        await session.close();
+      }
+    },
+  };
+}
+
+function buildTenantError(violation: Record<string, any>, payload: GraphValidationPayload): GraphValidationError {
+  const nodeId = violation.id ?? 'unknown';
+  const tenantId = violation.tenantId ?? 'null';
+  return {
+    code: 'TENANT_ID_MISMATCH',
+    message: `Node ${nodeId} has tenantId ${tenantId}, expected ${payload.tenantId}.`,
+    path: `nodes[id=${nodeId}].properties.tenantId`,
+    rule: 'tenant-consistency',
+    severity: 'ERROR',
+    details: violation,
+  };
+}
+
+function buildRelationshipTypeError(violation: Record<string, any>): GraphValidationError {
+  const relationshipId = violation.id ?? `${violation.sourceId}->${violation.targetId}`;
+  return {
+    code: 'RELATIONSHIP_TYPE_NOT_ALLOWED',
+    message: `Relationship ${relationshipId} uses unsupported type ${violation.type}.`,
+    path: `relationships[id=${relationshipId}].type`,
+    rule: 'relationship-allowlist',
+    severity: 'ERROR',
+    details: violation,
+  };
+}
+
+function buildRelationshipEndpointError(violation: Record<string, any>): GraphValidationError {
+  const relationshipId = violation.id ?? `${violation.sourceId}->${violation.targetId}`;
+  return {
+    code: 'RELATIONSHIP_ENDPOINT_NOT_FOUND',
+    message: `Relationship ${relationshipId} references missing node(s).`,
+    path: `relationships[id=${relationshipId}]`,
+    rule: 'relationship-endpoints',
+    severity: 'ERROR',
+    details: violation,
+  };
+}
+
+export const defaultGraphCypherRules: GraphCypherRule[] = [
+  {
+    name: 'tenant-consistency',
+    description: 'Ensures every node carries the tenantId matching the mutation input.',
+    statement: `
+      UNWIND $nodes AS node
+      WITH node
+      WHERE node.properties.tenantId IS NULL OR node.properties.tenantId <> $tenantId
+      RETURN collect({ id: node.id, tenantId: node.properties.tenantId }) AS violations
+    `,
+    errorCode: 'TENANT_ID_MISMATCH',
+    severity: 'ERROR',
+    buildError: (violation, payload) => buildTenantError(violation, payload),
+  },
+  {
+    name: 'relationship-allowlist',
+    description: 'Rejects relationships that use disallowed types.',
+    statement: `
+      UNWIND $relationships AS rel
+      WITH rel
+      WHERE NOT rel.type IN $allowedRelationshipTypes
+      RETURN collect({
+        id: coalesce(rel.id, rel.sourceId + '->' + rel.targetId),
+        type: rel.type,
+        sourceId: rel.sourceId,
+        targetId: rel.targetId
+      }) AS violations
+    `,
+    errorCode: 'RELATIONSHIP_TYPE_NOT_ALLOWED',
+    severity: 'ERROR',
+    buildError: (violation) => buildRelationshipTypeError(violation),
+  },
+  {
+    name: 'relationship-endpoints',
+    description: 'Verifies that every relationship endpoint exists in the payload.',
+    statement: `
+      UNWIND $relationships AS rel
+      WITH rel, $nodes AS nodes
+      WHERE NOT any(n IN nodes WHERE n.id = rel.sourceId)
+         OR NOT any(n IN nodes WHERE n.id = rel.targetId)
+      RETURN collect({
+        id: coalesce(rel.id, rel.sourceId + '->' + rel.targetId),
+        sourceId: rel.sourceId,
+        targetId: rel.targetId
+      }) AS violations
+    `,
+    errorCode: 'RELATIONSHIP_ENDPOINT_NOT_FOUND',
+    severity: 'ERROR',
+    buildError: (violation) => buildRelationshipEndpointError(violation),
+  },
+];

--- a/server/src/graph/validation/index.ts
+++ b/server/src/graph/validation/index.ts
@@ -1,0 +1,18 @@
+import { getNeo4jDriver } from '../../db/neo4j.js';
+import GraphValidationService from './GraphValidationService.js';
+import { createCypherExecutorFromDriver, defaultGraphCypherRules } from './cypherRules.js';
+export * from './types.js';
+export { defaultGraphCypherRules, createCypherExecutorFromDriver, GraphValidationService };
+
+let singleton: GraphValidationService | null = null;
+
+export function getGraphValidationService(): GraphValidationService {
+  if (!singleton) {
+    const driver = getNeo4jDriver();
+    singleton = new GraphValidationService({
+      cypherRules: defaultGraphCypherRules,
+      cypherExecutor: createCypherExecutorFromDriver(driver),
+    });
+  }
+  return singleton;
+}

--- a/server/src/graph/validation/types.ts
+++ b/server/src/graph/validation/types.ts
@@ -1,0 +1,65 @@
+export interface GraphNodePayload {
+  id: string;
+  labels: string[];
+  properties: Record<string, unknown>;
+}
+
+export interface GraphRelationshipPayload {
+  id?: string;
+  type: string;
+  sourceId: string;
+  targetId: string;
+  properties?: Record<string, unknown>;
+}
+
+export interface GraphValidationPayload {
+  tenantId: string;
+  nodes: GraphNodePayload[];
+  relationships: GraphRelationshipPayload[];
+}
+
+export type GraphValidationSeverity = 'ERROR' | 'WARNING';
+
+export interface GraphValidationError {
+  code: string;
+  message: string;
+  path: string;
+  rule?: string;
+  severity: GraphValidationSeverity;
+  details?: Record<string, unknown>;
+}
+
+export interface GraphValidationResult {
+  valid: boolean;
+  errors: GraphValidationError[];
+  warnings: string[];
+  appliedRules: string[];
+}
+
+export interface CypherQueryResult<T = any> {
+  records: T[];
+}
+
+export interface CypherExecutor {
+  run<T = any>(statement: string, params?: Record<string, unknown>): Promise<CypherQueryResult<T>>;
+}
+
+export interface GraphCypherRule {
+  name: string;
+  description: string;
+  statement: string;
+  errorCode: string;
+  severity?: GraphValidationSeverity;
+  buildError: (
+    violation: Record<string, any>,
+    payload: GraphValidationPayload
+  ) => GraphValidationError;
+}
+
+export interface GraphValidationOptions {
+  requiredNodeProperties?: string[];
+  requiredRelationshipProperties?: string[];
+  allowedRelationshipTypes?: string[];
+  cypherRules?: GraphCypherRule[];
+  cypherExecutor?: CypherExecutor;
+}

--- a/server/src/graphql/resolvers/__tests__/graphValidation.test.ts
+++ b/server/src/graphql/resolvers/__tests__/graphValidation.test.ts
@@ -1,0 +1,62 @@
+import { graphValidationResolvers } from '../graphValidation';
+
+const baseInput = {
+  tenantId: 'tenant-1',
+  nodes: [
+    {
+      id: 'node-1',
+      labels: ['Entity'],
+      properties: { tenantId: 'tenant-1', kind: 'PERSON', name: 'Alice' },
+    },
+  ],
+  relationships: [],
+};
+
+describe('graphValidationResolvers', () => {
+  it('delegates validation to the service and returns the result', async () => {
+    const validate = jest.fn().mockResolvedValue({
+      valid: true,
+      errors: [],
+      warnings: [],
+      appliedRules: ['json-schema'],
+    });
+
+    const context = {
+      user: { id: 'user-1', tenantId: 'tenant-1', roles: ['ADMIN'] },
+      graphValidationService: { validate },
+    } as any;
+
+    const result = await graphValidationResolvers.Mutation.validateGraphData(
+      {},
+      { input: baseInput },
+      context,
+    );
+
+    expect(validate).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      nodes: baseInput.nodes,
+      relationships: baseInput.relationships,
+    });
+    expect(result).toEqual({
+      valid: true,
+      errors: [],
+      warnings: [],
+      appliedRules: ['json-schema'],
+    });
+  });
+
+  it('throws when tenant isolation is violated', async () => {
+    const context = {
+      user: { id: 'user-1', tenantId: 'tenant-1', roles: ['ANALYST'] },
+      graphValidationService: { validate: jest.fn() },
+    } as any;
+
+    await expect(
+      graphValidationResolvers.Mutation.validateGraphData(
+        {},
+        { input: { ...baseInput, tenantId: 'tenant-2' } },
+        context,
+      ),
+    ).rejects.toThrow('Cross-tenant access denied');
+  });
+});

--- a/server/src/graphql/resolvers/graphValidation.ts
+++ b/server/src/graphql/resolvers/graphValidation.ts
@@ -1,0 +1,70 @@
+import baseLogger from '../../config/logger';
+import { TenantValidator } from '../../middleware/tenantValidator.js';
+import {
+  getGraphValidationService,
+  GraphValidationPayload,
+  GraphValidationService,
+} from '../../graph/validation/index.js';
+
+const logger = baseLogger.child({ name: 'graphValidationResolver' });
+
+type GraphValidationInput = {
+  tenantId: string;
+  nodes: Array<{ id: string; labels: string[]; properties: Record<string, unknown> }>;
+  relationships: Array<{
+    id?: string;
+    type: string;
+    sourceId: string;
+    targetId: string;
+    properties?: Record<string, unknown>;
+  }>;
+};
+
+type ResolverContext = {
+  user?: { id: string; tenantId?: string; roles?: string[] };
+  graphValidationService?: GraphValidationService;
+  [key: string]: unknown;
+};
+
+export const graphValidationResolvers = {
+  Mutation: {
+    async validateGraphData(
+      _parent: unknown,
+      { input }: { input: GraphValidationInput },
+      context: ResolverContext,
+    ) {
+      const service = context.graphValidationService ?? getGraphValidationService();
+      const tenantContext = TenantValidator.validateTenantAccess(context, input.tenantId, {
+        requireExplicitTenant: true,
+        validateOwnership: true,
+      });
+
+      const payload: GraphValidationPayload = {
+        tenantId: tenantContext.tenantId,
+        nodes: input.nodes ?? [],
+        relationships: input.relationships ?? [],
+      };
+
+      const result = await service.validate(payload);
+
+      logger.info(
+        {
+          tenantId: tenantContext.tenantId,
+          valid: result.valid,
+          errors: result.errors.length,
+          warnings: result.warnings.length,
+        },
+        'Graph data validation executed',
+      );
+
+      return {
+        valid: result.valid,
+        errors: result.errors,
+        warnings: result.warnings,
+        appliedRules: result.appliedRules,
+      };
+    },
+  },
+};
+
+export default graphValidationResolvers;

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -12,6 +12,7 @@ import { triggerN8nFlow } from '../../integrations/n8n.js';
 import { checkN8nTriggerAllowed } from '../../integrations/n8n-policy.js';
 import { isEnabled as flagEnabled } from '../../featureFlags/flagsmith.js';
 import { doclingResolvers } from './docling.ts';
+import graphValidationResolvers from './graphValidation.ts';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -69,6 +70,7 @@ const resolvers = {
     ...relationshipResolvers.Mutation,
     ...userResolvers.Mutation,
     ...investigationResolvers.Mutation,
+    ...graphValidationResolvers.Mutation,
 
     // Safe orchestration mutations (idempotent/dry-run aware)
     ...SafeMutationsResolvers.Mutation,

--- a/server/src/graphql/schema.graph-validation.ts
+++ b/server/src/graphql/schema.graph-validation.ts
@@ -1,0 +1,44 @@
+import { gql } from 'graphql-tag';
+
+export const graphValidationTypeDefs = gql`
+  input GraphNodeInput {
+    id: ID!
+    labels: [String!]!
+    properties: JSON!
+  }
+
+  input GraphRelationshipInput {
+    id: ID
+    type: String!
+    sourceId: ID!
+    targetId: ID!
+    properties: JSON
+  }
+
+  input GraphValidationInput {
+    tenantId: ID!
+    nodes: [GraphNodeInput!]!
+    relationships: [GraphRelationshipInput!]!
+  }
+
+  type GraphValidationError {
+    path: String!
+    message: String!
+    code: String!
+    rule: String
+    severity: String!
+  }
+
+  type GraphValidationResult {
+    valid: Boolean!
+    errors: [GraphValidationError!]!
+    warnings: [String!]!
+    appliedRules: [String!]!
+  }
+
+  extend type Mutation {
+    validateGraphData(input: GraphValidationInput!): GraphValidationResult!
+  }
+`;
+
+export default graphValidationTypeDefs;

--- a/server/src/graphql/schema/index.ts
+++ b/server/src/graphql/schema/index.ts
@@ -6,6 +6,7 @@ import aiModule from '../schema.ai.js';
 import annotationsModule from '../schema.annotations.js';
 import graphragTypesModule from '../types/graphragTypes.js';
 import { crystalTypeDefs } from '../schema.crystal.js';
+import { graphValidationTypeDefs } from '../schema.graph-validation.js';
 
 const { copilotTypeDefs } = copilotModule as { copilotTypeDefs: any };
 const { graphTypeDefs } = graphModule as { graphTypeDefs: any };
@@ -35,6 +36,7 @@ export const typeDefs = [
   coreTypeDefs,
   copilotTypeDefs,
   graphTypeDefs,
+  graphValidationTypeDefs,
   graphragTypes,
   aiTypeDefs,
   annotationsTypeDefs,

--- a/server/src/tests/GraphValidationService.test.ts
+++ b/server/src/tests/GraphValidationService.test.ts
@@ -1,0 +1,101 @@
+import GraphValidationService from '../graph/validation/GraphValidationService.js';
+import { GraphCypherRule, CypherExecutor } from '../graph/validation/types.js';
+
+describe('GraphValidationService', () => {
+  const basePayload = {
+    tenantId: 'tenant-1',
+    nodes: [
+      {
+        id: 'node-1',
+        labels: ['Entity'],
+        properties: {
+          tenantId: 'tenant-1',
+          kind: 'PERSON',
+          name: 'Alice',
+        },
+      },
+    ],
+    relationships: [],
+  };
+
+  it('returns a valid result when payload meets all constraints', async () => {
+    const service = new GraphValidationService();
+    const result = await service.validate(basePayload);
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.appliedRules).toContain('json-schema');
+  });
+
+  it('detects missing node properties through JSON schema validation', async () => {
+    const service = new GraphValidationService();
+    const invalid = {
+      ...basePayload,
+      nodes: [
+        {
+          id: 'node-2',
+          labels: ['Entity'],
+          properties: {
+            tenantId: 'tenant-1',
+            // Missing required fields kind and name
+          },
+        },
+      ],
+    };
+
+    const result = await service.validate(invalid as any);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((error) => error.code === 'NODE_PROPERTY_REQUIRED')).toBe(true);
+    expect(result.errors.some((error) => error.path.includes('properties.kind'))).toBe(true);
+  });
+
+  it('incorporates Cypher rule violations in the response', async () => {
+    const rule: GraphCypherRule = {
+      name: 'tenant-consistency-cypher',
+      description: 'Ensures tenants are consistent across nodes',
+      statement: 'UNWIND $nodes AS node RETURN collect(node) AS violations',
+      errorCode: 'TENANT_MISMATCH',
+      severity: 'ERROR',
+      buildError: (violation) => ({
+        code: 'TENANT_MISMATCH',
+        message: `Node ${violation.id} failed tenant rule`,
+        path: `nodes[id=${violation.id}]`,
+        severity: 'ERROR',
+        rule: 'tenant-consistency-cypher',
+        details: violation,
+      }),
+    };
+
+    const executor: CypherExecutor = {
+      run: jest.fn(async () => ({
+        records: [
+          {
+            violations: [
+              {
+                id: 'node-1',
+                tenantId: 'tenant-2',
+              },
+            ],
+          },
+        ],
+      })),
+    };
+
+    const service = new GraphValidationService({
+      cypherRules: [rule],
+      cypherExecutor: executor,
+    });
+
+    const result = await service.validate(basePayload);
+
+    expect(executor.run).toHaveBeenCalled();
+    expect(result.valid).toBe(false);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'TENANT_MISMATCH', rule: 'tenant-consistency-cypher' }),
+      ]),
+    );
+    expect(result.appliedRules).toContain('tenant-consistency-cypher');
+  });
+});


### PR DESCRIPTION
## Summary
- add a reusable GraphValidationService with JSON schema checks, rule execution, and OpenTelemetry logging before Neo4j ingestion
- expose a validateGraphData GraphQL mutation and schema additions that leverage the validator and tenant guardrails
- add cypher constraints, documentation, and Jest coverage for the validator and resolver workflows

## Testing
- npm test -- GraphValidationService *(fails: jest binary missing in workspace environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dbfcc20c8333834e4497af8172f3