### PR TITLE
Add Postgres-backed graph annotations

### DIFF
--- a/docs/features/custom-graph-annotations.md
+++ b/docs/features/custom-graph-annotations.md
@@ -1,0 +1,91 @@
+# Custom Graph Annotations
+
+The Summit graph now supports analyst-authored annotations on entities and relationships. Notes, tags, and confidence metadata are stored in PostgreSQL while still surfacing inside the Neo4j knowledge graph for traversal-heavy workloads.
+
+## Capabilities
+
+- Attach rich notes to either a node (`Entity`) or relationship (`Edge`).
+- Persist analyst confidence, security enclave, and optional tags on each annotation.
+- Enforce policy decisions through the existing OPA integration before read, create, update, or delete operations.
+- Maintain an audit trail for every mutation.
+
+## GraphQL Additions
+
+The schema introduces a `tags` field and uses dedicated mutations to manage annotations:
+
+```graphql
+mutation {
+  createEntityAnnotation(
+    entityId: "entity-123",
+    input: {
+      content: "Analyst note"
+      confidence: HIGH
+      enclave: US_ONLY
+      tags: ["priority", "watchlist"]
+    }
+  ) {
+    id
+    content
+    tags
+    createdAt
+  }
+}
+```
+
+Similar operations exist for edges (`createEdgeAnnotation`), updates (`updateAnnotation`), and deletes (`deleteAnnotation`). Querying `Entity.annotations` or `Edge.annotations` automatically filters responses with OPA to ensure analysts only see data they are cleared to access.
+
+## Storage Model
+
+### PostgreSQL
+
+Annotations are canonically persisted in the `graph_annotations` table:
+
+| Column        | Type      | Notes |
+| ------------- | --------- | ----- |
+| `id`          | `uuid`    | Primary key (generated server-side).
+| `target_type` | `text`    | `ENTITY` or `EDGE` for routing synchronisation logic.
+| `target_id`   | `text`    | Matches the entity ID or Neo4j relationship identifier.
+| `content`     | `text`    | Analyst note body.
+| `confidence`  | `text`    | Defaults to `UNKNOWN` when omitted.
+| `tags`        | `text[]`  | Optional tags, stored as a PostgreSQL array.
+| `enclave`     | `text`    | Security boundary used for OPA checks.
+| `created_by`  | `text`    | User identifier for auditing.
+| `updated_by`  | `text`    | Last user to modify the annotation.
+| `created_at`  | `timestamptz` | Timestamp of insertion.
+| `updated_at`  | `timestamptz` | Timestamp of latest update.
+
+Two supporting indexes accelerate lookups by `(target_type, target_id)` and by `enclave` for policy evaluation. A migration is included under `server/db/migrations/postgres/2025-09-15_graph_annotations.sql` and mirrored in the bootstrap path inside `server/src/config/database.ts` so local environments auto-create the table.
+
+### Neo4j Synchronisation
+
+Every mutation mirrors the row into Neo4j so graph traversals and visualisations continue to work without modification:
+
+1. Insert/update/delete in PostgreSQL.
+2. On success, run the corresponding Cypher query:
+   - `MATCH (e:Entity {id: $targetId}) … MERGE (e)-[:HAS_ANNOTATION]->(a)` for entities.
+   - `MATCH ()-[r]->() WHERE toString(id(r)) = $targetId … MERGE (r)-[:HAS_ANNOTATION]->(a)` for edges.
+3. Store metadata (content, confidence, tags, timestamps, createdBy, enclave) on the `Annotation` node.
+4. Record the audit event in `audit_events`.
+
+If synchronisation to Neo4j fails, the Postgres insert is rolled back to keep systems aligned.
+
+## Running Locally
+
+1. Apply migrations if you are not relying on the bootstrap helper:
+   ```bash
+   cd server
+   npm run db:migrate
+   ```
+2. Start the stack (`npm run dev`) and exercise the new GraphQL mutations via your preferred client.
+3. Inspect PostgreSQL (`SELECT * FROM graph_annotations;`) or Neo4j Browser to confirm the annotation mirrors.
+
+## Testing
+
+Unit coverage exists at `server/tests/graphql/annotations.resolvers.test.ts` with Jest-based mocks for both data stores and OPA. Run the suite with:
+
+```bash
+cd server
+npm test -- annotations.resolvers
+```
+
+This validates creation, updates, deletion, and policy-aware retrieval logic without requiring live database connections.

