### PR TITLE
feat: add custom workflow template support

### DIFF
--- a/docs/workflows/custom-workflow-templates.md
+++ b/docs/workflows/custom-workflow-templates.md
@@ -1,0 +1,112 @@
+# Custom Workflow Templates with Argo
+
+This guide describes how Summit operators can define reusable ingestion and processing pipelines using Argo Workflow templates. Templates are stored in PostgreSQL and executed through GraphQL mutations so analysts can launch automations with dynamic inputs.
+
+## Prerequisites
+
+- Summit server configured with access to PostgreSQL migrations (`server/migrations/20250901120000-create-workflow-templates.sql`).
+- Argo Workflows API available. Set the following environment variables for the server process:
+  - `ARGO_WORKFLOWS_URL`: Base URL of the Argo Workflows API (e.g. `https://argo.example.com`).
+  - `ARGO_WORKFLOWS_NAMESPACE`: Namespace used for submissions (defaults to `argo`).
+  - `ARGO_WORKFLOWS_TOKEN`: Optional bearer token for API authentication.
+- Workflow authors with a tenant context (passed via GraphQL context headers or explicit `tenantId`).
+
+## Defining Templates
+
+Create workflow definitions by calling the `createWorkflowTemplate` mutation. Each template stores:
+
+- `argoTemplate`: Raw Argo `Workflow` or `WorkflowTemplate` spec represented as JSON.
+- `variables`: A list of inputs that analysts can supply when they launch a run.
+
+Example mutation:
+
+```graphql
+mutation CreateWorkflowTemplate($input: CreateWorkflowTemplateInput!) {
+  createWorkflowTemplate(input: $input) {
+    id
+    name
+    variables { name required defaultValue }
+  }
+}
+```
+
+Example variables payload:
+
+```json
+{
+  "input": {
+    "tenantId": "tenant-1",
+    "name": "Data Ingestion",
+    "description": "Fetches and normalizes partner data",
+    "argoTemplate": {
+      "metadata": { "namespace": "intelgraph" },
+      "spec": {
+        "entrypoint": "ingestion-pipeline",
+        "templates": [
+          { "name": "ingestion-pipeline", "steps": [[{ "name": "fetch", "template": "fetch" }]] },
+          { "name": "fetch", "container": { "image": "ghcr.io/summit/fetcher:latest" } }
+        ]
+      }
+    },
+    "variables": [
+      { "name": "sourceUrl", "required": true },
+      { "name": "outputBucket", "required": true },
+      { "name": "batchSize", "defaultValue": 500 }
+    ]
+  }
+}
+```
+
+The mutation persists the template in PostgreSQL and returns the saved record. Templates can later be retrieved via the `workflowTemplates` query for validation or catalog purposes.
+
+## Executing Templates
+
+Launch workflows with the `executeWorkflowTemplate` mutation. Provide the stored template ID and any variables required by the definition. The resolver validates required variables, applies default values, and submits the workflow to Argo with merged parameters.
+
+```graphql
+mutation ExecuteWorkflowTemplate($input: ExecuteWorkflowTemplateInput!) {
+  executeWorkflowTemplate(input: $input) {
+    runId
+    status
+    submittedAt
+  }
+}
+```
+
+Example payload:
+
+```json
+{
+  "input": {
+    "templateId": "<template-uuid>",
+    "tenantId": "tenant-1",
+    "runName": "partner-daily",
+    "variables": {
+      "sourceUrl": "s3://partner/daily.json",
+      "outputBucket": "s3://summit-normalized",
+      "batchSize": 1000
+    }
+  }
+}
+```
+
+If `ARGO_WORKFLOWS_URL` is not set the resolver returns a `DRY_RUN` response so developers can test GraphQL flows locally without hitting Argo.
+
+## Sample Templates
+
+The repository includes reusable Argo YAML definitions under `workflows/templates/`.
+
+- [`custom-data-ingestion.yaml`](../../workflows/templates/custom-data-ingestion.yaml): Demonstrates a fetch → normalize → publish pipeline with parameter substitution for the source URL, output bucket, and batch size.
+
+Use these YAML files as starting points—load them, convert to JSON, and pass as the `argoTemplate` payload when creating templates.
+
+## Testing
+
+Jest tests in `server/__tests__/workflowTemplates.test.ts` cover repository mapping logic and the Argo submission service. Run them with:
+
+```bash
+cd server
+npm test -- workflowTemplates.test.ts
+```
+
+The dry-run mode makes the tests deterministic even without an Argo cluster.

