### PR TITLE
feat: add ML observability alerting assets

### DIFF
--- a/docs/runbooks/ml-alerting-guide.md
+++ b/docs/runbooks/ml-alerting-guide.md
@@ -1,0 +1,57 @@
+# ML Observability Alerting Guide
+
+## Overview
+This guide documents how Summit monitors machine learning services, the alerting thresholds applied in Prometheus, and how PagerDuty escalations are configured. Use it as the single source of truth for on-call response to ML-specific incidents.
+
+## Metrics & Dashboards
+- **Inference latency** (`ml_inference_latency_seconds_bucket`): visualized as the "ML p95 Inference Latency (5m)" stat panel and trend lines on the IntelGraph Overview dashboard.
+- **Model accuracy** (`ml_model_accuracy_score`, `ml_model_accuracy_target`): compared via the "Model Accuracy vs Target" panel with 1h rolling averages.
+- **Data drift** (`ml_data_drift_score`): summarized via a 30-minute average stat card and historical trend chart for context.
+- **Throughput & failures** (`ml_inference_requests_total`, `ml_inference_failures_total`): rendered as the "Inference Throughput vs Errors" timeseries to correlate load with error spikes.
+
+Access the panels in Grafana: *Dashboards → IntelGraph Overview → ML Observability row*. Filter by model using the **Model** template variable.
+
+## Alert Inventory
+### Model Accuracy Drift
+- **Source rule**: `ModelAccuracyDrift` in `ops/prometheus/prometheus-ml-alerts.yaml`.
+- **Trigger**: 1h rolling accuracy drops >5 percentage points below the declared target for 15 minutes.
+- **Impact**: Predictions may no longer meet product quality or contractual SLAs.
+- **Immediate actions**:
+  1. Validate data freshness and upstream feature pipelines.
+  2. Compare recent training/validation metrics; roll back if a bad model was promoted.
+  3. Engage the data science owner if accuracy continues to degrade after mitigation.
+
+### Inference Latency
+- **Source rule**: `ModelInferenceLatencyHigh` in `ops/prometheus/prometheus-ml-alerts.yaml`.
+- **Trigger**: p95 latency > 750ms for 10 minutes in production.
+- **Impact**: Customer-visible slow responses and potential timeout breaches.
+- **Immediate actions**:
+  1. Check Grafana panel for concurrency spikes and upstream dependency saturation.
+  2. Inspect accelerator (GPU/Inferentia) utilization; fail over to warm replicas if needed.
+  3. Confirm autoscaling targets; manually scale if queue backlog is rising.
+
+### Data Drift
+- **Source rule**: `ModelDataDriftHigh` in `ops/prometheus/prometheus-ml-alerts.yaml`.
+- **Trigger**: 30m average drift score > 0.7.
+- **Impact**: Model input distributions have shifted; accuracy degradation likely.
+- **Immediate actions**:
+  1. Inspect latest drift report for top-changing features.
+  2. Validate data ingestion and labeling freshness.
+  3. Coordinate with analytics to schedule retraining or hotfix rules.
+
+## PagerDuty Routing
+- Alerts are labeled with `component=ml-observability` and `service=ml-platform`.
+- Alertmanager routes these to the **ml-pagerduty** receiver (see `monitoring/alertmanager/sre-policy.yml`).
+- PagerDuty service configuration lives in `ops/alerts/pagerduty-ml-service.yaml` using the `PAGERDUTY_ML_ROUTING_KEY` secret.
+- Incidents page the ML primary, with SRE as secondary. Stakeholders `#ml-ops` and `#sre-alerts` are auto-subscribed.
+
+## Runbook Links
+- Accuracy drift: <https://runbooks.summit.ai/ml-alerting-guide#model-accuracy-drift>
+- Latency response: <https://runbooks.summit.ai/ml-alerting-guide#inference-latency>
+- Data drift: <https://runbooks.summit.ai/ml-alerting-guide#data-drift>
+
+## Post-Incident Checklist
+1. Capture Grafana panel snapshots for accuracy, latency, and drift.
+2. Tag the PagerDuty incident with `ml` and `customer-impact` as applicable.
+3. File follow-up issues for model retraining or platform fixes.
+4. Update this document with any new remediation steps discovered.

--- a/monitoring/alertmanager/sre-policy.yml
+++ b/monitoring/alertmanager/sre-policy.yml
@@ -71,6 +71,14 @@ route:
       group_interval: 15m
       repeat_interval: 2h
 
+    # ML observability alerts routed to PagerDuty + ML Ops channel
+    - match:
+        component: ml-observability
+      receiver: 'ml-pagerduty'
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 2h
+
 receivers:
   - name: 'default'
     slack_configs:
