### PR TITLE
feat: optimize graph metadata search indexing

### DIFF
--- a/docs/search/README.md
+++ b/docs/search/README.md
@@ -1,0 +1,53 @@
+# Search Indexing Playbook
+
+This guide explains how graph metadata is indexed into Elasticsearch, how to run a full reindex, and how to validate query performance with k6.
+
+## Incremental indexing on ingestion
+
+- The ingestion pipeline now streams entities and relationships directly into Elasticsearch using the `GraphMetadataIndexer` helper. The indexer tracks content hashes so only new or changed documents are sent, cutting redundant writes during steady-state ingestion.【F:simulated_ingestion/ingestion_pipeline.py†L1-L130】【F:simulated_ingestion/indexing.py†L1-L278】
+- Incremental runs persist a lightweight state file at `search/index/graph_metadata_index_state.json` and emit a full snapshot to `search/index/graph_metadata_snapshot.json` for disaster recovery or replay scenarios.【F:simulated_ingestion/indexing.py†L197-L273】
+- Elasticsearch mappings and analyzers are declared in `search/config/graph_metadata_index.json`. Tunables include custom analyzers for entity names, a 15 s refresh interval, and keyword subfields for faceting.【F:search/config/graph_metadata_index.json†L1-L78】
+
+### Running the simulated pipeline locally
+
+```bash
+poetry install  # or pip install -r requirements.in (ensure elasticsearch>=8)
+python simulated_ingestion/ingestion_pipeline.py
+```
+
+Set `ELASTICSEARCH_URL`, `ELASTICSEARCH_AUTH`, `ELASTICSEARCH_USERNAME`, and `ELASTICSEARCH_PASSWORD` as needed before running. When Elasticsearch is unreachable the pipeline completes without indexing and reports the condition in stdout.【F:simulated_ingestion/ingestion_pipeline.py†L58-L100】
+
+## Full reindex workflow
+
+Use the Python helper to rebuild indices from the most recent snapshot:
+
+```bash
+python search/scripts/reindex_graph_metadata.py --purge
+# Optional flags:
+#   --snapshot /path/to/snapshot.json
+#   --batch-size 1000
+#   --refresh none
+#   --dry-run
+```
+
+The script validates the snapshot, optionally drops/recreates indices, streams metadata through the incremental indexer, and prints a final document count summary.【F:search/scripts/reindex_graph_metadata.py†L1-L86】
+
+## Performance validation with k6
+
+- The scenario in `tests/k6/search-metadata.js` issues authenticated hybrid searches against `/api/search/search` with configurable VUs, duration, and pacing. Thresholds enforce p95 ≤ 300 ms and overall success rate ≥ 99 %.【F:tests/k6/search-metadata.js†L1-L65】
+- Provide a JWT via `AUTH_TOKEN`, point to the running service with `BASE_URL`, and adjust load using `VUS`, `DURATION`, or `SLEEP`:
+
+```bash
+k6 run tests/k6/search-metadata.js \
+  -e BASE_URL=http://localhost:4006 \
+  -e AUTH_TOKEN=$JWT \
+  -e VUS=15 -e DURATION=3m
+```
+
+Summaries, observations, and follow-up actions should be captured in `reports/search-metadata-k6-report.md` after each scheduled run.【F:reports/search-metadata-k6-report.md†L1-L62】
+
+## Ongoing maintenance checklist
+
+- Keep `requirements.in` in sync so the Python Elasticsearch client is available in local and CI environments.【F:requirements.in†L1-L15】
+- Update the index configuration when adding new searchable fields or analyzers and rerun the reindex script.
+- Record k6 results (baseline, regression, post-change) and attach them to change approvals.

