### PR TITLE
feat: add graph query debugging tooling

### DIFF
--- a/client/src/App.router.jsx
+++ b/client/src/App.router.jsx
@@ -40,6 +40,7 @@ import {
   Map,
   Assessment,
   Settings,
+  BugReport as BugReportIcon,
 } from '@mui/icons-material';
 import { getIntelGraphTheme } from './theme/intelgraphTheme';
 import { store } from './store';
@@ -77,12 +78,14 @@ import ClaimsViewer from './features/conductor/ClaimsViewer';
 import RetractionQueue from './features/conductor/RetractionQueue';
 import CostAdvisor from './features/conductor/CostAdvisor';
 import RunSearch from './features/conductor/RunSearch';
+import GraphQueryDebugPage from './pages/GraphQueryDebugPage';
 
 // Navigation items
 const navigationItems = [
   { path: '/dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
   { path: '/investigations', label: 'Timeline', icon: <Search /> },
   { path: '/graph', label: 'Graph Explorer', icon: <Timeline /> },
+  { path: '/graph/debug', label: 'Graph Debugger', icon: <BugReportIcon /> },
   { path: '/copilot', label: 'AI Copilot', icon: <Psychology /> },
   { path: '/conductor', label: 'Conductor Studio', icon: <Engineering /> },
   { path: '/conductor/approvals', label: 'Approvals', icon: <Engineering /> },
@@ -637,6 +640,7 @@ function MainLayout() {
             <Route path="/dashboard" element={<DashboardPage />} />
             <Route path="/investigations" element={<InvestigationsPage />} />
             <Route path="/graph" element={<GraphExplorerPage />} />
+            <Route path="/graph/debug" element={<GraphQueryDebugPage />} />
             <Route path="/copilot" element={<CopilotPage />} />
             <Route path="/conductor" element={<ConductorStudio />} />
             <Route path="/conductor/approvals" element={<ApprovalsPanel />} />

--- a/client/src/features/graph-debug/GraphQueryDebugger.tsx
+++ b/client/src/features/graph-debug/GraphQueryDebugger.tsx
@@ -1,0 +1,371 @@
+import React, { useMemo, useState } from 'react';
+import { gql, useLazyQuery } from '@apollo/client';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  Grid,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+const GRAPH_QUERY_DEBUG = gql`
+  query GraphQueryDebug($input: GraphQueryDebugInput!) {
+    graphQueryDebug(input: $input) {
+      cypher
+      parameters
+      plan
+      planSummary
+      suggestions {
+        title
+        detail
+        level
+        applied
+      }
+      errors {
+        stage
+        message
+        hint
+      }
+      metrics {
+        estimatedCost
+        complexity
+        nodeCount
+        relationshipCount
+        requiredIndexes
+      }
+    }
+  }
+`;
+
+const DEFAULT_QUERY = `query GraphDataPreview($investigationId: ID!) {
+  graphData(investigationId: $investigationId) {
+    nodeCount
+    edgeCount
+  }
+}`;
+
+const DEFAULT_VARIABLES = `{
+  "investigationId": "demo-investigation"
+}`;
+
+type PlanNode = {
+  operatorType: string;
+  identifiers?: string[];
+  arguments?: Record<string, unknown>;
+  children?: PlanNode[];
+};
+
+type DebugResult = {
+  cypher?: string | null;
+  parameters?: Record<string, unknown> | null;
+  plan?: PlanNode | null;
+  planSummary?: string | null;
+  suggestions: Array<{ title: string; detail: string; level: string; applied?: boolean | null }>;
+  errors: Array<{ stage: string; message: string; hint?: string | null }>;
+  metrics?: {
+    estimatedCost?: number | null;
+    complexity?: number | null;
+    nodeCount?: number | null;
+    relationshipCount?: number | null;
+    requiredIndexes?: string[] | null;
+  } | null;
+};
+
+const suggestionColor: Record<string, 'error' | 'warning' | 'info' | 'success'> = {
+  high: 'error',
+  medium: 'warning',
+  low: 'info',
+  info: 'info',
+  default: 'success',
+};
+
+function PlanBranch({ node, depth = 0 }: { node: PlanNode; depth?: number }) {
+  if (!node) {
+    return null;
+  }
+
+  const children = Array.isArray(node.children) ? node.children : [];
+  return (
+    <Box pl={depth ? 2 : 0} borderLeft={depth ? '1px solid rgba(0,0,0,0.08)' : 'none'} mt={depth ? 1 : 0}>
+      <Typography variant="body2" fontWeight={600} gutterBottom>
+        {node.operatorType}
+      </Typography>
+      {node.identifiers && node.identifiers.length > 0 && (
+        <Typography variant="caption" color="text.secondary" display="block">
+          Identifiers: {node.identifiers.join(', ')}
+        </Typography>
+      )}
+      {node.arguments && Object.keys(node.arguments).length > 0 && (
+        <Typography variant="caption" color="text.secondary" display="block" sx={{ wordBreak: 'break-word' }}>
+          Args: {JSON.stringify(node.arguments)}
+        </Typography>
+      )}
+      {children.map((child, index) => (
+        <PlanBranch node={child} depth={depth + 1} key={`${node.operatorType}-${depth}-${index}`} />
+      ))}
+    </Box>
+  );
+}
+
+function RequiredIndexes({ indexes }: { indexes?: string[] | null }) {
+  if (!indexes || indexes.length === 0) {
+    return null;
+  }
+  return (
+    <Stack direction="row" spacing={1} flexWrap="wrap" mt={1}>
+      {indexes.map((idx) => (
+        <Chip key={idx} label={idx} variant="outlined" size="small" />
+      ))}
+    </Stack>
+  );
+}
+
+const GraphQueryDebugger: React.FC = () => {
+  const [queryText, setQueryText] = useState<string>(DEFAULT_QUERY);
+  const [variablesText, setVariablesText] = useState<string>(DEFAULT_VARIABLES);
+  const [tenantId, setTenantId] = useState<string>('demo-tenant');
+  const [parseError, setParseError] = useState<string | null>(null);
+
+  const [runDebug, { data, loading, error }] = useLazyQuery<{ graphQueryDebug: DebugResult }>(GRAPH_QUERY_DEBUG, {
+    fetchPolicy: 'no-cache',
+  });
+
+  const result = data?.graphQueryDebug;
+
+  const stageError = useMemo(() => {
+    if (!result?.errors) return null;
+    return result.errors.reduce<Record<string, DebugResult['errors'][number]>>((acc, next) => {
+      acc[next.stage] = next;
+      return acc;
+    }, {} as Record<string, DebugResult['errors'][number]>);
+  }, [result?.errors]);
+
+  const handleRun = () => {
+    let parsedVariables: Record<string, unknown> | undefined = undefined;
+    if (variablesText.trim().length > 0) {
+      try {
+        parsedVariables = JSON.parse(variablesText);
+        setParseError(null);
+      } catch (err) {
+        setParseError((err as Error).message);
+        return;
+      }
+    } else {
+      setParseError(null);
+    }
+
+    runDebug({
+      variables: {
+        input: {
+          graphql: queryText,
+          variables: parsedVariables,
+          tenantId: tenantId || undefined,
+        },
+      },
+    }).catch((err) => {
+      console.error('Graph query debug failed', err);
+    });
+  };
+
+  const hasParseError = Boolean(parseError || stageError?.GRAPHQL_PARSE);
+
+  return (
+    <Card sx={{ borderRadius: 3, boxShadow: '0 12px 32px rgba(15, 46, 83, 0.08)' }}>
+      <CardContent>
+        <Box display="flex" alignItems="center" justifyContent="space-between" mb={2}>
+          <Box>
+            <Typography variant="h6">Graph Query Debugger</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Inspect the generated Cypher, execution plan, and optimization hints for your GraphQL queries.
+            </Typography>
+          </Box>
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={handleRun}
+            disabled={loading}
+            startIcon={loading ? <CircularProgress size={16} /> : null}
+          >
+            {loading ? 'Running…' : 'Run Debugger'}
+          </Button>
+        </Box>
+
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={7}>
+            <TextField
+              label="GraphQL Query"
+              value={queryText}
+              onChange={(event) => setQueryText(event.target.value)}
+              fullWidth
+              multiline
+              minRows={12}
+              error={hasParseError}
+              helperText={
+                parseError ?? stageError?.GRAPHQL_PARSE?.message ?? 'Provide a query to translate into Cypher.'
+              }
+            />
+          </Grid>
+          <Grid item xs={12} md={5}>
+            <Stack spacing={2}>
+              <TextField
+                label="Variables (JSON)"
+                value={variablesText}
+                onChange={(event) => setVariablesText(event.target.value)}
+                fullWidth
+                multiline
+                minRows={6}
+                error={Boolean(parseError)}
+                helperText={parseError ? `Invalid JSON: ${parseError}` : 'Optional GraphQL variables.'}
+              />
+              <TextField
+                label="Tenant ID (optional)"
+                value={tenantId}
+                onChange={(event) => setTenantId(event.target.value)}
+                fullWidth
+                helperText="Used for optimizer context; leave blank to infer from session."
+              />
+            </Stack>
+          </Grid>
+        </Grid>
+
+        {(error || result?.errors?.length) && (
+          <Stack spacing={1} mt={3}>
+            {error && <Alert severity="error">{error.message}</Alert>}
+            {result?.errors?.map((item, index) => (
+              <Alert
+                key={`${item.stage}-${index}`}
+                severity={item.stage === 'PLAN' || item.stage === 'TRANSLATION' ? 'error' : 'warning'}
+              >
+                <Typography variant="body2" fontWeight={600} component="span">
+                  {item.stage}:
+                </Typography>{' '}
+                {item.message}
+                {item.hint ? (
+                  <Typography variant="caption" display="block">
+                    Hint: {item.hint}
+                  </Typography>
+                ) : null}
+              </Alert>
+            ))}
+          </Stack>
+        )}
+
+        {result?.cypher && (
+          <Box mt={4}>
+            <Typography variant="subtitle1" gutterBottom>
+              Generated Cypher
+            </Typography>
+            <Box
+              component="pre"
+              sx={{
+                backgroundColor: '#0f1b2a',
+                color: '#e6f1ff',
+                borderRadius: 2,
+                p: 2,
+                overflowX: 'auto',
+                fontFamily: 'Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                fontSize: 13,
+              }}
+            >
+              {result.cypher}
+            </Box>
+          </Box>
+        )}
+
+        {result?.parameters && (
+          <Box mt={3}>
+            <Typography variant="subtitle1" gutterBottom>
+              Parameters
+            </Typography>
+            <Box
+              component="pre"
+              sx={{
+                backgroundColor: 'rgba(15, 46, 83, 0.06)',
+                borderRadius: 2,
+                p: 2,
+                overflowX: 'auto',
+                fontFamily: 'Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+                fontSize: 13,
+              }}
+            >
+              {JSON.stringify(result.parameters, null, 2)}
+            </Box>
+          </Box>
+        )}
+
+        {result?.metrics && (
+          <Box mt={4}>
+            <Typography variant="subtitle1" gutterBottom>
+              Metrics
+            </Typography>
+            <Stack direction="row" spacing={1} flexWrap="wrap">
+              {typeof result.metrics.estimatedCost === 'number' && (
+                <Chip label={`Estimated Cost: ${result.metrics.estimatedCost.toFixed(2)}`} color="secondary" />
+              )}
+              {typeof result.metrics.complexity === 'number' && (
+                <Chip label={`Complexity Score: ${result.metrics.complexity}`} variant="outlined" />
+              )}
+              {typeof result.metrics.nodeCount === 'number' && (
+                <Chip label={`Nodes: ${result.metrics.nodeCount}`} variant="outlined" />
+              )}
+              {typeof result.metrics.relationshipCount === 'number' && (
+                <Chip label={`Relationships: ${result.metrics.relationshipCount}`} variant="outlined" />
+              )}
+            </Stack>
+            <RequiredIndexes indexes={result.metrics.requiredIndexes ?? undefined} />
+          </Box>
+        )}
+
+        {result?.suggestions?.length ? (
+          <Box mt={4}>
+            <Typography variant="subtitle1" gutterBottom>
+              Optimization Suggestions
+            </Typography>
+            <Stack spacing={1}>
+              {result.suggestions.map((suggestion, index) => {
+                const severity = suggestionColor[suggestion.level] ?? suggestionColor.default;
+                return (
+                  <Alert key={`${suggestion.title}-${index}`} severity={severity} variant="outlined">
+                    <Typography variant="body2" fontWeight={600} component="span">
+                      {suggestion.title}
+                    </Typography>
+                    {suggestion.applied === true && (
+                      <Chip label="applied" size="small" color="success" sx={{ ml: 1 }} />
+                    )}
+                    <Typography variant="body2" sx={{ mt: 0.5 }}>
+                      {suggestion.detail}
+                    </Typography>
+                  </Alert>
+                );
+              })}
+            </Stack>
+          </Box>
+        ) : null}
+
+        {result?.plan && (
+          <Box mt={4}>
+            <Typography variant="subtitle1" gutterBottom>
+              Execution Plan
+            </Typography>
+            {result.planSummary && (
+              <Typography variant="body2" color="text.secondary" gutterBottom>
+                {result.planSummary}
+              </Typography>
+            )}
+            <Divider sx={{ mb: 2 }} />
+            <PlanBranch node={result.plan} />
+          </Box>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default GraphQueryDebugger;

--- a/client/src/pages/GraphQueryDebugPage.tsx
+++ b/client/src/pages/GraphQueryDebugPage.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Box, Container, Typography } from '@mui/material';
+import GraphQueryDebugger from '../features/graph-debug/GraphQueryDebugger';
+
+const GraphQueryDebugPage: React.FC = () => {
+  return (
+    <Container maxWidth="lg" sx={{ py: 4 }}>
+      <Box mb={3}>
+        <Typography variant="h4" gutterBottom>
+          Graph Query Debugger
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          Translate GraphQL operations into Neo4j Cypher, review execution plans, and uncover optimization hints before running
+          expensive graph workloads.
+        </Typography>
+      </Box>
+      <GraphQueryDebugger />
+    </Container>
+  );
+};
+
+export default GraphQueryDebugPage;

--- a/client/tests/e2e/graph-debug.spec.ts
+++ b/client/tests/e2e/graph-debug.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test';
+
+test('graph query debugger surfaces plan, metrics, and suggestions', async ({ page }) => {
+  await page.route('**/graphql', async (route) => {
+    const request = route.request();
+    const body = request.postData() ? JSON.parse(request.postData()!) : {};
+    if (body?.operationName === 'CurrentUser') {
+      await route.fulfill({
+        json: {
+          data: {
+            me: { id: 'user-1', email: 'analyst@example.com', role: 'ADMIN' },
+          },
+        },
+      });
+      return;
+    }
+
+    if (typeof body?.query === 'string' && body.query.includes('graphQueryDebug')) {
+      await route.fulfill({
+        json: {
+          data: {
+            graphQueryDebug: {
+              cypher: 'MATCH (e:Entity { tenantId: $tenantId }) RETURN e LIMIT 25',
+              parameters: { tenantId: 'demo-tenant' },
+              plan: {
+                operatorType: 'ProduceResults',
+                identifiers: ['result'],
+                arguments: { columns: ['result'] },
+                children: [
+                  {
+                    operatorType: 'Projection',
+                    identifiers: ['result'],
+                    arguments: { expressions: ['result'] },
+                    children: [
+                      {
+                        operatorType: 'NodeByLabelScan',
+                        identifiers: ['e'],
+                        arguments: { label: 'Entity' },
+                        children: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+              planSummary: 'Query type: READ_ONLY • Contains updates: no',
+              suggestions: [
+                {
+                  title: 'Add index on Entity(tenantId)',
+                  detail: 'Consider creating an index on Entity.tenantId for faster lookups.',
+                  level: 'medium',
+                  applied: false,
+                },
+              ],
+              errors: [],
+              metrics: {
+                estimatedCost: 1.37,
+                complexity: 4,
+                nodeCount: 2,
+                relationshipCount: 1,
+                requiredIndexes: ['Entity(tenantId)'],
+              },
+            },
+          },
+        },
+      });
+      return;
+    }
+
+    await route.fulfill({ json: { data: {} } });
+  });
+
+  await page.goto('/graph/debug');
+  await expect(page.getByRole('heading', { name: 'Graph Query Debugger' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Run Debugger' }).click();
+
+  await expect(page.getByText('MATCH (e:Entity')).toBeVisible();
+  await expect(page.getByText('Add index on Entity(tenantId)')).toBeVisible();
+  await expect(page.getByText('Estimated Cost', { exact: false })).toBeVisible();
+  await expect(page.getByText('ProduceResults')).toBeVisible();
+});

--- a/docs/features/graph-query-debugger.md
+++ b/docs/features/graph-query-debugger.md
@@ -1,0 +1,77 @@
+# Graph Query Debugger
+
+The Graph Query Debugger helps analysts and engineers understand how high-level GraphQL operations translate into Neo4j Cypher,
+what the database plans to do with those statements, and which optimizations will have the biggest impact. The feature combines
+backend instrumentation with a focused UI so you can iterate on graph workloads before promoting them to production.
+
+## Key capabilities
+
+- **GraphQL → Cypher translation** – Submit any read query that targets the graph API and preview the generated Cypher statement
+  along with the resolved parameters.
+- **Execution plan visibility** – Neo4j `EXPLAIN` output is normalized into a tree that highlights each operator and the order in
+  which it will execute.
+- **Optimization guidance** – The query optimizer evaluates the Cypher and surfaces index hints, rewrites, and execution tips with
+  impact levels.
+- **Inline diagnostics** – GraphQL syntax issues, unsupported fields, and plan errors appear inline with actionable hints so you
+  can correct them quickly.
+
+## Backend API
+
+The API is exposed through the `graphQueryDebug` GraphQL query. It accepts the GraphQL document you want to analyze along with
+optional variables and tenant context.
+
+```graphql
+query DebugCypher($tenantId: String!, $investigationId: ID!) {
+  graphQueryDebug(
+    input: {
+      graphql: "query($investigationId: ID!) { graphData(investigationId: $investigationId) { nodeCount edgeCount } }"
+      variables: { investigationId: $investigationId }
+      tenantId: $tenantId
+    }
+  ) {
+    cypher
+    plan
+    planSummary
+    metrics {
+      estimatedCost
+      nodeCount
+      relationshipCount
+    }
+    suggestions {
+      title
+      detail
+      level
+    }
+    errors {
+      stage
+      message
+      hint
+    }
+  }
+}
+```
+
+Responses include the generated Cypher, the Neo4j plan tree (as JSON), optimization metrics, and any diagnostics collected during
+parsing, translation, planning, or optimization.
+
+## Frontend workflow
+
+Navigate to **Graph Debugger** in the Summit navigation menu (or go directly to `/graph/debug`). The page provides:
+
+1. **GraphQL editor** – Paste the query you want to inspect; optional variables and tenant ID can be supplied in adjacent inputs.
+2. **Cypher preview** – Review the generated Cypher with syntax highlighting-like formatting.
+3. **Metrics and hints** – View estimated cost, complexity, node and relationship counts, and required index suggestions.
+4. **Execution plan** – Expandable tree that mirrors Neo4j operators so you can reason about traversal strategy and identify
+   hotspots before executing the query in production.
+
+Errors render inline with severity coloring and contextual hints so you can fix issues without leaving the page.
+
+## When to use it
+
+- Tuning graph workbench queries before deploying to analysts.
+- Validating that new predicates take advantage of available indexes.
+- Comparing alternate GraphQL shapes to see which produces the most efficient Cypher.
+- Triaging production incidents where graph calls are unexpectedly slow.
+
+Because the debugger runs queries in `EXPLAIN` mode it is safe to use against production data—it never mutates graph state. For
+writes or destructive operations, run the Cypher manually after confirming the plan.

--- a/server/src/graphql/resolvers/graphDebug.ts
+++ b/server/src/graphql/resolvers/graphDebug.ts
@@ -1,0 +1,509 @@
+import {
+  FieldNode,
+  Kind,
+  OperationDefinitionNode,
+  parse,
+  valueFromASTUntyped,
+} from 'graphql';
+import neo4j from 'neo4j-driver';
+import { getNeo4jDriver } from '../../db/neo4j.js';
+import { queryOptimizer } from '../../db/queryOptimizer.js';
+
+interface Translation {
+  cypher: string;
+  params: Record<string, any>;
+  target: string;
+  readOnly: boolean;
+}
+
+interface DebugError {
+  stage: string;
+  message: string;
+  hint?: string;
+}
+
+interface PlanNode {
+  operatorType: string;
+  identifiers?: string[];
+  arguments?: Record<string, unknown>;
+  children?: PlanNode[];
+}
+
+function collectArgs(field: FieldNode, variables: Record<string, any>): Record<string, any> {
+  const args: Record<string, any> = {};
+  for (const arg of field.arguments ?? []) {
+    args[arg.name.value] = valueFromASTUntyped(arg.value, variables);
+  }
+  return args;
+}
+
+function buildGraphDataTranslation(args: Record<string, any>): Translation {
+  const investigationId = args.investigationId;
+  if (!investigationId) {
+    throw new Error('graphData requires an investigationId argument.');
+  }
+
+  const filter = args.filter ?? {};
+  const params: Record<string, any> = {
+    investigationId,
+    minConfidence: filter.minConfidence ?? null,
+    tags: filter.tags ?? null,
+    startDate: filter.startDate ?? null,
+    endDate: filter.endDate ?? null,
+  };
+
+  const cypher = `
+MATCH (e:Entity { investigationId: $investigationId })
+WHERE ($minConfidence IS NULL OR e.confidence >= $minConfidence)
+  AND ($startDate IS NULL OR e.createdAt >= $startDate)
+  AND ($endDate IS NULL OR e.createdAt <= $endDate)
+  AND ($tags IS NULL OR size($tags) = 0 OR any(tag IN $tags WHERE tag IN coalesce(e.tags, [])))
+WITH collect(e) AS nodes
+OPTIONAL MATCH (from:Entity { investigationId: $investigationId })-[rel:RELATIONSHIP]->(to:Entity { investigationId: $investigationId })
+WHERE ($minConfidence IS NULL OR rel.confidence >= $minConfidence)
+RETURN {
+  nodes: nodes,
+  edges: collect({ id: rel.id, type: type(rel), from: from.id, to: to.id, confidence: rel.confidence }),
+  nodeCount: size(nodes),
+  edgeCount: size(collect(rel))
+} AS debugResult`;
+
+  return { cypher, params, target: 'graphData', readOnly: true };
+}
+
+function buildEntityTranslation(args: Record<string, any>): Translation {
+  const id = args.id;
+  if (!id) {
+    throw new Error('entity requires an id argument.');
+  }
+  const params: Record<string, any> = {
+    id,
+    tenantId: args.tenantId ?? null,
+  };
+
+  const whereParts = ['e.id = $id'];
+  if (params.tenantId) {
+    whereParts.push('e.tenantId = $tenantId');
+  }
+
+  const cypher = `MATCH (e:Entity) WHERE ${whereParts.join(' AND ')} RETURN e`;
+  return { cypher, params, target: 'entity', readOnly: true };
+}
+
+function buildEntitiesTranslation(args: Record<string, any>): Translation {
+  const input = args.input ?? {};
+  const tenantId = input.tenantId ?? args.tenantId;
+  if (!tenantId) {
+    throw new Error('entities requires a tenantId in input.');
+  }
+
+  const params: Record<string, any> = {
+    tenantId,
+    kind: input.kind ?? null,
+    limit: input.limit ?? 100,
+    offset: input.offset ?? 0,
+  };
+
+  const whereParts = ['e.tenantId = $tenantId'];
+  if (params.kind) {
+    whereParts.push('e.kind = $kind');
+  }
+
+  const cypher = `
+MATCH (e:Entity)
+WHERE ${whereParts.join(' AND ')}
+WITH e
+SKIP $offset
+LIMIT $limit
+RETURN e`;
+
+  return { cypher, params, target: 'entities', readOnly: true };
+}
+
+function buildRelationshipTranslation(args: Record<string, any>): Translation {
+  const id = args.id;
+  if (!id) {
+    throw new Error('relationship requires an id argument.');
+  }
+  const params: Record<string, any> = {
+    id,
+    tenantId: args.tenantId ?? null,
+  };
+  const conditions = ['r.id = $id'];
+  if (params.tenantId) {
+    conditions.push('r.tenantId = $tenantId');
+  }
+  const cypher = `
+MATCH ()-[r:RELATIONSHIP]-()
+WHERE ${conditions.join(' AND ')}
+RETURN r`;
+  return { cypher, params, target: 'relationship', readOnly: true };
+}
+
+function buildRelationshipsTranslation(args: Record<string, any>): Translation {
+  const input = args.input ?? {};
+  const tenantId = input.tenantId ?? args.tenantId;
+  if (!tenantId) {
+    throw new Error('relationships requires a tenantId in input.');
+  }
+
+  const params: Record<string, any> = {
+    tenantId,
+    type: input.type ?? null,
+    limit: input.limit ?? 100,
+    offset: input.offset ?? 0,
+  };
+
+  const conditions = ['r.tenantId = $tenantId'];
+  if (params.type) {
+    conditions.push('type(r) = $type');
+  }
+
+  const cypher = `
+MATCH (source:Entity)-[r:RELATIONSHIP]->(target:Entity)
+WHERE ${conditions.join(' AND ')}
+WITH r, source, target
+SKIP $offset
+LIMIT $limit
+RETURN {
+  id: r.id,
+  type: type(r),
+  source: source.id,
+  target: target.id,
+  confidence: r.confidence
+} AS relationship`;
+
+  return { cypher, params, target: 'relationships', readOnly: true };
+}
+
+function buildRelatedEntitiesTranslation(args: Record<string, any>): Translation {
+  const entityId = args.entityId;
+  if (!entityId) {
+    throw new Error('relatedEntities requires an entityId argument.');
+  }
+  const params = { entityId };
+  const cypher = `
+MATCH (e:Entity { id: $entityId })-[r:RELATIONSHIP]-(neighbor:Entity)
+RETURN {
+  entity: neighbor,
+  strength: coalesce(r.confidence, 1.0),
+  relationshipType: type(r)
+} AS related
+LIMIT 100`;
+  return { cypher, params, target: 'relatedEntities', readOnly: true };
+}
+
+function buildGraphNeighborhoodTranslation(args: Record<string, any>): Translation {
+  const input = args.input ?? {};
+  const startEntityId = input.startEntityId;
+  if (!startEntityId) {
+    throw new Error('graphNeighborhood requires input.startEntityId.');
+  }
+
+  const params: Record<string, any> = {
+    startEntityId,
+    tenantId: input.tenantId ?? null,
+    maxDepth: input.maxDepth ?? 2,
+    relationshipTypes: input.relationshipTypes ?? null,
+    entityKinds: input.entityKinds ?? null,
+    limit: input.limit ?? 100,
+  };
+
+  const tenantCondition = params.tenantId ? 'AND neighbor.tenantId = $tenantId' : '';
+
+  const cypher = `
+MATCH (start:Entity { id: $startEntityId })
+CALL apoc.path.subgraphNodes(start, {
+  maxLevel: $maxDepth,
+  limit: $limit,
+  relationshipFilter: $relationshipTypes,
+  labelFilter: $entityKinds
+}) YIELD node AS neighbor
+WHERE neighbor <> start ${tenantCondition}
+WITH collect(DISTINCT neighbor) AS neighbors, start
+OPTIONAL MATCH (start)-[r:RELATIONSHIP*1..$maxDepth]-(other:Entity)
+RETURN {
+  center: start,
+  entities: neighbors,
+  relationships: collect(r[0])
+} AS neighborhood`;
+
+  return { cypher, params, target: 'graphNeighborhood', readOnly: true };
+}
+
+const translators: Record<string, (args: Record<string, any>) => Translation> = {
+  graphData: buildGraphDataTranslation,
+  entity: buildEntityTranslation,
+  entities: buildEntitiesTranslation,
+  relationship: buildRelationshipTranslation,
+  relationships: buildRelationshipsTranslation,
+  relatedEntities: buildRelatedEntitiesTranslation,
+  graphNeighborhood: buildGraphNeighborhoodTranslation,
+};
+
+function toPlanNode(plan: any | undefined): PlanNode | null {
+  if (!plan) return null;
+  const children = Array.isArray(plan.children)
+    ? plan.children.map((child: any) => toPlanNode(child)).filter(Boolean) as PlanNode[]
+    : [];
+  return {
+    operatorType: plan.operatorType,
+    identifiers: plan.identifiers,
+    arguments: plan.arguments,
+    children,
+  };
+}
+
+function buildPlanSummary(summary: any): string {
+  if (!summary) return '';
+  const parts: string[] = [];
+  if (summary.queryType) {
+    parts.push(`Query type: ${summary.queryType}`);
+  }
+  if (typeof summary.containsUpdates === 'boolean') {
+    parts.push(`Contains updates: ${summary.containsUpdates ? 'yes' : 'no'}`);
+  }
+  if (summary.counters && summary.counters.containsUpdates) {
+    parts.push('Counters reported updates');
+  }
+  if (summary.server?.address) {
+    parts.push(`Server: ${summary.server.address}`);
+  }
+  if (summary.notifications?.length) {
+    parts.push(`Notifications: ${summary.notifications.length}`);
+  }
+  return parts.join(' • ');
+}
+
+function analyzeCypher(cypher: string) {
+  const nodeCount = (cypher.match(/\([^)]*\)/g) || []).length;
+  const relationshipCount = (cypher.match(/-\[[^\]]*\]-/g) || []).length;
+  const complexity =
+    nodeCount +
+    relationshipCount +
+    (cypher.match(/\bWHERE\b/gi) || []).length +
+    (cypher.match(/\bWITH\b/gi) || []).length;
+  return { nodeCount, relationshipCount, complexity };
+}
+
+export const graphDebugResolvers = {
+  Query: {
+    async graphQueryDebug(_parent: unknown, args: { input: any }, ctx: any) {
+      const errors: DebugError[] = [];
+      const { input } = args;
+      const variables = (input?.variables as Record<string, any>) ?? {};
+      const graphqlSource: string = input?.graphql ?? '';
+      const operationName: string | undefined = input?.operationName || undefined;
+
+      if (!graphqlSource.trim()) {
+        return {
+          cypher: null,
+          parameters: null,
+          plan: null,
+          planSummary: null,
+          suggestions: [],
+          errors: [
+            {
+              stage: 'GRAPHQL_PARSE',
+              message: 'GraphQL query text is required.',
+              hint: 'Provide a GraphQL query to translate.',
+            },
+          ],
+          metrics: null,
+        };
+      }
+
+      let operation: OperationDefinitionNode | null = null;
+      try {
+        const document = parse(graphqlSource);
+        const operations = document.definitions.filter(
+          (def): def is OperationDefinitionNode =>
+            def.kind === Kind.OPERATION_DEFINITION && def.operation === 'query',
+        );
+
+        if (operationName) {
+          operation = operations.find((op) => op.name?.value === operationName) ?? null;
+          if (!operation) {
+            errors.push({
+              stage: 'GRAPHQL_PARSE',
+              message: `Operation "${operationName}" was not found in the provided document.`,
+              hint: 'Check the operationName or omit it to use the first query.',
+            });
+          }
+        } else {
+          operation = operations[0] ?? null;
+        }
+
+        if (!operation) {
+          errors.push({
+            stage: 'GRAPHQL_PARSE',
+            message: 'No query operation found in GraphQL document.',
+            hint: 'Ensure the document contains a query operation.',
+          });
+        }
+      } catch (err) {
+        errors.push({
+          stage: 'GRAPHQL_PARSE',
+          message: (err as Error).message,
+          hint: 'Verify that the GraphQL syntax is valid.',
+        });
+      }
+
+      if (!operation) {
+        return {
+          cypher: null,
+          parameters: null,
+          plan: null,
+          planSummary: null,
+          suggestions: [],
+          errors,
+          metrics: null,
+        };
+      }
+
+      const selections = operation.selectionSet.selections;
+      if (selections.length === 0) {
+        errors.push({
+          stage: 'TRANSLATION',
+          message: 'Query has no selected fields to translate.',
+        });
+        return {
+          cypher: null,
+          parameters: null,
+          plan: null,
+          planSummary: null,
+          suggestions: [],
+          errors,
+          metrics: null,
+        };
+      }
+
+      if (selections.length > 1) {
+        errors.push({
+          stage: 'TRANSLATION',
+          message: 'Multiple top-level fields detected; only the first will be analyzed.',
+          hint: 'Run fields separately for detailed analysis.',
+        });
+      }
+
+      const primarySelection = selections[0];
+      if (primarySelection.kind !== Kind.FIELD) {
+        errors.push({
+          stage: 'TRANSLATION',
+          message: 'Unsupported selection type for translation.',
+        });
+        return {
+          cypher: null,
+          parameters: null,
+          plan: null,
+          planSummary: null,
+          suggestions: [],
+          errors,
+          metrics: null,
+        };
+      }
+
+      const field = primarySelection;
+      const translator = translators[field.name.value];
+      let translation: Translation | null = null;
+      if (!translator) {
+        errors.push({
+          stage: 'TRANSLATION',
+          message: `No Cypher translation is available for field "${field.name.value}" yet.`,
+          hint: 'Extend the translator to support this field.',
+        });
+      } else {
+        try {
+          const argsObject = collectArgs(field, variables);
+          translation = translator(argsObject);
+        } catch (err) {
+          errors.push({
+            stage: 'TRANSLATION',
+            message: (err as Error).message,
+          });
+        }
+      }
+
+      if (!translation) {
+        return {
+          cypher: null,
+          parameters: null,
+          plan: null,
+          planSummary: null,
+          suggestions: [],
+          errors,
+          metrics: null,
+        };
+      }
+
+      let planNode: PlanNode | null = null;
+      let planSummary: string | null = null;
+      const driver = getNeo4jDriver();
+      const session = driver.session({ defaultAccessMode: neo4j.session.READ });
+      try {
+        const result = await session.run(`EXPLAIN ${translation.cypher}`, translation.params);
+        planNode = toPlanNode(result.summary.plan);
+        planSummary = buildPlanSummary(result.summary);
+      } catch (err) {
+        errors.push({
+          stage: 'PLAN',
+          message: (err as Error).message,
+          hint: 'Validate that the generated Cypher is executable.',
+        });
+      } finally {
+        await session.close();
+      }
+
+      const suggestions: Array<{ title: string; detail: string; level: string; applied?: boolean }> = [];
+      let metrics: any = null;
+      try {
+        const tenantId = input?.tenantId || ctx?.tenantId || ctx?.user?.tenantId || 'debug-tenant';
+        const optimization = await queryOptimizer.optimizeQuery(translation.cypher, translation.params, {
+          tenantId,
+          queryType: 'cypher',
+          priority: 'medium',
+          cacheEnabled: false,
+        });
+        for (const opt of optimization.optimizations) {
+          suggestions.push({
+            title: opt.name,
+            detail: opt.description,
+            level: opt.impact,
+            applied: opt.applied,
+          });
+        }
+        for (const hint of optimization.executionHints) {
+          suggestions.push({
+            title: `Hint: ${hint.type}`,
+            detail: hint.description || String(hint.value),
+            level: 'info',
+          });
+        }
+        const basics = analyzeCypher(translation.cypher);
+        metrics = {
+          estimatedCost: optimization.estimatedCost ?? null,
+          complexity: basics.complexity,
+          nodeCount: basics.nodeCount,
+          relationshipCount: basics.relationshipCount,
+          requiredIndexes: optimization.indexes,
+        };
+      } catch (err) {
+        errors.push({
+          stage: 'OPTIMIZER',
+          message: (err as Error).message,
+          hint: 'Ensure the query optimizer is configured or inspect the Cypher manually.',
+        });
+      }
+
+      return {
+        cypher: translation.cypher,
+        parameters: translation.params,
+        plan: planNode,
+        planSummary,
+        suggestions,
+        errors,
+        metrics,
+      };
+    },
+  },
+};

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -12,6 +12,7 @@ import { triggerN8nFlow } from '../../integrations/n8n.js';
 import { checkN8nTriggerAllowed } from '../../integrations/n8n-policy.js';
 import { isEnabled as flagEnabled } from '../../featureFlags/flagsmith.js';
 import { doclingResolvers } from './docling.ts';
+import { graphDebugResolvers } from './graphDebug.ts';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -25,6 +26,7 @@ const resolvers = {
     // Production core resolvers (PostgreSQL + Neo4j)
     ...coreResolvers.Query,
     ...doclingResolvers.Query,
+    ...graphDebugResolvers.Query,
     async pipeline(_p: any, args: { id: string }) {
       const { getPipelineDef } = await import('../../db/repositories/pipelines.js');
       return await getPipelineDef(args.id);

--- a/server/src/graphql/schema.core.js
+++ b/server/src/graphql/schema.core.js
@@ -9,6 +9,34 @@ export const coreTypeDefs = gql`
   scalar DateTime
   scalar JSON
 
+  input GraphQueryDebugInput {
+    graphql: String!
+    variables: JSON
+    operationName: String
+    tenantId: String
+  }
+
+  type GraphQueryDebugError {
+    stage: String!
+    message: String!
+    hint: String
+  }
+
+  type GraphQueryOptimizationSuggestion {
+    title: String!
+    detail: String!
+    level: String!
+    applied: Boolean
+  }
+
+  type GraphQueryMetrics {
+    estimatedCost: Float
+    complexity: Int
+    nodeCount: Int
+    relationshipCount: Int
+    requiredIndexes: [String!]
+  }
+
   # Core entity types
   type Entity {
     id: ID!
@@ -191,8 +219,21 @@ export const coreTypeDefs = gql`
     # Graph operations
     graphNeighborhood(input: GraphTraversalInput!): GraphNeighborhood!
 
+    # Graph debugging
+    graphQueryDebug(input: GraphQueryDebugInput!): GraphQueryDebugPayload!
+
     # Search across all entity types
     searchEntities(tenantId: String!, query: String!, kinds: [String!], limit: Int = 50): [Entity!]!
+  }
+
+  type GraphQueryDebugPayload {
+    cypher: String
+    parameters: JSON
+    plan: JSON
+    planSummary: String
+    suggestions: [GraphQueryOptimizationSuggestion!]!
+    errors: [GraphQueryDebugError!]!
+    metrics: GraphQueryMetrics
   }
 
   # Extended Mutation operations


### PR DESCRIPTION
## Summary
- expose a `graphQueryDebug` GraphQL endpoint that translates queries, captures Neo4j plans, and surfaces optimizer hints
- add a Graph Query Debugger page in the client with an interactive editor, plan tree, metrics, and error guidance
- document the workflow and add an end-to-end test that exercises the debugger UI

## Testing
- npm run lint *(fails: turbo not installed in execution environment)*
- npx playwright test tests/e2e/graph-debug.spec.ts *(fails: playwright not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dc0b95c48333abfe2b1007d754d5