### PR TITLE
Add guided tours with persisted onboarding state

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -58,6 +58,7 @@
     "react-dom": "^19.1.1",
     "react-grid-layout": "^1.5.2",
     "react-hook-form": "^7.62.0",
+    "react-joyride": "^2.9.5",
     "react-leaflet": "^5.0.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.8.2",

--- a/client/src/App.router.jsx
+++ b/client/src/App.router.jsx
@@ -77,6 +77,15 @@ import ClaimsViewer from './features/conductor/ClaimsViewer';
 import RetractionQueue from './features/conductor/RetractionQueue';
 import CostAdvisor from './features/conductor/CostAdvisor';
 import RunSearch from './features/conductor/RunSearch';
+import GoldenPathWizard from './components/onboarding/GoldenPathWizard.jsx';
+import { QueryChipBuilder } from './components/search/QueryChipBuilder.tsx';
+import { FeatureTourProvider, useFeatureTour } from './features/onboarding/FeatureTourProvider.tsx';
+import {
+  ingestWizardSteps,
+  queryBuilderSteps,
+  INGEST_WIZARD_TOUR_KEY,
+  QUERY_BUILDER_TOUR_KEY,
+} from './features/onboarding/tourSteps.tsx';
 
 // Navigation items
 const navigationItems = [
@@ -246,6 +255,11 @@ function DashboardPage() {
     activeUsers: 8,
     alertsCount: 2,
   });
+  const [wizardOpen, setWizardOpen] = React.useState(false);
+  const [queryChips, setQueryChips] = React.useState([]);
+  const { progress } = useFeatureTour();
+  const ingestTour = progress[INGEST_WIZARD_TOUR_KEY];
+  const queryTour = progress[QUERY_BUILDER_TOUR_KEY];
 
   // Simulate real-time updates
   React.useEffect(() => {
@@ -283,6 +297,31 @@ function DashboardPage() {
               </Typography>
               <Typography variant="h6" sx={{ opacity: 0.9 }}>
                 Real-time intelligence analysis and monitoring dashboard
+              </Typography>
+              <Box
+                sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5, mt: 2 }}
+                role="group"
+                aria-label="Onboarding shortcuts"
+              >
+                <Button
+                  variant="outlined"
+                  color="inherit"
+                  onClick={() => setWizardOpen(true)}
+                  data-testid="open-ingest-wizard"
+                  aria-label="Open ingest onboarding wizard"
+                >
+                  Launch ingest wizard
+                </Button>
+              </Box>
+              <Typography
+                variant="body2"
+                sx={{ opacity: 0.9, mt: 1 }}
+                role="status"
+                aria-live="polite"
+              >
+                {ingestTour?.completed
+                  ? 'Guided tour completed. You can replay it from within the wizard.'
+                  : 'Use the ingest wizard to explore the guided setup for new data sources.'}
               </Typography>
             </CardContent>
           </Card>
@@ -503,6 +542,32 @@ function DashboardPage() {
           </Card>
         </Grid>
 
+        {/* Query Builder Guide */}
+        <Grid item xs={12} md={6}>
+          <Card sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                🔎 Query Builder Playground
+              </Typography>
+              <Typography variant="body2" color="text.secondary" paragraph>
+                Craft reusable search filters and experiment with keyboard-friendly chip controls.
+              </Typography>
+              <QueryChipBuilder chips={queryChips} onChipsChange={setQueryChips} />
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mt: 2 }}
+                role="status"
+                aria-live="polite"
+              >
+                {queryTour?.completed
+                  ? 'Query builder tour completed. Replay it from the guided tour button inside the card.'
+                  : 'Take the guided tour to learn how to add, remove, and share advanced filters.'}
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+
         {/* Live Collaboration Panel */}
         <Grid item xs={12} md={4}>
           <LiveCollaborationPanel />
@@ -562,6 +627,12 @@ function DashboardPage() {
           </Card>
         </Grid>
       </Grid>
+
+      <GoldenPathWizard
+        open={wizardOpen}
+        onClose={() => setWizardOpen(false)}
+        onComplete={() => setWizardOpen(false)}
+      />
     </Container>
   );
 }