--- a/reports/search-metadata-k6-report.md
+++ b/reports/search-metadata-k6-report.md
@@ -1,0 +1,41 @@
+# Search Metadata k6 Performance Report
+
+## Summary
+
+- **Scenario:** Authenticated hybrid search traffic against `/api/search/search` using `tests/k6/search-metadata.js`.
+- **Goal:** Validate that incremental indexing keeps query latency within the 300 ms p95 budget under sustained load.
+- **Status:** Pending execution in this environment (Elasticsearch/search engine not running during authoring).
+
+## Test configuration
+
+| Setting | Value |
+| --- | --- |
+| Command | `k6 run tests/k6/search-metadata.js -e BASE_URL=<search-url> -e AUTH_TOKEN=<jwt>` |
+| Virtual users | `VUS=15` (override via env) |
+| Duration | `DURATION=3m` (override via env) |
+| Think time | `SLEEP=1` second between iterations |
+| Thresholds | `http_req_duration{}` p95 < 300 ms, p99 < 500 ms; `checks` > 99 % |
+
+## Results template
+
+| Metric | Threshold | Observed | Status |
+| --- | --- | --- | --- |
+| HTTP p95 | < 300 ms | _TBD_ | ☐ |
+| HTTP p99 | < 500 ms | _TBD_ | ☐ |
+| Success rate | > 99 % | _TBD_ | ☐ |
+| Error rate | < 1 % | _TBD_ | ☐ |
+
+> Replace `_TBD_` once the test is executed. Attach the k6 JSON summary artifact to the change record for traceability.
+
+## Recommended next steps
+
+1. Launch the search engine with Elasticsearch running locally or in staging.
+2. Obtain a short-lived JWT and export it as `AUTH_TOKEN`.
+3. Run the command above and capture the k6 summary plus the generated trend metrics.
+4. Update the table with observed values and raise alerts if thresholds regress.
+
+## References
+
+- Test script: `tests/k6/search-metadata.js`【F:tests/k6/search-metadata.js†L1-L65】
+- Incremental indexer implementation: `simulated_ingestion/indexing.py`【F:simulated_ingestion/indexing.py†L1-L278】
+- Reindex automation: `search/scripts/reindex_graph_metadata.py`【F:search/scripts/reindex_graph_metadata.py†L1-L86】

--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,4 @@ passlib[bcrypt]==1.7.4
 python-dotenv==1.1.*
 httpx==0.28.*
 jinja2==3.1.*
+elasticsearch==8.15.*