@@ -158,6 +166,26 @@ receivers:
           *Model*: {{ .CommonLabels.model }}
           *Issue*: {{ .CommonAnnotations.summary }}
           *Drift Score*: {{ .CommonAnnotations.drift_score }}
+
+  - name: 'ml-pagerduty'
+    pagerduty_configs:
+      - service_key: '{{ .PagerDutyServiceKey }}'
+        description: 'ML Observability Alert: {{ .CommonAnnotations.summary }}'
+        severity: '{{ if eq .CommonLabels.severity "page" }}critical{{ else }}warning{{ end }}'
+        details:
+          service: '{{ .CommonLabels.service }}'
+          model: '{{ .CommonLabels.model }}'
+          runbook: '{{ .CommonAnnotations.runbook_url }}'
+    slack_configs:
+      - api_url: '{{ .SlackWebhookURL }}'
+        channel: '#ml-ops'
+        title: '🤖 ML Observability Alert'
+        text: |
+          *Alert*: {{ .CommonLabels.alertname }}
+          *Model*: {{ .CommonLabels.model }}
+          *Deployment*: {{ .CommonLabels.deployment }}
+          *Severity*: {{ .CommonLabels.severity }}
+          *Runbook*: {{ .CommonAnnotations.runbook_url }}
 
 # Inhibition rules to prevent alert fatigue
 inhibit_rules:

--- a/ops/alerts/pagerduty-ml-service.yaml
+++ b/ops/alerts/pagerduty-ml-service.yaml
@@ -1,0 +1,43 @@
+# PagerDuty service configuration for ML observability alerts
+apiVersion: pagerduty.summit.ai/v1alpha1
+kind: PagerDutyService
+metadata:
+  name: intelgraph-ml-observability
+spec:
+  description: PagerDuty service dedicated to ML metrics (accuracy, latency, drift).
+  escalation_policy: sre-ml-primary
+  response_play: ml-major-incident
+  integrations:
+    - name: Prometheus Alertmanager
+      type: events-api-v2
+      routing_key_secret: PAGERDUTY_ML_ROUTING_KEY
+      vendor: prometheus
+      auto_resolve: true
+  incident_urgency_rules:
+    during_support_hours:
+      type: constant
+      urgency: high
+    outside_support_hours:
+      type: constant
+      urgency: high
+  event_rules:
+    - description: Route ML observability alerts as critical incidents
+      conditions:
+        operator: and
+        subconditions:
+          - fact: details.component
+            operator: equals
+            value: ml-observability
+          - fact: severity
+            operator: equals
+            value: page
+      actions:
+        severity: critical
+        route_to: intelgraph-ml-observability
+        suppress: false
+        annotate: "Triggered by Prometheus ML alert. See runbook: https://runbooks.summit.ai/ml-alerting-guide"
+  stakeholders:
+    - team: ml-platform
+      contact: '#ml-ops'
+    - team: sre
+      contact: '#sre-alerts'

--- a/ops/grafana/dashboards/intelgraph-overview.json
+++ b/ops/grafana/dashboards/intelgraph-overview.json
@@ -311,6 +311,116 @@
       "transformations": [{ "id": "labelsToFields", "options": { "mode": "columns" } }],
       "fieldConfig": { "defaults": { "unit": "percentunit", "decimals": 2 } },
       "options": { "showHeader": true }