--- a/server/db/migrations/postgres/2025-09-15_graph_annotations.sql
+++ b/server/db/migrations/postgres/2025-09-15_graph_annotations.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS graph_annotations (
+  id UUID PRIMARY KEY,
+  target_type TEXT NOT NULL CHECK (target_type IN ('ENTITY', 'EDGE')),
+  target_id TEXT NOT NULL,
+  content TEXT NOT NULL,
+  confidence TEXT NOT NULL DEFAULT 'UNKNOWN',
+  tags TEXT[] DEFAULT '{}'::TEXT[],
+  enclave TEXT NOT NULL,
+  created_by TEXT NOT NULL,
+  updated_by TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS graph_annotations_target_idx
+  ON graph_annotations (target_type, target_id);
+
+CREATE INDEX IF NOT EXISTS graph_annotations_enclave_idx
+  ON graph_annotations (enclave);

--- a/server/src/config/database.ts
+++ b/server/src/config/database.ts
@@ -187,6 +187,22 @@ async function createPostgresTables(): Promise<void> {
       )
     `);
 
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS graph_annotations (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        target_type TEXT NOT NULL CHECK (target_type IN ('ENTITY', 'EDGE')),
+        target_id TEXT NOT NULL,
+        content TEXT NOT NULL,
+        confidence TEXT NOT NULL DEFAULT 'UNKNOWN',
+        tags TEXT[] DEFAULT '{}'::TEXT[],
+        enclave TEXT NOT NULL,
+        created_by TEXT NOT NULL,
+        updated_by TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
     await client.query('CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs(user_id)');
     await client.query(
       'CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs(created_at)',
@@ -194,6 +210,12 @@ async function createPostgresTables(): Promise<void> {
     await client.query('CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON user_sessions(user_id)');
     await client.query(
       'CREATE INDEX IF NOT EXISTS idx_analysis_investigation ON analysis_results(investigation_id)',
+    );
+    await client.query(
+      'CREATE INDEX IF NOT EXISTS idx_graph_annotations_target ON graph_annotations(target_type, target_id)',
+    );
+    await client.query(
+      'CREATE INDEX IF NOT EXISTS idx_graph_annotations_enclave ON graph_annotations(enclave)',
     );
 
     logger.info('PostgreSQL tables created');

--- a/server/src/graphql/schema.annotations.js
+++ b/server/src/graphql/schema.annotations.js
@@ -25,6 +25,7 @@ const annotationsTypeDefs = gql`
     updatedAt: String!
     createdBy: String!
     enclave: Enclave!
+    tags: [String!]!
     # history: [AnnotationHistory!] # To be implemented later if needed for detailed history
   }
 