--- a/search/config/graph_metadata_index.json
+++ b/search/config/graph_metadata_index.json
@@ -1,0 +1,99 @@
+{
+  "entities": {
+    "index": "graph-metadata-entities-v1",
+    "aliases": ["graph-metadata-entities"],
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1,
+      "refresh_interval": "15s",
+      "analysis": {
+        "analyzer": {
+          "metadata_text": {
+            "type": "custom",
+            "tokenizer": "standard",
+            "filter": ["lowercase", "asciifolding", "metadata_stop"]
+          }
+        },
+        "filter": {
+          "metadata_stop": {
+            "type": "stop",
+            "stopwords": "_english_"
+          }
+        }
+      }
+    },
+    "mappings": {
+      "dynamic": true,
+      "properties": {
+        "entity_id": { "type": "keyword" },
+        "entity_type": { "type": "keyword" },
+        "name": {
+          "type": "text",
+          "analyzer": "metadata_text",
+          "fields": { "keyword": { "type": "keyword", "ignore_above": 256 } }
+        },
+        "summary": { "type": "text", "analyzer": "metadata_text" },
+        "properties": {
+          "type": "object",
+          "dynamic": true
+        },
+        "tags": { "type": "keyword" },
+        "source": { "type": "keyword" },
+        "ingested_at": { "type": "date" },
+        "metadata_hash": { "type": "keyword" }
+      },
+      "dynamic_templates": [
+        {
+          "properties_strings": {
+            "path_match": "properties.*",
+            "mapping": {
+              "type": "text",
+              "analyzer": "metadata_text",
+              "fields": {
+                "keyword": { "type": "keyword", "ignore_above": 256 }
+              }
+            }
+          }
+        }
+      ]
+    }
+  },
+  "relationships": {
+    "index": "graph-metadata-relationships-v1",
+    "aliases": ["graph-metadata-relationships"],
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1,
+      "refresh_interval": "15s"
+    },
+    "mappings": {
+      "dynamic": true,
+      "properties": {
+        "relationship_id": { "type": "keyword" },
+        "relationship_type": { "type": "keyword" },
+        "source_id": { "type": "keyword" },
+        "target_id": { "type": "keyword" },
+        "properties": {
+          "type": "object",
+          "dynamic": true
+        },
+        "ingested_at": { "type": "date" },
+        "metadata_hash": { "type": "keyword" }
+      },
+      "dynamic_templates": [
+        {
+          "properties_strings": {
+            "path_match": "properties.*",
+            "mapping": {
+              "type": "text",
+              "analyzer": "standard",
+              "fields": {
+                "keyword": { "type": "keyword", "ignore_above": 256 }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/search/scripts/reindex_graph_metadata.py
+++ b/search/scripts/reindex_graph_metadata.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Full reindex utility for graph metadata search indices."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from simulated_ingestion.indexing import (  # noqa: E402
+    GraphMetadataIndexer,
+    load_graph_metadata_snapshot,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    default_snapshot = PROJECT_ROOT / "search" / "index" / "graph_metadata_snapshot.json"
+
+    parser = argparse.ArgumentParser(description="Reindex Elasticsearch with graph metadata snapshot data")
+    parser.add_argument(
+        "--snapshot",
+        type=Path,
+        default=default_snapshot,
+        help=f"Path to snapshot file (default: {default_snapshot})",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=500,
+        help="Number of documents per bulk request",
+    )
+    parser.add_argument(
+        "--refresh",
+        default="wait_for",
+        help="Elasticsearch refresh policy (default: wait_for)",
+    )
+    parser.add_argument(
+        "--purge",
+        action="store_true",
+        help="Drop and recreate indices before indexing",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print counts without sending data to Elasticsearch",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    if not args.snapshot.exists():
+        print(f"Snapshot not found at {args.snapshot}. Run the ingestion pipeline first.")
+        return 2
+
+    entities, relationships, metadata = load_graph_metadata_snapshot(args.snapshot)
+
+    print("Graph metadata snapshot loaded")
+    print(f"  Generated at: {metadata.get('generated_at')}")
+    print(f"  Entities: {len(entities)}")
+    print(f"  Relationships: {len(relationships)}")
+
+    if args.dry_run:
+        print("Dry run mode enabled — exiting before indexing")
+        return 0
+
+    indexer = GraphMetadataIndexer(batch_size=args.batch_size, refresh=args.refresh)
+    if not indexer.enabled:
+        print("Elasticsearch is unavailable. Aborting reindex.")
+        return 1
+
+    if args.purge:
+        print("Purging existing indices before reindexing")
+        indexer.reset_indices()
+
+    indexer.index_entities(entities)
+    indexer.index_relationships(relationships)
+    indexer.flush()
+
+    state = indexer.snapshot_state()
+    print("Reindex complete")
+    print(f"  Indexed entities: {len(state['entities'])}")
+    print(f"  Indexed relationships: {len(state['relationships'])}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/simulated_ingestion/__init__.py
+++ b/simulated_ingestion/__init__.py
@@ -1,0 +1,6 @@
+"""Simulated ingestion utilities for Summit graph metadata."""
+
+__all__ = [
+    "indexing",
+    "ingestion_pipeline",
+]

--- a/simulated_ingestion/indexing.py
+++ b/simulated_ingestion/indexing.py
@@ -1,0 +1,439 @@
+"""Utilities for indexing graph metadata into Elasticsearch."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+from elasticsearch import Elasticsearch
+from elasticsearch import exceptions as es_exceptions
+
+
+LOGGER = logging.getLogger("graph_metadata_indexer")
+if not LOGGER.handlers:
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s"),
+    )
+    LOGGER.addHandler(handler)
+LOGGER.setLevel(logging.INFO)
+
+
+@dataclass
+class IndexDefinition:
+    """Container for Elasticsearch index settings."""
+
+    name: str
+    aliases: List[str]
+    settings: Mapping[str, Any]
+    mappings: Mapping[str, Any]
+
+
+class GraphMetadataIndexer:
+    """Incrementally index graph metadata documents in Elasticsearch."""
+
+    def __init__(
+        self,
+        *,
+        batch_size: int = 500,
+        refresh: str = "wait_for",
+        state_path: Optional[Path] = None,
+        request_timeout: int = 30,
+        max_retries: int = 3,
+    ) -> None:
+        self.logger = LOGGER
+        self.batch_size = max(batch_size, 1)
+        self.refresh = refresh
+        self.state_path = state_path or Path(__file__).resolve().parents[1] / "search" / "index" / "graph_metadata_index_state.json"
+        self.state: Dict[str, Dict[str, str]] = {"entities": {}, "relationships": {}}
+        self.pending_state_updates: Dict[str, Dict[str, str]] = {"entities": {}, "relationships": {}}
+        self.operations: List[Dict[str, Any]] = []
+        self.enabled = True
+
+        self.index_definitions = self._load_index_definitions()
+
+        es_url = os.environ.get("ELASTICSEARCH_URL", "http://localhost:9200")
+        auth_enabled = os.environ.get("ELASTICSEARCH_AUTH")
+        username = os.environ.get("ELASTICSEARCH_USERNAME", "elastic") if auth_enabled else None
+        password = os.environ.get("ELASTICSEARCH_PASSWORD", "changeme") if auth_enabled else None
+
+        self.logger.debug(
+            "Initializing Elasticsearch client",
+            extra={"url": es_url, "auth": bool(auth_enabled)},
+        )
+
+        try:
+            self.client = Elasticsearch(
+                hosts=[es_url],
+                basic_auth=(username, password) if username and password else None,
+                request_timeout=request_timeout,
+                max_retries=max_retries,
+            )
+            if not self.client.ping():
+                self.logger.warning(
+                    "Elasticsearch cluster is unreachable; disabling incremental indexing",
+                )
+                self.enabled = False
+        except Exception:
+            self.logger.exception("Failed to initialize Elasticsearch client; disabling incremental indexing")
+            self.enabled = False
+
+        self._load_state()
+
+        if self.enabled:
+            self.ensure_indices()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def ensure_indices(self) -> None:
+        """Create indices if they do not already exist."""
+
+        if not self.enabled:
+            return
+
+        for key, definition in self.index_definitions.items():
+            try:
+                if self.client.indices.exists(index=definition.name):
+                    continue
+
+                self.logger.info("Creating Elasticsearch index", extra={"index": definition.name})
+                self.client.indices.create(
+                    index=definition.name,
+                    settings=definition.settings,
+                    mappings=definition.mappings,
+                )
+
+                if definition.aliases:
+                    actions = [
+                        {"add": {"index": definition.name, "alias": alias}}
+                        for alias in definition.aliases
+                    ]
+                    self.client.indices.update_aliases(actions=actions)
+            except Exception:
+                self.logger.exception("Failed to ensure index", extra={"index": definition.name, "key": key})
+                self.enabled = False
+                break
+
+    def reset_indices(self) -> None:
+        """Drop indices and clear local state before a full reindex."""
+
+        if not self.enabled:
+            return
+
+        for definition in self.index_definitions.values():
+            try:
+                if self.client.indices.exists(index=definition.name):
+                    self.logger.info("Deleting Elasticsearch index", extra={"index": definition.name})
+                    self.client.indices.delete(index=definition.name)
+            except es_exceptions.NotFoundError:
+                continue
+            except Exception:
+                self.logger.exception("Failed to delete index", extra={"index": definition.name})
+                raise
+
+        self._clear_state()
+        self.ensure_indices()
+
+    def index_entities(self, entities: Iterable[Mapping[str, Any]]) -> None:
+        """Queue entity documents for incremental indexing."""
+
+        if not self.enabled:
+            return
+
+        for entity in entities:
+            self.index_entity(entity)
+
+    def index_relationships(self, relationships: Iterable[Mapping[str, Any]]) -> None:
+        """Queue relationship documents for incremental indexing."""
+
+        if not self.enabled:
+            return
+
+        for relationship in relationships:
+            self.index_relationship(relationship)
+
+    def index_entity(self, entity: Mapping[str, Any]) -> None:
+        if not self.enabled:
+            return
+
+        entity_id = self._extract_entity_id(entity)
+        if not entity_id:
+            self.logger.warning("Skipping entity without identifier", extra={"entity": entity})
+            return
+
+        index_name = self.index_definitions["entities"].name
+        document = self._build_entity_document(entity, entity_id)
+        metadata_hash = self._hash_document(document)
+        document["metadata_hash"] = metadata_hash
+
+        if self._is_duplicate("entities", entity_id, metadata_hash):
+            return
+
+        self._queue_update(index_name, entity_id, document, "entities", metadata_hash)
+
+    def index_relationship(self, relationship: Mapping[str, Any]) -> None:
+        if not self.enabled:
+            return
+
+        relationship_id = self._extract_relationship_id(relationship)
+        if not relationship_id:
+            self.logger.warning(
+                "Skipping relationship without identifier",
+                extra={"relationship": relationship},
+            )
+            return
+
+        index_name = self.index_definitions["relationships"].name
+        document = self._build_relationship_document(relationship, relationship_id)
+        metadata_hash = self._hash_document(document)
+        document["metadata_hash"] = metadata_hash
+
+        if self._is_duplicate("relationships", relationship_id, metadata_hash):
+            return
+
+        self._queue_update(index_name, relationship_id, document, "relationships", metadata_hash)
+
+    def flush(self) -> None:
+        """Send queued operations to Elasticsearch."""
+
+        if not self.enabled:
+            return
+
+        if not self.operations:
+            if any(self.pending_state_updates.values()):
+                self._commit_state_updates()
+            return
+
+        try:
+            self.logger.info(
+                "Flushing bulk operations",
+                extra={"operation_count": len(self.operations) // 2},
+            )
+            response = self.client.bulk(operations=self.operations, refresh=self.refresh)
+
+            if response.get("errors"):
+                failures = [item for item in response.get("items", []) if any(v.get("error") for v in item.values())]
+                self.logger.error(
+                    "Bulk indexing completed with errors",
+                    extra={"failure_count": len(failures), "failures": failures[:5]},
+                )
+            else:
+                self.logger.info(
+                    "Bulk indexing succeeded",
+                    extra={"took_ms": response.get("took"), "items": len(response.get("items", []))},
+                )
+                self._commit_state_updates()
+        finally:
+            self.operations = []
+            self.pending_state_updates = {"entities": {}, "relationships": {}}
+
+    # ------------------------------------------------------------------
+    # Snapshot helpers
+    # ------------------------------------------------------------------
+    def snapshot_state(self) -> Dict[str, Dict[str, str]]:
+        """Return the cached metadata hashes for debugging."""
+
+        return {
+            "entities": dict(self.state["entities"]),
+            "relationships": dict(self.state["relationships"]),
+        }
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _queue_update(
+        self,
+        index_name: str,
+        doc_id: str,
+        document: Mapping[str, Any],
+        bucket: str,
+        metadata_hash: str,
+    ) -> None:
+        self.operations.append({"update": {"_index": index_name, "_id": doc_id}})
+        self.operations.append({"doc": document, "doc_as_upsert": True})
+        self.pending_state_updates[bucket][doc_id] = metadata_hash
+
+        if len(self.operations) // 2 >= self.batch_size:
+            self.flush()
+
+    def _extract_entity_id(self, entity: Mapping[str, Any]) -> Optional[str]:
+        if "id" in entity:
+            return str(entity["id"])
+
+        properties = entity.get("properties") if isinstance(entity, Mapping) else None
+        if isinstance(properties, Mapping) and "id" in properties:
+            return str(properties["id"])
+
+        return None
+
+    def _extract_relationship_id(self, relationship: Mapping[str, Any]) -> Optional[str]:
+        if "id" in relationship:
+            return str(relationship["id"])
+
+        source = relationship.get("source_id") if isinstance(relationship, Mapping) else None
+        target = relationship.get("target_id") if isinstance(relationship, Mapping) else None
+        rel_type = relationship.get("type")
+
+        if source and target and rel_type:
+            return f"{source}->{target}:{rel_type}"
+
+        return None
+
+    def _build_entity_document(self, entity: Mapping[str, Any], entity_id: str) -> Dict[str, Any]:
+        properties = dict(entity.get("properties", {})) if isinstance(entity.get("properties"), Mapping) else {}
+        now = datetime.now(timezone.utc).isoformat()
+
+        document = {
+            "entity_id": entity_id,
+            "entity_type": entity.get("type", "Unknown"),
+            "name": properties.get("name"),
+            "summary": properties.get("summary"),
+            "properties": properties,
+            "tags": properties.get("tags", []),
+            "source": properties.get("source"),
+            "ingested_at": now,
+        }
+        return document
+
+    def _build_relationship_document(self, relationship: Mapping[str, Any], relationship_id: str) -> Dict[str, Any]:
+        now = datetime.now(timezone.utc).isoformat()
+        document = {
+            "relationship_id": relationship_id,
+            "relationship_type": relationship.get("type", "Unknown"),
+            "source_id": relationship.get("source_id"),
+            "target_id": relationship.get("target_id"),
+            "properties": relationship.get("properties", {}),
+            "ingested_at": now,
+        }
+        return document
+
+    def _is_duplicate(self, bucket: str, doc_id: str, metadata_hash: str) -> bool:
+        previous = self.state.get(bucket, {}).get(doc_id)
+        if previous == metadata_hash:
+            self.logger.debug(
+                "Skipping unchanged document",
+                extra={"bucket": bucket, "doc_id": doc_id},
+            )
+            return True
+        return False
+
+    def _hash_document(self, document: Mapping[str, Any]) -> str:
+        normalized = json.dumps(document, sort_keys=True, default=str)
+        return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+
+    def _load_index_definitions(self) -> Dict[str, IndexDefinition]:
+        config_path = Path(__file__).resolve().parents[1] / "search" / "config" / "graph_metadata_index.json"
+        try:
+            with config_path.open("r", encoding="utf-8") as handle:
+                config = json.load(handle)
+        except FileNotFoundError as exc:
+            raise RuntimeError(f"Missing Elasticsearch index config at {config_path}") from exc
+
+        definitions: Dict[str, IndexDefinition] = {}
+        for key, payload in config.items():
+            definitions[key] = IndexDefinition(
+                name=payload["index"],
+                aliases=payload.get("aliases", []),
+                settings=payload.get("settings", {}),
+                mappings=payload.get("mappings", {}),
+            )
+
+        return definitions
+
+    def _load_state(self) -> None:
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.state_path.exists():
+            self._save_state()
+            return
+
+        try:
+            with self.state_path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+                self.state = {
+                    "entities": data.get("entities", {}),
+                    "relationships": data.get("relationships", {}),
+                }
+        except json.JSONDecodeError:
+            self.logger.warning("State file is corrupt; resetting incremental index state")
+            self._save_state()
+
+    def _save_state(self) -> None:
+        payload = {
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "entities": self.state.get("entities", {}),
+            "relationships": self.state.get("relationships", {}),
+        }
+        with self.state_path.open("w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+
+    def _commit_state_updates(self) -> None:
+        for bucket, updates in self.pending_state_updates.items():
+            self.state.setdefault(bucket, {}).update(updates)
+        self._save_state()
+
+    def _clear_state(self) -> None:
+        self.state = {"entities": {}, "relationships": {}}
+        self.pending_state_updates = {"entities": {}, "relationships": {}}
+        if self.state_path.exists():
+            self.state_path.unlink()
+        self._save_state()
+
+
+def export_graph_metadata_snapshot(
+    entities: Iterable[Mapping[str, Any]],
+    relationships: Iterable[Mapping[str, Any]],
+    *,
+    output_path: Optional[Path] = None,
+) -> Path:
+    """Persist a snapshot of graph metadata for full reindex runs."""
+
+    entities_list = list(entities)
+    relationships_list = list(relationships)
+    snapshot_path = output_path or Path(__file__).resolve().parents[1] / "search" / "index" / "graph_metadata_snapshot.json"
+    snapshot_path.parent.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "entity_count": len(entities_list),
+        "relationship_count": len(relationships_list),
+        "entities": entities_list,
+        "relationships": relationships_list,
+    }
+
+    with snapshot_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+
+    LOGGER.info(
+        "Graph metadata snapshot written",
+        extra={
+            "path": str(snapshot_path),
+            "entities": len(entities_list),
+            "relationships": len(relationships_list),
+        },
+    )
+
+    return snapshot_path
+
+
+def load_graph_metadata_snapshot(path: Path) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]], Dict[str, Any]]:
+    """Load a previously exported graph metadata snapshot."""
+
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    entities = payload.get("entities", [])
+    relationships = payload.get("relationships", [])
+    metadata = {
+        "generated_at": payload.get("generated_at"),
+        "entity_count": payload.get("entity_count", len(entities)),
+        "relationship_count": payload.get("relationship_count", len(relationships)),
+    }
+
+    return entities, relationships, metadata

--- a/tests/k6/search-metadata.js
+++ b/tests/k6/search-metadata.js
@@ -1,0 +1,80 @@
+import http from 'k6/http';
+import { check, sleep, Trend } from 'k6';
+import { randomItem } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+export const options = {
+  scenarios: {
+    metadata_search: {
+      executor: 'constant-vus',
+      vus: Number(__ENV.VUS || 10),
+      duration: __ENV.DURATION || '2m',
+      gracefulStop: '30s',
+    },
+  },
+  thresholds: {
+    http_req_duration: ['p(95)<300', 'p(99)<500'],
+    checks: ['rate>0.99'],
+  },
+};
+
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:4006';
+const AUTH_TOKEN = __ENV.AUTH_TOKEN;
+
+if (!AUTH_TOKEN) {
+  throw new Error('AUTH_TOKEN environment variable is required for the search metadata test');
+}
+
+const responseTimeTrend = new Trend('search_metadata_response_time', true);
+
+const queries = [
+  {
+    name: 'projects_by_keyword',
+    text: 'Project Alpha risk assessment',
+    filters: { entityTypes: ['Project'] },
+  },
+  {
+    name: 'people_and_assets',
+    text: 'Alice relationships hardware assets',
+    filters: { entityTypes: ['Person', 'Asset'] },
+  },
+  {
+    name: 'supply_chain',
+    text: 'supply chain vendor delays',
+    filters: { tags: ['supply-chain'] },
+  },
+  {
+    name: 'threat_intel',
+    text: 'credential leak investigation',
+    filters: { sources: ['threat-intel'] },
+  },
+];
+
+const requestHeaders = {
+  headers: {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${AUTH_TOKEN}`,
+  },
+};
+
+export default function metadataSearch() {
+  const query = randomItem(queries);
+  const body = {
+    query: query.text,
+    searchType: 'hybrid',
+    filters: query.filters,
+    pagination: { page: 1, size: 10 },
+    highlight: { fields: ['name', 'summary'], fragmentSize: 120, numberOfFragments: 2 },
+  };
+
+  const response = http.post(`${BASE_URL}/api/search/search`, JSON.stringify(body), requestHeaders);
+
+  responseTimeTrend.add(response.timings.duration, { scenario: query.name });
+
+  check(response, {
+    'status is 200': (res) => res.status === 200,
+    'body parses to JSON': (res) => !!res.json(),
+    'returned results quickly': (res) => res.timings.duration < 400,
+  });
+
+  sleep(Number(__ENV.SLEEP || '1'));
+}


### PR DESCRIPTION
## Summary
- add a reusable GraphMetadataIndexer to stream ingestion changes into Elasticsearch and persist snapshots
- define graph metadata index settings plus a Python reindex entrypoint and k6 load test for query latency
- document the indexing workflow and capture performance reporting guidance under docs/search

## Testing
- python -m compileall simulated_ingestion search/scripts

------
https://chatgpt.com/codex/tasks/task_e_68d6f54d6f70833386c6af1646d1df30