### PR TITLE
feat: add data preview step to ingest wizard

### DIFF
--- a/packages/ingest-wizard/package.json
+++ b/packages/ingest-wizard/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "dev": "tsc --watch",
     "test": "jest",
-    "lint": "eslint src --ext .ts,.tsx",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -24,12 +24,16 @@
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
+    "@types/node": "^20.11.5",
     "typescript": "^5.3.0",
     "jest": "^29.7.0",
     "@types/jest": "^29.5.0",
     "eslint": "^8.56.0",
     "@typescript-eslint/eslint-plugin": "^6.19.0",
-    "@typescript-eslint/parser": "^6.19.0"
+    "@typescript-eslint/parser": "^6.19.0",
+    "@playwright/test": "^1.55.0",
+    "@storybook/react": "^7.6.6",
+    "@eslint/js": "^8.57.1"
   },
   "peerDependencies": {
     "react": "^18.0.0",

--- a/packages/ingest-wizard/src/DataPreviewTable.tsx
+++ b/packages/ingest-wizard/src/DataPreviewTable.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+
+export type DataPreviewScalar = string | number | boolean | null | undefined;
+
+export interface DataPreviewRow {
+  [key: string]: DataPreviewScalar;
+}
+
+export type RawPreviewRow = Record<string, unknown> | Array<unknown>;
+
+export interface DataPreviewTableProps {
+  columns: string[];
+  rows: DataPreviewRow[];
+  totalRows?: number;
+  isTruncated?: boolean;
+  emptyMessage?: string;
+}
+
+export const formatPreviewValue = (value: DataPreviewScalar): string => {
+  if (value === null || value === undefined) {
+    return '—';
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+
+  return String(value);
+};
+
+export const normalizePreviewRows = (
+  rows: RawPreviewRow[],
+  columns: string[] = []
+): DataPreviewRow[] => {
+  return rows.map((row) => {
+    if (Array.isArray(row)) {
+      return columns.reduce<DataPreviewRow>((acc, column, index) => {
+        acc[column] = row[index] as DataPreviewScalar;
+        return acc;
+      }, {});
+    }
+
+    return Object.entries(row).reduce<DataPreviewRow>((acc, [key, value]) => {
+      if (value === null || value === undefined) {
+        acc[key] = value as DataPreviewScalar;
+        return acc;
+      }
+
+      if (typeof value === 'object') {
+        try {
+          acc[key] = JSON.stringify(value);
+        } catch (error) {
+          acc[key] = String(value);
+        }
+        return acc;
+      }
+
+      acc[key] = value as DataPreviewScalar;
+      return acc;
+    }, {});
+  });
+};
+
+export const inferPreviewColumns = (
+  rows: DataPreviewRow[],
+  explicitColumns?: string[]
+): string[] => {
+  if (explicitColumns && explicitColumns.length > 0) {
+    return explicitColumns;
+  }
+
+  const columnSet = new Set<string>();
+  rows.forEach((row) => {
+    Object.keys(row).forEach((key) => columnSet.add(key));
+  });
+
+  return Array.from(columnSet);
+};
+
+export const DataPreviewTable: React.FC<DataPreviewTableProps> = ({
+  columns,
+  rows,
+  totalRows,
+  isTruncated,
+  emptyMessage = 'No sample data available.'
+}) => {
+  const hasData = columns.length > 0 && rows.length > 0;
+
+  return (
+    <div className="border border-gray-200 rounded-md overflow-hidden shadow-sm bg-white">
+      <div className="overflow-auto max-h-96">
+        {hasData ? (
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                {columns.map((column) => (
+                  <th
+                    key={column}
+                    scope="col"
+                    className="px-4 py-2 text-left font-semibold text-gray-700 uppercase tracking-wide text-xs"
+                  >
+                    {column}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {rows.map((row, rowIndex) => (
+                <tr key={rowIndex} className="hover:bg-gray-50">
+                  {columns.map((column) => (
+                    <td key={column} className="px-4 py-2 text-gray-700 whitespace-nowrap">
+                      {formatPreviewValue(row[column])}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <div className="p-6 text-center text-gray-500 text-sm">{emptyMessage}</div>
+        )}
+      </div>
+      {typeof totalRows === 'number' && (
+        <div className="px-4 py-2 text-xs text-gray-500 bg-gray-50 border-t border-gray-100">
+          Showing {rows.length} of {totalRows} rows
+          {isTruncated ? ' (truncated)' : ''}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DataPreviewTable;

--- a/packages/ingest-wizard/src/__tests__/dataPreview.spec.ts
+++ b/packages/ingest-wizard/src/__tests__/dataPreview.spec.ts
@@ -1,0 +1,45 @@
+/// <reference types="@playwright/test" />
+
+import { expect, test } from '@playwright/test';
+import {
+  formatPreviewValue,
+  inferPreviewColumns,
+  normalizePreviewRows,
+  DataPreviewRow
+} from '../DataPreviewTable';
+
+test.describe('Data preview helpers', () => {
+  test('normalizePreviewRows converts CSV arrays into row objects', () => {
+    const rows = normalizePreviewRows(
+      [
+        ['1', 'Alice', 'true'],
+        ['2', 'Bob', 'false']
+      ],
+      ['id', 'name', 'active']
+    );
+
+    const expected: DataPreviewRow[] = [
+      { id: '1', name: 'Alice', active: 'true' },
+      { id: '2', name: 'Bob', active: 'false' }
+    ];
+
+    expect(rows).toEqual(expected);
+  });
+
+  test('inferPreviewColumns derives columns from JSON rows', () => {
+    const rows = normalizePreviewRows([
+      { id: 1, metadata: { source: 's3', region: 'us-east-1' } },
+      { id: 2, metadata: { source: 'gcs', region: 'us-central1' }, owner: 'ops' }
+    ]);
+
+    expect(inferPreviewColumns(rows)).toEqual(['id', 'metadata', 'owner']);
+  });
+
+  test('formatPreviewValue stringifies special values consistently', () => {
+    expect(formatPreviewValue(true)).toBe('true');
+    expect(formatPreviewValue(false)).toBe('false');
+    expect(formatPreviewValue(null)).toBe('—');
+    expect(formatPreviewValue(undefined)).toBe('—');
+    expect(formatPreviewValue(42)).toBe('42');
+  });
+});

--- a/packages/ingest-wizard/src/index.tsx
+++ b/packages/ingest-wizard/src/index.tsx
@@ -3,13 +3,20 @@
  * Shared UI components for data ingestion with DPIA compliance
  */
 
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useMemo } from 'react';
 import { z } from 'zod';
 import * as Form from '@radix-ui/react-form';
 import * as Select from '@radix-ui/react-select';
 import * as Checkbox from '@radix-ui/react-checkbox';
 import * as Progress from '@radix-ui/react-progress';
 import { clsx } from 'clsx';
+import {
+  DataPreviewTable,
+  inferPreviewColumns,
+  normalizePreviewRows,
+  RawPreviewRow,
+  DataPreviewRow
+} from './DataPreviewTable';
 
 // Schemas
 export const DataSourceConfigSchema = z.object({
@@ -46,6 +53,23 @@ export const DPIAFormSchema = z.object({
 export type DataSourceConfig = z.infer<typeof DataSourceConfigSchema>;
 export type DPIAForm = z.infer<typeof DPIAFormSchema>;
 
+type DataPreviewFormat = 'csv' | 'json';
+
+const SUPPORTED_PREVIEW_FORMATS: DataPreviewFormat[] = ['csv', 'json'];
+const DEFAULT_PAGE_SIZE = 10;
+
+const DEFAULT_PREVIEW_QUERY = `
+  query DataPreview($input: DataPreviewInput!) {
+    dataPreview(input: $input) {
+      format
+      columns
+      rows
+      totalRows
+      truncated
+    }
+  }
+`;
+
 // Step indicator component
 interface StepIndicatorProps {
   currentStep: number;
@@ -58,6 +82,11 @@ export const StepIndicator: React.FC<StepIndicatorProps> = ({
   totalSteps,
   steps
 }) => {
+  const progress = Math.min(
+    100,
+    Math.max(0, ((currentStep + 1) / totalSteps) * 100)
+  );
+
   return (
     <div className="w-full max-w-4xl mx-auto px-4 py-6">
       <div className="flex items-center justify-between">
@@ -84,7 +113,7 @@ export const StepIndicator: React.FC<StepIndicatorProps> = ({
       <Progress.Root className="relative overflow-hidden bg-gray-200 rounded-full w-full h-2 mt-4">
         <Progress.Indicator
           className="bg-blue-500 w-full h-full transition-transform duration-300 ease-out"
-          style={{ transform: `translateX(-${100 - (currentStep / totalSteps) * 100}%)` }}
+          style={{ transform: `translateX(-${100 - progress}%)` }}
         />
       </Progress.Root>
     </div>
@@ -216,10 +245,377 @@ export const DataSourceStep: React.FC<DataSourceStepProps> = ({
             type="submit"
             className="w-full bg-blue-500 text-white py-2 px-4 rounded-md hover:bg-blue-600"
           >
-            Next: DPIA Assessment
+            Next: Preview Data
           </button>
         </Form.Submit>
       </Form.Root>
+    </div>
+  );
+};
+
+interface GraphQLPreviewPayload {
+  columns?: string[] | null;
+  rows?: RawPreviewRow[] | null;
+  totalRows?: number | null;
+  format?: string | null;
+  truncated?: boolean | null;
+}
+
+interface GraphQLPreviewResponse {
+  data?: Record<string, GraphQLPreviewPayload | null | undefined>;
+  errors?: Array<{ message?: string }>;
+}
+
+interface DataPreviewResult {
+  columns: string[];
+  rows: DataPreviewRow[];
+  totalRows: number;
+  format: DataPreviewFormat;
+  truncated?: boolean;
+}
+
+interface DataPreviewStepProps {
+  config: Partial<DataSourceConfig>;
+  graphqlEndpoint: string;
+  graphqlHeaders?: Record<string, string>;
+  query: string;
+  previewField: string;
+  onBack: () => void;
+  onNext: () => void;
+}
+
+export const DataPreviewStep: React.FC<DataPreviewStepProps> = ({
+  config,
+  graphqlEndpoint,
+  graphqlHeaders,
+  query,
+  previewField,
+  onBack,
+  onNext
+}) => {
+  const [page, setPage] = useState(0);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [previewData, setPreviewData] = useState<DataPreviewResult | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [activeFormat, setActiveFormat] = useState<DataPreviewFormat>('csv');
+
+  const configSignature = useMemo(() => JSON.stringify(config ?? {}), [config]);
+  const resolvedHeaders = useMemo(
+    () => ({ 'Content-Type': 'application/json', ...(graphqlHeaders ?? {}) }),
+    [graphqlHeaders]
+  );
+
+  const previewSupported = useMemo(() => {
+    return config?.source_type
+      ? SUPPORTED_PREVIEW_FORMATS.includes(config.source_type as DataPreviewFormat)
+      : false;
+  }, [config?.source_type]);
+
+  const hasConnectionDetails = useMemo(() => {
+    if (!config?.source_config) {
+      return false;
+    }
+    return Object.keys(config.source_config).length > 0;
+  }, [config?.source_config]);
+
+  const totalPages = useMemo(() => {
+    if (!previewData || previewData.totalRows === 0) {
+      return 1;
+    }
+    return Math.max(1, Math.ceil(previewData.totalRows / DEFAULT_PAGE_SIZE));
+  }, [previewData]);
+
+  const canGoForward = useMemo(() => {
+    if (loading) {
+      return false;
+    }
+
+    if (!previewSupported) {
+      return true;
+    }
+
+    if (!hasConnectionDetails) {
+      return true;
+    }
+
+    return Boolean(previewData) || Boolean(error);
+  }, [error, hasConnectionDetails, loading, previewData, previewSupported]);
+
+  useEffect(() => {
+    const defaultFormat = previewSupported
+      ? (config?.source_type as DataPreviewFormat)
+      : 'csv';
+
+    setActiveFormat((current) => (current === defaultFormat ? current : defaultFormat));
+  }, [config?.source_type, previewSupported]);
+
+  useEffect(() => {
+    setPage(0);
+  }, [configSignature, activeFormat]);
+
+  useEffect(() => {
+    if (!previewSupported || !hasConnectionDetails) {
+      setPreviewData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+
+    const fetchPreview = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(graphqlEndpoint, {
+          method: 'POST',
+          headers: resolvedHeaders,
+          body: JSON.stringify({
+            query,
+            variables: {
+              input: {
+                config,
+                format: activeFormat,
+                pagination: {
+                  offset: page * DEFAULT_PAGE_SIZE,
+                  limit: DEFAULT_PAGE_SIZE
+                }
+              }
+            }
+          }),
+          signal: controller.signal
+        });
+
+        if (!response.ok) {
+          throw new Error(`GraphQL request failed with status ${response.status}`);
+        }
+
+        const payload = (await response.json()) as GraphQLPreviewResponse;
+
+        if (payload.errors?.length) {
+          throw new Error(
+            payload.errors
+              .map((item) => item.message)
+              .filter(Boolean)
+              .join('; ') || 'Unable to fetch preview data.'
+          );
+        }
+
+        const graphData = payload.data ?? {};
+        const previewPayload = graphData[previewField] as GraphQLPreviewPayload | undefined;
+
+        const rawRows = (previewPayload?.rows ?? []) as RawPreviewRow[];
+        const normalizedRows = normalizePreviewRows(rawRows, previewPayload?.columns ?? undefined);
+        const columns = inferPreviewColumns(normalizedRows, previewPayload?.columns ?? undefined);
+        const resolvedFormat = (previewPayload?.format?.toLowerCase() as DataPreviewFormat) || activeFormat;
+
+        if (!cancelled) {
+          setPreviewData({
+            columns,
+            rows: normalizedRows,
+            totalRows: previewPayload?.totalRows ?? normalizedRows.length,
+            format: SUPPORTED_PREVIEW_FORMATS.includes(resolvedFormat) ? resolvedFormat : activeFormat,
+            truncated: previewPayload?.truncated ?? false
+          });
+        }
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+
+        if ((err as Error).name === 'AbortError') {
+          return;
+        }
+
+        const message = (err as Error).message || 'Failed to load preview data.';
+        setError(message);
+        setPreviewData(null);
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchPreview();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [
+    activeFormat,
+    config,
+    configSignature,
+    graphqlEndpoint,
+    resolvedHeaders,
+    hasConnectionDetails,
+    page,
+    previewField,
+    previewSupported,
+    query,
+    refreshKey
+  ]);
+
+  if (!previewSupported) {
+    return (
+      <div className="max-w-2xl mx-auto p-6">
+        <h2 className="text-2xl font-bold mb-4">Sample Data Preview</h2>
+        <div className="rounded-md border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
+          Data previews are currently supported for CSV and JSON sources. You can continue to the DPIA
+          assessment without previewing this data source.
+        </div>
+        <div className="mt-6 flex space-x-4">
+          <button
+            type="button"
+            onClick={onBack}
+            className="flex-1 rounded-md bg-gray-500 px-4 py-2 text-white hover:bg-gray-600"
+          >
+            Back
+          </button>
+          <button
+            type="button"
+            onClick={onNext}
+            className="flex-1 rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          >
+            Next: DPIA Assessment
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto p-6">
+      <h2 className="text-2xl font-bold mb-2">Sample Data Preview</h2>
+      <p className="mb-6 text-sm text-gray-600">
+        The wizard requests a small sample via GraphQL so you can validate formatting and column headers before
+        continuing.
+      </p>
+
+      <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="text-sm text-gray-600">
+          Source type: <span className="font-medium text-gray-800">{config?.source_type || 'unknown'}</span>
+        </div>
+        <div className="flex items-center space-x-2">
+          <span className="text-xs font-semibold uppercase tracking-wide text-gray-500">Format</span>
+          <div className="inline-flex overflow-hidden rounded-md border border-gray-200 bg-white shadow-sm">
+            {SUPPORTED_PREVIEW_FORMATS.map((format) => {
+              const disabled = previewSupported && format !== (config?.source_type as DataPreviewFormat);
+              return (
+                <button
+                  key={format}
+                  type="button"
+                  onClick={() => {
+                    if (!disabled) {
+                      setActiveFormat(format);
+                    }
+                  }}
+                  className={clsx(
+                    'px-3 py-1 text-sm font-medium transition-colors',
+                    activeFormat === format
+                      ? 'bg-blue-500 text-white'
+                      : 'text-gray-600 hover:bg-gray-100',
+                    disabled && 'cursor-not-allowed opacity-40'
+                  )}
+                  disabled={disabled}
+                >
+                  {format === 'csv' ? 'CSV Preview' : 'JSON Preview'}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {!hasConnectionDetails && (
+        <div className="mb-4 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          Provide connection details in the previous step to request a preview. You can still continue to the next
+          step if a preview is not required.
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded-md border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900">
+          {error}
+        </div>
+      )}
+
+      <div className="mb-4">
+        {loading ? (
+          <div className="flex h-48 items-center justify-center text-sm text-gray-500">Loading sample data…</div>
+        ) : (
+          <DataPreviewTable
+            columns={previewData?.columns ?? []}
+            rows={previewData?.rows ?? []}
+            totalRows={previewData?.totalRows}
+            isTruncated={previewData?.truncated}
+            emptyMessage={
+              hasConnectionDetails
+                ? 'No sample rows returned for this data source.'
+                : 'Provide connection details to preview data.'
+            }
+          />
+        )}
+      </div>
+
+      <div className="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between text-sm text-gray-600">
+        <div>
+          Page {page + 1} of {totalPages}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setPage((current) => Math.max(current - 1, 0))}
+            className="rounded-md border border-gray-200 px-3 py-1 text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={loading || page === 0}
+          >
+            Previous page
+          </button>
+          <button
+            type="button"
+            onClick={() => setPage((current) => Math.min(current + 1, totalPages - 1))}
+            className="rounded-md border border-gray-200 px-3 py-1 text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={
+              loading || !previewData || previewData.totalRows <= (page + 1) * DEFAULT_PAGE_SIZE
+            }
+          >
+            Next page
+          </button>
+          <button
+            type="button"
+            onClick={() => setRefreshKey((value) => value + 1)}
+            className="rounded-md border border-gray-200 px-3 py-1 text-sm text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+            disabled={loading || !hasConnectionDetails}
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="flex space-x-4">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex-1 rounded-md bg-gray-500 px-4 py-2 text-white hover:bg-gray-600"
+        >
+          Back
+        </button>
+        <button
+          type="button"
+          onClick={onNext}
+          className={clsx(
+            'flex-1 rounded-md bg-blue-500 px-4 py-2 text-white hover:bg-blue-600',
+            (!canGoForward || loading) && 'cursor-not-allowed opacity-50'
+          )}
+          disabled={!canGoForward}
+        >
+          Next: DPIA Assessment
+        </button>
+      </div>
     </div>
   );
 };
@@ -401,11 +797,19 @@ export const DPIAStep: React.FC<DPIAStepProps> = ({
 
 // Complete wizard component
 interface IngestWizardProps {
+  graphqlEndpoint?: string;
+  graphqlHeaders?: Record<string, string>;
+  previewQuery?: string;
+  previewField?: string;
   onComplete: (config: DataSourceConfig, dpia: DPIAForm) => void;
   onCancel?: () => void;
 }
 
 export const IngestWizard: React.FC<IngestWizardProps> = ({
+  graphqlEndpoint = '/graphql',
+  graphqlHeaders,
+  previewQuery = DEFAULT_PREVIEW_QUERY,
+  previewField = 'dataPreview',
   onComplete,
   onCancel
 }) => {
@@ -413,7 +817,7 @@ export const IngestWizard: React.FC<IngestWizardProps> = ({
   const [dataSourceConfig, setDataSourceConfig] = useState<Partial<DataSourceConfig>>({});
   const [dpiaAssessment, setDPIAAssessment] = useState<Partial<DPIAForm>>({});
 
-  const steps = ['Data Source', 'DPIA Assessment', 'Review'];
+  const steps = ['Data Source', 'Preview Data', 'DPIA Assessment', 'Review'];
 
   const handleNext = useCallback(() => {
     setCurrentStep(prev => Math.min(prev + 1, steps.length - 1));
@@ -451,6 +855,18 @@ export const IngestWizard: React.FC<IngestWizardProps> = ({
         )}
 
         {currentStep === 1 && (
+          <DataPreviewStep
+            config={dataSourceConfig}
+            graphqlEndpoint={graphqlEndpoint}
+            graphqlHeaders={graphqlHeaders}
+            query={previewQuery}
+            previewField={previewField}
+            onBack={handleBack}
+            onNext={handleNext}
+          />
+        )}
+
+        {currentStep === 2 && (
           <DPIAStep
             assessment={dpiaAssessment}
             onChange={setDPIAAssessment}
@@ -459,7 +875,7 @@ export const IngestWizard: React.FC<IngestWizardProps> = ({
           />
         )}
 
-        {currentStep === 2 && (
+        {currentStep === 3 && (
           <div className="max-w-2xl mx-auto p-6">
             <h2 className="text-2xl font-bold mb-6">Review & Submit</h2>
 
@@ -514,6 +930,8 @@ export const IngestWizard: React.FC<IngestWizardProps> = ({
     </div>
   );
 };
+
+export { DataPreviewTable, formatPreviewValue, normalizePreviewRows, inferPreviewColumns } from './DataPreviewTable';
 
 // Utility functions
 export const createLicenseEnforcementClient = (baseUrl: string) => ({

--- a/packages/ingest-wizard/src/stories/DataPreviewTable.stories.tsx
+++ b/packages/ingest-wizard/src/stories/DataPreviewTable.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { DataPreviewTable, DataPreviewRow } from '../DataPreviewTable';
+
+const sampleColumns = ['id', 'name', 'email', 'active'];
+const sampleRows: DataPreviewRow[] = [
+  { id: 1, name: 'Alice', email: 'alice@example.com', active: true },
+  { id: 2, name: 'Bob', email: 'bob@example.com', active: false },
+  { id: 3, name: 'Charlie', email: 'charlie@example.com', active: true }
+];
+
+const meta: Meta<typeof DataPreviewTable> = {
+  title: 'Ingest Wizard/Data Preview Table',
+  component: DataPreviewTable,
+  parameters: {
+    layout: 'centered'
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DataPreviewTable>;
+
+export const CSVPreview: Story = {
+  args: {
+    columns: sampleColumns,
+    rows: sampleRows,
+    totalRows: 30,
+    isTruncated: false
+  }
+};
+
+const jsonRows: DataPreviewRow[] = [
+  { id: 'a-001', metadata: '{"region":"EMEA","priority":1}', status: 'ready' },
+  { id: 'a-002', metadata: '{"region":"APAC","priority":2}', status: 'processing' }
+];
+
+export const JSONPreview: Story = {
+  args: {
+    columns: ['id', 'metadata', 'status'],
+    rows: jsonRows,
+    totalRows: 2,
+    isTruncated: false
+  }
+};
+
+export const EmptyState: Story = {
+  args: {
+    columns: sampleColumns,
+    rows: [],
+    totalRows: 0,
+    emptyMessage: 'No preview rows returned. Adjust your filters and try again.'
+  }
+};

--- a/packages/ingest-wizard/tsconfig.json
+++ b/packages/ingest-wizard/tsconfig.json
@@ -1,7 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node", "jest"],
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "typeRoots": ["./node_modules/@types"]
   },
   "include": ["src"],
   "references": [{ "path": "../types" }]


### PR DESCRIPTION
## Summary
- add a GraphQL-powered data preview step to the ingest wizard with pagination controls
- introduce a reusable DataPreviewTable component along with Storybook coverage
- add Playwright helper tests and update local TypeScript configuration and tooling dependencies

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d6f529704883338fe69d80bcc77359