@@ -32,12 +33,14 @@ const annotationsTypeDefs = gql`
     content: String!
     confidence: Confidence
     enclave: Enclave!
+    tags: [String!]
   }
 
   input UpdateAnnotationInput {
     content: String
     confidence: Confidence
     enclave: Enclave
+    tags: [String!]
   }
 
   type Edge { # Define the Edge type here

--- a/server/tests/graphql/annotations.resolvers.test.ts
+++ b/server/tests/graphql/annotations.resolvers.test.ts
@@ -1,0 +1,294 @@
+import { jest } from '@jest/globals';
+
+type QueryResult<T> = { rows: T[] };
+
+type AnnotationRow = {
+  id: string;
+  content: string;
+  confidence?: string;
+  tags?: string[] | null;
+  enclave: string;
+  created_at: Date;
+  updated_at: Date;
+  created_by: string;
+  target_type?: string;
+  target_id?: string;
+};
+
+const mockUuid = jest.fn();
+const mockPgQuery = jest.fn<Promise<QueryResult<any>>, any>();
+const mockNeoRun = jest.fn();
+const mockSessionClose = jest.fn();
+const mockEvaluateOPA = jest.fn();
+
+const mockSession = {
+  run: mockNeoRun,
+  close: mockSessionClose,
+};
+
+const mockGetPostgresPool = jest.fn(() => ({ query: mockPgQuery }));
+const mockGetNeo4jDriver = jest.fn(() => ({ session: () => mockSession }));
+
+jest.unstable_mockModule('uuid', () => ({ v4: mockUuid }));
+jest.unstable_mockModule('../../src/config/database', () => ({
+  getNeo4jDriver: mockGetNeo4jDriver,
+  getPostgresPool: mockGetPostgresPool,
+}));
+jest.unstable_mockModule('../../src/services/AccessControl', () => ({
+  evaluateOPA: mockEvaluateOPA,
+}));
+
+const { default: annotationsResolvers } = await import('../../src/graphql/resolvers.annotations.js');
+
+const contextLogger = { error: jest.fn() };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSessionClose.mockResolvedValue(undefined);
+  mockNeoRun.mockResolvedValue({ records: [{}] });
+  mockUuid.mockReturnValue('annotation-1');
+});
+
+describe('Entity annotations resolver', () => {
+  test('filters annotations using OPA policy', async () => {
+    const createdAt = new Date('2024-01-01T00:00:00Z');
+    const deniedAt = new Date('2024-01-02T00:00:00Z');
+    mockPgQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 'allowed',
+          content: 'Visible note',
+          confidence: 'HIGH',
+          tags: ['tag1'],
+          enclave: 'US_ONLY',
+          created_at: createdAt,
+          updated_at: createdAt,
+          created_by: 'user-2',
+        },
+        {
+          id: 'denied',
+          content: 'Hidden note',
+          confidence: 'LOW',
+          tags: null,
+          enclave: 'FIVE_EYES',
+          created_at: deniedAt,
+          updated_at: deniedAt,
+          created_by: 'user-3',
+        },
+      ] satisfies AnnotationRow[],
+    });
+    mockEvaluateOPA.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    const result = await annotationsResolvers.Entity.annotations(
+      { id: 'entity-1' },
+      undefined,
+      { user: { id: 'user-1', role: 'ANALYST' }, logger: contextLogger },
+    );
+
+    expect(mockGetPostgresPool).toHaveBeenCalledTimes(1);
+    expect(mockPgQuery).toHaveBeenCalledWith(
+      expect.stringContaining('FROM graph_annotations'),
+      ['ENTITY', 'entity-1'],
+    );
+    expect(result).toEqual([
+      {
+        id: 'allowed',
+        content: 'Visible note',
+        confidence: 'HIGH',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+        createdBy: 'user-2',
+        enclave: 'US_ONLY',
+        tags: ['tag1'],
+      },
+    ]);
+    expect(mockNeoRun).not.toHaveBeenCalled();
+  });
+});
+
+describe('Mutation resolvers', () => {
+  const userContext = { user: { id: 'user-1', role: 'ANALYST' }, logger: contextLogger } as const;
+
+  test('createEntityAnnotation stores data in Postgres and Neo4j', async () => {
+    const timestamp = new Date('2024-01-03T12:00:00Z');
+    mockEvaluateOPA.mockResolvedValueOnce(true);
+    mockPgQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'annotation-1',
+            content: 'Entity note',
+            confidence: 'HIGH',
+            tags: ['mission'],
+            enclave: 'US_ONLY',
+            created_at: timestamp,
+            updated_at: timestamp,
+            created_by: 'user-1',
+          } satisfies AnnotationRow,
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await annotationsResolvers.Mutation.createEntityAnnotation(
+      null,
+      {
+        entityId: 'entity-99',
+        input: { content: 'Entity note', confidence: 'HIGH', enclave: 'US_ONLY', tags: ['mission'] },
+      },
+      userContext,
+    );
+
+    expect(mockPgQuery).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('INSERT INTO graph_annotations'),
+      [
+        'annotation-1',
+        'ENTITY',
+        'entity-99',
+        'Entity note',
+        'HIGH',
+        ['mission'],
+        'US_ONLY',
+        'user-1',
+        expect.any(String),
+      ],
+    );
+    expect(mockNeoRun).toHaveBeenCalledWith(
+      expect.stringContaining('MERGE (a:Annotation'),
+      expect.objectContaining({
+        targetId: 'entity-99',
+        annotationId: 'annotation-1',
+        tags: ['mission'],
+      }),
+    );
+    expect(result).toEqual({
+      id: 'annotation-1',
+      content: 'Entity note',
+      confidence: 'HIGH',
+      createdAt: '2024-01-03T12:00:00.000Z',
+      updatedAt: '2024-01-03T12:00:00.000Z',
+      createdBy: 'user-1',
+      enclave: 'US_ONLY',
+      tags: ['mission'],
+    });
+  });
+
+  test('updateAnnotation syncs changes and audits the update', async () => {
+    const createdAt = new Date('2024-01-04T10:00:00Z');
+    const updatedAt = new Date('2024-01-04T11:00:00Z');
+    mockEvaluateOPA.mockResolvedValueOnce(true);
+    mockPgQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'annotation-2',
+            target_type: 'EDGE',
+            target_id: '12',
+            content: 'Old note',
+            confidence: 'LOW',
+            tags: ['legacy'],
+            enclave: 'NATO',
+            created_at: createdAt,
+            updated_at: createdAt,
+            created_by: 'user-2',
+          } satisfies AnnotationRow,
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'annotation-2',
+            target_type: 'EDGE',
+            target_id: '12',
+            content: 'Updated note',
+            confidence: 'MEDIUM',
+            tags: ['refined'],
+            enclave: 'NATO',
+            created_at: createdAt,
+            updated_at: updatedAt,
+            created_by: 'user-2',
+          } satisfies AnnotationRow,
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await annotationsResolvers.Mutation.updateAnnotation(
+      null,
+      {
+        id: 'annotation-2',
+        input: { content: 'Updated note', confidence: 'MEDIUM', tags: ['refined'] },
+      },
+      userContext,
+    );
+
+    expect(mockPgQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('UPDATE graph_annotations'),
+      [
+        'Updated note',
+        'MEDIUM',
+        ['refined'],
+        'user-1',
+        'annotation-2',
+      ],
+    );
+    expect(mockNeoRun).toHaveBeenCalledWith(
+      expect.stringContaining('MATCH ()-[r]->()'),
+      expect.objectContaining({
+        targetId: '12',
+        annotationId: 'annotation-2',
+        content: 'Updated note',
+      }),
+    );
+    expect(result).toEqual({
+      id: 'annotation-2',
+      content: 'Updated note',
+      confidence: 'MEDIUM',
+      createdAt: '2024-01-04T10:00:00.000Z',
+      updatedAt: '2024-01-04T11:00:00.000Z',
+      createdBy: 'user-2',
+      enclave: 'NATO',
+      tags: ['refined'],
+    });
+  });
+
+  test('deleteAnnotation removes annotation and logs audit event', async () => {
+    mockEvaluateOPA.mockResolvedValueOnce(true);
+    mockPgQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 'annotation-3',
+            target_type: 'ENTITY',
+            target_id: 'entity-7',
+            enclave: 'UNCLASSIFIED',
+            created_by: 'user-3',
+            content: 'Obsolete',
+            confidence: 'UNKNOWN',
+            tags: [],
+            created_at: new Date('2024-01-05T09:00:00Z'),
+            updated_at: new Date('2024-01-05T09:00:00Z'),
+          } satisfies AnnotationRow,
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'annotation-3' }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await annotationsResolvers.Mutation.deleteAnnotation(
+      null,
+      { id: 'annotation-3' },
+      userContext,
+    );
+
+    expect(mockPgQuery).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining('DELETE FROM graph_annotations'),
+      ['annotation-3'],
+    );
+    expect(mockNeoRun).toHaveBeenCalledWith(
+      expect.stringContaining('DETACH DELETE a'),
+      { id: 'annotation-3' },
+    );
+    expect(result).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- extend the GraphQL schema to support annotation tags and persist data in PostgreSQL
- synchronize entity and edge annotation mutations between Postgres and Neo4j while auditing changes
- add resolver unit tests and author a feature guide for custom graph annotations

## Testing
- npm test -- --runTestsByPath tests/graphql/annotations.resolvers.test.ts *(fails: local Jest binary unavailable before install)*
- npm install *(fails: npm cannot resolve workspace:* protocol in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d72546ff4c8333b8cf9a5c31c9ec7c