--- a/server/__tests__/workflowTemplates.test.ts
+++ b/server/__tests__/workflowTemplates.test.ts
@@ -1,0 +1,138 @@
+import type { Pool } from 'pg';
+import { WorkflowTemplateRepo } from '../src/repos/WorkflowTemplateRepo.js';
+import { ArgoWorkflowService } from '../src/services/workflows/ArgoWorkflowService.js';
+
+describe('WorkflowTemplateRepo', () => {
+  const fixedDate = new Date('2024-01-01T00:00:00.000Z');
+
+  function createMockPool(response: any): Pool {
+    return {
+      query: jest.fn().mockResolvedValue(response),
+    } as unknown as Pool;
+  }
+
+  it('creates workflow templates and maps database rows', async () => {
+    const mockRow = {
+      id: '11111111-2222-3333-4444-555555555555',
+      tenant_id: 'tenant-1',
+      name: 'Ingest Twitter Feed',
+      description: 'Pulls tweets for enrichment',
+      argo_template: JSON.stringify({ metadata: { generateName: 'twitter-' }, spec: { entrypoint: 'main' } }),
+      variables: JSON.stringify([{ name: 'feedUrl', required: true }]),
+      created_by: 'analyst',
+      created_at: fixedDate,
+      updated_at: fixedDate,
+    };
+
+    const pool = createMockPool({ rows: [mockRow] });
+    const repo = new WorkflowTemplateRepo(pool);
+
+    const result = await repo.createTemplate(
+      {
+        tenantId: 'tenant-1',
+        name: 'Ingest Twitter Feed',
+        description: 'Pulls tweets for enrichment',
+        argoTemplate: { metadata: { generateName: 'twitter-' }, spec: { entrypoint: 'main' } },
+        variables: [{ name: 'feedUrl', required: true }],
+      },
+      'analyst',
+    );
+
+    expect((pool.query as jest.Mock).mock.calls[0][0]).toContain('INSERT INTO workflow_templates');
+    expect(result).toEqual({
+      id: mockRow.id,
+      tenantId: mockRow.tenant_id,
+      name: mockRow.name,
+      description: mockRow.description,
+      argoTemplate: { metadata: { generateName: 'twitter-' }, spec: { entrypoint: 'main' } },
+      variables: [{ name: 'feedUrl', required: true, type: undefined, description: undefined, defaultValue: undefined }],
+      createdBy: 'analyst',
+      createdAt: fixedDate,
+      updatedAt: fixedDate,
+    });
+  });
+
+  it('lists templates for a tenant', async () => {
+    const mockRows = [
+      {
+        id: 'aaaa1111-2222-3333-4444-555555555555',
+        tenant_id: 'tenant-1',
+        name: 'Template One',
+        description: null,
+        argo_template: { spec: { entrypoint: 'main' } },
+        variables: [],
+        created_by: 'analyst',
+        created_at: fixedDate,
+        updated_at: fixedDate,
+      },
+    ];
+
+    const pool = createMockPool({ rows: mockRows });
+    const repo = new WorkflowTemplateRepo(pool);
+
+    const results = await repo.listTemplates('tenant-1', 10, 0);
+
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT * FROM workflow_templates'),
+      ['tenant-1', 10, 0],
+    );
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe('Template One');
+  });
+});
+
+describe('ArgoWorkflowService', () => {
+  it('returns a dry-run response when no base URL configured', async () => {
+    const service = new ArgoWorkflowService();
+    const result = await service.submitWorkflow({ metadata: {}, spec: {} }, {
+      variables: { source: 's3://bucket/path' },
+    });
+
+    expect(result.status).toBe('DRY_RUN');
+    expect(result.workflow).toEqual({
+      template: { metadata: {}, spec: {} },
+      variables: { source: 's3://bucket/path' },
+    });
+  });
+
+  it('submits workflows to Argo when configured', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ metadata: { name: 'workflow-abc' } }),
+    });
+
+    const service = new ArgoWorkflowService({
+      baseUrl: 'https://argo.example.com',
+      namespace: 'intel',
+      authToken: 'token123',
+      fetchImpl: fetchMock as any,
+    });
+
+    const template = { metadata: {}, spec: { arguments: { parameters: [{ name: 'existing', value: 'keep' }] } } };
+    const result = await service.submitWorkflow(template, {
+      runName: 'ingest-twitter',
+      variables: { feedUrl: 'https://twitter.com' },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://argo.example.com/api/v1/workflows/intel');
+    expect(init.headers.Authorization).toBe('Bearer token123');
+
+    const payload = JSON.parse(init.body);
+    expect(payload.workflow.metadata.generateName).toBe('ingest-twitter-');
+    expect(payload.workflow.spec.arguments.parameters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'existing', value: 'keep' }),
+        expect.objectContaining({ name: 'feedUrl', value: 'https://twitter.com' }),
+      ]),
+    );
+
+    expect(result).toEqual({
+      runId: 'workflow-abc',
+      status: 'SUBMITTED',
+      submittedAt: expect.any(Date),
+      workflow: { metadata: { name: 'workflow-abc' } },
+    });
+  });
+});

