### PR TITLE
feat: add GraphQL API key management system

### DIFF
--- a/docs/api/api-key-management.md
+++ b/docs/api/api-key-management.md
@@ -1,0 +1,72 @@
+# API Key Management for External Clients
+
+## Overview
+Summit's GraphQL API now supports first-class API keys for machine-to-machine access. Keys are stored in PostgreSQL with enforced expiration and tenant scoping, allowing security teams to rotate and revoke credentials without redeploying services. Every API request that includes an `x-api-key` header is authenticated server side and mapped onto an RBAC role before resolvers execute.
+
+## Database Schema
+API keys are persisted in the `api_keys` table created by the `2025-09-02_api_keys.sql` migration. Each record tracks:
+
+- `id` (UUID primary key)
+- `name` (friendly label surfaced in tooling)
+- `scope` (`VIEWER`, `ANALYST`, `OPERATOR`, or `ADMIN`)
+- `tenant_id` (optional tenant scoping)
+- `created_by` / `revoked_by` (actor IDs for auditing)
+- `expires_at`, `revoked_at`, and `last_used_at` timestamps
+- `key_hash` (SHA-256 hash of the issued secret)
+
+Secrets are never stored in plaintext; only hashed values are persisted and lookups are performed against the hash.
+
+## GraphQL Operations
+New GraphQL schema elements expose administrative workflows:
+
+```graphql
+# Query
+query ListKeys {
+  apiKeys(includeRevoked: false) {
+    id
+    name
+    scope
+    expiresAt
+    revokedAt
+    lastUsedAt
+  }
+}
+
+# Mutations
+mutation CreateKey($input: CreateApiKeyInput!) {
+  createApiKey(input: $input) {
+    key      # return this once and store it securely
+    apiKey {
+      id
+      scope
+      expiresAt
+    }
+  }
+}
+
+mutation RevokeKey($id: ID!) {
+  revokeApiKey(id: $id) {
+    id
+    revokedAt
+    revokedBy
+  }
+}
+```
+
+`CreateApiKeyInput` requires a name, scope, and ISO 8601 expiration timestamp. The optional `tenantId` defaults to the caller's tenant.
+
+## RBAC Guardrails
+Only administrators (`role: ADMIN`) may list, create, or revoke API keys. Attempting to call any of the above operations as a non-admin results in a `forbidden` GraphQL error. Issued keys inherit the configured scope and are projected into the request context as their acting role, ensuring downstream resolvers honour existing RBAC checks.
+
+## Request Authentication Flow
+1. Clients send `x-api-key: <secret>` with each GraphQL request.
+2. Middleware hashes the secret, loads the key record from PostgreSQL, and validates expiry/revocation.
+3. On success, the request context receives a synthetic user `{ id: "api-key:<uuid>", role: <scope>, tenantId, type: 'API_KEY' }`.
+4. The `last_used_at` column is updated for auditability.
+5. Standard bearer token authentication continues to work when no API key header is present.
+
+## Operational Guidance
+- Rotate keys by creating a replacement, updating clients, then revoking the prior key.
+- Use descriptive names (e.g., `partner-crm-prod`) to simplify audits.
+- Monitor `last_used_at` to detect dormant or compromised credentials.
+- Store the returned secret in a secure vault; the platform cannot recover it after creation.

