### PR TITLE
feat: add cross-region database replication artifacts

### DIFF
--- a/docs/deployment/cross-region-replication.md
+++ b/docs/deployment/cross-region-replication.md
@@ -1,0 +1,120 @@
+# Cross-Region Database Replication Runbook
+
+## Overview
+
+This guide documents how Summit operates PostgreSQL and Neo4j in a highly available, cross-region topology. The configuration aligns with Workstream 90 requirements and complements the manifests in `ops/dr/` plus the Helm charts in `ga-graphai/infra/helm`.
+
+* **PostgreSQL** – Aurora-compatible streaming replication with one writer in `us-east-1` and read replicas in `us-west-2` and `eu-central-1`.
+* **Neo4j** – Causal Cluster cores and read replicas distributed across the same three regions for low-latency queries.
+* **Chaos Mesh** – Failure drills that validate regional failover and replication lag budgets.
+
+## Architecture Summary
+
+| Component | Primary Region | Secondary Regions | Notes |
+|-----------|----------------|-------------------|-------|
+| PostgreSQL | `us-east-1` writer | `us-west-2`, `eu-central-1` async replicas | Shared WAL archive in S3, Prometheus exporter, WAL replay guardrails |
+| Neo4j | `us-east-1` cores (3 pods) | `us-west-2` core (1 pod), read replicas in both regions | Backups streamed to S3, discovery via headless Service |
+
+## Helm Configuration
+
+### PostgreSQL
+
+Key values from `ga-graphai/infra/helm/postgres/values.yaml`:
+
+```yaml
+primaryRegion: us-east-1
+secondaryRegions:
+  - name: us-west-2
+    replicas: 1
+  - name: eu-central-1
+    replicas: 1
+replication:
+  username: replicator
+  password: CHANGEME_replicator
+  maximumLagSeconds: "30"
+monitoring:
+  enabled: true
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9187"
+init:
+  s3WalArchive:
+    enabled: true
+    bucket: s3://summit-database-wal-archive
+```
+
+Apply the release:
+
+```bash
+helm upgrade --install summit-postgres ga-graphai/infra/helm/postgres \
+  --namespace data-plane --create-namespace \
+  --values ga-graphai/infra/helm/postgres/values.yaml
+```
+
+### Neo4j
+
+Relevant values from `ga-graphai/infra/helm/neo4j/values.yaml`:
+
+```yaml
+regions:
+  primary:
+    name: us-east-1
+    coreReplicas: 3
+    readReplicas: 1
+  secondary:
+    - name: us-west-2
+      coreReplicas: 1
+      readReplicas: 2
+    - name: eu-central-1
+      coreReplicas: 0
+      readReplicas: 2
+backup:
+  enabled: true
+  s3Bucket: s3://summit-neo4j-backups
+```
+
+Deploy the cluster:
+
+```bash
+helm upgrade --install summit-neo4j ga-graphai/infra/helm/neo4j \
+  --namespace data-plane --values ga-graphai/infra/helm/neo4j/values.yaml
+```
+
+Both charts expose annotations such as `replication.summit.sh/role` to allow GitOps or observability tooling to auto-discover topology.
+
+## Reference Manifests
+
+For environments that are not yet Helm-enabled, apply the curated manifests directly:
+
+```bash
+kubectl apply -f ops/dr/postgres-cross-region.yaml
+kubectl apply -f ops/dr/neo4j-cross-region.yaml
+```
+
+These manifests mirror the Helm topology and include region-aware `StatefulSet` scheduling, replication credentials, and headless discovery services.
+
+## Chaos Mesh Validation
+
+`ops/chaos/experiments.yaml` defines two new scenarios:
+
+1. **`postgres_primary_region_outage`** – Deletes the writer pod in `us-east-1`, waits for a replica promotion, and measures RPO/RTO with the replication lag budget from the Helm values.
+2. **`neo4j_secondary_region_partition`** – Applies a network partition to `us-west-2` graph nodes to verify causal cluster recovery and routing fallbacks.
+
+Run the suite:
+
+```bash
+kubectl apply -f ops/chaos/experiments.yaml
+chaosctl run intelgraph-reliability-tests --focus cross-region
+```
+
+Monitor Prometheus alerts for `replication_applied_lag_seconds` (PostgreSQL) and `neo4j_cluster_available` to confirm the SLOs are maintained.
+
+## Operational Playbook
+
+1. **Bootstrap** – Deploy Helm releases, confirm pods scheduled per region labels, and register WAL/archive buckets.
+2. **Failover Drill** – Execute the Chaos Mesh suite quarterly; ensure `kubectl get services` exposes the promoted writer endpoint.
+3. **Backups** – Verify the Neo4j backup CronJob uploads to S3 and that WAL archives rotate per `retentionHours`.
+4. **Observability** – Surface replication metrics in Grafana (port 9187 for PostgreSQL exporter) and configure alert thresholds aligned with `maximumLagSeconds`.
+5. **Runbooks** – Update incident response docs with the annotations produced by the Helm charts for rapid triage.
+
+Following these steps provides deterministic recovery across AWS regions while minimizing write lag and maintaining query locality.

--- a/ga-graphai/infra/helm/neo4j/Chart.yaml
+++ b/ga-graphai/infra/helm/neo4j/Chart.yaml
@@ -1,3 +1,5 @@
 apiVersion: v2
 name: neo4j
-version: 0.1.0
+description: Neo4j causal cluster with cross-region awareness for Summit
+version: 0.2.0
+appVersion: "5.22.0"