--- a/server/migrations/20250901120000-create-workflow-templates.sql
+++ b/server/migrations/20250901120000-create-workflow-templates.sql
@@ -1,0 +1,14 @@
+-- Workflow Templates schema for custom Argo workflows
+CREATE TABLE IF NOT EXISTS workflow_templates (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  tenant_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  argo_template JSONB NOT NULL,
+  variables JSONB NOT NULL DEFAULT '[]'::jsonb,
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_templates_tenant ON workflow_templates (tenant_id, name);

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -12,6 +12,7 @@ import { triggerN8nFlow } from '../../integrations/n8n.js';
 import { checkN8nTriggerAllowed } from '../../integrations/n8n-policy.js';
 import { isEnabled as flagEnabled } from '../../featureFlags/flagsmith.js';
 import { doclingResolvers } from './docling.ts';
+import workflowTemplateResolvers from './workflowTemplates.ts';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -25,6 +26,7 @@ const resolvers = {
     // Production core resolvers (PostgreSQL + Neo4j)
     ...coreResolvers.Query,
     ...doclingResolvers.Query,
+    ...workflowTemplateResolvers.Query,
     async pipeline(_p: any, args: { id: string }) {
       const { getPipelineDef } = await import('../../db/repositories/pipelines.js');
       return await getPipelineDef(args.id);
@@ -63,6 +65,7 @@ const resolvers = {
     // Production core resolvers
     ...coreResolvers.Mutation,
     ...doclingResolvers.Mutation,
+    ...workflowTemplateResolvers.Mutation,
 
     // Legacy resolvers (will be phased out)
     ...entityResolvers.Mutation,

--- a/server/src/graphql/resolvers/workflowTemplates.ts
+++ b/server/src/graphql/resolvers/workflowTemplates.ts
@@ -1,0 +1,135 @@
+import { z } from 'zod';
+import { getPostgresPool } from '../../db/postgres.js';
+import { WorkflowTemplateRepo } from '../../repos/WorkflowTemplateRepo.js';
+import type { WorkflowTemplate } from '../../repos/WorkflowTemplateRepo.js';
+import { ArgoWorkflowService } from '../../services/workflows/ArgoWorkflowService.ts';
+import logger from '../../config/logger.js';
+
+const resolverLogger = logger.child({ name: 'WorkflowTemplateResolvers' });
+
+const TemplateVariableInputZ = z.object({
+  name: z.string().min(1),
+  type: z.string().optional(),
+  description: z.string().optional(),
+  required: z.boolean().optional(),
+  defaultValue: z.any().optional(),
+});
+
+const CreateTemplateInputZ = z.object({
+  tenantId: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().optional(),
+  argoTemplate: z.record(z.any()),
+  variables: z.array(TemplateVariableInputZ).default([]),
+});
+
+const ExecuteTemplateInputZ = z.object({
+  templateId: z.string().uuid(),
+  tenantId: z.string().optional(),
+  variables: z.record(z.any()).optional(),
+  runName: z.string().optional(),
+});
+
+const ListTemplatesInputZ = z.object({
+  tenantId: z.string().min(1),
+  limit: z.number().int().min(1).max(100).default(20),
+  offset: z.number().int().min(0).default(0),
+});
+
+const repo = new WorkflowTemplateRepo(getPostgresPool());
+const argoService = new ArgoWorkflowService({
+  baseUrl: process.env.ARGO_WORKFLOWS_URL,
+  namespace: process.env.ARGO_WORKFLOWS_NAMESPACE,
+  authToken: process.env.ARGO_WORKFLOWS_TOKEN,
+});
+
+function resolveTenantId(explicitTenantId: string | undefined, contextTenantId: string | undefined): string {
+  const tenantId = explicitTenantId || contextTenantId;
+  if (!tenantId) {
+    throw new Error('Tenant ID is required');
+  }
+  return tenantId;
+}
+
+function buildVariableMap(template: WorkflowTemplate, inputVariables: Record<string, unknown> = {}): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const variable of template.variables) {
+    const provided = inputVariables[variable.name];
+
+    if (provided === undefined) {
+      if (variable.defaultValue !== undefined) {
+        result[variable.name] = variable.defaultValue;
+      } else if (variable.required) {
+        throw new Error(`Missing required variable '${variable.name}'`);
+      }
+    } else {
+      result[variable.name] = provided;
+    }
+  }
+
+  for (const [name, value] of Object.entries(inputVariables)) {
+    if (!(name in result)) {
+      resolverLogger.debug({ name }, 'Passing through additional workflow variable');
+      result[name] = value;
+    }
+  }
+
+  return result;
+}
+
+export const workflowTemplateResolvers = {
+  Query: {
+    workflowTemplate: async (_: unknown, args: { id: string; tenantId?: string }, context: any) => {
+      const tenantId = resolveTenantId(args.tenantId, context.tenantId);
+      return repo.getTemplateById(args.id, tenantId);
+    },
+    workflowTemplates: async (
+      _: unknown,
+      args: { tenantId: string; limit?: number; offset?: number },
+      context: any,
+    ) => {
+      const parsed = ListTemplatesInputZ.parse({ ...args, limit: args.limit ?? undefined, offset: args.offset ?? undefined });
+      const tenantId = resolveTenantId(parsed.tenantId, context.tenantId);
+      return repo.listTemplates(tenantId, parsed.limit, parsed.offset);
+    },
+  },
+  Mutation: {
+    createWorkflowTemplate: async (_: unknown, args: { input: unknown }, context: any) => {
+      const parsed = CreateTemplateInputZ.parse(args.input);
+      const tenantId = resolveTenantId(parsed.tenantId, context.tenantId);
+      const userId = context.user?.sub || context.user?.id || 'system';
+
+      const template = await repo.createTemplate(
+        { ...parsed, tenantId, variables: parsed.variables },
+        userId,
+      );
+
+      return template;
+    },
+    executeWorkflowTemplate: async (_: unknown, args: { input: unknown }, context: any) => {
+      const parsed = ExecuteTemplateInputZ.parse(args.input);
+      const tenantId = resolveTenantId(parsed.tenantId, context.tenantId);
+      const template = await repo.getTemplateById(parsed.templateId, tenantId);
+
+      if (!template) {
+        throw new Error('Workflow template not found');
+      }
+
+      const variables = buildVariableMap(template, parsed.variables || {});
+      const submission = await argoService.submitWorkflow(template.argoTemplate, {
+        runName: parsed.runName,
+        variables,
+      });
+
+      return {
+        runId: submission.runId,
+        status: submission.status,
+        submittedAt: submission.submittedAt,
+        workflow: submission.workflow,
+      };
+    },
+  },
+};
+
+export default workflowTemplateResolvers;

--- a/server/src/graphql/schema.workflowTemplates.ts
+++ b/server/src/graphql/schema.workflowTemplates.ts
@@ -1,0 +1,65 @@
+import { gql } from 'graphql-tag';
+
+export const workflowTemplateTypeDefs = gql`
+  type WorkflowTemplateVariable {
+    name: String!
+    type: String
+    description: String
+    required: Boolean!
+    defaultValue: JSON
+  }
+
+  input WorkflowTemplateVariableInput {
+    name: String!
+    type: String
+    description: String
+    required: Boolean = false
+    defaultValue: JSON
+  }
+
+  type WorkflowTemplate {
+    id: ID!
+    tenantId: String!
+    name: String!
+    description: String
+    argoTemplate: JSON!
+    variables: [WorkflowTemplateVariable!]!
+    createdBy: String!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+  }
+
+  type WorkflowExecution {
+    runId: String!
+    status: String!
+    submittedAt: DateTime!
+    workflow: JSON
+  }
+
+  input CreateWorkflowTemplateInput {
+    tenantId: String!
+    name: String!
+    description: String
+    argoTemplate: JSON!
+    variables: [WorkflowTemplateVariableInput!] = []
+  }
+
+  input ExecuteWorkflowTemplateInput {
+    templateId: ID!
+    tenantId: String
+    variables: JSON
+    runName: String
+  }
+
+  extend type Query {
+    workflowTemplate(id: ID!, tenantId: String): WorkflowTemplate
+    workflowTemplates(tenantId: String!, limit: Int = 20, offset: Int = 0): [WorkflowTemplate!]!
+  }
+
+  extend type Mutation {
+    createWorkflowTemplate(input: CreateWorkflowTemplateInput!): WorkflowTemplate!
+    executeWorkflowTemplate(input: ExecuteWorkflowTemplateInput!): WorkflowExecution!
+  }
+`;
+
+export default workflowTemplateTypeDefs;

--- a/server/src/graphql/schema/index.ts
+++ b/server/src/graphql/schema/index.ts
@@ -6,6 +6,7 @@ import aiModule from '../schema.ai.js';
 import annotationsModule from '../schema.annotations.js';
 import graphragTypesModule from '../types/graphragTypes.js';
 import { crystalTypeDefs } from '../schema.crystal.js';
+import { workflowTemplateTypeDefs } from '../schema.workflowTemplates.ts';
 
 const { copilotTypeDefs } = copilotModule as { copilotTypeDefs: any };
 const { graphTypeDefs } = graphModule as { graphTypeDefs: any };
@@ -39,6 +40,7 @@ export const typeDefs = [
   aiTypeDefs,
   annotationsTypeDefs,
   crystalTypeDefs,
+  workflowTemplateTypeDefs,
 ];
 
 export default typeDefs;

--- a/server/src/repos/WorkflowTemplateRepo.ts
+++ b/server/src/repos/WorkflowTemplateRepo.ts
@@ -1,0 +1,163 @@
+import { Pool } from 'pg';
+import logger from '../config/logger.js';
+
+const repoLogger = logger.child({ name: 'WorkflowTemplateRepo' });
+
+export interface WorkflowTemplateVariable {
+  name: string;
+  type?: string;
+  description?: string;
+  required: boolean;
+  defaultValue?: unknown;
+}
+
+interface WorkflowTemplateRow {
+  id: string;
+  tenant_id: string;
+  name: string;
+  description: string | null;
+  argo_template: any;
+  variables: any;
+  created_by: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface WorkflowTemplate {
+  id: string;
+  tenantId: string;
+  name: string;
+  description?: string | null;
+  argoTemplate: Record<string, unknown>;
+  variables: WorkflowTemplateVariable[];
+  createdBy: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateWorkflowTemplateInput {
+  tenantId: string;
+  name: string;
+  description?: string;
+  argoTemplate: Record<string, unknown>;
+  variables?: WorkflowTemplateVariable[];
+}
+
+export class WorkflowTemplateRepo {
+  constructor(private readonly pg: Pool) {}
+
+  async createTemplate(input: CreateWorkflowTemplateInput, userId: string): Promise<WorkflowTemplate> {
+    const variables = (input.variables || []).map((variable) => ({
+      ...variable,
+      required: Boolean(variable.required),
+    }));
+
+    const { rows } = await this.pg.query<WorkflowTemplateRow>(
+      `INSERT INTO workflow_templates (tenant_id, name, description, argo_template, variables, created_by)
+       VALUES ($1, $2, $3, $4, $5, $6)
+       RETURNING *`,
+      [
+        input.tenantId,
+        input.name,
+        input.description ?? null,
+        JSON.stringify(input.argoTemplate),
+        JSON.stringify(variables),
+        userId,
+      ],
+    );
+
+    const row = rows[0];
+    repoLogger.debug({ templateId: row?.id }, 'Workflow template created');
+    return this.mapRow(row);
+  }
+
+  async getTemplateById(id: string, tenantId: string): Promise<WorkflowTemplate | null> {
+    const { rows } = await this.pg.query<WorkflowTemplateRow>(
+      `SELECT * FROM workflow_templates WHERE id = $1 AND tenant_id = $2`,
+      [id, tenantId],
+    );
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    return this.mapRow(rows[0]);
+  }
+
+  async listTemplates(tenantId: string, limit = 20, offset = 0): Promise<WorkflowTemplate[]> {
+    const { rows } = await this.pg.query<WorkflowTemplateRow>(
+      `SELECT * FROM workflow_templates
+       WHERE tenant_id = $1
+       ORDER BY created_at DESC
+       LIMIT $2 OFFSET $3`,
+      [tenantId, limit, offset],
+    );
+
+    return rows.map((row) => this.mapRow(row));
+  }
+
+  private mapRow(row: WorkflowTemplateRow): WorkflowTemplate {
+    const argoTemplate = this.ensureObject(row.argo_template, {});
+    const variables = this.ensureArray(row.variables).map((variable: any) => ({
+      name: variable?.name,
+      type: variable?.type ?? undefined,
+      description: variable?.description ?? undefined,
+      required: Boolean(variable?.required),
+      defaultValue: variable?.defaultValue,
+    }));
+
+    return {
+      id: row.id,
+      tenantId: row.tenant_id,
+      name: row.name,
+      description: row.description,
+      argoTemplate,
+      variables,
+      createdBy: row.created_by,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  private ensureObject(value: unknown, fallback: Record<string, unknown>): Record<string, unknown> {
+    if (!value) {
+      return fallback;
+    }
+
+    if (typeof value === 'string') {
+      try {
+        return JSON.parse(value);
+      } catch (error) {
+        repoLogger.warn({ error }, 'Failed to parse argo template JSON value; returning fallback');
+        return fallback;
+      }
+    }
+
+    if (typeof value === 'object') {
+      return value as Record<string, unknown>;
+    }
+
+    return fallback;
+  }
+
+  private ensureArray(value: unknown): any[] {
+    if (!value) {
+      return [];
+    }
+
+    if (typeof value === 'string') {
+      try {
+        return JSON.parse(value);
+      } catch (error) {
+        repoLogger.warn({ error }, 'Failed to parse workflow template variable list');
+        return [];
+      }
+    }
+
+    if (Array.isArray(value)) {
+      return value;
+    }
+
+    return [];
+  }
+}

--- a/server/src/services/workflows/ArgoWorkflowService.ts
+++ b/server/src/services/workflows/ArgoWorkflowService.ts
@@ -1,0 +1,174 @@
+import logger from '../../config/logger.js';
+
+export interface WorkflowSubmissionResult {
+  runId: string;
+  status: 'DRY_RUN' | 'SUBMITTED';
+  submittedAt: Date;
+  workflow?: Record<string, unknown>;
+}
+
+export interface SubmitWorkflowOptions {
+  runName?: string;
+  variables?: Record<string, unknown>;
+}
+
+interface ServiceOptions {
+  baseUrl?: string;
+  namespace?: string;
+  authToken?: string;
+  fetchImpl?: typeof fetch;
+}
+
+const serviceLogger = logger.child({ name: 'ArgoWorkflowService' });
+
+export class ArgoWorkflowService {
+  private readonly baseUrl?: string;
+  private readonly namespace: string;
+  private readonly authToken?: string;
+  private readonly fetchImpl?: typeof fetch;
+
+  constructor(options: ServiceOptions = {}) {
+    this.baseUrl = options.baseUrl?.replace(/\/$/, '');
+    this.namespace = options.namespace || 'argo';
+    this.authToken = options.authToken;
+    this.fetchImpl = options.fetchImpl ?? (typeof fetch !== 'undefined' ? fetch.bind(globalThis) : undefined);
+  }
+
+  async submitWorkflow(
+    template: Record<string, unknown>,
+    { runName, variables = {} }: SubmitWorkflowOptions = {},
+  ): Promise<WorkflowSubmissionResult> {
+    const submittedAt = new Date();
+
+    if (!this.baseUrl) {
+      serviceLogger.warn('Argo base URL not configured. Returning dry-run response.');
+      return {
+        runId: `dryrun-${submittedAt.getTime()}`,
+        status: 'DRY_RUN',
+        submittedAt,
+        workflow: {
+          template,
+          variables,
+        },
+      };
+    }
+
+    if (!this.fetchImpl) {
+      throw new Error('fetch implementation is not available in this runtime');
+    }
+
+    const workflowPayload = this.prepareWorkflowPayload(template, variables, runName);
+    const namespace = (workflowPayload.metadata?.namespace as string) || this.namespace;
+
+    const response = await this.fetchImpl(`${this.baseUrl}/api/v1/workflows/${namespace}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {}),
+      },
+      body: JSON.stringify({ workflow: workflowPayload }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => '');
+      serviceLogger.error({ status: response.status, body: errorBody }, 'Argo workflow submission failed');
+      throw new Error(`Failed to submit workflow to Argo (status ${response.status}): ${errorBody}`);
+    }
+
+    const payload = await response
+      .json()
+      .catch(() => ({ metadata: { name: `workflow-${submittedAt.getTime()}` } })) as Record<string, unknown>;
+
+    const metadata = (payload.metadata as Record<string, unknown>) || {};
+    const runId = (metadata.name as string) || (metadata.generateName as string) || `workflow-${submittedAt.getTime()}`;
+
+    serviceLogger.info({ runId, namespace }, 'Argo workflow submitted');
+
+    return {
+      runId,
+      status: 'SUBMITTED',
+      submittedAt,
+      workflow: payload,
+    };
+  }
+
+  private prepareWorkflowPayload(
+    template: Record<string, unknown>,
+    variables: Record<string, unknown>,
+    runName?: string,
+  ): Record<string, unknown> {
+    const payload = this.clone(template);
+    const metadata = { ...(payload.metadata as Record<string, unknown> | undefined) };
+
+    metadata.namespace = (metadata.namespace as string) || this.namespace;
+
+    if (runName) {
+      metadata.generateName = `${runName}-`;
+      delete metadata.name;
+    } else if (!metadata.name && !metadata.generateName) {
+      metadata.generateName = 'workflow-';
+    }
+
+    payload.metadata = metadata;
+
+    const spec = { ...(payload.spec as Record<string, unknown> | undefined) };
+    const argumentsBlock = { ...(spec.arguments as Record<string, unknown> | undefined) };
+    const existingParameters = Array.isArray(argumentsBlock.parameters)
+      ? [...(argumentsBlock.parameters as any[])]
+      : [];
+
+    const mergedParameters = this.mergeParameters(existingParameters, variables);
+    if (mergedParameters.length > 0) {
+      argumentsBlock.parameters = mergedParameters;
+    }
+
+    spec.arguments = argumentsBlock;
+    payload.spec = spec;
+
+    return payload;
+  }
+
+  private mergeParameters(existing: any[], variables: Record<string, unknown>): any[] {
+    const paramsByName = new Map<string, any>();
+
+    for (const param of existing) {
+      if (param?.name) {
+        paramsByName.set(param.name, { ...param });
+      }
+    }
+
+    for (const [name, value] of Object.entries(variables)) {
+      paramsByName.set(name, {
+        ...(paramsByName.get(name) || {}),
+        name,
+        value: this.serialiseValue(value),
+      });
+    }
+
+    return Array.from(paramsByName.values());
+  }
+
+  private serialiseValue(value: unknown): string {
+    if (value === null || value === undefined) {
+      return '';
+    }
+
+    if (typeof value === 'string') {
+      return value;
+    }
+
+    if (typeof value === 'number' || typeof value === 'boolean') {
+      return String(value);
+    }
+
+    return JSON.stringify(value);
+  }
+
+  private clone<T>(value: T): T {
+    try {
+      return structuredClone(value);
+    } catch (error) {
+      return JSON.parse(JSON.stringify(value));
+    }
+  }
+}

--- a/workflows/templates/custom-data-ingestion.yaml
+++ b/workflows/templates/custom-data-ingestion.yaml
@@ -1,0 +1,57 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: data-ingestion-template
+  namespace: intelgraph
+  labels:
+    summit.svc/component: pipelines
+spec:
+  entrypoint: ingestion-pipeline
+  arguments:
+    parameters:
+      - name: sourceUrl
+        description: Source endpoint for ingestion
+      - name: outputBucket
+        description: S3 bucket used to persist normalized data
+      - name: batchSize
+        value: "500"
+        description: Maximum records per batch before upload
+  templates:
+    - name: ingestion-pipeline
+      steps:
+        - - name: fetch-raw
+            template: fetch-raw
+        - - name: normalize
+            template: normalize
+            arguments:
+              parameters:
+                - name: batchSize
+                  value: "{{workflow.parameters.batchSize}}"
+        - - name: publish
+            template: publish
+    - name: fetch-raw
+      inputs:
+        parameters:
+          - name: sourceUrl
+      container:
+        image: ghcr.io/summit/ingestion-fetcher:latest
+        command: ["/bin/ingest"]
+        args:
+          - "--source={{inputs.parameters.sourceUrl}}"
+    - name: normalize
+      inputs:
+        parameters:
+          - name: batchSize
+      container:
+        image: ghcr.io/summit/ingestion-normalizer:latest
+        args:
+          - "--batch-size={{inputs.parameters.batchSize}}"
+    - name: publish
+      inputs:
+        parameters:
+          - name: outputBucket
+      container:
+        image: ghcr.io/summit/ingestion-publisher:latest
+        args:
+          - "--bucket={{workflow.parameters.outputBucket}}"
+          - "--input=/data/out"


### PR DESCRIPTION
## Summary
- add a PostgreSQL migration and repository for storing reusable Argo workflow templates with variable metadata
- expose GraphQL queries and mutations plus an Argo submission service to create and execute workflow templates
- document authoring/execution flows and ship sample Argo template with Jest coverage for repo/service behavior

## Testing
- npm test -- workflowTemplates.test.ts *(fails: jest binary unavailable because npm install is blocked by unsupported workspace protocol)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dc2ac8a08333a46d75e5e960b024