### PR TITLE
Add environment-specific synthetic CI checks

### DIFF
--- a/.github/workflows/environment-specific-tests.yml
+++ b/.github/workflows/environment-specific-tests.yml
@@ -1,0 +1,59 @@
+name: Environment Specific Tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/environment-specific-tests.yml'
+      - 'docker-compose.env-tests.yml'
+      - 'scripts/tests/**'
+      - 'docs/ci/**'
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/environment-specific-tests.yml'
+      - 'docker-compose.env-tests.yml'
+      - 'scripts/tests/**'
+      - 'docs/ci/**'
+
+jobs:
+  environment-tests:
+    name: ${{ matrix.service }} service - ${{ matrix.environment }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - environment: dev
+            service: node
+            runtime: docker
+          - environment: dev
+            service: python
+            runtime: docker
+          - environment: staging
+            service: node
+            runtime: kubernetes
+          - environment: staging
+            service: python
+            runtime: kubernetes
+          - environment: prod
+            service: node
+            runtime: docker
+          - environment: prod
+            service: python
+            runtime: docker
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Kind for staging tests
+        if: matrix.runtime == 'kubernetes'
+        uses: helm/kind-action@v1.8.0
+        with:
+          version: v0.22.0
+
+      - name: Run environment synthetic tests
+        run: ./scripts/tests/run_env_tests.sh ${{ matrix.environment }} ${{ matrix.service }}
+        shell: bash

--- a/docker-compose.env-tests.yml
+++ b/docker-compose.env-tests.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  node-tests:
+    image: node:20-alpine
+    working_dir: /workspace
+    volumes:
+      - .:/workspace:ro
+    environment:
+      TEST_ENVIRONMENT: ${TEST_ENVIRONMENT:-dev}
+      SYNTHETIC_DATA_PATH: /workspace/scripts/tests/data/synthetic-test-data.json
+    command: ["node", "scripts/tests/run_node_tests.mjs"]
+
+  python-tests:
+    image: python:3.11-slim
+    working_dir: /workspace
+    volumes:
+      - .:/workspace:ro
+    environment:
+      TEST_ENVIRONMENT: ${TEST_ENVIRONMENT:-dev}
+      SYNTHETIC_DATA_PATH: /workspace/scripts/tests/data/synthetic-test-data.json
+    command: ["python", "scripts/tests/run_python_tests.py"]

--- a/docs/ci/environment-specific-testing.md
+++ b/docs/ci/environment-specific-testing.md
@@ -1,0 +1,59 @@
+# Environment-Specific Test Automation
+
+This guide explains how the new CI jobs validate the Summit Node.js and Python services across development (`dev`), staging, and production (`prod`) environments. The workflow runs automatically in GitHub Actions and can also be exercised locally for debugging.
+
+## Overview
+
+- **Workflow**: `.github/workflows/environment-specific-tests.yml` orchestrates environment-aware checks for both stacks.
+- **Local orchestration**: Development and production checks run with Docker Compose, using lightweight utility containers that mount the repository.
+- **Staging orchestration**: Staging checks run inside a disposable Kubernetes (Kind) cluster to mimic the platform deployment topology.
+- **Synthetic data coverage**: Shared JSON fixtures (`scripts/tests/data/synthetic-test-data.json`) describe expected behaviour for each environment, enabling deterministic assertions.
+
+## GitHub Actions workflow
+
+The workflow fan-outs over the matrix `{dev, staging, prod} × {node, python}` and executes the scripts below. Highlights:
+
+1. `dev` and `prod` jobs call Docker Compose via `scripts/tests/run_local_env_tests.sh`, which in turn launches either `node:20-alpine` or `python:3.11-slim` to run the synthetic checks.
+2. `staging` jobs bootstrap a Kind cluster and call `scripts/tests/run_k8s_env_tests.sh`. The script packages the test artefacts in a ConfigMap and creates a Kubernetes `Job` to run the validations in-cluster.
+3. All jobs rely on `scripts/tests/run_env_tests.sh` for a common entry point, making it straightforward to reproduce the CI behaviour locally.
+
+## Synthetic test coverage
+
+Synthetic fixtures assert environment guarantees for both service types:
+
+- **Node.js** (`scripts/tests/run_node_tests.mjs`)
+  - Validates schema version consistency for dev/staging/prod inputs.
+  - Enforces latency budgets that tighten progressively from dev (150 ms) to prod (90 ms).
+  - Ensures experimental feature flags are stripped from production samples while required feature flags remain enabled in dev/staging.
+- **Python** (`scripts/tests/run_python_tests.py`)
+  - Verifies anomaly counts stay below environment-specific thresholds.
+  - Checks minimum confidence levels (0.6→0.9) and positive synthetic event counts.
+  - Guards production coverage by requiring ≥10 synthetic events.
+
+## Running the checks locally
+
+```bash
+# Dev Node.js checks (Docker Compose)
+scripts/tests/run_env_tests.sh dev node
+
+# Prod Python checks (Docker Compose)
+scripts/tests/run_env_tests.sh prod python
+
+# Staging Node.js checks (requires a running Kubernetes cluster, e.g. Kind)
+scripts/tests/run_env_tests.sh staging node
+```
+
+For staging runs you need `kubectl` access to a cluster. Locally you can create one with [Kind](https://kind.sigs.k8s.io/), or rely on the GitHub Actions automation which uses the `helm/kind-action` setup.
+
+## Artefact reference
+
+| Artefact | Purpose |
+| --- | --- |
+| `docker-compose.env-tests.yml` | Defines the Docker Compose services used for dev/prod synthetic checks. |
+| `scripts/tests/run_env_tests.sh` | Unified entry point that selects Docker Compose or Kubernetes orchestration. |
+| `scripts/tests/run_local_env_tests.sh` | Handles Docker Compose orchestration for Node.js/Python containers. |
+| `scripts/tests/run_k8s_env_tests.sh` | Creates the staging Kubernetes job and streams its logs. |
+| `scripts/tests/run_node_tests.mjs` | Node.js synthetic assertions executed in both Docker Compose and Kubernetes flows. |
+| `scripts/tests/run_python_tests.py` | Python synthetic assertions executed in both Docker Compose and Kubernetes flows. |
+| `scripts/tests/data/synthetic-test-data.json` | Shared dataset describing expected environment behaviour. |
+

--- a/scripts/tests/data/synthetic-test-data.json
+++ b/scripts/tests/data/synthetic-test-data.json
@@ -1,0 +1,42 @@
+{
+  "nodeService": [
+    {
+      "environment": "dev",
+      "requestLatencyMs": 120,
+      "featureFlags": ["beta-insights", "synthetic-metrics"],
+      "schemaVersion": 1
+    },
+    {
+      "environment": "staging",
+      "requestLatencyMs": 95,
+      "featureFlags": ["synthetic-metrics"],
+      "schemaVersion": 1
+    },
+    {
+      "environment": "prod",
+      "requestLatencyMs": 80,
+      "featureFlags": [],
+      "schemaVersion": 1
+    }
+  ],
+  "pythonService": [
+    {
+      "environment": "dev",
+      "anomaliesDetected": 2,
+      "confidence": 0.68,
+      "syntheticEvents": 25
+    },
+    {
+      "environment": "staging",
+      "anomaliesDetected": 1,
+      "confidence": 0.82,
+      "syntheticEvents": 18
+    },
+    {
+      "environment": "prod",
+      "anomaliesDetected": 0,
+      "confidence": 0.94,
+      "syntheticEvents": 15
+    }
+  ]
+}

--- a/scripts/tests/run_env_tests.sh
+++ b/scripts/tests/run_env_tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <environment> <service>" >&2
+  exit 1
+fi
+
+environment=$1
+service=$2
+
+case "${environment}" in
+  dev|prod)
+    "$(dirname "${BASH_SOURCE[0]}")/run_local_env_tests.sh" "${environment}" "${service}"
+    ;;
+  staging)
+    "$(dirname "${BASH_SOURCE[0]}")/run_k8s_env_tests.sh" "${environment}" "${service}"
+    ;;
+  *)
+    echo "Unsupported environment '${environment}'. Expected dev, staging, or prod." >&2
+    exit 1
+    ;;
+esac

