### PR TITLE
feat: add onboarding wizard with persisted progress

### DIFF
--- a/client/src/App.router.jsx
+++ b/client/src/App.router.jsx
@@ -40,6 +40,7 @@ import {
   Map,
   Assessment,
   Settings,
+  School,
 } from '@mui/icons-material';
 import { getIntelGraphTheme } from './theme/intelgraphTheme';
 import { store } from './store';
@@ -58,6 +59,7 @@ import ExecutiveDashboard from './features/wargame/ExecutiveDashboard'; // WAR-G
 import { MilitaryTech } from '@mui/icons-material'; // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
 import AccessIntelPage from './features/rbac/AccessIntelPage.jsx';
 import ConductorStudio from './features/conductor/ConductorStudio.tsx';
+import OnboardingWizard from './features/onboarding/OnboardingWizard';
 import VisualPipelines from './pages/VisualPipelines.tsx';
 import ExecutorsPage from './pages/Executors.tsx';
 import MCPRegistry from './pages/MCPRegistry.tsx';
@@ -81,6 +83,7 @@ import RunSearch from './features/conductor/RunSearch';
 // Navigation items
 const navigationItems = [
   { path: '/dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
+  { path: '/onboarding', label: 'Onboarding', icon: <School /> },
   { path: '/investigations', label: 'Timeline', icon: <Search /> },
   { path: '/graph', label: 'Graph Explorer', icon: <Timeline /> },
   { path: '/copilot', label: 'AI Copilot', icon: <Psychology /> },
@@ -199,17 +202,29 @@ function NavigationDrawer({ open, onClose }) {
     <Drawer anchor="left" open={open} onClose={onClose}>
       <Box sx={{ width: 250, mt: 8 }}>
         <List>
-          {items.map((item) => (
-            <ListItem
-              key={item.path}
-              button
-              selected={location.pathname === item.path}
-              onClick={() => handleNavigation(item)}
-            >
-              <ListItemIcon>{item.icon}</ListItemIcon>
-              <ListItemText primary={item.label} />
-            </ListItem>
-          ))}
+          {items.map((item) => {
+            const sanitized = (item.path || item.label || 'nav')
+              .toString()
+              .replace(/^https?:\/\//, '')
+              .replace(/^\//, '')
+              .replace(/[^a-z0-9]+/gi, '-')
+              .replace(/^-+|-+$/g, '')
+              .toLowerCase();
+            const testId = `${sanitized || 'nav-item'}-nav`;
+
+            return (
+              <ListItem
+                key={item.path}
+                button
+                selected={location.pathname === item.path}
+                onClick={() => handleNavigation(item)}
+                data-testid={testId}
+              >
+                <ListItemIcon>{item.icon}</ListItemIcon>
+                <ListItemText primary={item.label} />
+              </ListItem>
+            );
+          })}
         </List>
       </Box>
     </Drawer>
@@ -635,6 +650,7 @@ function MainLayout() {
           <Route element={<ProtectedRoute />}>
             <Route path="/" element={<Navigate to="/dashboard" replace />} />
             <Route path="/dashboard" element={<DashboardPage />} />
+            <Route path="/onboarding" element={<OnboardingWizard />} />
             <Route path="/investigations" element={<InvestigationsPage />} />
             <Route path="/graph" element={<GraphExplorerPage />} />
             <Route path="/copilot" element={<CopilotPage />} />

--- a/client/src/features/onboarding/OnboardingWizard.tsx
+++ b/client/src/features/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,410 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Grid,
+  LinearProgress,
+  MenuItem,
+  Stack,
+  Step,
+  StepButton,
+  Stepper,
+  TextField,
+  Typography,
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import PendingActionsIcon from '@mui/icons-material/PendingActions';
+import ReplayIcon from '@mui/icons-material/Replay';
+import SaveAltIcon from '@mui/icons-material/SaveAlt';
+import VerifiedIcon from '@mui/icons-material/Verified';
+import { useMutation, useQuery } from '@apollo/client';
+import { useAuth } from '../../context/AuthContext.jsx';
+import { useAppDispatch, useAppSelector } from '../../store';
+import {
+  hydrateProgress,
+  resetLocal,
+  setCurrentStep,
+  setError,
+  setLoading,
+  type OnboardingStep,
+} from '../../store/slices/onboardingSlice';
+import {
+  ONBOARDING_PROGRESS,
+  RESET_ONBOARDING_PROGRESS,
+  UPSERT_ONBOARDING_STEP,
+} from '../../graphql/onboarding.gql.js';
+
+const STEP_FIELD_CONFIG: Record<
+  string,
+  Array<
+    {
+      name: string;
+      label: string;
+      type?: 'text' | 'textarea' | 'select';
+      placeholder?: string;
+      helperText?: string;
+      options?: Array<{ label: string; value: string }>;
+    }
+  >
+> = {
+  'connect-data': [
+    {
+      name: 'sourceType',
+      label: 'Source Type',
+      type: 'select',
+      options: [
+        { label: 'PostgreSQL', value: 'postgres' },
+        { label: 'Snowflake', value: 'snowflake' },
+        { label: 'Kafka Topic', value: 'kafka' },
+        { label: 'REST API', value: 'rest' },
+      ],
+    },
+    {
+      name: 'connectionUri',
+      label: 'Connection URI',
+      placeholder: 'postgresql://user:pass@host:5432/database',
+      helperText: 'Use a read-only credential; secrets are stored in Vault in production.',
+    },
+  ],
+  'map-entities': [
+    {
+      name: 'entityModel',
+      label: 'Entity Model Template',
+      type: 'select',
+      options: [
+        { label: 'Threat Intelligence', value: 'threat-intel' },
+        { label: 'Supply Chain', value: 'supply-chain' },
+        { label: 'Financial Crimes', value: 'financial-crimes' },
+        { label: 'Custom Schema', value: 'custom' },
+      ],
+    },
+    {
+      name: 'fieldMappings',
+      label: 'Field → Property Mappings',
+      type: 'textarea',
+      placeholder: 'source_field -> entity.property',
+      helperText: 'Document key mappings, e.g. `acct_id -> Account.externalId`',
+    },
+  ],
+  'create-first-query': [
+    {
+      name: 'queryName',
+      label: 'Saved Query Name',
+      placeholder: 'First Ingestion Validation',
+    },
+    {
+      name: 'cypher',
+      label: 'Cypher or GraphQL Query',
+      type: 'textarea',
+      placeholder: 'MATCH (p:Person)-[:CONNECTED_TO]->(c:Company) RETURN p, c LIMIT 25',
+      helperText: 'Store parametrized queries so analysts can reuse them.',
+    },
+  ],
+  'share-insights': [
+    {
+      name: 'audience',
+      label: 'Target Audience',
+      placeholder: 'Intel Operations, Fusion Center, etc.',
+    },
+    {
+      name: 'deliveryChannel',
+      label: 'Delivery Channel',
+      type: 'select',
+      options: [
+        { label: 'Email Digest', value: 'email' },
+        { label: 'Slack Notification', value: 'slack' },
+        { label: 'PagerDuty On-Call', value: 'pagerduty' },
+        { label: 'ServiceNow Ticket', value: 'servicenow' },
+      ],
+    },
+    {
+      name: 'notes',
+      label: 'Launch Notes',
+      type: 'textarea',
+      placeholder: 'Share acceptance criteria, dashboards, or alert routing.',
+    },
+  ],
+};
+
+type StepFormState = Record<string, Record<string, string>>;
+
+function getInitialFormState(steps: OnboardingStep[]): StepFormState {
+  return steps.reduce<StepFormState>((acc, step) => {
+    const entries = STEP_FIELD_CONFIG[step.key] ?? [];
+    const data = (step.data as Record<string, string> | null) ?? {};
+    acc[step.key] = entries.reduce<Record<string, string>>((fields, field) => {
+      fields[field.name] = data[field.name] ?? '';
+      return fields;
+    }, {});
+    return acc;
+  }, {});
+}
+
+export default function OnboardingWizard() {
+  const dispatch = useAppDispatch();
+  const { user, loading: authLoading } = useAuth();
+  const { steps, currentStepKey, loading, error, lastSyncedAt } = useAppSelector((state) => state.onboarding);
+  const [formState, setFormState] = useState<StepFormState>(() => getInitialFormState(steps));
+
+  const userId = user?.id ?? 'demo-user';
+
+  const {
+    data,
+    loading: queryLoading,
+    error: queryError,
+    refetch,
+  } = useQuery(ONBOARDING_PROGRESS, {
+    variables: { userId },
+    skip: !userId,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const [upsertStep, { loading: mutationLoading }] = useMutation(UPSERT_ONBOARDING_STEP);
+  const [resetProgress, { loading: resetLoading }] = useMutation(RESET_ONBOARDING_PROGRESS);
+
+  useEffect(() => {
+    dispatch(setLoading(authLoading || queryLoading));
+  }, [authLoading, queryLoading, dispatch]);
+
+  useEffect(() => {
+    if (queryError) {
+      dispatch(setError(queryError.message));
+    }
+  }, [queryError, dispatch]);
+
+  useEffect(() => {
+    if (data?.onboardingProgress) {
+      dispatch(hydrateProgress(data.onboardingProgress));
+    }
+  }, [data, dispatch]);
+
+  useEffect(() => {
+    setFormState(getInitialFormState(steps));
+  }, [steps]);
+
+  const activeStepIndex = useMemo(() => {
+    if (!currentStepKey) {
+      return steps.length;
+    }
+    const index = steps.findIndex((step) => step.key === currentStepKey);
+    return index >= 0 ? index : 0;
+  }, [steps, currentStepKey]);
+
+  const activeStep = steps[activeStepIndex] ?? steps[steps.length - 1];
+  const completedCount = steps.filter((step) => step.completed).length;
+  const progressPercent = steps.length === 0 ? 0 : Math.round((completedCount / steps.length) * 100);
+
+  const handleFieldChange = (stepKey: string, fieldName: string, value: string) => {
+    setFormState((prev) => ({
+      ...prev,
+      [stepKey]: {
+        ...(prev[stepKey] ?? {}),
+        [fieldName]: value,
+      },
+    }));
+  };
+
+  const persistStep = async (stepKey: string, shouldComplete: boolean) => {
+    const payload = {
+      input: {
+        userId,
+        stepKey,
+        completed: shouldComplete,
+        status: shouldComplete ? 'COMPLETED' : 'IN_PROGRESS',
+        data: formState[stepKey] ?? {},
+      },
+    };
+
+    try {
+      const result = await upsertStep({ variables: payload });
+      if (result.data?.upsertOnboardingStep) {
+        dispatch(hydrateProgress(result.data.upsertOnboardingStep));
+      }
+    } catch (mutationError) {
+      dispatch(setError((mutationError as Error).message));
+    }
+  };
+
+  const handleReset = async () => {
+    try {
+      await resetProgress({ variables: { userId } });
+      dispatch(resetLocal());
+      await refetch();
+    } catch (resetError) {
+      dispatch(setError((resetError as Error).message));
+    }
+  };
+
+  const renderField = (stepKey: string, fieldConfig: (typeof STEP_FIELD_CONFIG)['connect-data'][number]) => {
+    const value = formState[stepKey]?.[fieldConfig.name] ?? '';
+
+    if (fieldConfig.type === 'select') {
+      return (
+        <TextField
+          key={fieldConfig.name}
+          select
+          fullWidth
+          label={fieldConfig.label}
+          value={value}
+          onChange={(event) => handleFieldChange(stepKey, fieldConfig.name, event.target.value)}
+          helperText={fieldConfig.helperText}
+          data-testid={`field-${stepKey}-${fieldConfig.name}`}
+        >
+          {(fieldConfig.options ?? []).map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              {option.label}
+            </MenuItem>
+          ))}
+        </TextField>
+      );
+    }
+
+    return (
+      <TextField
+        key={fieldConfig.name}
+        fullWidth
+        multiline={fieldConfig.type === 'textarea'}
+        minRows={fieldConfig.type === 'textarea' ? 3 : undefined}
+        label={fieldConfig.label}
+        value={value}
+        placeholder={fieldConfig.placeholder}
+        helperText={fieldConfig.helperText}
+        onChange={(event) => handleFieldChange(stepKey, fieldConfig.name, event.target.value)}
+        data-testid={`field-${stepKey}-${fieldConfig.name}`}
+      />
+    );
+  };
+
+  return (
+    <Box data-testid="onboarding-wizard" sx={{ maxWidth: 1200, margin: '0 auto', py: 4 }}>
+      <Stack spacing={3}>
+        <Box>
+          <Typography variant="h3" gutterBottom>
+            Welcome to Summit Onboarding
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            Follow the guided wizard to connect your first dataset, model entities, and publish actionable insights. Progress is
+            saved automatically via GraphQL so you can pause and resume at any time.
+          </Typography>
+        </Box>
+
+        {(loading || mutationLoading || resetLoading) && <LinearProgress data-testid="onboarding-loading" />}
+
+        {error && (
+          <Alert severity="error" data-testid="onboarding-error">
+            {error}
+          </Alert>
+        )}
+
+        <Card>
+          <CardContent>
+            <Stack spacing={2}>
+              <Box display="flex" alignItems="center" justifyContent="space-between">
+                <Typography variant="h6">Setup Progress</Typography>
+                <Chip
+                  color={completedCount === steps.length && steps.length > 0 ? 'success' : 'info'}
+                  icon={completedCount === steps.length && steps.length > 0 ? <VerifiedIcon /> : <PendingActionsIcon />}
+                  label={`${completedCount}/${steps.length} steps complete`}
+                  data-testid="onboarding-summary"
+                />
+              </Box>
+              <LinearProgress
+                variant="determinate"
+                value={progressPercent}
+                sx={{ height: 10, borderRadius: 5 }}
+                data-testid="onboarding-progress-bar"
+              />
+              <Typography variant="caption" color="text.secondary" data-testid="onboarding-progress-percent">
+                {progressPercent}% complete{lastSyncedAt ? ` · Last synced ${new Date(lastSyncedAt).toLocaleTimeString()}` : ''}
+              </Typography>
+            </Stack>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <Stepper activeStep={activeStepIndex} alternativeLabel>
+              {steps.map((step) => (
+                <Step key={step.key} completed={step.completed} data-testid={`onboarding-step-${step.key}`}>
+                  <StepButton onClick={() => dispatch(setCurrentStep(step.key))} data-testid={`step-button-${step.key}`}>
+                    {step.title}
+                  </StepButton>
+                </Step>
+              ))}
+            </Stepper>
+          </CardContent>
+        </Card>
+
+        {activeStep && (
+          <Card data-testid={`onboarding-detail-${activeStep.key}`}>
+            <CardContent>
+              <Stack spacing={3}>
+                <Box display="flex" alignItems="center" justifyContent="space-between">
+                  <Box>
+                    <Typography variant="h5" gutterBottom>
+                      {activeStep.title}
+                    </Typography>
+                    <Typography variant="body1" color="text.secondary">
+                      {activeStep.description}
+                    </Typography>
+                  </Box>
+                  <Chip
+                    color={activeStep.completed ? 'success' : activeStep.status === 'IN_PROGRESS' ? 'warning' : 'default'}
+                    icon={activeStep.completed ? <CheckCircleIcon /> : <PendingActionsIcon />}
+                    label={activeStep.completed ? 'Completed' : activeStep.status === 'IN_PROGRESS' ? 'In Progress' : 'Not Started'}
+                    data-testid={`step-status-${activeStep.key}`}
+                  />
+                </Box>
+
+                <Grid container spacing={2}>
+                  {(STEP_FIELD_CONFIG[activeStep.key] ?? []).map((field) => (
+                    <Grid item xs={12} md={field.type === 'textarea' ? 12 : 6} key={field.name}>
+                      {renderField(activeStep.key, field)}
+                    </Grid>
+                  ))}
+                </Grid>
+
+                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    startIcon={<SaveAltIcon />}
+                    onClick={() => persistStep(activeStep.key, false)}
+                    disabled={mutationLoading}
+                    data-testid={`save-step-${activeStep.key}`}
+                  >
+                    Save Progress
+                  </Button>
+                  <Button
+                    variant="contained"
+                    color="success"
+                    startIcon={<CheckCircleIcon />}
+                    onClick={() => persistStep(activeStep.key, true)}
+                    disabled={mutationLoading || activeStep.completed}
+                    data-testid={`complete-step-${activeStep.key}`}
+                  >
+                    Mark Step Complete
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    color="inherit"
+                    startIcon={<ReplayIcon />}
+                    onClick={handleReset}
+                    disabled={resetLoading}
+                    data-testid="reset-onboarding"
+                  >
+                    Restart Wizard
+                  </Button>
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        )}
+      </Stack>
+    </Box>
+  );
+}

--- a/client/src/graphql/onboarding.gql.js
+++ b/client/src/graphql/onboarding.gql.js
@@ -1,0 +1,49 @@
+import { gql } from '@apollo/client';
+
+export const ONBOARDING_PROGRESS = gql`
+  query OnboardingProgress($userId: ID!) {
+    onboardingProgress(userId: $userId) {
+      userId
+      currentStepKey
+      completed
+      completedAt
+      steps {
+        key
+        title
+        description
+        status
+        completed
+        data
+        updatedAt
+        completedAt
+      }
+    }
+  }
+`;
+
+export const UPSERT_ONBOARDING_STEP = gql`
+  mutation UpsertOnboardingStep($input: OnboardingStepInput!) {
+    upsertOnboardingStep(input: $input) {
+      userId
+      currentStepKey
+      completed
+      completedAt
+      steps {
+        key
+        title
+        description
+        status
+        completed
+        data
+        updatedAt
+        completedAt
+      }
+    }
+  }
+`;
+
+export const RESET_ONBOARDING_PROGRESS = gql`
+  mutation ResetOnboardingProgress($userId: ID!) {
+    resetOnboardingProgress(userId: $userId)
+  }
+`;

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -8,6 +8,7 @@ import aiInsightsReducer from './slices/aiInsightsSlice'; // Import the new aiIn
 import timelineReducer from './slices/timelineSlice';
 import graphData from './graphSlice';
 import socket from './socketSlice';
+import onboarding from './slices/onboardingSlice.ts';
 
 export const store = configureStore({
   reducer: {
@@ -20,6 +21,7 @@ export const store = configureStore({
     aiInsights: aiInsightsReducer, // Add the new aiInsightsReducer
     graphData,
     socket,
+    onboarding,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({

--- a/client/src/store/index.ts
+++ b/client/src/store/index.ts
@@ -1,9 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
 import ui from './slices/ui';
+import onboarding from './slices/onboardingSlice';
 
 const store = configureStore({
-  reducer: { ui },
+  reducer: { ui, onboarding },
 });
 
 export type RootState = ReturnType<typeof store.getState>;
@@ -11,4 +12,5 @@ export type AppDispatch = typeof store.dispatch;
 export const useAppDispatch: () => AppDispatch = useDispatch as any;
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
 
+export { store };
 export default store;

--- a/client/src/store/slices/onboardingSlice.ts
+++ b/client/src/store/slices/onboardingSlice.ts
@@ -1,0 +1,137 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export type OnboardingStepStatus = 'NOT_STARTED' | 'IN_PROGRESS' | 'COMPLETED';
+
+export interface OnboardingStep {
+  key: string;
+  title: string;
+  description: string;
+  status: OnboardingStepStatus;
+  completed: boolean;
+  data: Record<string, unknown> | null;
+  updatedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface OnboardingProgress {
+  userId: string;
+  steps: OnboardingStep[];
+  currentStepKey: string | null;
+  completed: boolean;
+  completedAt: string | null;
+}
+
+export interface OnboardingState {
+  steps: OnboardingStep[];
+  currentStepKey: string | null;
+  loading: boolean;
+  error: string | null;
+  lastSyncedAt: string | null;
+}
+
+export const DEFAULT_ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    key: 'connect-data',
+    title: 'Connect Data Sources',
+    description: 'Authenticate a connector and configure ingestion cadence so IntelGraph can mirror your source systems.',
+    status: 'NOT_STARTED',
+    completed: false,
+    data: null,
+    updatedAt: null,
+    completedAt: null,
+  },
+  {
+    key: 'map-entities',
+    title: 'Model Entities & Relationships',
+    description: 'Define how source fields map into graph entities and relationships for explainable analytics.',
+    status: 'NOT_STARTED',
+    completed: false,
+    data: null,
+    updatedAt: null,
+    completedAt: null,
+  },
+  {
+    key: 'create-first-query',
+    title: 'Create Your First Query',
+    description: 'Build and execute a starter query to validate the ingestion and model configuration.',
+    status: 'NOT_STARTED',
+    completed: false,
+    data: null,
+    updatedAt: null,
+    completedAt: null,
+  },
+  {
+    key: 'share-insights',
+    title: 'Share Insights with Stakeholders',
+    description: 'Publish dashboards or alerts so downstream teams can operationalize the findings.',
+    status: 'NOT_STARTED',
+    completed: false,
+    data: null,
+    updatedAt: null,
+    completedAt: null,
+  },
+];
+
+const initialState: OnboardingState = {
+  steps: DEFAULT_ONBOARDING_STEPS.map((step) => ({ ...step })),
+  currentStepKey: DEFAULT_ONBOARDING_STEPS[0]?.key ?? null,
+  loading: false,
+  error: null,
+  lastSyncedAt: null,
+};
+
+function mergeSteps(base: OnboardingStep[], incoming: OnboardingStep[]): OnboardingStep[] {
+  const incomingMap = new Map(incoming.map((step) => [step.key, step]));
+  return base.map((step) => {
+    const override = incomingMap.get(step.key);
+    if (!override) {
+      return { ...step };
+    }
+    return {
+      ...step,
+      ...override,
+      data: override.data ?? null,
+      updatedAt: override.updatedAt ?? step.updatedAt,
+      completedAt: override.completedAt ?? step.completedAt,
+    };
+  });
+}
+
+const onboardingSlice = createSlice({
+  name: 'onboarding',
+  initialState,
+  reducers: {
+    setLoading(state, action: PayloadAction<boolean>) {
+      state.loading = action.payload;
+      if (action.payload) {
+        state.error = null;
+      }
+    },
+    setError(state, action: PayloadAction<string | null>) {
+      state.error = action.payload;
+    },
+    setCurrentStep(state, action: PayloadAction<string | null>) {
+      state.currentStepKey = action.payload;
+    },
+    hydrateProgress(state, action: PayloadAction<OnboardingProgress>) {
+      const merged = mergeSteps(DEFAULT_ONBOARDING_STEPS, action.payload.steps ?? []);
+      state.steps = merged;
+      state.currentStepKey =
+        action.payload.currentStepKey || merged.find((step) => !step.completed)?.key || merged[merged.length - 1]?.key || null;
+      state.loading = false;
+      state.error = null;
+      state.lastSyncedAt = new Date().toISOString();
+    },
+    resetLocal(state) {
+      state.steps = DEFAULT_ONBOARDING_STEPS.map((step) => ({ ...step }));
+      state.currentStepKey = DEFAULT_ONBOARDING_STEPS[0]?.key ?? null;
+      state.loading = false;
+      state.error = null;
+      state.lastSyncedAt = null;
+    },
+  },
+});
+
+export const { setLoading, setError, setCurrentStep, hydrateProgress, resetLocal } = onboardingSlice.actions;
+
+export default onboardingSlice.reducer;

--- a/client/tests/e2e/onboarding-wizard.spec.ts
+++ b/client/tests/e2e/onboarding-wizard.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+const SELECT_TIMEOUT = { timeout: 10000 };
+
+test.describe('Onboarding Wizard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/onboarding');
+    await expect(page.getByTestId('onboarding-wizard')).toBeVisible(SELECT_TIMEOUT);
+  });
+
+  test('completes the connect data step and persists progress', async ({ page }) => {
+    const sourceTypeField = page.getByTestId('field-connect-data-sourceType');
+    await sourceTypeField.click();
+    await page.getByRole('option', { name: 'PostgreSQL' }).click();
+
+    await page.getByTestId('field-connect-data-connectionUri').fill('postgresql://demo:demo@localhost:5432/intelgraph');
+
+    await page.getByTestId('save-step-connect-data').click();
+    await expect(page.getByTestId('step-status-connect-data')).toContainText(/In Progress|Completed/);
+
+    await page.getByTestId('complete-step-connect-data').click();
+    await expect(page.getByTestId('step-status-connect-data')).toHaveText(/Completed/i);
+
+    await expect(page.getByTestId('onboarding-progress-percent')).toContainText('% complete');
+
+    await page.reload();
+    await expect(page.getByTestId('onboarding-wizard')).toBeVisible(SELECT_TIMEOUT);
+    await expect(page.getByTestId('step-status-connect-data')).toContainText(/Completed/i);
+  });
+});

--- a/docs/onboarding/interactive-wizard.md
+++ b/docs/onboarding/interactive-wizard.md
@@ -1,0 +1,49 @@
+# Summit Interactive Onboarding Wizard
+
+The onboarding wizard gives new Summit users a guided setup to connect data sources, model entities, create queries, and share dashboards. Progress is persisted through the Summit GraphQL API and stored in PostgreSQL so teams can pause and resume onboarding without losing state.
+
+## Feature Overview
+
+- **Redux-managed state** keeps the wizard responsive and synchronised across components.
+- **GraphQL-backed persistence** guarantees step completion and form data is stored in the `onboarding_progress` table.
+- **Material UI stepper experience** walks users through each milestone with contextual helper text.
+- **Playwright E2E coverage** verifies that core interactions (saving and completing steps) work end-to-end.
+
+### Default Steps
+
+1. **Connect Data Sources** – configure connectors and ingestion cadence.
+2. **Model Entities & Relationships** – align incoming fields with graph entities.
+3. **Create Your First Query** – validate the data pipeline with a saved query.
+4. **Share Insights** – prepare downstream delivery channels for insights.
+
+Each step provides structured inputs and helper text. The wizard exposes data-testid hooks for testing and automation: `onboarding-wizard`, `field-<step>-<field>`, `complete-step-<step>`, etc.
+
+## GraphQL Contract
+
+The wizard integrates with the following mutations and queries:
+
+```graphql
+query OnboardingProgress($userId: ID!) { ... }
+mutation UpsertOnboardingStep($input: OnboardingStepInput!) { ... }
+mutation ResetOnboardingProgress($userId: ID!) { ... }
+```
+
+Schema types are defined in `server/src/graphql/schema/onboarding.ts`. Resolvers live in `server/src/graphql/resolvers/onboarding.ts` and delegate to the `OnboardingProgressRepo` which handles PostgreSQL persistence with an in-memory fallback for local development.
+
+## Database Schema
+
+A migration (`016_onboarding_progress.sql`) creates the `onboarding_progress` table with indexes for user and step lookups plus a trigger that keeps `updated_at` fresh. Insert/upsert logic ensures that completing a step records timestamps while edits remain idempotent.
+
+## Testing Strategy
+
+- **Playwright E2E** – `client/tests/e2e/onboarding-wizard.spec.ts` validates saving and completing the first step survives a reload.
+- **Redux slice** – `client/src/store/slices/onboardingSlice.ts` manages loading state, hydration, and resets.
+
+To run the Playwright test locally:
+
+```bash
+cd client
+npm run test:e2e -- onboarding-wizard.spec.ts
+```
+
+The wizard is accessible via the **Onboarding** navigation item at `/onboarding` once the Summit client is running (`npm run dev`).

--- a/server/src/db/migrations/016_onboarding_progress.sql
+++ b/server/src/db/migrations/016_onboarding_progress.sql
@@ -1,0 +1,33 @@
+-- Onboarding progress tracking table
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+CREATE TABLE IF NOT EXISTS onboarding_progress (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id TEXT NOT NULL,
+  step_key TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'NOT_STARTED',
+  completed BOOLEAN NOT NULL DEFAULT FALSE,
+  data JSONB NOT NULL DEFAULT '{}'::jsonb,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT onboarding_progress_user_step_unique UNIQUE (user_id, step_key)
+);
+
+CREATE INDEX IF NOT EXISTS onboarding_progress_user_idx ON onboarding_progress (user_id);
+CREATE INDEX IF NOT EXISTS onboarding_progress_step_idx ON onboarding_progress (step_key);
+
+-- Trigger to keep updated_at fresh
+CREATE OR REPLACE FUNCTION onboarding_progress_touch_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS onboarding_progress_touch ON onboarding_progress;
+CREATE TRIGGER onboarding_progress_touch
+BEFORE UPDATE ON onboarding_progress
+FOR EACH ROW
+EXECUTE FUNCTION onboarding_progress_touch_updated_at();

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -12,6 +12,7 @@ import { triggerN8nFlow } from '../../integrations/n8n.js';
 import { checkN8nTriggerAllowed } from '../../integrations/n8n-policy.js';
 import { isEnabled as flagEnabled } from '../../featureFlags/flagsmith.js';
 import { doclingResolvers } from './docling.ts';
+import { onboardingResolvers } from './onboarding';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -25,6 +26,7 @@ const resolvers = {
     // Production core resolvers (PostgreSQL + Neo4j)
     ...coreResolvers.Query,
     ...doclingResolvers.Query,
+    ...onboardingResolvers.Query,
     async pipeline(_p: any, args: { id: string }) {
       const { getPipelineDef } = await import('../../db/repositories/pipelines.js');
       return await getPipelineDef(args.id);
@@ -63,6 +65,7 @@ const resolvers = {
     // Production core resolvers
     ...coreResolvers.Mutation,
     ...doclingResolvers.Mutation,
+    ...onboardingResolvers.Mutation,
 
     // Legacy resolvers (will be phased out)
     ...entityResolvers.Mutation,

--- a/server/src/graphql/resolvers/onboarding.ts
+++ b/server/src/graphql/resolvers/onboarding.ts
@@ -1,0 +1,49 @@
+import { OnboardingProgressRepo } from '../../repos/OnboardingProgressRepo.ts';
+import type { OnboardingStepStatus } from '../../repos/OnboardingProgressRepo.ts';
+
+const repo = new OnboardingProgressRepo();
+
+export const onboardingResolvers = {
+  Query: {
+    onboardingProgress: async (_: unknown, args: { userId?: string }, ctx: any) => {
+      const userId = args?.userId || ctx?.user?.id || ctx?.req?.user?.id;
+      if (!userId) {
+        throw new Error('User ID is required to fetch onboarding progress');
+      }
+
+      return await repo.getProgress(userId);
+    },
+  },
+  Mutation: {
+    upsertOnboardingStep: async (
+      _: unknown,
+      args: { input: { userId?: string; stepKey: string; status?: OnboardingStepStatus; completed: boolean; data?: any } },
+      ctx: any,
+    ) => {
+      const { input } = args;
+      const userId = input?.userId || ctx?.user?.id || ctx?.req?.user?.id;
+      if (!userId) {
+        throw new Error('User ID is required to update onboarding progress');
+      }
+
+      return await repo.upsertStep({
+        userId,
+        stepKey: input.stepKey,
+        status: input.status,
+        completed: input.completed,
+        data: input.data ?? null,
+      });
+    },
+    resetOnboardingProgress: async (_: unknown, args: { userId?: string }, ctx: any) => {
+      const userId = args?.userId || ctx?.user?.id || ctx?.req?.user?.id;
+      if (!userId) {
+        throw new Error('User ID is required to reset onboarding progress');
+      }
+
+      await repo.reset(userId);
+      return true;
+    },
+  },
+};
+
+export default onboardingResolvers;

--- a/server/src/graphql/schema/index.ts
+++ b/server/src/graphql/schema/index.ts
@@ -6,6 +6,7 @@ import aiModule from '../schema.ai.js';
 import annotationsModule from '../schema.annotations.js';
 import graphragTypesModule from '../types/graphragTypes.js';
 import { crystalTypeDefs } from '../schema.crystal.js';
+import { onboardingTypeDefs } from './onboarding';
 
 const { copilotTypeDefs } = copilotModule as { copilotTypeDefs: any };
 const { graphTypeDefs } = graphModule as { graphTypeDefs: any };
@@ -39,6 +40,7 @@ export const typeDefs = [
   aiTypeDefs,
   annotationsTypeDefs,
   crystalTypeDefs,
+  onboardingTypeDefs,
 ];
 
 export default typeDefs;

--- a/server/src/graphql/schema/onboarding.ts
+++ b/server/src/graphql/schema/onboarding.ts
@@ -1,0 +1,47 @@
+import { gql } from 'graphql-tag';
+
+export const onboardingTypeDefs = gql`
+  enum OnboardingStepStatus {
+    NOT_STARTED
+    IN_PROGRESS
+    COMPLETED
+  }
+
+  type OnboardingStep {
+    key: String!
+    title: String!
+    description: String!
+    status: OnboardingStepStatus!
+    completed: Boolean!
+    data: JSON
+    updatedAt: DateTime
+    completedAt: DateTime
+  }
+
+  type OnboardingProgress {
+    userId: ID!
+    steps: [OnboardingStep!]!
+    currentStepKey: String
+    completed: Boolean!
+    completedAt: DateTime
+  }
+
+  input OnboardingStepInput {
+    userId: ID!
+    stepKey: String!
+    status: OnboardingStepStatus
+    completed: Boolean!
+    data: JSON
+  }
+
+  extend type Query {
+    onboardingProgress(userId: ID!): OnboardingProgress!
+  }
+
+  extend type Mutation {
+    upsertOnboardingStep(input: OnboardingStepInput!): OnboardingProgress!
+    resetOnboardingProgress(userId: ID!): Boolean!
+  }
+`;
+
+export default onboardingTypeDefs;

--- a/server/src/repos/OnboardingProgressRepo.ts
+++ b/server/src/repos/OnboardingProgressRepo.ts
@@ -1,0 +1,235 @@
+import type { Pool } from 'pg';
+import logger from '../config/logger.js';
+import { getPostgresPool } from '../db/postgres.js';
+
+export type OnboardingStepStatus = 'NOT_STARTED' | 'IN_PROGRESS' | 'COMPLETED';
+
+export interface OnboardingStepRecord {
+  key: string;
+  title: string;
+  description: string;
+  status: OnboardingStepStatus;
+  completed: boolean;
+  data: Record<string, unknown> | null;
+  updatedAt: string | null;
+  completedAt: string | null;
+}
+
+export interface OnboardingProgressRecord {
+  userId: string;
+  steps: OnboardingStepRecord[];
+  currentStepKey: string | null;
+  completed: boolean;
+  completedAt: string | null;
+}
+
+export const DEFAULT_ONBOARDING_STEPS: Array<Pick<OnboardingStepRecord, 'key' | 'title' | 'description'>> = [
+  {
+    key: 'connect-data',
+    title: 'Connect Data Sources',
+    description: 'Authenticate a data source and configure ingestion windows to bring your first dataset online.',
+  },
+  {
+    key: 'map-entities',
+    title: 'Model Entities & Relationships',
+    description: 'Align incoming fields with graph entities and relationships to unlock explainable analytics.',
+  },
+  {
+    key: 'create-first-query',
+    title: 'Create Your First Query',
+    description: 'Author and save a starter Cypher query to validate the ingestion pipeline and surface insights.',
+  },
+  {
+    key: 'share-insights',
+    title: 'Share Insights with Stakeholders',
+    description: 'Publish dashboards or schedule alerts so teammates can act on the intelligence you curated.',
+  },
+];
+
+type StepPersistenceRow = {
+  step_key: string;
+  status: OnboardingStepStatus;
+  completed: boolean;
+  data: Record<string, unknown> | null;
+  completed_at: Date | null;
+  updated_at: Date | null;
+};
+
+export class OnboardingProgressRepo {
+  private readonly pool: Pool;
+  private readonly memoryStore: Map<string, Map<string, OnboardingStepRecord>> = new Map();
+  private readonly log = logger.child({ module: 'OnboardingProgressRepo' });
+
+  constructor(pool?: Pool) {
+    this.pool = pool ?? getPostgresPool();
+  }
+
+  async getProgress(userId: string): Promise<OnboardingProgressRecord> {
+    const dbRows = await this.fetchRows(userId).catch((error) => {
+      this.log.warn({ err: error, userId }, 'Falling back to in-memory onboarding progress store.');
+      return [] as StepPersistenceRow[];
+    });
+
+    const mergedRows = new Map<string, StepPersistenceRow>();
+    for (const row of dbRows) {
+      mergedRows.set(row.step_key, row);
+    }
+
+    const memorySteps = this.memoryStore.get(userId);
+    if (memorySteps) {
+      for (const [key, step] of memorySteps.entries()) {
+        if (!mergedRows.has(key)) {
+          mergedRows.set(key, {
+            step_key: key,
+            status: step.status,
+            completed: step.completed,
+            data: step.data,
+            completed_at: step.completedAt ? new Date(step.completedAt) : null,
+            updated_at: step.updatedAt ? new Date(step.updatedAt) : null,
+          });
+        }
+      }
+    }
+
+    const steps: OnboardingStepRecord[] = DEFAULT_ONBOARDING_STEPS.map((definition) => {
+      const row = mergedRows.get(definition.key);
+      const completed = row?.completed ?? false;
+      const status: OnboardingStepStatus = row?.status
+        ? row.status
+        : completed
+        ? 'COMPLETED'
+        : 'NOT_STARTED';
+
+      return {
+        key: definition.key,
+        title: definition.title,
+        description: definition.description,
+        status,
+        completed,
+        data: (row?.data as Record<string, unknown> | null) ?? null,
+        updatedAt: row?.updated_at ? row.updated_at.toISOString() : null,
+        completedAt: row?.completed_at ? row.completed_at.toISOString() : null,
+      };
+    });
+
+    const completedSteps = steps.filter((step) => step.completed);
+    const completedAt = completedSteps.length === steps.length
+      ? completedSteps.reduce<string | null>((latest, step) => {
+          if (!step.completedAt) {
+            return latest;
+          }
+          if (!latest || step.completedAt > latest) {
+            return step.completedAt;
+          }
+          return latest;
+        }, null)
+      : null;
+
+    const currentStep = steps.find((step) => !step.completed)?.key ?? null;
+
+    return {
+      userId,
+      steps,
+      currentStepKey: currentStep,
+      completed: completedSteps.length === steps.length,
+      completedAt,
+    };
+  }
+
+  async upsertStep(input: {
+    userId: string;
+    stepKey: string;
+    status?: OnboardingStepStatus;
+    completed: boolean;
+    data?: Record<string, unknown> | null;
+  }): Promise<OnboardingProgressRecord> {
+    const { userId, stepKey } = input;
+    const definition = DEFAULT_ONBOARDING_STEPS.find((step) => step.key === stepKey);
+    if (!definition) {
+      throw new Error(`Unknown onboarding step: ${stepKey}`);
+    }
+
+    const status: OnboardingStepStatus = input.completed
+      ? 'COMPLETED'
+      : input.status ?? (input.data && Object.keys(input.data).length > 0 ? 'IN_PROGRESS' : 'NOT_STARTED');
+
+    const data = input.data ?? null;
+
+    const payload = [userId, stepKey, status, input.completed, data];
+
+    const query = `
+      INSERT INTO onboarding_progress (user_id, step_key, status, completed, data, completed_at)
+      VALUES ($1, $2, $3, $4, COALESCE($5::jsonb, '{}'::jsonb), CASE WHEN $4 THEN NOW() ELSE NULL END)
+      ON CONFLICT (user_id, step_key)
+      DO UPDATE
+        SET status = EXCLUDED.status,
+            completed = EXCLUDED.completed,
+            data = EXCLUDED.data,
+            completed_at = CASE
+              WHEN EXCLUDED.completed THEN COALESCE(onboarding_progress.completed_at, NOW())
+              ELSE NULL
+            END,
+            updated_at = NOW()
+      RETURNING step_key, status, completed, data, completed_at, updated_at;
+    `;
+
+    let dbResult: StepPersistenceRow | undefined;
+    try {
+      const result = await this.pool.query(query, payload as any[]);
+      dbResult = result.rows?.[0] as StepPersistenceRow | undefined;
+    } catch (error) {
+      this.log.warn({ err: error, userId, stepKey }, 'Failed to persist onboarding progress to PostgreSQL; using memory store.');
+    }
+
+    const now = new Date().toISOString();
+    const completedAt = input.completed
+      ? dbResult?.completed_at?.toISOString?.() ?? now
+      : null;
+
+    const record: OnboardingStepRecord = {
+      key: stepKey,
+      title: definition.title,
+      description: definition.description,
+      status,
+      completed: input.completed,
+      data,
+      updatedAt: dbResult?.updated_at?.toISOString?.() ?? now,
+      completedAt,
+    };
+
+    const userStore = this.getUserStore(userId);
+    userStore.set(stepKey, record);
+
+    return await this.getProgress(userId);
+  }
+
+  async reset(userId: string): Promise<boolean> {
+    try {
+      await this.pool.query('DELETE FROM onboarding_progress WHERE user_id = $1', [userId]);
+    } catch (error) {
+      this.log.warn({ err: error, userId }, 'Failed to reset onboarding progress in PostgreSQL; clearing memory store only.');
+    }
+
+    this.memoryStore.delete(userId);
+    return true;
+  }
+
+  private getUserStore(userId: string): Map<string, OnboardingStepRecord> {
+    if (!this.memoryStore.has(userId)) {
+      this.memoryStore.set(userId, new Map());
+    }
+
+    return this.memoryStore.get(userId)!;
+  }
+
+  private async fetchRows(userId: string): Promise<StepPersistenceRow[]> {
+    const result = await this.pool.query<StepPersistenceRow>(
+      `SELECT step_key, status, completed, data, completed_at, updated_at
+       FROM onboarding_progress
+       WHERE user_id = $1`,
+      [userId],
+    );
+
+    return result.rows ?? [];
+  }
+}


### PR DESCRIPTION
## Summary
- add a Redux-backed onboarding wizard with Material UI stepper and navigation entry
- expose onboarding GraphQL schema, resolvers, and Postgres repo with migration for persisted step data
- document the flow, ship supporting client GraphQL hooks, and cover the wizard with Playwright E2E test

## Testing
- `npm run lint -- --max-warnings=0` *(fails: Missing dev dependency `globals` in eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e482b06c833393c1792d87536c62