+    },
+    {
+      "type": "row",
+      "title": "ML Observability",
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 92 }
+    },
+    {
+      "type": "stat",
+      "title": "ML p95 Inference Latency (5m)",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "x": 0, "y": 93, "w": 8, "h": 7 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "model:inference_latency_seconds:p95{deployment=\"prod\",model=~\"$model\"}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "value": 0.5, "color": "yellow" },
+              { "value": 0.75, "color": "red" }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "values": false }, "colorMode": "value" }
+    },
+    {
+      "type": "timeseries",
+      "title": "Model Accuracy vs Target (1h avg)",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "x": 8, "y": 93, "w": 16, "h": 7 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "model:accuracy_avg_1h{deployment=\"prod\",model=~\"$model\"}",
+          "legendFormat": "{{model}} accuracy"
+        },
+        {
+          "refId": "B",
+          "expr": "ml_model_accuracy_target{deployment=\"prod\",model=~\"$model\"}",
+          "legendFormat": "{{model}} target"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Data Drift Score (30m avg)",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "x": 0, "y": 100, "w": 8, "h": 7 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "avg_over_time(ml_data_drift_score{deployment=\"prod\",model=~\"$model\"}[30m])"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green" },
+              { "value": 0.5, "color": "yellow" },
+              { "value": 0.7, "color": "red" }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"], "values": false }, "colorMode": "value" }
+    },
+    {
+      "type": "timeseries",
+      "title": "Inference Throughput vs Errors",
+      "datasource": { "type": "prometheus" },
+      "gridPos": { "x": 8, "y": 100, "w": 16, "h": 7 },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum by (model) (rate(ml_inference_requests_total{deployment=\"prod\",model=~\"$model\"}[5m]))",
+          "legendFormat": "{{model}} req/s"
+        },
+        {
+          "refId": "B",
+          "expr": "sum by (model) (rate(ml_inference_failures_total{deployment=\"prod\",model=~\"$model\"}[5m]))",
+          "legendFormat": "{{model}} failures/s"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "options": { "legend": { "displayMode": "table", "placement": "bottom" } }
     }
   ],
   "refresh": "30s",
@@ -328,6 +438,18 @@
         "query": "label_values(apollo_request_total, tenant)",
         "refresh": 2,
         "includeAll": true,
+        "current": { "text": "All", "value": "$__all", "selected": true }
+      },
+      {
+        "type": "query",
+        "name": "model",
+        "label": "Model",
+        "hide": 0,
+        "datasource": "Prometheus",
+        "query": "label_values(ml_model_accuracy_score, model)",
+        "refresh": 2,
+        "includeAll": true,
+        "allValue": ".*",
         "current": { "text": "All", "value": "$__all", "selected": true }
       },
       {

--- a/ops/prometheus/prometheus-ml-alerts.yaml
+++ b/ops/prometheus/prometheus-ml-alerts.yaml
@@ -1,0 +1,59 @@
+# ML observability alert rules for Prometheus
+# Focuses on model accuracy, inference latency, and data drift metrics.
+groups:
+  - name: ml-observability
+    interval: 30s
+    rules:
+      - record: model:inference_latency_seconds:p95
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum by (le, model, deployment) (
+              rate(ml_inference_latency_seconds_bucket{deployment="prod"}[5m])
+            )
+          )
+      - record: model:accuracy_avg_1h
+        expr: avg_over_time(ml_model_accuracy_score{deployment="prod"}[1h])
+      - alert: ModelAccuracyDrift
+        expr: |
+          model:accuracy_avg_1h{deployment="prod"}
+            < (ml_model_accuracy_target{deployment="prod"} - 0.05)
+        for: 15m
+        labels:
+          severity: page
+          component: ml-observability
+          service: ml-platform
+        annotations:
+          summary: 'Model accuracy drift beyond threshold'
+          description: |
+            Accuracy for model {{ $labels.model }} in {{ $labels.deployment }} dropped more than 5% below target for 15 minutes.
+            Investigate dataset freshness, concept drift, and retraining pipelines.
+          runbook_url: 'https://runbooks.summit.ai/ml-alerting-guide#model-accuracy-drift'
+      - alert: ModelInferenceLatencyHigh
+        expr: |
+          model:inference_latency_seconds:p95{deployment="prod"} > 0.75
+        for: 10m
+        labels:
+          severity: page
+          component: ml-observability
+          service: ml-platform
+        annotations:
+          summary: 'p95 inference latency above 750ms'
+          description: |
+            p95 inference latency for model {{ $labels.model }} in {{ $labels.deployment }} has exceeded 750ms for 10 minutes.
+            Check feature service, hardware accelerators, and upstream dependencies.
+          runbook_url: 'https://runbooks.summit.ai/ml-alerting-guide#inference-latency'
+      - alert: ModelDataDriftHigh
+        expr: |
+          avg_over_time(ml_data_drift_score{deployment="prod"}[30m]) > 0.7
+        for: 30m
+        labels:
+          severity: page
+          component: ml-observability
+          service: ml-platform
+        annotations:
+          summary: 'Data drift score above 0.7'
+          description: |
+            Data drift score for model {{ $labels.model }} exceeded 0.7 over the last 30 minutes.
+            Validate upstream data quality, feature distributions, and refresh cadence.
+          runbook_url: 'https://runbooks.summit.ai/ml-alerting-guide#data-drift'


### PR DESCRIPTION
## Summary
- add Prometheus recording rules and alerts for ML accuracy, latency, and data drift
- route ML observability alerts to PagerDuty via a dedicated Alertmanager receiver and service config
- extend the IntelGraph overview dashboard with ML panels and document the on-call runbook

## Testing
- `pre-commit run --files ops/prometheus/prometheus-ml-alerts.yaml ops/alerts/pagerduty-ml-service.yaml ops/grafana/dashboards/intelgraph-overview.json monitoring/alertmanager/sre-policy.yml docs/runbooks/ml-alerting-guide.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f558169883339cdb3c81d7b06ae3