--- a/scripts/tests/run_k8s_env_tests.sh
+++ b/scripts/tests/run_k8s_env_tests.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <environment> <service>" >&2
+  exit 1
+fi
+
+environment=$1
+service=$2
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+configmap_name="env-test-scripts"
+job_name="${service}-${environment}-synthetic-tests"
+
+if [[ "${service}" != "node" && "${service}" != "python" ]]; then
+  echo "Unsupported service '${service}'. Expected 'node' or 'python'." >&2
+  exit 1
+fi
+
+printf 'Preparing Kubernetes job for %s synthetic checks in %s...\n' "${service}" "${environment}"
+
+kubectl create configmap "${configmap_name}" \
+  --from-file="${repo_root}/scripts/tests/run_node_tests.mjs" \
+  --from-file="${repo_root}/scripts/tests/run_python_tests.py" \
+  --from-file="${repo_root}/scripts/tests/data/synthetic-test-data.json" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+kubectl delete job "${job_name}" --ignore-not-found >/dev/null 2>&1
+
+if [[ "${service}" == "node" ]]; then
+  image="node:20-alpine"
+  container_command="node /workspace/run_node_tests.mjs"
+elif [[ "${service}" == "python" ]]; then
+  image="python:3.11-slim"
+  container_command="python /workspace/run_python_tests.py"
+fi
+
+cat <<MANIFEST | kubectl apply -f -
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${job_name}
+  labels:
+    app: environment-tests
+    environment: ${environment}
+    service: ${service}
+spec:
+  backoffLimit: 0
+  template:
+    metadata:
+      labels:
+        app: environment-tests
+        environment: ${environment}
+        service: ${service}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: ${service}-synthetic-tests
+          image: ${image}
+          command:
+            - /bin/sh
+            - -c
+            - "${container_command}"
+          env:
+            - name: TEST_ENVIRONMENT
+              value: "${environment}"
+            - name: SYNTHETIC_DATA_PATH
+              value: /workspace/synthetic-test-data.json
+          volumeMounts:
+            - name: test-scripts
+              mountPath: /workspace
+      volumes:
+        - name: test-scripts
+          configMap:
+            name: ${configmap_name}
+            defaultMode: 0555
+MANIFEST
+
+kubectl wait --for=condition=complete "job/${job_name}" --timeout=180s
+kubectl logs "job/${job_name}"
+kubectl delete job "${job_name}" >/dev/null 2>&1