--- a/ga-graphai/infra/helm/neo4j/templates/_helpers.tpl
+++ b/ga-graphai/infra/helm/neo4j/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{- define "neo4j.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "neo4j.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "neo4j.labels" -}}
+app.kubernetes.io/name: {{ include "neo4j.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "neo4j.matchLabels" -}}
+{{- $root := index . "root" -}}
+{{- $component := index . "component" | default "core" -}}
+app.kubernetes.io/name: {{ include "neo4j.name" $root }}
+app.kubernetes.io/instance: {{ $root.Release.Name }}
+app.kubernetes.io/component: {{ $component }}
+{{- end -}}
+
+{{- define "neo4j.totalCores" -}}
+{{- $vals := dict "count" (int .Values.regions.primary.coreReplicas) -}}
+{{- range .Values.regions.secondary }}
+{{- $_ := set $vals "count" (add $vals.count (int .coreReplicas)) -}}
+{{- end -}}
+{{- $vals.count -}}
+{{- end -}}

--- a/ga-graphai/infra/helm/neo4j/templates/backup-cronjob.yaml
+++ b/ga-graphai/infra/helm/neo4j/templates/backup-cronjob.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "neo4j.fullname" . }}-backup
+  labels:
+    {{- include "neo4j.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "neo4j.labels" . | nindent 12 }}
+            app.kubernetes.io/component: backup
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: neo4j-backup
+              image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command:
+                - /bin/bash
+                - -c
+              args:
+                - |
+                  set -euo pipefail
+                  if command -v apt-get >/dev/null 2>&1; then
+                    apt-get update && apt-get install -y awscli && rm -rf /var/lib/apt/lists/*
+                  elif command -v apk >/dev/null 2>&1; then
+                    apk add --no-cache aws-cli
+                  fi
+                  neo4j-admin database backup neo4j --backup-dir=/backups/latest --overwrite-destination=true
+                  aws s3 sync /backups {{ .Values.backup.s3Bucket | quote }} --delete
+              env:
+                - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+                  value: "yes"
+                - name: NEO4J_CONF
+                  value: /conf/neo4j.conf
+                - name: AWS_REGION
+                  value: {{ .Values.regions.primary.name | quote }}
+              {{- if .Values.auth.enabled }}
+                - name: NEO4J_AUTH
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ include "neo4j.fullname" . }}-auth{{ end }}
+                      key: NEO4J_AUTH
+              {{- end }}
+              volumeMounts:
+                - name: core-data
+                  mountPath: /data
+                - name: config
+                  mountPath: /conf
+                  readOnly: true
+                - name: backups
+                  mountPath: /backups
+          volumes:
+            - name: core-data
+              persistentVolumeClaim:
+                claimName: data-{{ include "neo4j.fullname" . }}-core-0
+            - name: config
+              configMap:
+                name: {{ include "neo4j.fullname" . }}-config
+            - name: backups
+              emptyDir: {}
+{{- end }}

--- a/ga-graphai/infra/helm/neo4j/templates/configmap.yaml
+++ b/ga-graphai/infra/helm/neo4j/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "neo4j.fullname" . }}-config
+  labels:
+    {{- include "neo4j.labels" . | nindent 4 }}
+    app.kubernetes.io/component: config
+  annotations:
+    replication.summit.sh/graph-cluster: {{ .Values.clusterName | quote }}
+data:
+  neo4j.conf: |
+    {{- range $key, $value := .Values.config }}
+    {{ $key }}={{ $value }}
+    {{- end }}

--- a/ga-graphai/infra/helm/neo4j/templates/secret.yaml
+++ b/ga-graphai/infra/helm/neo4j/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- if and .Values.auth.enabled (not .Values.auth.existingSecret) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "neo4j.fullname" . }}-auth
+  labels:
+    {{- include "neo4j.labels" . | nindent 4 }}
+    app.kubernetes.io/component: auth
+  annotations:
+    replication.summit.sh/graph-auth: managed
+type: Opaque
+data:
+  NEO4J_AUTH: {{ printf "%s/%s" .Values.auth.username .Values.auth.password | b64enc | quote }}
+{{- end }}

--- a/ga-graphai/infra/helm/neo4j/templates/service.yaml
+++ b/ga-graphai/infra/helm/neo4j/templates/service.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "neo4j.fullname" . }}-discovery
+  labels:
+    {{- include "neo4j.labels" . | nindent 4 }}
+    app.kubernetes.io/component: discovery
+  annotations:
+    replication.summit.sh/global-role: discovery
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    {{- include "neo4j.matchLabels" (dict "root" . "component" "core") | nindent 4 }}
+  ports:
+    - name: discovery
+      port: {{ .Values.service.discovery.port }}
+      targetPort: discovery
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "neo4j.fullname" . }}-bolt
+  labels:
+    {{- include "neo4j.labels" . | nindent 4 }}
+    app.kubernetes.io/component: routing
+  annotations:
+    replication.summit.sh/global-role: router
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "neo4j.matchLabels" (dict "root" . "component" "core") | nindent 4 }}
+  ports:
+    - name: bolt
+      port: {{ .Values.service.bolt.port }}
+      targetPort: bolt
+    - name: http
+      port: {{ .Values.service.http.port }}
+      targetPort: http

--- a/ga-graphai/infra/helm/neo4j/templates/statefulset-core-secondary.yaml
+++ b/ga-graphai/infra/helm/neo4j/templates/statefulset-core-secondary.yaml
@@ -1,0 +1,119 @@
+{{- $root := . }}
+{{- range $index, $region := .Values.regions.secondary }}
+{{- if gt (int $region.coreReplicas) 0 }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "neo4j.fullname" $root }}-core-{{ $region.name | lower | replace "_" "-" }}
+  labels:
+    {{- include "neo4j.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: core
+    summit.slo/region: {{ $region.name | quote }}
+  annotations:
+    replication.summit.sh/role: core-secondary
+    replication.summit.sh/region: {{ $region.name | quote }}
+spec:
+  serviceName: {{ include "neo4j.fullname" $root }}-discovery
+  replicas: {{ $region.coreReplicas }}
+  selector:
+    matchLabels:
+      {{- include "neo4j.matchLabels" (dict "root" $root "component" "core") | nindent 6 }}
+      summit.slo/region: {{ $region.name | quote }}
+  template:
+    metadata:
+      labels:
+        {{- include "neo4j.matchLabels" (dict "root" $root "component" "core") | nindent 8 }}
+        summit.slo/region: {{ $region.name | quote }}
+      annotations:
+        replication.summit.sh/region: {{ $region.name | quote }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - {{ $region.name }}
+        {{- with $root.Values.extraAffinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if $root.Values.tolerations }}
+      tolerations:
+        {{- range $root.Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: neo4j
+          image: {{ $root.Values.image.repository }}:{{ $root.Values.image.tag }}
+          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          ports:
+            - name: bolt
+              containerPort: {{ $root.Values.service.bolt.port }}
+            - name: http
+              containerPort: {{ $root.Values.service.http.port }}
+            - name: discovery
+              containerPort: {{ $root.Values.service.discovery.port }}
+          env:
+            - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+              value: "yes"
+            - name: NEO4J_CONF
+              value: /conf/neo4j.conf
+            - name: NEO4J_dbms_mode
+              value: CORE
+            - name: NEO4J_causal__clustering_expected__core__cluster__size
+              value: {{ include "neo4j.totalCores" $root | quote }}
+            - name: NEO4J_causal__clustering_kubernetes_service__name
+              value: {{ include "neo4j.fullname" $root }}-discovery
+            - name: NEO4J_causal__clustering_kubernetes_service__namespace
+              value: {{ $root.Release.Namespace }}
+            - name: NEO4J_causal__clustering_kubernetes_label__selector
+              value: app.kubernetes.io/component=core,app.kubernetes.io/instance={{ $root.Release.Name }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NEO4J_causal__clustering_discovery__advertised__address
+              value: $(POD_NAME).{{ include "neo4j.fullname" $root }}-discovery:{{ $root.Values.service.discovery.port }}
+            - name: NEO4J_causal__clustering_transaction__advertised__address
+              value: $(POD_IP):{{ $root.Values.service.bolt.port }}
+            - name: NEO4J_dbms_default__advertised__address
+              value: $(POD_IP)
+          {{- if $root.Values.auth.enabled }}
+          envFrom:
+            - secretRef:
+                name: {{ if $root.Values.auth.existingSecret }}{{ $root.Values.auth.existingSecret }}{{ else }}{{ include "neo4j.fullname" $root }}-auth{{ end }}
+          {{- end }}
+          resources:
+            {{- toYaml $root.Values.coreResources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "neo4j.fullname" $root }}-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        annotations:
+          replication.summit.sh/tier: core
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: {{ $root.Values.storage.className | quote }}
+        resources:
+          requests:
+            storage: {{ $root.Values.storage.size | quote }}
+---
+{{- end }}
+{{- end }}

--- a/ga-graphai/infra/helm/neo4j/templates/statefulset-core.yaml
+++ b/ga-graphai/infra/helm/neo4j/templates/statefulset-core.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "neo4j.fullname" . }}-core
+  labels:
+    {{- include "neo4j.labels" . | nindent 4 }}
+    app.kubernetes.io/component: core
+  annotations:
+    replication.summit.sh/role: core
+spec:
+  serviceName: {{ include "neo4j.fullname" . }}-discovery
+  replicas: {{ .Values.regions.primary.coreReplicas }}
+  selector:
+    matchLabels:
+      {{- include "neo4j.matchLabels" (dict "root" . "component" "core") | nindent 6 }}
+      summit.slo/region: {{ .Values.regions.primary.name | quote }}
+  template:
+    metadata:
+      labels:
+        {{- include "neo4j.matchLabels" (dict "root" . "component" "core") | nindent 8 }}
+        summit.slo/region: {{ .Values.regions.primary.name | quote }}
+      annotations:
+        replication.summit.sh/region: {{ .Values.regions.primary.name | quote }}
+    spec:
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- range .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - {{ .Values.regions.primary.name }}
+        {{- with .Values.extraAffinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: neo4j
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: bolt
+              containerPort: {{ .Values.service.bolt.port }}
+            - name: http
+              containerPort: {{ .Values.service.http.port }}
+            - name: discovery
+              containerPort: {{ .Values.service.discovery.port }}
+          env:
+            - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+              value: "yes"
+            - name: NEO4J_CONF
+              value: /conf/neo4j.conf
+            - name: NEO4J_dbms_mode
+              value: CORE
+            - name: NEO4J_causal__clustering_expected__core__cluster__size
+              value: {{ include "neo4j.totalCores" . | quote }}
+            - name: NEO4J_causal__clustering_kubernetes_service__name
+              value: {{ include "neo4j.fullname" . }}-discovery
+            - name: NEO4J_causal__clustering_kubernetes_service__namespace
+              value: {{ .Release.Namespace }}
+            - name: NEO4J_causal__clustering_kubernetes_label__selector
+              value: app.kubernetes.io/component=core,app.kubernetes.io/instance={{ .Release.Name }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: NEO4J_causal__clustering_discovery__advertised__address
+              value: $(POD_NAME).{{ include "neo4j.fullname" . }}-discovery:{{ .Values.service.discovery.port }}
+            - name: NEO4J_causal__clustering_transaction__advertised__address
+              value: $(POD_IP):{{ .Values.service.bolt.port }}
+            - name: NEO4J_dbms_default__advertised__address
+              value: $(POD_IP)
+          {{- if .Values.auth.enabled }}
+          envFrom:
+            - secretRef:
+                name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ include "neo4j.fullname" . }}-auth{{ end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.coreResources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /db/manage/server/ha/available
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: bolt
+            initialDelaySeconds: 60
+            periodSeconds: 20
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "neo4j.fullname" . }}-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        annotations:
+          replication.summit.sh/tier: core
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: {{ .Values.storage.className | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.size | quote }}

--- a/ga-graphai/infra/helm/neo4j/templates/statefulset-readreplica.yaml
+++ b/ga-graphai/infra/helm/neo4j/templates/statefulset-readreplica.yaml
@@ -1,0 +1,212 @@
+{{- $root := . }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "neo4j.fullname" . }}-rr
+  labels:
+    {{- include "neo4j.labels" . | nindent 4 }}
+    app.kubernetes.io/component: read-replica
+    summit.slo/region: {{ .Values.regions.primary.name | quote }}
+  annotations:
+    replication.summit.sh/role: read-replica
+spec:
+  serviceName: {{ include "neo4j.fullname" . }}-discovery
+  replicas: {{ .Values.regions.primary.readReplicas }}
+  selector:
+    matchLabels:
+      {{- include "neo4j.matchLabels" (dict "root" . "component" "read-replica") | nindent 6 }}
+      summit.slo/region: {{ .Values.regions.primary.name | quote }}
+  template:
+    metadata:
+      labels:
+        {{- include "neo4j.matchLabels" (dict "root" . "component" "read-replica") | nindent 8 }}
+        summit.slo/region: {{ .Values.regions.primary.name | quote }}
+      annotations:
+        replication.summit.sh/region: {{ .Values.regions.primary.name | quote }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - {{ .Values.regions.primary.name }}
+        {{- with .Values.extraAffinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- range .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: neo4j
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: bolt
+              containerPort: {{ .Values.service.bolt.port }}
+            - name: http
+              containerPort: {{ .Values.service.http.port }}
+          env:
+            - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+              value: "yes"
+            - name: NEO4J_CONF
+              value: /conf/neo4j.conf
+            - name: NEO4J_dbms_mode
+              value: READ_REPLICA
+            - name: NEO4J_causal__clustering_kubernetes_service__name
+              value: {{ include "neo4j.fullname" . }}-discovery
+            - name: NEO4J_causal__clustering_kubernetes_service__namespace
+              value: {{ .Release.Namespace }}
+            - name: NEO4J_causal__clustering_kubernetes_label__selector
+              value: app.kubernetes.io/component=core,app.kubernetes.io/instance={{ .Release.Name }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          {{- if .Values.auth.enabled }}
+          envFrom:
+            - secretRef:
+                name: {{ if .Values.auth.existingSecret }}{{ .Values.auth.existingSecret }}{{ else }}{{ include "neo4j.fullname" . }}-auth{{ end }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.readReplicaResources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "neo4j.fullname" . }}-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        annotations:
+          replication.summit.sh/tier: read-replica
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: {{ .Values.readReplicaStorage.className | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.readReplicaStorage.size | quote }}
+---
+{{- range $index, $region := .Values.regions.secondary }}
+{{- if gt (int $region.readReplicas) 0 }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "neo4j.fullname" $root }}-rr-{{ $region.name | lower | replace "_" "-" }}
+  labels:
+    {{- include "neo4j.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: read-replica
+    summit.slo/region: {{ $region.name | quote }}
+  annotations:
+    replication.summit.sh/role: read-replica
+    replication.summit.sh/region: {{ $region.name | quote }}
+spec:
+  serviceName: {{ include "neo4j.fullname" $root }}-discovery
+  replicas: {{ $region.readReplicas }}
+  selector:
+    matchLabels:
+      {{- include "neo4j.matchLabels" (dict "root" $root "component" "read-replica") | nindent 6 }}
+      summit.slo/region: {{ $region.name | quote }}
+  template:
+    metadata:
+      labels:
+        {{- include "neo4j.matchLabels" (dict "root" $root "component" "read-replica") | nindent 8 }}
+        summit.slo/region: {{ $region.name | quote }}
+      annotations:
+        replication.summit.sh/region: {{ $region.name | quote }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - {{ $region.name }}
+        {{- with $root.Values.extraAffinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if $root.Values.tolerations }}
+      tolerations:
+        {{- range $root.Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: neo4j
+          image: {{ $root.Values.image.repository }}:{{ $root.Values.image.tag }}
+          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          ports:
+            - name: bolt
+              containerPort: {{ $root.Values.service.bolt.port }}
+            - name: http
+              containerPort: {{ $root.Values.service.http.port }}
+          env:
+            - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+              value: "yes"
+            - name: NEO4J_CONF
+              value: /conf/neo4j.conf
+            - name: NEO4J_dbms_mode
+              value: READ_REPLICA
+            - name: NEO4J_causal__clustering_kubernetes_service__name
+              value: {{ include "neo4j.fullname" $root }}-discovery
+            - name: NEO4J_causal__clustering_kubernetes_service__namespace
+              value: {{ $root.Release.Namespace }}
+            - name: NEO4J_causal__clustering_kubernetes_label__selector
+              value: app.kubernetes.io/component=core,app.kubernetes.io/instance={{ $root.Release.Name }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          {{- if $root.Values.auth.enabled }}
+          envFrom:
+            - secretRef:
+                name: {{ if $root.Values.auth.existingSecret }}{{ $root.Values.auth.existingSecret }}{{ else }}{{ include "neo4j.fullname" $root }}-auth{{ end }}
+          {{- end }}
+          resources:
+            {{- toYaml $root.Values.readReplicaResources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "neo4j.fullname" $root }}-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        annotations:
+          replication.summit.sh/tier: read-replica
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: {{ $root.Values.readReplicaStorage.className | quote }}
+        resources:
+          requests:
+            storage: {{ $root.Values.readReplicaStorage.size | quote }}
+---
+{{- end }}
+{{- end }}

--- a/ga-graphai/infra/helm/neo4j/values.yaml
+++ b/ga-graphai/infra/helm/neo4j/values.yaml
@@ -1,1 +1,79 @@
-# values for neo4j
+clusterName: summit-graph
+fullnameOverride: ""
+nameOverride: ""
+
+image:
+  repository: neo4j
+  tag: "5.22.0-enterprise"
+  pullPolicy: IfNotPresent
+
+auth:
+  enabled: true
+  username: neo4j
+  password: CHANGEME_neo4j
+  existingSecret: ""
+
+regions:
+  primary:
+    name: us-east-1
+    coreReplicas: 3
+    readReplicas: 1
+  secondary:
+    - name: us-west-2
+      coreReplicas: 1
+      readReplicas: 2
+    - name: eu-central-1
+      coreReplicas: 0
+      readReplicas: 2
+
+service:
+  bolt:
+    port: 7687
+  http:
+    port: 7474
+  discovery:
+    port: 5000
+
+config:
+  dbms.default_listen_address: "0.0.0.0"
+  dbms.default_advertised_address: "$(POD_IP)"
+  dbms.routing.enabled: "true"
+  causal_clustering.discovery_type: "K8S"
+  causal_clustering.k8s.service_port_name: "discovery"
+  causal_clustering.load_balancing_config: "server_policies: { default: { read: any, write: any }}"
+  dbms.memory.heap.initial_size: "4G"
+  dbms.memory.heap.max_size: "4G"
+  dbms.memory.pagecache.size: "6G"
+  dbms.security.procedures.unrestricted: "apoc.*"
+
+storage:
+  className: gp3-retained
+  size: 200Gi
+readReplicaStorage:
+  className: gp3-retained
+  size: 150Gi
+
+coreResources:
+  requests:
+    cpu: 1
+    memory: 6Gi
+  limits:
+    cpu: 4
+    memory: 12Gi
+
+readReplicaResources:
+  requests:
+    cpu: 500m
+    memory: 4Gi
+  limits:
+    cpu: 2
+    memory: 8Gi
+
+backup:
+  enabled: true
+  s3Bucket: s3://summit-neo4j-backups
+  schedule: "0 * * * *"
+
+extraAffinity: {}
+nodeSelector: {}
+tolerations: []

--- a/ga-graphai/infra/helm/postgres/Chart.yaml
+++ b/ga-graphai/infra/helm/postgres/Chart.yaml
@@ -1,3 +1,5 @@
 apiVersion: v2
 name: postgres
-version: 0.1.0
+description: Summit cross-region PostgreSQL deployment with Aurora-compatible replication knobs
+version: 0.2.0
+appVersion: "15.3"

--- a/ga-graphai/infra/helm/postgres/templates/_helpers.tpl
+++ b/ga-graphai/infra/helm/postgres/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{- define "postgres.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "postgres.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "postgres.labels" -}}
+app.kubernetes.io/name: {{ include "postgres.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "postgres.matchLabels" -}}
+{{- $root := index . "root" -}}
+{{- $component := index . "component" | default "writer" -}}
+app.kubernetes.io/name: {{ include "postgres.name" $root }}
+app.kubernetes.io/instance: {{ $root.Release.Name }}
+app.kubernetes.io/component: {{ $component }}
+{{- end -}}

--- a/ga-graphai/infra/helm/postgres/templates/configmap.yaml
+++ b/ga-graphai/infra/helm/postgres/templates/configmap.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "postgres.fullname" . }}-config
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+    app.kubernetes.io/component: config
+  annotations:
+    replication.summit.sh/cluster-name: {{ .Values.clusterName | quote }}
+    replication.summit.sh/primary-region: {{ .Values.primaryRegion | quote }}
+data:
+  postgresql.conf: |
+    {{- range $key, $value := .Values.config }}
+    {{ $key }} = {{ $value | quote }}
+    {{- end }}
+{{- end }}

--- a/ga-graphai/infra/helm/postgres/templates/secret.yaml
+++ b/ga-graphai/infra/helm/postgres/templates/secret.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.replication }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "postgres.fullname" . }}-replication
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+    app.kubernetes.io/component: replication
+  annotations:
+    replication.summit.sh/slot-prefix: {{ .Values.replication.slotPrefix | default "summit" | quote }}
+type: Opaque
+data:
+  username: {{ .Values.replication.username | default "replicator" | b64enc | quote }}
+  password: {{ .Values.replication.password | default "CHANGEME_replicator" | b64enc | quote }}
+{{- end }}

--- a/ga-graphai/infra/helm/postgres/templates/service-writer.yaml
+++ b/ga-graphai/infra/helm/postgres/templates/service-writer.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postgres.fullname" . }}-writer
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+    app.kubernetes.io/component: writer
+  annotations:
+    replication.summit.sh/global-role: writer
+    {{- if .Values.monitoring.enabled }}
+    {{- with .Values.monitoring.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgres
+      port: {{ .Values.service.port }}
+      targetPort: postgres
+  selector:
+    {{- include "postgres.matchLabels" (dict "root" . "component" "writer") | nindent 4 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "postgres.fullname" . }}-replicas
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+    app.kubernetes.io/component: replica
+  annotations:
+    replication.summit.sh/global-role: replica
+spec:
+  clusterIP: None
+  ports:
+    - name: postgres
+      port: {{ .Values.service.port }}
+      targetPort: postgres
+  selector:
+    {{- include "postgres.matchLabels" (dict "root" . "component" "replica") | nindent 4 }}

--- a/ga-graphai/infra/helm/postgres/templates/statefulset-replica.yaml
+++ b/ga-graphai/infra/helm/postgres/templates/statefulset-replica.yaml
@@ -1,0 +1,102 @@
+{{- $root := . }}
+{{- range $index, $region := .Values.secondaryRegions }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "postgres.fullname" $root }}-replica-{{ $region.name | lower | replace "_" "-" }}
+  labels:
+    {{- include "postgres.labels" $root | nindent 4 }}
+    app.kubernetes.io/component: replica
+    summit.slo/region: {{ $region.name | quote }}
+  annotations:
+    replication.summit.sh/role: read-replica
+    replication.summit.sh/upstream-region: {{ $root.Values.primaryRegion | quote }}
+spec:
+  serviceName: {{ include "postgres.fullname" $root }}-replicas
+  replicas: {{ $region.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "postgres.matchLabels" (dict "root" $root "component" "replica") | nindent 6 }}
+      summit.slo/region: {{ $region.name | quote }}
+  template:
+    metadata:
+      labels:
+        {{- include "postgres.matchLabels" (dict "root" $root "component" "replica") | nindent 8 }}
+        summit.slo/region: {{ $region.name | quote }}
+      annotations:
+        replication.summit.sh/region: {{ $region.name | quote }}
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - {{ $region.name }}
+        {{- with $root.Values.extraAffinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if $root.Values.tolerations }}
+      tolerations:
+        {{- range $root.Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: postgres
+          image: {{ $root.Values.image.repository }}:{{ $root.Values.image.tag }}
+          imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: {{ $root.Values.service.port }}
+          env:
+            - name: POSTGRESQL_PORT_NUMBER
+              value: {{ $root.Values.service.port | quote }}
+            - name: POSTGRESQL_REPLICATION_MODE
+              value: read
+            - name: POSTGRESQL_PRIMARY_HOST
+              value: {{ include "postgres.fullname" $root }}-writer
+            - name: POSTGRESQL_PRIMARY_PORT_NUMBER
+              value: {{ $root.Values.service.port | quote }}
+            - name: POSTGRESQL_REPLICATION_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.fullname" $root }}-replication
+                  key: username
+            - name: POSTGRESQL_REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.fullname" $root }}-replication
+                  key: password
+            - name: AURORA_GLOBAL_DB_ID
+              value: {{ $root.Values.clusterName | quote }}
+            - name: AURORA_SOURCE_REGION
+              value: {{ $root.Values.primaryRegion | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "postgres.fullname" $root }}-config
+          resources:
+            {{- toYaml $root.Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+          args:
+            - "-c"
+            - "config_file=/conf/postgresql.conf"
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: {{ $root.Values.storage.className | quote }}
+        resources:
+          requests:
+            storage: {{ $root.Values.storage.size | quote }}
+---
+{{- end }}

--- a/ga-graphai/infra/helm/postgres/templates/statefulset-writer.yaml
+++ b/ga-graphai/infra/helm/postgres/templates/statefulset-writer.yaml
@@ -1,0 +1,146 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "postgres.fullname" . }}-writer
+  labels:
+    {{- include "postgres.labels" . | nindent 4 }}
+    app.kubernetes.io/component: writer
+  annotations:
+    replication.summit.sh/role: primary
+spec:
+  serviceName: {{ include "postgres.fullname" . }}-writer
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "postgres.matchLabels" (dict "root" . "component" "writer") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "postgres.matchLabels" (dict "root" . "component" "writer") | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        replication.summit.sh/region: {{ .Values.primaryRegion | quote }}
+    spec:
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- range .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - {{ .Values.primaryRegion }}
+        {{- with .Values.extraAffinity }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- if .Values.init.s3WalArchive.enabled }}
+      initContainers:
+        - name: wal-restore
+          image: amazon/aws-cli:2.15.16
+          command:
+            - /bin/sh
+            - -c
+            - |
+              aws s3 sync {{ .Values.init.s3WalArchive.bucket | quote }} /wal-archive --exact-timestamps
+          env:
+            - name: AWS_REGION
+              value: {{ .Values.init.s3WalArchive.awsRegion | default .Values.primaryRegion | quote }}
+          volumeMounts:
+            - name: wal-archive
+              mountPath: /wal-archive
+      {{- end }}
+      containers:
+        - name: postgres
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.service.port }}
+          env:
+            - name: POSTGRESQL_PORT_NUMBER
+              value: {{ .Values.service.port | quote }}
+            - name: POSTGRESQL_REPLICATION_MODE
+              value: primary
+            - name: POSTGRESQL_REPLICATION_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.fullname" . }}-replication
+                  key: username
+            - name: POSTGRESQL_REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.fullname" . }}-replication
+                  key: password
+            - name: AURORA_GLOBAL_DB_ID
+              value: {{ .Values.clusterName | quote }}
+            - name: AURORA_APPLY_DELAY
+              value: {{ .Values.replication.applyDelaySeconds | default "0" | quote }}
+            - name: AURORA_MAX_LAG
+              value: {{ .Values.replication.maximumLagSeconds | default "30" | quote }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "postgres.fullname" . }}-config
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+          args:
+            - "-c"
+            - "config_file=/conf/postgresql.conf"
+        {{- if .Values.monitoring.enabled }}
+        - name: exporter
+          image: {{ .Values.monitoring.exporter.image }}:{{ .Values.monitoring.exporter.tag }}
+          imagePullPolicy: {{ .Values.monitoring.exporter.pullPolicy }}
+          ports:
+            - name: metrics
+              containerPort: 9187
+          env:
+            - name: DATA_SOURCE_URI
+              value: localhost:{{ .Values.service.port }}?sslmode=disable
+            - name: DATA_SOURCE_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.fullname" . }}-replication
+                  key: username
+            - name: DATA_SOURCE_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "postgres.fullname" . }}-replication
+                  key: password
+          resources:
+            {{- toYaml .Values.monitoring.exporter.resources | nindent 12 }}
+        {{- end }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "postgres.fullname" . }}-config
+        {{- if .Values.init.s3WalArchive.enabled }}
+        - name: wal-archive
+          emptyDir: {}
+        {{- end }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        annotations:
+          replication.summit.sh/wal-archive-retention-hours: {{ .Values.init.s3WalArchive.retentionHours | quote }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: {{ .Values.storage.className | quote }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.size | quote }}

--- a/ga-graphai/infra/helm/postgres/values.yaml
+++ b/ga-graphai/infra/helm/postgres/values.yaml
@@ -1,1 +1,75 @@
-# values for postgres
+clusterName: summit-postgres
+fullnameOverride: ""
+nameOverride: ""
+
+image:
+  repository: public.ecr.aws/rds/aurora-postgresql
+  tag: "15.3"
+  pullPolicy: IfNotPresent
+
+primaryRegion: us-east-1
+secondaryRegions:
+  - name: us-west-2
+    replicas: 1
+  - name: eu-central-1
+    replicas: 1
+
+service:
+  port: 5432
+  annotations: {}
+
+storage:
+  className: gp3-retained
+  size: 200Gi
+
+config:
+  max_connections: "500"
+  shared_buffers: "512MB"
+  wal_level: "logical"
+  max_wal_senders: "20"
+  max_replication_slots: "20"
+  hot_standby: "on"
+  wal_keep_size: "4096MB"
+
+replication:
+  username: replicator
+  password: CHANGEME_replicator
+  maximumLagSeconds: "30"
+  slotPrefix: summit
+  applyDelaySeconds: "0"
+
+monitoring:
+  enabled: true
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "9187"
+  exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter
+    tag: v0.15.0
+    pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
+
+init:
+  s3WalArchive:
+    enabled: true
+    bucket: s3://summit-database-wal-archive
+    retentionHours: 24
+    awsRegion: us-east-1
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 2Gi
+  limits:
+    cpu: 2
+    memory: 6Gi
+
+nodeSelector: {}
+tolerations: []
+extraAffinity: {}

--- a/ops/chaos/experiments.yaml
+++ b/ops/chaos/experiments.yaml
@@ -68,6 +68,51 @@ experiments:
       - timeout_rate: "<10%"
       - circuit_breaker_trips: ">0"
 
+  - name: "postgres_primary_region_outage"
+    description: "Validate promotion when the us-east-1 writer disappears"
+    type: "pod_kill"
+    target:
+      service: "postgres"
+      selector:
+        replication.summit.sh/role: primary
+        topology.kubernetes.io/region: us-east-1
+
+    fault_injection:
+      type: "pod_kill"
+      duration: "2m"
+
+    expected_behavior:
+      - replica_promotion: true
+      - lag_budget_respected: "<=30s"
+      - service_endpoint_updates: true
+
+    success_criteria:
+      - rpo_seconds: "<=5"
+      - rto_minutes: "<=3"
+      - read_traffic_preserved: ">=90%"
+
+  - name: "neo4j_secondary_region_partition"
+    description: "Ensure causal cluster heals after isolating us-west-2"
+    type: "network"
+    target:
+      service: "neo4j"
+      selector:
+        topology.kubernetes.io/region: us-west-2
+
+    fault_injection:
+      type: "network_partition"
+      duration: "4m"
+
+    expected_behavior:
+      - routing_table_rebuild: true
+      - writes_redirected_to_primary: true
+      - read_queries_served_from_remaining_regions: true
+
+    success_criteria:
+      - bolt_availability: 0.95
+      - cluster_core_quorum: true
+      - replication_queue_drain: "<120s"
+
   # API Gateway resilience
   - name: "api_gateway_overload"
     description: "Test rate limiting and backpressure mechanisms"

--- a/ops/dr/neo4j-cross-region.yaml
+++ b/ops/dr/neo4j-cross-region.yaml
@@ -1,0 +1,523 @@
+# Summit reference manifest for Neo4j causal cluster spanning three regions
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: summit-neo4j-config
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-neo4j
+    app.kubernetes.io/component: config
+  annotations:
+    replication.summit.sh/graph-cluster: summit-graph
+    replication.summit.sh/primary-region: "us-east-1"
+data:
+  neo4j.conf: |
+    dbms.default_listen_address=0.0.0.0
+    dbms.routing.enabled=true
+    causal_clustering.discovery_type=K8S
+    causal_clustering.k8s.service_port_name=discovery
+    dbms.security.procedures.unrestricted=apoc.*
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: summit-neo4j-auth
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-neo4j
+    app.kubernetes.io/component: auth
+stringData:
+  NEO4J_AUTH: neo4j/Sup3rSecure!
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: summit-neo4j-discovery
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-neo4j
+    app.kubernetes.io/component: discovery
+spec:
+  clusterIP: None
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: summit-neo4j
+    app.kubernetes.io/component: core
+  ports:
+    - name: discovery
+      port: 5000
+      targetPort: discovery
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: summit-neo4j-bolt
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-neo4j
+    app.kubernetes.io/component: routing
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: summit-neo4j
+    app.kubernetes.io/component: core
+  ports:
+    - name: bolt
+      port: 7687
+      targetPort: bolt
+    - name: http
+      port: 7474
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: summit-neo4j-core
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-neo4j
+    app.kubernetes.io/component: core
+    topology.kubernetes.io/region: us-east-1
+spec:
+  serviceName: summit-neo4j-discovery
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: summit-neo4j
+      app.kubernetes.io/component: core
+      topology.kubernetes.io/region: us-east-1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: summit-neo4j
+        app.kubernetes.io/component: core
+        topology.kubernetes.io/region: us-east-1
+      annotations:
+        replication.summit.sh/region: "us-east-1"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - us-east-1
+      containers:
+        - name: neo4j
+          image: neo4j:5.22.0-enterprise
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: bolt
+              containerPort: 7687
+            - name: http
+              containerPort: 7474
+            - name: discovery
+              containerPort: 5000
+          env:
+            - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+              value: "yes"
+            - name: NEO4J_CONF
+              value: /conf/neo4j.conf
+            - name: NEO4J_dbms_mode
+              value: CORE
+            - name: NEO4J_causal__clustering_expected__core__cluster__size
+              value: "4"
+            - name: NEO4J_causal__clustering_kubernetes_service__name
+              value: summit-neo4j-discovery
+            - name: NEO4J_causal__clustering_kubernetes_service__namespace
+              value: data-plane
+            - name: NEO4J_causal__clustering_kubernetes_label__selector
+              value: app.kubernetes.io/component=core,app.kubernetes.io/name=summit-neo4j
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          envFrom:
+            - secretRef:
+                name: summit-neo4j-auth
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: summit-neo4j-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: gp3-retained
+        resources:
+          requests:
+            storage: 200Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: summit-neo4j-core-us-west-2
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-neo4j
+    app.kubernetes.io/component: core
+    topology.kubernetes.io/region: us-west-2
+spec:
+  serviceName: summit-neo4j-discovery
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: summit-neo4j
+      app.kubernetes.io/component: core
+      topology.kubernetes.io/region: us-west-2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: summit-neo4j
+        app.kubernetes.io/component: core
+        topology.kubernetes.io/region: us-west-2
+      annotations:
+        replication.summit.sh/region: "us-west-2"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - us-west-2
+      containers:
+        - name: neo4j
+          image: neo4j:5.22.0-enterprise
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: bolt
+              containerPort: 7687
+            - name: http
+              containerPort: 7474
+            - name: discovery
+              containerPort: 5000
+          env:
+            - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+              value: "yes"
+            - name: NEO4J_CONF
+              value: /conf/neo4j.conf
+            - name: NEO4J_dbms_mode
+              value: CORE
+            - name: NEO4J_causal__clustering_expected__core__cluster__size
+              value: "4"
+            - name: NEO4J_causal__clustering_kubernetes_service__name
+              value: summit-neo4j-discovery
+            - name: NEO4J_causal__clustering_kubernetes_service__namespace
+              value: data-plane
+            - name: NEO4J_causal__clustering_kubernetes_label__selector
+              value: app.kubernetes.io/component=core,app.kubernetes.io/name=summit-neo4j
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          envFrom:
+            - secretRef:
+                name: summit-neo4j-auth
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: summit-neo4j-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: gp3-retained
+        resources:
+          requests:
+            storage: 200Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: summit-neo4j-rr
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-neo4j
+    app.kubernetes.io/component: read-replica
+    topology.kubernetes.io/region: us-east-1
+spec:
+  serviceName: summit-neo4j-discovery
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: summit-neo4j
+      app.kubernetes.io/component: read-replica
+      topology.kubernetes.io/region: us-east-1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: summit-neo4j
+        app.kubernetes.io/component: read-replica
+        topology.kubernetes.io/region: us-east-1
+      annotations:
+        replication.summit.sh/region: "us-east-1"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - us-east-1
+      containers:
+        - name: neo4j
+          image: neo4j:5.22.0-enterprise
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: bolt
+              containerPort: 7687
+            - name: http
+              containerPort: 7474
+          env:
+            - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+              value: "yes"
+            - name: NEO4J_CONF
+              value: /conf/neo4j.conf
+            - name: NEO4J_dbms_mode
+              value: READ_REPLICA
+            - name: NEO4J_causal__clustering_kubernetes_service__name
+              value: summit-neo4j-discovery
+            - name: NEO4J_causal__clustering_kubernetes_service__namespace
+              value: data-plane
+            - name: NEO4J_causal__clustering_kubernetes_label__selector
+              value: app.kubernetes.io/component=core,app.kubernetes.io/name=summit-neo4j
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          envFrom:
+            - secretRef:
+                name: summit-neo4j-auth
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: summit-neo4j-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: gp3-retained
+        resources:
+          requests:
+            storage: 150Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: summit-neo4j-rr-us-west-2
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-neo4j
+    app.kubernetes.io/component: read-replica
+    topology.kubernetes.io/region: us-west-2
+spec:
+  serviceName: summit-neo4j-discovery
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: summit-neo4j
+      app.kubernetes.io/component: read-replica
+      topology.kubernetes.io/region: us-west-2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: summit-neo4j
+        app.kubernetes.io/component: read-replica
+        topology.kubernetes.io/region: us-west-2
+      annotations:
+        replication.summit.sh/region: "us-west-2"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - us-west-2
+      containers:
+        - name: neo4j
+          image: neo4j:5.22.0-enterprise
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: bolt
+              containerPort: 7687
+            - name: http
+              containerPort: 7474
+          env:
+            - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+              value: "yes"
+            - name: NEO4J_CONF
+              value: /conf/neo4j.conf
+            - name: NEO4J_dbms_mode
+              value: READ_REPLICA
+            - name: NEO4J_causal__clustering_kubernetes_service__name
+              value: summit-neo4j-discovery
+            - name: NEO4J_causal__clustering_kubernetes_service__namespace
+              value: data-plane
+            - name: NEO4J_causal__clustering_kubernetes_label__selector
+              value: app.kubernetes.io/component=core,app.kubernetes.io/name=summit-neo4j
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          envFrom:
+            - secretRef:
+                name: summit-neo4j-auth
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: summit-neo4j-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: gp3-retained
+        resources:
+          requests:
+            storage: 150Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: summit-neo4j-rr-eu-central-1
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-neo4j
+    app.kubernetes.io/component: read-replica
+    topology.kubernetes.io/region: eu-central-1
+spec:
+  serviceName: summit-neo4j-discovery
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: summit-neo4j
+      app.kubernetes.io/component: read-replica
+      topology.kubernetes.io/region: eu-central-1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: summit-neo4j
+        app.kubernetes.io/component: read-replica
+        topology.kubernetes.io/region: eu-central-1
+      annotations:
+        replication.summit.sh/region: "eu-central-1"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - eu-central-1
+      containers:
+        - name: neo4j
+          image: neo4j:5.22.0-enterprise
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: bolt
+              containerPort: 7687
+            - name: http
+              containerPort: 7474
+          env:
+            - name: NEO4J_ACCEPT_LICENSE_AGREEMENT
+              value: "yes"
+            - name: NEO4J_CONF
+              value: /conf/neo4j.conf
+            - name: NEO4J_dbms_mode
+              value: READ_REPLICA
+            - name: NEO4J_causal__clustering_kubernetes_service__name
+              value: summit-neo4j-discovery
+            - name: NEO4J_causal__clustering_kubernetes_service__namespace
+              value: data-plane
+            - name: NEO4J_causal__clustering_kubernetes_label__selector
+              value: app.kubernetes.io/component=core,app.kubernetes.io/name=summit-neo4j
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          envFrom:
+            - secretRef:
+                name: summit-neo4j-auth
+          volumeMounts:
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: summit-neo4j-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: gp3-retained
+        resources:
+          requests:
+            storage: 150Gi

--- a/ops/dr/postgres-cross-region.yaml
+++ b/ops/dr/postgres-cross-region.yaml
@@ -1,0 +1,343 @@
+# Summit reference manifest for cross-region PostgreSQL replication using Aurora-compatible settings
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: summit-postgres-config
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-postgres
+    app.kubernetes.io/component: config
+    replication.summit.sh/cluster-role: config
+  annotations:
+    replication.summit.sh/primary-region: "us-east-1"
+data:
+  postgresql.conf: |
+    wal_level = 'logical'
+    max_wal_senders = '20'
+    max_replication_slots = '20'
+    max_connections = '500'
+    hot_standby = 'on'
+    wal_keep_size = '4096MB'
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: summit-postgres-replication
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-postgres
+    app.kubernetes.io/component: replication
+stringData:
+  username: replicator
+  password: "Sup3rSecure!"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: summit-postgres-writer
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-postgres
+    app.kubernetes.io/component: writer
+  annotations:
+    replication.summit.sh/global-role: writer
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+  selector:
+    app.kubernetes.io/name: summit-postgres
+    app.kubernetes.io/component: writer
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: summit-postgres-readers
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-postgres
+    app.kubernetes.io/component: replica
+  annotations:
+    replication.summit.sh/global-role: replica
+spec:
+  clusterIP: None
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+  selector:
+    app.kubernetes.io/name: summit-postgres
+    app.kubernetes.io/component: replica
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: summit-postgres-writer
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-postgres
+    app.kubernetes.io/component: writer
+  annotations:
+    replication.summit.sh/role: primary
+spec:
+  serviceName: summit-postgres-writer
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: summit-postgres
+      app.kubernetes.io/component: writer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: summit-postgres
+        app.kubernetes.io/component: writer
+        topology.kubernetes.io/region: us-east-1
+      annotations:
+        replication.summit.sh/region: "us-east-1"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - us-east-1
+      containers:
+        - name: postgres
+          image: public.ecr.aws/rds/aurora-postgresql:15.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_REPLICATION_MODE
+              value: primary
+            - name: POSTGRESQL_REPLICATION_USER
+              valueFrom:
+                secretKeyRef:
+                  name: summit-postgres-replication
+                  key: username
+            - name: POSTGRESQL_REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: summit-postgres-replication
+                  key: password
+            - name: AURORA_GLOBAL_DB_ID
+              value: summit-intelgraph
+            - name: AURORA_MAX_LAG
+              value: "30"
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+          args:
+            - "-c"
+            - "config_file=/conf/postgresql.conf"
+      volumes:
+        - name: config
+          configMap:
+            name: summit-postgres-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        annotations:
+          replication.summit.sh/wal-archive-retention-hours: "24"
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: gp3-retained
+        resources:
+          requests:
+            storage: 200Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: summit-postgres-replica-us-west-2
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-postgres
+    app.kubernetes.io/component: replica
+    topology.kubernetes.io/region: us-west-2
+  annotations:
+    replication.summit.sh/role: read-replica
+    replication.summit.sh/upstream-region: "us-east-1"
+spec:
+  serviceName: summit-postgres-readers
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: summit-postgres
+      app.kubernetes.io/component: replica
+      topology.kubernetes.io/region: us-west-2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: summit-postgres
+        app.kubernetes.io/component: replica
+        topology.kubernetes.io/region: us-west-2
+      annotations:
+        replication.summit.sh/region: "us-west-2"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - us-west-2
+      containers:
+        - name: postgres
+          image: public.ecr.aws/rds/aurora-postgresql:15.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_REPLICATION_MODE
+              value: read
+            - name: POSTGRESQL_PRIMARY_HOST
+              value: summit-postgres-writer
+            - name: POSTGRESQL_PRIMARY_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_REPLICATION_USER
+              valueFrom:
+                secretKeyRef:
+                  name: summit-postgres-replication
+                  key: username
+            - name: POSTGRESQL_REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: summit-postgres-replication
+                  key: password
+            - name: AURORA_SOURCE_REGION
+              value: us-east-1
+            - name: AURORA_GLOBAL_DB_ID
+              value: summit-intelgraph
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+          args:
+            - "-c"
+            - "config_file=/conf/postgresql.conf"
+      volumes:
+        - name: config
+          configMap:
+            name: summit-postgres-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: gp3-retained
+        resources:
+          requests:
+            storage: 200Gi
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: summit-postgres-replica-eu-central-1
+  namespace: data-plane
+  labels:
+    app.kubernetes.io/name: summit-postgres
+    app.kubernetes.io/component: replica
+    topology.kubernetes.io/region: eu-central-1
+  annotations:
+    replication.summit.sh/role: read-replica
+    replication.summit.sh/upstream-region: "us-east-1"
+spec:
+  serviceName: summit-postgres-readers
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: summit-postgres
+      app.kubernetes.io/component: replica
+      topology.kubernetes.io/region: eu-central-1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: summit-postgres
+        app.kubernetes.io/component: replica
+        topology.kubernetes.io/region: eu-central-1
+      annotations:
+        replication.summit.sh/region: "eu-central-1"
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: topology.kubernetes.io/region
+                    operator: In
+                    values:
+                      - eu-central-1
+      containers:
+        - name: postgres
+          image: public.ecr.aws/rds/aurora-postgresql:15.3
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_REPLICATION_MODE
+              value: read
+            - name: POSTGRESQL_PRIMARY_HOST
+              value: summit-postgres-writer
+            - name: POSTGRESQL_PRIMARY_PORT_NUMBER
+              value: "5432"
+            - name: POSTGRESQL_REPLICATION_USER
+              valueFrom:
+                secretKeyRef:
+                  name: summit-postgres-replication
+                  key: username
+            - name: POSTGRESQL_REPLICATION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: summit-postgres-replication
+                  key: password
+            - name: AURORA_SOURCE_REGION
+              value: us-east-1
+            - name: AURORA_GLOBAL_DB_ID
+              value: summit-intelgraph
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: config
+              mountPath: /conf
+              readOnly: true
+          args:
+            - "-c"
+            - "config_file=/conf/postgresql.conf"
+      volumes:
+        - name: config
+          configMap:
+            name: summit-postgres-config
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        storageClassName: gp3-retained
+        resources:
+          requests:
+            storage: 200Gi


### PR DESCRIPTION
## Summary
- add multi-region PostgreSQL Helm templates with Aurora-compatible replication controls and exporters
- extend Neo4j Helm chart with causal cluster topology, regional scheduling, and S3 backup automation
- deliver reference manifests, chaos experiments, and a runbook documenting cross-region failover operations

## Testing
- `pre-commit run --files ga-graphai/infra/helm/neo4j/Chart.yaml ga-graphai/infra/helm/neo4j/values.yaml ga-graphai/infra/helm/neo4j/templates/_helpers.tpl ga-graphai/infra/helm/neo4j/templates/configmap.yaml ga-graphai/infra/helm/neo4j/templates/secret.yaml ga-graphai/infra/helm/neo4j/templates/service.yaml ga-graphai/infra/helm/neo4j/templates/statefulset-core.yaml ga-graphai/infra/helm/neo4j/templates/statefulset-core-secondary.yaml ga-graphai/infra/helm/neo4j/templates/statefulset-readreplica.yaml ga-graphai/infra/helm/neo4j/templates/backup-cronjob.yaml ga-graphai/infra/helm/postgres/Chart.yaml ga-graphai/infra/helm/postgres/values.yaml ga-graphai/infra/helm/postgres/templates/_helpers.tpl ga-graphai/infra/helm/postgres/templates/configmap.yaml ga-graphai/infra/helm/postgres/templates/secret.yaml ga-graphai/infra/helm/postgres/templates/service-writer.yaml ga-graphai/infra/helm/postgres/templates/statefulset-writer.yaml ga-graphai/infra/helm/postgres/templates/statefulset-replica.yaml ops/chaos/experiments.yaml ops/dr/postgres-cross-region.yaml ops/dr/neo4j-cross-region.yaml docs/deployment/cross-region-replication.md` *(fails: `.pre-commit-config.yaml` is invalid at line 171 column 139)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dc004ef4833382c9a3cf34b59632