--- a/server/db/migrations/postgres/2025-09-02_api_keys.sql
+++ b/server/db/migrations/postgres/2025-09-02_api_keys.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS api_keys (
+  id UUID PRIMARY KEY,
+  name TEXT NOT NULL,
+  key_hash TEXT NOT NULL UNIQUE,
+  scope TEXT NOT NULL CHECK (scope IN ('VIEWER','ANALYST','OPERATOR','ADMIN')),
+  tenant_id TEXT,
+  created_by TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ,
+  revoked_by TEXT,
+  last_used_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys (key_hash);
+CREATE INDEX IF NOT EXISTS idx_api_keys_active ON api_keys (tenant_id, scope) WHERE revoked_at IS NULL;

--- a/server/src/graphql/resolvers/__tests__/apiKey.test.ts
+++ b/server/src/graphql/resolvers/__tests__/apiKey.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+
+const listKeys = jest.fn();
+const createKey = jest.fn();
+const revokeKey = jest.fn();
+
+jest.mock('../../../services/ApiKeyService.js', () => {
+  return jest.fn().mockImplementation(() => ({
+    listKeys,
+    createKey,
+    revokeKey,
+  }));
+});
+
+const { apiKeyResolvers } = require('../apiKey');
+
+describe('apiKeyResolvers', () => {
+  beforeEach(() => {
+    listKeys.mockReset();
+    createKey.mockReset();
+    revokeKey.mockReset();
+  });
+
+  it('requires admin role for listing keys', async () => {
+    await expect(
+      apiKeyResolvers.Query.apiKeys({}, {}, { user: { role: 'VIEWER' } }),
+    ).rejects.toThrow('forbidden');
+  });
+
+  it('lists keys for admins scoped to tenant', async () => {
+    listKeys.mockResolvedValueOnce([{ id: 'key-1' }]);
+    const result = await apiKeyResolvers.Query.apiKeys(
+      {},
+      {},
+      { user: { role: 'ADMIN', tenantId: 'tenant-123' } },
+    );
+
+    expect(listKeys).toHaveBeenCalledWith({ tenantId: 'tenant-123', includeRevoked: undefined });
+    expect(result).toEqual([{ id: 'key-1' }]);
+  });
+
+  it('prevents non-admins from creating keys', async () => {
+    await expect(
+      apiKeyResolvers.Mutation.createApiKey(
+        {},
+        { input: { name: 'Test', scope: 'VIEWER', expiresAt: new Date().toISOString() } },
+        { user: { role: 'VIEWER' } },
+      ),
+    ).rejects.toThrow('forbidden');
+  });
+
+  it('creates keys for admins and returns secret payload', async () => {
+    createKey.mockResolvedValueOnce({ secret: 'sk_secret', apiKey: { id: 'key-1' } });
+    const expiresAt = new Date().toISOString();
+
+    const result = await apiKeyResolvers.Mutation.createApiKey(
+      {},
+      { input: { name: 'Prod', scope: 'VIEWER', expiresAt } },
+      { user: { role: 'ADMIN', id: 'admin-1', tenantId: 'tenant-1' } },
+    );
+
+    expect(createKey).toHaveBeenCalledWith({
+      name: 'Prod',
+      scope: 'VIEWER',
+      expiresAt: expect.any(Date),
+      createdBy: 'admin-1',
+      tenantId: 'tenant-1',
+    });
+    expect(result).toEqual({ key: 'sk_secret', apiKey: { id: 'key-1' } });
+  });
+
+  it('rejects invalid expiration date input', async () => {
+    await expect(
+      apiKeyResolvers.Mutation.createApiKey(
+        {},
+        { input: { name: 'Prod', scope: 'VIEWER', expiresAt: 'not-a-date' } },
+        { user: { role: 'ADMIN', id: 'admin-1' } },
+      ),
+    ).rejects.toThrow('Invalid expiration date');
+  });
+
+  it('revokes keys with admin context', async () => {
+    revokeKey.mockResolvedValueOnce({ id: 'key-1', revokedBy: 'admin-1' });
+
+    const result = await apiKeyResolvers.Mutation.revokeApiKey(
+      {},
+      { id: 'key-1' },
+      { user: { role: 'ADMIN', id: 'admin-1' } },
+    );
+
+    expect(revokeKey).toHaveBeenCalledWith('key-1', 'admin-1');
+    expect(result).toEqual({ id: 'key-1', revokedBy: 'admin-1' });
+  });
+});

--- a/server/src/graphql/resolvers/apiKey.ts
+++ b/server/src/graphql/resolvers/apiKey.ts
@@ -1,0 +1,50 @@
+import ApiKeyService from '../../services/ApiKeyService.js';
+
+const service = new ApiKeyService();
+
+function assertAdmin(ctx: any) {
+  const role = ctx?.user?.role;
+  if (role !== 'ADMIN') {
+    throw new Error('forbidden');
+  }
+}
+
+export const apiKeyResolvers = {
+  Query: {
+    async apiKeys(_parent: unknown, args: { includeRevoked?: boolean }, ctx: any) {
+      assertAdmin(ctx);
+      const tenantId = ctx?.user?.tenantId ?? null;
+      return service.listKeys({ tenantId, includeRevoked: args?.includeRevoked });
+    },
+  },
+  Mutation: {
+    async createApiKey(
+      _parent: unknown,
+      args: { input: { name: string; scope: string; expiresAt: string; tenantId?: string | null } },
+      ctx: any,
+    ) {
+      assertAdmin(ctx);
+      const expiresAt = new Date(args.input.expiresAt);
+      if (Number.isNaN(expiresAt.getTime())) {
+        throw new Error('Invalid expiration date');
+      }
+
+      const tenantId = args.input.tenantId ?? ctx?.user?.tenantId ?? null;
+      const { secret, apiKey } = await service.createKey({
+        name: args.input.name,
+        scope: args.input.scope as any,
+        expiresAt,
+        createdBy: ctx?.user?.id ?? null,
+        tenantId,
+      });
+
+      return { key: secret, apiKey };
+    },
+    async revokeApiKey(_parent: unknown, args: { id: string }, ctx: any) {
+      assertAdmin(ctx);
+      return service.revokeKey(args.id, ctx?.user?.id ?? null);
+    },
+  },
+};
+
+export default apiKeyResolvers;

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -12,6 +12,7 @@ import { triggerN8nFlow } from '../../integrations/n8n.js';
 import { checkN8nTriggerAllowed } from '../../integrations/n8n-policy.js';
 import { isEnabled as flagEnabled } from '../../featureFlags/flagsmith.js';
 import { doclingResolvers } from './docling.ts';
+import { apiKeyResolvers } from './apiKey';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -25,6 +26,7 @@ const resolvers = {
     // Production core resolvers (PostgreSQL + Neo4j)
     ...coreResolvers.Query,
     ...doclingResolvers.Query,
+    ...apiKeyResolvers.Query,
     async pipeline(_p: any, args: { id: string }) {
       const { getPipelineDef } = await import('../../db/repositories/pipelines.js');
       return await getPipelineDef(args.id);
@@ -63,6 +65,7 @@ const resolvers = {
     // Production core resolvers
     ...coreResolvers.Mutation,
     ...doclingResolvers.Mutation,
+    ...apiKeyResolvers.Mutation,
 
     // Legacy resolvers (will be phased out)
     ...entityResolvers.Mutation,

--- a/server/src/graphql/schema.api-keys.ts
+++ b/server/src/graphql/schema.api-keys.ts
@@ -1,0 +1,46 @@
+import { gql } from 'graphql-tag';
+
+export const apiKeyTypeDefs = gql`
+  enum ApiKeyScope {
+    VIEWER
+    ANALYST
+    OPERATOR
+    ADMIN
+  }
+
+  type ApiKey {
+    id: ID!
+    name: String!
+    scope: ApiKeyScope!
+    tenantId: String
+    createdBy: String
+    createdAt: DateTime!
+    expiresAt: DateTime!
+    revokedAt: DateTime
+    revokedBy: String
+    lastUsedAt: DateTime
+  }
+
+  type ApiKeySecret {
+    key: String!
+    apiKey: ApiKey!
+  }
+
+  input CreateApiKeyInput {
+    name: String!
+    scope: ApiKeyScope!
+    expiresAt: DateTime!
+    tenantId: String
+  }
+
+  extend type Query {
+    apiKeys(includeRevoked: Boolean = false): [ApiKey!]!
+  }
+
+  extend type Mutation {
+    createApiKey(input: CreateApiKeyInput!): ApiKeySecret!
+    revokeApiKey(id: ID!): ApiKey!
+  }
+`;
+
+export default apiKeyTypeDefs;

--- a/server/src/graphql/schema/index.ts
+++ b/server/src/graphql/schema/index.ts
@@ -6,6 +6,7 @@ import aiModule from '../schema.ai.js';
 import annotationsModule from '../schema.annotations.js';
 import graphragTypesModule from '../types/graphragTypes.js';
 import { crystalTypeDefs } from '../schema.crystal.js';
+import { apiKeyTypeDefs } from '../schema.api-keys.ts';
 
 const { copilotTypeDefs } = copilotModule as { copilotTypeDefs: any };
 const { graphTypeDefs } = graphModule as { graphTypeDefs: any };
@@ -39,6 +40,7 @@ export const typeDefs = [
   aiTypeDefs,
   annotationsTypeDefs,
   crystalTypeDefs,
+  apiKeyTypeDefs,
 ];
 
 export default typeDefs;

--- a/server/src/middleware/auth.ts
+++ b/server/src/middleware/auth.ts
@@ -1,23 +1,13 @@
 import { Request, Response, NextFunction } from 'express';
 import AuthService from '../services/AuthService.js';
-import logger from '../utils/logger.js';
+import ApiKeyService from '../services/ApiKeyService.js';
 
 interface AuthenticatedRequest extends Request {
   user?: any;
 }
 
-type ApiKey = { key: string; scope: "admin"|"read"|"write"; expiresAt: number };
-const parseApiKeys = (): ApiKey[] => {
-  const raw = process.env.API_KEYS || process.env.API_KEY || "";
-  // Format: key:scope:ttlHours[,key:scope:ttlHours...]
-  return raw.split(",").filter(Boolean).map(s => {
-    const [key, scope="read", ttl="24"] = s.split(":");
-    return { key, scope: scope as any, expiresAt: Date.now() + parseInt(ttl,10)*3600*1000 };
-  });
-};
-const API_KEYS_CACHE = parseApiKeys();
-
 let authService: AuthService | null = null;
+let apiKeyService: ApiKeyService | null = null;
 
 function getAuthService(): AuthService {
   if (!authService) {
@@ -26,22 +16,35 @@ function getAuthService(): AuthService {
   return authService;
 }
 
+function getApiKeyService(): ApiKeyService {
+  if (!apiKeyService) {
+    apiKeyService = new ApiKeyService();
+  }
+  return apiKeyService;
+}
+
 export async function ensureAuthenticated(
   req: AuthenticatedRequest,
   res: Response,
   next: NextFunction,
 ): Promise<void | Response> {
   try {
-    // Optional API key stop-gap (guarded by ENABLE_API_KEYS)
-    const apiKeyHeader = (req.headers["x-api-key"] as string) || "";
-    if (process.env.ENABLE_API_KEYS === "1" && apiKeyHeader) {
-      const k = apiKeyHeader;
-      const hit = API_KEYS_CACHE.find(x => x.key === k && Date.now() < x.expiresAt);
-      if (hit) {
-        req.user = { id: "api-key", role: hit.scope === "admin" ? "ADMIN" : hit.scope.toUpperCase() };
-        res.setHeader("X-Auth-Method", "api-key"); // auditable
-        return next();
+    const apiKeyHeader = (req.headers['x-api-key'] as string) || '';
+    if (apiKeyHeader) {
+      const apiKeyRecord = await getApiKeyService().validateKey(apiKeyHeader);
+      if (!apiKeyRecord) {
+        return res.status(401).json({ error: 'Unauthorized' });
       }
+
+      req.user = {
+        id: `api-key:${apiKeyRecord.id}`,
+        role: apiKeyRecord.scope,
+        tenantId: apiKeyRecord.tenantId ?? undefined,
+        type: 'API_KEY',
+        name: apiKeyRecord.name,
+      };
+      res.setHeader('X-Auth-Method', 'api-key');
+      return next();
     }
 
     const auth = req.headers.authorization || '';

--- a/server/src/services/ApiKeyService.ts
+++ b/server/src/services/ApiKeyService.ts
@@ -1,0 +1,147 @@
+import { randomBytes, createHash } from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
+import { Pool } from 'pg';
+import { getPostgresPool } from '../db/postgres.js';
+
+export type ApiKeyScope = 'VIEWER' | 'ANALYST' | 'OPERATOR' | 'ADMIN';
+
+export interface ApiKeyRecord {
+  id: string;
+  name: string;
+  scope: ApiKeyScope;
+  tenantId: string | null;
+  createdBy: string | null;
+  createdAt: Date;
+  expiresAt: Date;
+  revokedAt: Date | null;
+  revokedBy: string | null;
+  lastUsedAt: Date | null;
+}
+
+interface CreateApiKeyOptions {
+  name: string;
+  scope: ApiKeyScope;
+  expiresAt: Date;
+  createdBy: string | null;
+  tenantId: string | null;
+}
+
+interface ListOptions {
+  tenantId: string | null;
+  includeRevoked?: boolean;
+}
+
+export default class ApiKeyService {
+  private pool: Pool;
+
+  constructor(pool: Pool = getPostgresPool()) {
+    this.pool = pool;
+  }
+
+  async listKeys(options: ListOptions): Promise<ApiKeyRecord[]> {
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+
+    if (options.tenantId) {
+      conditions.push(`tenant_id = $${params.length + 1}`);
+      params.push(options.tenantId);
+    }
+
+    if (!options.includeRevoked) {
+      conditions.push(`revoked_at IS NULL`);
+      conditions.push(`expires_at > NOW()`);
+    }
+
+    let query =
+      'SELECT id, name, scope, tenant_id, created_by, created_at, expires_at, revoked_at, revoked_by, last_used_at FROM api_keys';
+
+    if (conditions.length > 0) {
+      query += ` WHERE ${conditions.join(' AND ')}`;
+    }
+
+    query += ' ORDER BY created_at DESC';
+
+    const { rows } = await this.pool.query(query, params);
+    return rows.map((row) => this.mapRow(row));
+  }
+
+  async createKey(options: CreateApiKeyOptions): Promise<{ secret: string; apiKey: ApiKeyRecord }> {
+    const id = uuidv4();
+    const secret = this.generateSecret();
+    const hash = this.hashSecret(secret);
+
+    const { rows } = await this.pool.query(
+      `INSERT INTO api_keys (id, name, key_hash, scope, tenant_id, created_by, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)
+       RETURNING id, name, scope, tenant_id, created_by, created_at, expires_at, revoked_at, revoked_by, last_used_at`,
+      [id, options.name, hash, options.scope, options.tenantId, options.createdBy, options.expiresAt],
+    );
+
+    const apiKey = this.mapRow(rows[0]);
+    return { secret, apiKey };
+  }
+
+  async revokeKey(id: string, revokedBy: string | null): Promise<ApiKeyRecord> {
+    const { rows } = await this.pool.query(
+      `UPDATE api_keys
+       SET revoked_at = NOW(), revoked_by = $2
+       WHERE id = $1 AND revoked_at IS NULL
+       RETURNING id, name, scope, tenant_id, created_by, created_at, expires_at, revoked_at, revoked_by, last_used_at`,
+      [id, revokedBy],
+    );
+
+    if (rows.length === 0) {
+      throw new Error('API key not found or already revoked');
+    }
+
+    return this.mapRow(rows[0]);
+  }
+
+  async validateKey(rawKey: string): Promise<ApiKeyRecord | null> {
+    const hash = this.hashSecret(rawKey);
+    const { rows } = await this.pool.query(
+      `SELECT id, name, scope, tenant_id, created_by, created_at, expires_at, revoked_at, revoked_by, last_used_at
+       FROM api_keys
+       WHERE key_hash = $1`,
+      [hash],
+    );
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    const record = this.mapRow(rows[0]);
+
+    if (record.revokedAt || record.expiresAt.getTime() <= Date.now()) {
+      return null;
+    }
+
+    await this.pool.query('UPDATE api_keys SET last_used_at = NOW() WHERE id = $1', [record.id]);
+
+    return record;
+  }
+
+  private generateSecret(): string {
+    const token = randomBytes(32).toString('hex');
+    return `sk_${token}`;
+  }
+
+  private hashSecret(secret: string): string {
+    return createHash('sha256').update(secret).digest('hex');
+  }
+
+  private mapRow(row: any): ApiKeyRecord {
+    return {
+      id: row.id,
+      name: row.name,
+      scope: row.scope,
+      tenantId: row.tenant_id ?? null,
+      createdBy: row.created_by ?? null,
+      createdAt: new Date(row.created_at),
+      expiresAt: new Date(row.expires_at),
+      revokedAt: row.revoked_at ? new Date(row.revoked_at) : null,
+      revokedBy: row.revoked_by ?? null,
+      lastUsedAt: row.last_used_at ? new Date(row.last_used_at) : null,
+    };
+  }
+}

--- a/server/tests/api-key.service.test.ts
+++ b/server/tests/api-key.service.test.ts
@@ -1,0 +1,156 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import * as crypto from 'crypto';
+import ApiKeyService from '../src/services/ApiKeyService.js';
+
+jest.mock('../src/db/postgres.js', () => ({
+  getPostgresPool: jest.fn(),
+}));
+
+describe('ApiKeyService', () => {
+  let service: ApiKeyService;
+  let mockPool: { query: jest.Mock };
+
+  beforeEach(() => {
+    const { getPostgresPool } = require('../src/db/postgres.js');
+    mockPool = {
+      query: jest.fn(),
+    };
+    getPostgresPool.mockReturnValue(mockPool);
+    service = new ApiKeyService();
+  });
+
+  afterEach(() => {
+    const { getPostgresPool } = require('../src/db/postgres.js');
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+    getPostgresPool.mockReset();
+  });
+
+  it('creates API keys with hashed secrets', async () => {
+    const randomSpy = jest
+      .spyOn(crypto, 'randomBytes')
+      .mockReturnValue(Buffer.from('fixture-secret'));
+
+    const now = new Date('2025-09-01T00:00:00Z');
+
+    mockPool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'key-123',
+          name: 'Integration',
+          scope: 'VIEWER',
+          tenant_id: null,
+          created_by: 'admin-user',
+          created_at: now,
+          expires_at: now,
+          revoked_at: null,
+          revoked_by: null,
+          last_used_at: null,
+        },
+      ],
+    });
+
+    const result = await service.createKey({
+      name: 'Integration',
+      scope: 'VIEWER',
+      expiresAt: now,
+      createdBy: 'admin-user',
+      tenantId: null,
+    });
+
+    const expectedSecret = `sk_${Buffer.from('fixture-secret').toString('hex')}`;
+    const expectedHash = crypto.createHash('sha256').update(expectedSecret).digest('hex');
+    const insertArgs = mockPool.query.mock.calls[0][1];
+
+    expect(randomSpy).toHaveBeenCalled();
+    expect(insertArgs[2]).toEqual(expectedHash);
+    expect(result.secret).toEqual(expectedSecret);
+    expect(result.apiKey).toMatchObject({
+      id: 'key-123',
+      name: 'Integration',
+      scope: 'VIEWER',
+    });
+  });
+
+  it('validates active API keys and updates last used timestamp', async () => {
+    const expires = new Date(Date.now() + 3600_000);
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'key-abc',
+            name: 'Partner',
+            scope: 'VIEWER',
+            tenant_id: 'tenant-1',
+            created_by: 'admin',
+            created_at: new Date(),
+            expires_at: expires,
+            revoked_at: null,
+            revoked_by: null,
+            last_used_at: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await service.validateKey('sk_sample');
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toEqual('key-abc');
+    expect(mockPool.query).toHaveBeenCalledWith('UPDATE api_keys SET last_used_at = NOW() WHERE id = $1', ['key-abc']);
+  });
+
+  it('rejects expired keys without updating usage metadata', async () => {
+    const expires = new Date(Date.now() - 60_000);
+    mockPool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'expired-key',
+          name: 'Legacy',
+          scope: 'VIEWER',
+          tenant_id: null,
+          created_by: 'admin',
+          created_at: new Date(),
+          expires_at: expires,
+          revoked_at: null,
+          revoked_by: null,
+          last_used_at: null,
+        },
+      ],
+    });
+
+    const result = await service.validateKey('sk_expired');
+
+    expect(result).toBeNull();
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('revokes keys and returns updated record', async () => {
+    const now = new Date();
+    mockPool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'key-to-revoke',
+          name: 'Integration',
+          scope: 'VIEWER',
+          tenant_id: null,
+          created_by: 'admin',
+          created_at: now,
+          expires_at: new Date(now.getTime() + 3600_000),
+          revoked_at: now,
+          revoked_by: 'admin',
+          last_used_at: null,
+        },
+      ],
+    });
+
+    const result = await service.revokeKey('key-to-revoke', 'admin');
+
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE api_keys'),
+      ['key-to-revoke', 'admin'],
+    );
+    expect(result.revokedBy).toEqual('admin');
+    expect(result.revokedAt).toBeInstanceOf(Date);
+  });
+});


### PR DESCRIPTION
## Summary
- add a PostgreSQL migration and service for issuing, validating, and revoking API keys with hashed storage and auditing fields
- update authentication middleware plus GraphQL schema/resolvers to expose admin-only key management mutations and queries
- document the workflow and cover the new service and resolvers with targeted Jest specs

## Testing
- `npm test -- api-key` *(fails: jest binary missing because workspace installation relies on unsupported `workspace:*` protocol in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6dd2dcae083339f729fda55fe3240