--- a/scripts/tests/run_local_env_tests.sh
+++ b/scripts/tests/run_local_env_tests.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <environment> <service>" >&2
+  exit 1
+fi
+
+environment=$1
+service=$2
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+compose_file="${repo_root}/docker-compose.env-tests.yml"
+project_name="envtests"
+
+if [[ ! -f "${compose_file}" ]]; then
+  echo "Docker Compose file not found at ${compose_file}" >&2
+  exit 1
+fi
+
+container_service="${service}-tests"
+if [[ "${service}" != "node" && "${service}" != "python" ]]; then
+  echo "Unsupported service '${service}'. Expected 'node' or 'python'." >&2
+  exit 1
+fi
+
+export TEST_ENVIRONMENT="${environment}"
+export SYNTHETIC_DATA_PATH="${repo_root}/scripts/tests/data/synthetic-test-data.json"
+export COMPOSE_PROJECT_NAME="${project_name}-${service}-${environment}"
+
+cleanup() {
+  docker compose -f "${compose_file}" down --remove-orphans >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+printf 'Running %s synthetic checks for %s using Docker Compose...\n' "${service}" "${environment}"
+docker compose -f "${compose_file}" run --rm "${container_service}"

--- a/scripts/tests/run_node_tests.mjs
+++ b/scripts/tests/run_node_tests.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const environment = process.env.TEST_ENVIRONMENT ?? 'dev';
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultDataPath = join(__dirname, 'data', 'synthetic-test-data.json');
+const dataPath = process.env.SYNTHETIC_DATA_PATH ?? defaultDataPath;
+
+function fail(message) {
+  console.error(`Node service synthetic test failed: ${message}`);
+  process.exit(1);
+}
+
+function loadData(path) {
+  try {
+    const raw = readFileSync(path, 'utf-8');
+    return JSON.parse(raw);
+  } catch (error) {
+    fail(`Unable to load synthetic data from ${path}: ${error.message}`);
+  }
+}
+
+const data = loadData(dataPath);
+const nodeEvents = Array.isArray(data.nodeService) ? data.nodeService : [];
+const envSample = nodeEvents.find((entry) => entry.environment === environment);
+
+if (!envSample) {
+  fail(`No synthetic sample found for environment '${environment}'.`);
+}
+
+if (envSample.schemaVersion !== 1) {
+  fail(`Unexpected schema version ${envSample.schemaVersion} for environment '${environment}'.`);
+}
+
+const latencyBudgetByEnv = {
+  dev: 150,
+  staging: 110,
+  prod: 90,
+};
+
+const latencyBudget = latencyBudgetByEnv[environment];
+if (typeof latencyBudget !== 'number') {
+  fail(`No latency budget defined for environment '${environment}'.`);
+}
+
+if (envSample.requestLatencyMs > latencyBudget) {
+  fail(
+    `Latency ${envSample.requestLatencyMs}ms exceeds budget ${latencyBudget}ms for environment '${environment}'.`
+  );
+}
+
+if (environment === 'prod' && envSample.featureFlags.length !== 0) {
+  fail('Production synthetic sample should not contain experimental feature flags.');
+}
+
+if (['dev', 'staging'].includes(environment)) {
+  const requiredFlag = 'synthetic-metrics';
+  if (!envSample.featureFlags.includes(requiredFlag)) {
+    fail(`Expected feature flag '${requiredFlag}' for environment '${environment}'.`);
+  }
+}
+
+console.log(
+  `Node service synthetic validation succeeded for ${environment}. Latency=${envSample.requestLatencyMs}ms, flags=${envSample.featureFlags.join(',') || 'none'}.`
+);

--- a/scripts/tests/run_python_tests.py
+++ b/scripts/tests/run_python_tests.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Environment-aware synthetic data checks for Python services."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+from typing import NoReturn
+
+ENVIRONMENT = os.getenv("TEST_ENVIRONMENT", "dev")
+DATA_PATH = Path(
+    os.getenv("SYNTHETIC_DATA_PATH", Path(__file__).parent / "data" / "synthetic-test-data.json")
+)
+
+THRESHOLDS = {
+    "dev": {"confidence": 0.6, "max_anomalies": 3},
+    "staging": {"confidence": 0.75, "max_anomalies": 2},
+    "prod": {"confidence": 0.9, "max_anomalies": 1},
+}
+
+
+def fail(message: str) -> NoReturn:
+    print(f"Python service synthetic test failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def load_data(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except Exception as exc:  # noqa: BLE001 - surfacing failure context
+        fail(f"Unable to load synthetic data from {path}: {exc}")
+
+
+def main() -> None:
+    data = load_data(DATA_PATH)
+    samples = [
+        sample
+        for sample in data.get("pythonService", [])
+        if sample.get("environment") == ENVIRONMENT
+    ]
+
+    if not samples:
+        fail(f"No synthetic sample found for environment '{ENVIRONMENT}'.")
+
+    sample = samples[0]
+    thresholds = THRESHOLDS.get(ENVIRONMENT)
+    if thresholds is None:
+        fail(f"No threshold defined for environment '{ENVIRONMENT}'.")
+
+    confidence = float(sample.get("confidence", 0))
+    if confidence < thresholds["confidence"]:
+        fail(
+            "Confidence score {:.2f} below threshold {:.2f} for environment '{}'".format(
+                confidence, thresholds["confidence"], ENVIRONMENT
+            )
+        )
+
+    anomalies = int(sample.get("anomaliesDetected", -1))
+    if anomalies < 0:
+        fail("Anomaly count missing from synthetic dataset.")
+
+    if anomalies > thresholds["max_anomalies"]:
+        fail(
+            "Synthetic anomaly count {} exceeds limit {} for environment '{}'".format(
+                anomalies, thresholds["max_anomalies"], ENVIRONMENT
+            )
+        )
+
+    synthetic_events = int(sample.get("syntheticEvents", 0))
+    if synthetic_events <= 0:
+        fail("Synthetic events must be a positive integer.")
+
+    if ENVIRONMENT == "prod" and synthetic_events < 10:
+        fail("Production synthetic dataset should contain at least 10 events for regression coverage.")
+
+    print(
+        "Python service synthetic validation succeeded for {}. Confidence={:.2f}, anomalies={}, events={}.".format(
+            ENVIRONMENT, confidence, anomalies, synthetic_events
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a workflow that runs environment-specific Node.js and Python synthetic tests across dev, staging, and prod
- provide Docker Compose and Kubernetes orchestration scripts plus shared synthetic data fixtures
- document the new CI flow in docs/ci/environment-specific-testing.md

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d6f6918f688333a584d990f1f48f1e