@@ -725,11 +796,13 @@ function App() {
     <Provider store={store}>
       <ApolloProvider client={apolloClient}>
         <AuthProvider>
-          <ThemedAppShell>
-            <Router>
-              <MainLayout />
-            </Router>
-          </ThemedAppShell>
+          <FeatureTourProvider>
+            <ThemedAppShell>
+              <Router>
+                <MainLayout />
+              </Router>
+            </ThemedAppShell>
+          </FeatureTourProvider>
         </AuthProvider>
       </ApolloProvider>
     </Provider>

--- a/client/src/components/search/QueryChipBuilder.tsx
+++ b/client/src/components/search/QueryChipBuilder.tsx
@@ -11,6 +11,11 @@ import {
   Button,
 } from '@mui/material';
 import { Add, Clear, FilterList, Save, Share } from '@mui/icons-material';
+import { useFeatureTour } from '../../features/onboarding/FeatureTourProvider.tsx';
+import {
+  queryBuilderSteps,
+  QUERY_BUILDER_TOUR_KEY,
+} from '../../features/onboarding/tourSteps.tsx';
 
 export interface QueryChip {
   id: string;
@@ -47,6 +52,8 @@ const OPERATORS = {
 export function QueryChipBuilder({ chips, onChipsChange, onSave, onShare }: QueryChipBuilderProps) {
   const [newChip, setNewChip] = useState<Partial<QueryChip>>({});
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const { startTour, resetTour, progress } = useFeatureTour();
+  const completedTour = progress[QUERY_BUILDER_TOUR_KEY]?.completed ?? false;
 
   const addChip = useCallback(() => {
     if (!newChip.field || !newChip.operator || !newChip.value) return;
@@ -91,13 +98,29 @@ export function QueryChipBuilder({ chips, onChipsChange, onSave, onShare }: Quer
     [chips, onChipsChange],
   );
 
+  const handleTour = useCallback(() => {
+    if (completedTour) {
+      resetTour(QUERY_BUILDER_TOUR_KEY);
+    }
+    startTour(QUERY_BUILDER_TOUR_KEY, queryBuilderSteps);
+  }, [completedTour, resetTour, startTour]);
+
   return (
-    <Paper elevation={1} sx={{ p: 2, mb: 2 }}>
+    <Paper elevation={1} sx={{ p: 2, mb: 2 }} data-tour-id="query-builder-card">
       <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
         <FilterList color="primary" />
         <Typography variant="subtitle2">Query Builder</Typography>
 
         <Box sx={{ ml: 'auto', display: 'flex', gap: 1 }}>
+          <Button
+            size="small"
+            variant="outlined"
+            onClick={handleTour}
+            data-tour-id="query-builder-tour-button"
+            aria-label={completedTour ? 'Replay query builder tour' : 'Start query builder tour'}
+          >
+            {completedTour ? 'Replay tour' : 'Guided tour'}
+          </Button>
           {onSave && (
             <Tooltip title="Save search">
               <IconButton size="small" onClick={() => setSaveDialogOpen(true)}>
@@ -124,7 +147,10 @@ export function QueryChipBuilder({ chips, onChipsChange, onSave, onShare }: Quer
 
       {/* Active filter chips */}
       {chips.length > 0 && (
-        <Box sx={{ mb: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+        <Box
+          sx={{ mb: 2, display: 'flex', flexWrap: 'wrap', gap: 1 }}
+          data-tour-id="query-builder-chips"
+        >
           {chips.map((chip) => (
             <Chip
               key={chip.id}
@@ -151,11 +177,12 @@ export function QueryChipBuilder({ chips, onChipsChange, onSave, onShare }: Quer
             }
           }}
           helperText="Press Enter to parse. Format: field:value, field>value, field<value"
+          data-tour-id="query-builder-dsl"
         />
       </Box>
 
       {/* Manual chip builder */}
-      <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-end' }}>
+      <Box sx={{ display: 'flex', gap: 1, alignItems: 'flex-end' }} data-tour-id="query-builder-fields">
         <Autocomplete
           size="small"
           sx={{ minWidth: 120 }}
@@ -195,7 +222,13 @@ export function QueryChipBuilder({ chips, onChipsChange, onSave, onShare }: Quer
       </Box>
 
       {chips.length > 0 && (
-        <Typography variant="caption" color="text.secondary" sx={{ mt: 1, display: 'block' }}>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ mt: 1, display: 'block' }}
+          role="status"
+          aria-live="polite"
+        >
           {chips.length} active filter{chips.length !== 1 ? 's' : ''}
         </Typography>
       )}

--- a/client/src/features/onboarding/FeatureTourProvider.tsx
+++ b/client/src/features/onboarding/FeatureTourProvider.tsx
@@ -1,0 +1,221 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import Joyride, { CallBackProps, STATUS, Step } from 'react-joyride';
+import { useMutation, useQuery } from '@apollo/client';
+import {
+  FEATURE_TOUR_PROGRESS,
+  RECORD_FEATURE_TOUR_PROGRESS,
+} from '../../graphql/onboarding.gql.js';
+import { useAuth } from '../../context/AuthContext.jsx';
+
+type TourKey = string;
+
+type TourProgressState = {
+  completed: boolean;
+  lastStep: number | null;
+  completedAt: string | null;
+};
+
+interface FeatureTourContextValue {
+  startTour: (tourKey: TourKey, steps: Step[]) => void;
+  resetTour: (tourKey: TourKey) => void;
+  progress: Record<TourKey, TourProgressState>;
+  isRunning: boolean;
+  activeTourKey: TourKey | null;
+}
+
+interface JoyrideState {
+  running: boolean;
+  steps: Step[];
+  tourKey: TourKey | null;
+}
+
+const FeatureTourContext = createContext<FeatureTourContextValue | undefined>(undefined);
+
+const DEFAULT_PROGRESS: TourProgressState = {
+  completed: false,
+  lastStep: null,
+  completedAt: null,
+};
+
+export function FeatureTourProvider({ children }: { children: React.ReactNode }) {
+  const { user, loading: authLoading } = useAuth();
+  const canPersist = Boolean(user?.id);
+  const [tourState, setTourState] = useState<JoyrideState>({ running: false, steps: [], tourKey: null });
+  const [progressMap, setProgressMap] = useState<Record<TourKey, TourProgressState>>({});
+
+  const { data } = useQuery(FEATURE_TOUR_PROGRESS, {
+    skip: authLoading || !canPersist,
+    fetchPolicy: 'cache-first',
+  });
+
+  const [recordProgress] = useMutation(RECORD_FEATURE_TOUR_PROGRESS);
+
+  useEffect(() => {
+    if (!data?.featureTourProgresses) return;
+
+    setProgressMap((prev) => {
+      const next = { ...prev };
+      for (const item of data.featureTourProgresses) {
+        next[item.tourKey] = {
+          completed: Boolean(item.completed),
+          lastStep: typeof item.lastStep === 'number' ? item.lastStep : null,
+          completedAt: item.completedAt ?? null,
+        };
+      }
+      return next;
+    });
+  }, [data]);
+
+  const persistProgress = useCallback(
+    (tourKey: TourKey, completed: boolean, lastStep: number | null) => {
+      if (!canPersist) return;
+
+      const timestamp = completed ? new Date().toISOString() : null;
+
+      void recordProgress({
+        variables: {
+          input: {
+            tourKey,
+            completed,
+            lastStep,
+          },
+        },
+        optimisticResponse: {
+          recordFeatureTourProgress: {
+            __typename: 'FeatureTourProgress',
+            id: `feature-tour-${tourKey}`,
+            tourKey,
+            completed,
+            completedAt: timestamp,
+            lastStep,
+          },
+        },
+      }).catch((error) => {
+        if (import.meta.env.DEV) {
+          console.warn('Failed to persist feature tour progress', error);
+        }
+      });
+    },
+    [recordProgress, canPersist],
+  );
+
+  const startTour = useCallback(
+    (tourKey: TourKey, steps: Step[]) => {
+      if (!steps?.length) return;
+
+      setTourState({ running: true, steps, tourKey });
+      setProgressMap((prev) => ({
+        ...prev,
+        [tourKey]: { ...DEFAULT_PROGRESS },
+      }));
+      persistProgress(tourKey, false, null);
+    },
+    [persistProgress],
+  );
+
+  const resetTour = useCallback(
+    (tourKey: TourKey) => {
+      setProgressMap((prev) => ({
+        ...prev,
+        [tourKey]: { ...DEFAULT_PROGRESS },
+      }));
+      persistProgress(tourKey, false, null);
+    },
+    [persistProgress],
+  );
+
+  const handleJoyrideCallback = useCallback(
+    (callbackData: CallBackProps) => {
+      const { status, index, type } = callbackData;
+      const activeKey = tourState.tourKey;
+      if (!activeKey) return;
+
+      if (type === 'step:after' || type === 'target:notFound') {
+        setProgressMap((prev) => ({
+          ...prev,
+          [activeKey]: {
+            completed: false,
+            lastStep: index,
+            completedAt: null,
+          },
+        }));
+        persistProgress(activeKey, false, index);
+      }
+
+      if ([STATUS.FINISHED, STATUS.SKIPPED].includes(status)) {
+        const completed = status === STATUS.FINISHED;
+        const completedAt = completed ? new Date().toISOString() : null;
+
+        setTourState({ running: false, steps: [], tourKey: null });
+        setProgressMap((prev) => ({
+          ...prev,
+          [activeKey]: {
+            completed,
+            lastStep: index,
+            completedAt,
+          },
+        }));
+        persistProgress(activeKey, completed, index);
+      }
+    },
+    [tourState.tourKey, persistProgress],
+  );
+
+  const contextValue = useMemo<FeatureTourContextValue>(
+    () => ({
+      startTour,
+      resetTour,
+      progress: progressMap,
+      isRunning: tourState.running,
+      activeTourKey: tourState.tourKey,
+    }),
+    [startTour, resetTour, progressMap, tourState.running, tourState.tourKey],
+  );
+
+  return (
+    <FeatureTourContext.Provider value={contextValue}>
+      {children}
+      <Joyride
+        callback={handleJoyrideCallback}
+        continuous
+        disableScrolling
+        run={tourState.running}
+        scrollToFirstStep
+        showSkipButton
+        showProgress
+        steps={tourState.steps}
+        styles={{
+          options: {
+            zIndex: 2000,
+          },
+          tooltipContent: {
+            fontSize: '0.95rem',
+            lineHeight: 1.5,
+          },
+        }}
+        locale={{
+          back: 'Back',
+          close: 'Close',
+          last: 'Done',
+          next: 'Next',
+          skip: 'Skip tour',
+        }}
+      />
+    </FeatureTourContext.Provider>
+  );
+}
+
+export function useFeatureTour(): FeatureTourContextValue {
+  const context = useContext(FeatureTourContext);
+  if (!context) {
+    throw new Error('useFeatureTour must be used within a FeatureTourProvider');
+  }
+  return context;
+}

--- a/client/src/features/onboarding/tourSteps.tsx
+++ b/client/src/features/onboarding/tourSteps.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import type { Step } from 'react-joyride';
+
+export const INGEST_WIZARD_TOUR_KEY = 'ingest-wizard';
+export const QUERY_BUILDER_TOUR_KEY = 'query-builder';
+
+export const ingestWizardSteps: Step[] = [
+  {
+    target: '[data-tour-id="ingest-wizard-title"]',
+    title: 'Guided ingest setup',
+    content: (
+      <div>
+        <p>
+          This dialog walks you through importing new intelligence data and configuring Copilot
+          analysis. We will highlight the key controls so you can safely follow along with a screen
+          reader.
+        </p>
+      </div>
+    ),
+    disableBeacon: true,
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour-id="ingest-wizard-demo-toggle"]',
+    title: 'Demo mode shortcut',
+    content: (
+      <div>
+        <p>
+          Turn on demo mode to auto-populate sample data. This is helpful for training sessions and
+          keeps production tenants untouched.
+        </p>
+      </div>
+    ),
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour-id="ingest-wizard-progress"]',
+    title: 'Track your progress',
+    content: (
+      <div>
+        <p>
+          The progress bar and step list update as you finish each action. They provide real-time
+          feedback for assistive technologies via polite announcements.
+        </p>
+      </div>
+    ),
+    placement: 'bottom',
+  },
+  {
+    target: '[data-tour-id="ingest-wizard-action"]',
+    title: 'Complete each task',
+    content: (
+      <div>
+        <p>
+          Follow the instructions in this panel to add entities, upload files, and launch Copilot.
+          Each step validates inputs so you can confidently move forward.
+        </p>
+      </div>
+    ),
+    placement: 'top',
+  },
+];
+
+export const queryBuilderSteps: Step[] = [
+  {
+    target: '[data-tour-id="query-builder-card"]',
+    title: 'Flexible query builder',
+    content: (
+      <div>
+        <p>
+          Build complex search filters with chips or using the accessible quick search field. All
+          controls support keyboard navigation.
+        </p>
+      </div>
+    ),
+    disableBeacon: true,
+  },
+  {
+    target: '[data-tour-id="query-builder-dsl"]',
+    title: 'Keyboard friendly input',
+    content: (
+      <div>
+        <p>
+          Type structured filters such as <code>status:active</code> and press Enter to convert them
+          into chips instantly.
+        </p>
+      </div>
+    ),
+    placement: 'top',
+  },
+  {
+    target: '[data-tour-id="query-builder-fields"]',
+    title: 'Pick fields and operators',
+    content: (
+      <div>
+        <p>
+          Use the dropdowns to choose a field and operator. These components announce their labels
+          and support arrow key navigation for WCAG 2.1 compliance.
+        </p>
+      </div>
+    ),
+  },
+  {
+    target: '[data-tour-id="query-builder-chips"]',
+    title: 'Review active filters',
+    content: (
+      <div>
+        <p>
+          All active filters appear as chips that you can remove with a keyboard or pointer. The
+          status text updates politely so screen readers stay in sync.
+        </p>
+      </div>
+    ),
+    placement: 'top',
+  },
+];

--- a/client/src/graphql/onboarding.gql.js
+++ b/client/src/graphql/onboarding.gql.js
@@ -1,0 +1,25 @@
+import { gql } from '@apollo/client';
+
+export const FEATURE_TOUR_PROGRESS = gql`
+  query FeatureTourProgresses {
+    featureTourProgresses {
+      id
+      tourKey
+      completed
+      completedAt
+      lastStep
+    }
+  }
+`;
+
+export const RECORD_FEATURE_TOUR_PROGRESS = gql`
+  mutation RecordFeatureTourProgress($input: FeatureTourProgressInput!) {
+    recordFeatureTourProgress(input: $input) {
+      id
+      tourKey
+      completed
+      completedAt
+      lastStep
+    }
+  }
+`;

--- a/client/tests/e2e/guided-tours.spec.ts
+++ b/client/tests/e2e/guided-tours.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, Page } from '@playwright/test';
+
+const WEB_URL = process.env.WEB_URL || 'http://localhost:3000';
+const E2E_USER = process.env.E2E_USER || 'admin@example.com';
+const E2E_PASS = process.env.E2E_PASS || 'password123';
+
+async function login(page: Page) {
+  await page.goto(WEB_URL);
+  if (await page.getByLabel('Email').isVisible().catch(() => false)) {
+    await page.getByLabel('Email').fill(E2E_USER);
+    await page.getByLabel('Password').fill(E2E_PASS);
+    await page.getByRole('button', { name: /sign in/i }).click();
+  }
+  await expect(page.getByText('Intelligence Command Center')).toBeVisible();
+}
+
+const ingestStepTitles = [
+  'Guided ingest setup',
+  'Demo mode shortcut',
+  'Track your progress',
+  'Complete each task',
+];
+
+const queryBuilderStepTitles = [
+  'Flexible query builder',
+  'Keyboard friendly input',
+  'Pick fields and operators',
+  'Review active filters',
+];
+
+test.describe('guided onboarding tours', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('walks through the ingest wizard tour', async ({ page }) => {
+    await page.getByTestId('open-ingest-wizard').click();
+    await expect(page.getByRole('heading', { name: 'IntelGraph Quick Start' })).toBeVisible();
+
+    const tourButton = page.locator('[data-tour-id="ingest-wizard-tour-button"]');
+    await tourButton.click();
+    await expect(page.getByText('This dialog walks you through importing new intelligence data')).toBeVisible();
+
+    for (let i = 0; i < ingestStepTitles.length; i += 1) {
+      const title = ingestStepTitles[i];
+      const dialog = page.getByRole('dialog', { name: title });
+      await expect(dialog).toBeVisible();
+      if (i < ingestStepTitles.length - 1) {
+        await dialog.getByRole('button', { name: 'Next' }).click();
+        await expect(page.getByRole('dialog', { name: ingestStepTitles[i + 1] })).toBeVisible();
+      } else {
+        await dialog.getByRole('button', { name: 'Done' }).click();
+      }
+    }
+
+    await expect(tourButton).toHaveText(/Replay tour/i);
+    await page.getByRole('button', { name: 'Close wizard' }).click();
+    await expect(
+      page.getByText('Guided tour completed. You can replay it from within the wizard.'),
+    ).toBeVisible();
+  });
+
+  test('guides the query builder tour', async ({ page }) => {
+    const builderButton = page.locator('[data-tour-id="query-builder-tour-button"]');
+    await expect(builderButton).toBeVisible();
+    await builderButton.click();
+    await expect(
+      page.getByText('Build complex search filters with chips or using the accessible quick search field.'),
+    ).toBeVisible();
+
+    for (let i = 0; i < queryBuilderStepTitles.length; i += 1) {
+      const title = queryBuilderStepTitles[i];
+      const dialog = page.getByRole('dialog', { name: title });
+      await expect(dialog).toBeVisible();
+      if (i < queryBuilderStepTitles.length - 1) {
+        await dialog.getByRole('button', { name: 'Next' }).click();
+        await expect(page.getByRole('dialog', { name: queryBuilderStepTitles[i + 1] })).toBeVisible();
+      } else {
+        await dialog.getByRole('button', { name: 'Done' }).click();
+      }
+    }
+
+    await expect(builderButton).toHaveText(/Replay tour/i);
+    await expect(
+      page.getByText('Query builder tour completed. Replay it from the guided tour button inside the card.'),
+    ).toBeVisible();
+  });
+});

--- a/docs/onboarding/guided-tours.md
+++ b/docs/onboarding/guided-tours.md
@@ -1,0 +1,83 @@
+# Guided Tours Overview
+
+Summit's UI now includes accessible guided tours for major onboarding surfaces. Tours are powered by [React Joyride](https://github.com/gilbarbara/react-joyride), persisted through GraphQL, and recorded in PostgreSQL so completion state survives across sessions.
+
+## Feature coverage
+
+| Tour key | Experience | Entry point |
+| --- | --- | --- |
+| `ingest-wizard` | IntelGraph ingest wizard walkthrough | Dashboard → **Launch ingest wizard** |
+| `query-builder` | Search query chip builder | Dashboard → **Query Builder Playground** |
+
+The `FeatureTourProvider` exposes `startTour`, `resetTour`, and live `progress` so any feature can enable contextual onboarding.
+
+## Architecture
+
+### Client
+
+- **Provider:** `src/features/onboarding/FeatureTourProvider.tsx` wraps the authenticated app shell and manages Joyride sessions, optimistic Apollo updates, and accessibility defaults.
+- **Tour definitions:** `src/features/onboarding/tourSteps.tsx` centralizes step metadata, including selectors and copy tuned for WCAG 2.1 AA.
+- **Components:**
+  - Ingest wizard (`src/components/onboarding/GoldenPathWizard.jsx`) exposes a “Guided tour” control, announces progress, and maps each step to a stable `data-tour-id`.
+  - Query builder (`src/components/search/QueryChipBuilder.tsx`) adds a replayable tour toggle, keyboard-friendly selectors, and polite status updates.
+
+### GraphQL + persistence
+
+- **Schema:** `FeatureTourProgress` types live in `server/src/graphql/schema/featureTours.ts` and extend the core schema with `featureTourProgresses` query plus `recordFeatureTourProgress` mutation.
+- **Resolvers:** `server/src/graphql/resolvers/featureTours.ts` enforce authentication, upsert completion status via PostgreSQL, and expose `completed`, `completedAt`, and `lastStep` metadata.
+- **Database:** Migration `server/db/migrations/postgres/2025-09-30_feature_tour_progress.sql` creates the `feature_tour_progress` table, unique (user_id, tour_key) index, and touch-up trigger for `updated_at`.
+
+### Accessibility highlights
+
+- Joyride tooltips include semantic headings, consistent button labels, and polite `aria-live` updates for progress copy.
+- Primary tour controls supply `aria-label`s, preserve keyboard focus, and avoid color-only cues.
+- Ingest wizard progress bars expose `aria-label="Wizard progress"`; query builder status lines use `role="status"` for screen reader announcements.
+
+## GraphQL usage
+
+```
+query FeatureTourProgresses {
+  featureTourProgresses {
+    id
+    tourKey
+    completed
+    completedAt
+    lastStep
+  }
+}
+
+mutation RecordFeatureTourProgress($input: FeatureTourProgressInput!) {
+  recordFeatureTourProgress(input: $input) {
+    id
+    tourKey
+    completed
+    completedAt
+    lastStep
+  }
+}
+```
+
+Clients should call `startTour` with the appropriate key. The provider automatically records intermediate progress and marks tours complete when Joyride emits a `FINISHED` event. Use `resetTour(key)` to clear state and replay a tour.
+
+## Testing
+
+Playwright coverage lives at `client/tests/e2e/guided-tours.spec.ts` and exercises both tours end-to-end (login, start, advance through steps, and assert completion messaging).
+
+Run the suite after installing dependencies:
+
+```
+cd client
+npm install
+npm run test:e2e guided-tours.spec.ts
+```
+
+## Adding a new tour
+
+1. Define selectors in the target component (prefer `data-tour-id` attributes).
+2. Append step metadata to `tourSteps.tsx` with accessible copy and deterministic targets.
+3. Consume the `FeatureTourProvider` hook where the tour starts and expose a launch button with `aria-label` and replay affordances.
+4. Persist progress by invoking `startTour(tourKey, steps)` and optionally `resetTour(tourKey)` before replays.
+5. Extend `feature_tour_progress` seed data or migrations if new defaults are needed.
+6. Add Playwright coverage under `client/tests/e2e` that confirms the tooltip flow and status updates.
+
+Following this pattern keeps onboarding stateful, accessible, and auditable.

--- a/server/db/migrations/postgres/2025-09-30_feature_tour_progress.sql
+++ b/server/db/migrations/postgres/2025-09-30_feature_tour_progress.sql
@@ -1,0 +1,28 @@
+CREATE TABLE IF NOT EXISTS feature_tour_progress (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,
+  tour_key TEXT NOT NULL,
+  completed_at TIMESTAMPTZ,
+  last_step INTEGER,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT feature_tour_progress_user_fk FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT feature_tour_progress_unique UNIQUE (user_id, tour_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_tour_progress_user ON feature_tour_progress(user_id);
+CREATE INDEX IF NOT EXISTS idx_feature_tour_progress_tour ON feature_tour_progress(tour_key);
+
+CREATE OR REPLACE FUNCTION set_feature_tour_progress_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_feature_tour_progress_updated ON feature_tour_progress;
+CREATE TRIGGER trg_feature_tour_progress_updated
+BEFORE UPDATE ON feature_tour_progress
+FOR EACH ROW
+EXECUTE FUNCTION set_feature_tour_progress_updated_at();

--- a/server/src/graphql/resolvers/featureTours.ts
+++ b/server/src/graphql/resolvers/featureTours.ts
@@ -1,0 +1,123 @@
+import type { Pool } from 'pg';
+import { getPostgresPool } from '../../config/database.js';
+
+interface FeatureTourRow {
+  id: string;
+  userId: string;
+  tourKey: string;
+  completed: boolean;
+  completedAt: string | null;
+  lastStep: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function getPool(): Pool {
+  const pool = getPostgresPool();
+  if (!pool) {
+    throw new Error('PostgreSQL pool is not configured');
+  }
+  return pool as Pool;
+}
+
+export const featureTourResolvers = {
+  Query: {
+    async featureTourProgress(_: unknown, args: { tourKey: string }, ctx: any) {
+      const userId = ctx?.user?.id;
+      if (!userId) {
+        throw new Error('Not authenticated');
+      }
+
+      const pool = getPool();
+      const { rows } = await pool.query<FeatureTourRow>(
+        `
+          SELECT
+            id,
+            tour_key AS "tourKey",
+            user_id AS "userId",
+            completed_at IS NOT NULL AS "completed",
+            completed_at AS "completedAt",
+            last_step AS "lastStep",
+            created_at AS "createdAt",
+            updated_at AS "updatedAt"
+          FROM feature_tour_progress
+          WHERE user_id = $1 AND tour_key = $2
+        `,
+        [userId, args.tourKey],
+      );
+
+      return rows[0] ?? null;
+    },
+
+    async featureTourProgresses(_: unknown, _args: unknown, ctx: any) {
+      const userId = ctx?.user?.id;
+      if (!userId) {
+        throw new Error('Not authenticated');
+      }
+
+      const pool = getPool();
+      const { rows } = await pool.query<FeatureTourRow>(
+        `
+          SELECT
+            id,
+            tour_key AS "tourKey",
+            user_id AS "userId",
+            completed_at IS NOT NULL AS "completed",
+            completed_at AS "completedAt",
+            last_step AS "lastStep",
+            created_at AS "createdAt",
+            updated_at AS "updatedAt"
+          FROM feature_tour_progress
+          WHERE user_id = $1
+          ORDER BY tour_key
+        `,
+        [userId],
+      );
+
+      return rows;
+    },
+  },
+
+  Mutation: {
+    async recordFeatureTourProgress(
+      _: unknown,
+      { input }: { input: { tourKey: string; completed?: boolean | null; lastStep?: number | null } },
+      ctx: any,
+    ) {
+      const userId = ctx?.user?.id;
+      if (!userId) {
+        throw new Error('Not authenticated');
+      }
+
+      const pool = getPool();
+      const completedAt = input.completed ? new Date().toISOString() : null;
+      const lastStep = typeof input.lastStep === 'number' ? input.lastStep : null;
+
+      const { rows } = await pool.query<FeatureTourRow>(
+        `
+          INSERT INTO feature_tour_progress (user_id, tour_key, completed_at, last_step)
+          VALUES ($1, $2, $3, $4)
+          ON CONFLICT (user_id, tour_key)
+          DO UPDATE SET
+            completed_at = EXCLUDED.completed_at,
+            last_step = EXCLUDED.last_step,
+            updated_at = NOW()
+          RETURNING
+            id,
+            tour_key AS "tourKey",
+            user_id AS "userId",
+            completed_at IS NOT NULL AS "completed",
+            completed_at AS "completedAt",
+            last_step AS "lastStep",
+            created_at AS "createdAt",
+            updated_at AS "updatedAt"
+        `,
+        [userId, input.tourKey, completedAt, lastStep],
+      );
+
+      return rows[0];
+    },
+  },
+};
+
+export default featureTourResolvers;

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -12,6 +12,7 @@ import { triggerN8nFlow } from '../../integrations/n8n.js';
 import { checkN8nTriggerAllowed } from '../../integrations/n8n-policy.js';
 import { isEnabled as flagEnabled } from '../../featureFlags/flagsmith.js';
 import { doclingResolvers } from './docling.ts';
+import featureTourResolvers from './featureTours.ts';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -25,6 +26,7 @@ const resolvers = {
     // Production core resolvers (PostgreSQL + Neo4j)
     ...coreResolvers.Query,
     ...doclingResolvers.Query,
+    ...featureTourResolvers.Query,
     async pipeline(_p: any, args: { id: string }) {
       const { getPipelineDef } = await import('../../db/repositories/pipelines.js');
       return await getPipelineDef(args.id);
@@ -63,6 +65,7 @@ const resolvers = {
     // Production core resolvers
     ...coreResolvers.Mutation,
     ...doclingResolvers.Mutation,
+    ...featureTourResolvers.Mutation,
 
     // Legacy resolvers (will be phased out)
     ...entityResolvers.Mutation,

--- a/server/src/graphql/schema/featureTours.ts
+++ b/server/src/graphql/schema/featureTours.ts
@@ -1,0 +1,31 @@
+import { gql } from 'graphql-tag';
+
+export const featureTourTypeDefs = gql`
+  type FeatureTourProgress {
+    id: ID!
+    userId: ID!
+    tourKey: String!
+    completed: Boolean!
+    completedAt: DateTime
+    lastStep: Int
+    createdAt: DateTime!
+    updatedAt: DateTime!
+  }
+
+  input FeatureTourProgressInput {
+    tourKey: String!
+    completed: Boolean
+    lastStep: Int
+  }
+
+  extend type Query {
+    featureTourProgress(tourKey: String!): FeatureTourProgress
+    featureTourProgresses: [FeatureTourProgress!]!
+  }
+
+  extend type Mutation {
+    recordFeatureTourProgress(input: FeatureTourProgressInput!): FeatureTourProgress!
+  }
+`;
+
+export default featureTourTypeDefs;

--- a/server/src/graphql/schema/index.ts
+++ b/server/src/graphql/schema/index.ts
@@ -6,6 +6,7 @@ import aiModule from '../schema.ai.js';
 import annotationsModule from '../schema.annotations.js';
 import graphragTypesModule from '../types/graphragTypes.js';
 import { crystalTypeDefs } from '../schema.crystal.js';
+import { featureTourTypeDefs } from './featureTours.ts';
 
 const { copilotTypeDefs } = copilotModule as { copilotTypeDefs: any };
 const { graphTypeDefs } = graphModule as { graphTypeDefs: any };
@@ -39,6 +40,7 @@ export const typeDefs = [
   aiTypeDefs,
   annotationsTypeDefs,
   crystalTypeDefs,
+  featureTourTypeDefs,
 ];
 
 export default typeDefs;


### PR DESCRIPTION
## Summary
- introduce a reusable FeatureTourProvider that drives React Joyride tours for the ingest wizard and query builder along with accessible step definitions
- refresh the ingest wizard, dashboard, and query builder UI to expose guided tour controls, WCAG-friendly annotations, and status messaging backed by new onboarding GraphQL operations
- persist tour progress in PostgreSQL via new schema/resolver plumbing, document the onboarding workflow, and add Playwright coverage for both tours

## Testing
- `npm run lint` *(fails: missing package 'globals' because dependencies were not installable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6f5d86664833394989e524b3ffe32