### PR TITLE
feat: add neo4j graph deduplication workflow

### DIFF
--- a/docs/ingestion/graph-deduplication.md
+++ b/docs/ingestion/graph-deduplication.md
@@ -1,0 +1,122 @@
+# Graph Data Deduplication
+
+The graph deduplication tooling eliminates duplicate nodes and relationships in
+Neo4j based on configurable attribute rules. It consists of:
+
+- A Python deduplication script (`server/python/graph_deduplication.py`) that
+  reads a JSON payload from `stdin`, searches for duplicate groups, and merges
+  them using APOC refactor helpers while emitting a structured summary.
+- A GraphQL mutation (`runGraphDeduplication`) that validates client input,
+  spawns the Python script, and relays execution telemetry via OpenTelemetry.
+- Pytest coverage for the orchestration logic (`server/python/tests`).
+
+## Configuration Model
+
+The mutation accepts a `GraphDeduplicationInput`:
+
+```graphql
+input NodeDeduplicationRuleInput {
+  label: String!
+  matchAttributes: [String!]!
+}
+
+input RelationshipDeduplicationRuleInput {
+  type: String!
+  matchAttributes: [String!]!
+}
+
+input GraphDeduplicationInput {
+  nodeRules: [NodeDeduplicationRuleInput!]
+  relationshipRules: [RelationshipDeduplicationRuleInput!]
+  dryRun: Boolean = false
+  database: String
+  context: JSON
+}
+```
+
+Rules describe which labels or relationship types should be deduplicated and
+list the attributes that compose the deduplication key. Empty keys are skipped
+so entities lacking the configured attributes are never merged.
+
+The resolver converts this structure into the JSON document that the Python
+script expects. Optional context metadata (tenant, user, request ID, etc.) is
+forwarded for traceability.
+
+## Running the Mutation
+
+```graphql
+mutation DeduplicateGraph($input: GraphDeduplicationInput!) {
+  runGraphDeduplication(input: $input) {
+    operationId
+    dryRun
+    mergedNodes
+    mergedRelationships
+    nodeSummary
+    relationshipSummary
+    logs
+  }
+}
+```
+
+Example variables:
+
+```json
+{
+  "input": {
+    "nodeRules": [
+      { "label": "Person", "matchAttributes": ["externalId", "name"] }
+    ],
+    "relationshipRules": [
+      { "type": "ASSOCIATED_WITH", "matchAttributes": ["sourceId"] }
+    ],
+    "dryRun": true
+  }
+}
+```
+
+When `dryRun` is `true`, the script reports duplicate groups without merging
+records. For live merges set `dryRun` to `false` (default) and review the
+`logs`, `nodeSummary`, and `relationshipSummary` payloads for auditing.
+
+## Telemetry
+
+- The resolver wraps execution in a span named `graph.runGraphDeduplication`.
+- Key metrics recorded as span attributes include operation ID, whether the run
+  was dry, how many node/relationship groups were found, and how many were
+  merged.
+- The Python script logs merge decisions which the resolver attaches as span
+  events (first five entries) to simplify root cause analysis.
+
+## Local Execution
+
+The script can be exercised directly for debugging:
+
+```bash
+export NEO4J_URI=bolt://localhost:7687
+export NEO4J_USER=neo4j
+export NEO4J_PASSWORD=secret
+
+python3 server/python/graph_deduplication.py <<'JSON'
+{
+  "node_rules": [
+    { "label": "Person", "match_attributes": ["externalId"] }
+  ],
+  "dry_run": true
+}
+JSON
+```
+
+The command prints a JSON summary describing discovered duplicates.
+
+## Testing
+
+Unit tests are located in `server/python/tests/test_graph_deduplication.py` and
+can be run with:
+
+```bash
+pytest server/python/tests -q
+```
+
+These tests mock the Neo4j driver to validate query construction, rule
+normalization, and the dry-run/merge execution paths without requiring a live
+Neo4j instance.

--- a/server/python/graph_deduplication.py
+++ b/server/python/graph_deduplication.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Graph data deduplication utility for Neo4j.
+
+This script reads a JSON configuration from STDIN describing how duplicate
+nodes and relationships should be identified. It connects to the configured
+Neo4j database, finds duplicate groups based on the provided rules, and merges
+those duplicates using APOC refactor helpers.
+
+The script is designed to be triggered by the Summit GraphQL API but can be run
+manually for troubleshooting:
+
+    echo '{"node_rules": [{"label": "Person", "match_attributes": ["externalId"]}]}' \
+      | python3 server/python/graph_deduplication.py
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Sequence
+
+from neo4j import GraphDatabase, Driver
+from neo4j.exceptions import ClientError
+
+
+class DeduplicationConfigError(ValueError):
+    """Raised when the provided configuration is invalid."""
+
+
+class DeduplicationExecutionError(RuntimeError):
+    """Raised when the deduplication procedure fails."""
+
+
+def _validate_identifier(name: str, kind: str) -> str:
+    if not isinstance(name, str) or not name.strip():
+        raise DeduplicationConfigError(f"{kind} must be a non-empty string")
+    name = name.strip()
+    if not all(ch.isalnum() or ch == '_' for ch in name):
+        raise DeduplicationConfigError(
+            f"{kind} '{name}' contains unsupported characters. "
+            "Only alphanumeric characters and underscores are allowed."
+        )
+    return name
+
+
+def _validate_attributes(attributes: Iterable[str], kind: str) -> List[str]:
+    cleaned: List[str] = []
+    for attr in attributes:
+        cleaned.append(_validate_identifier(attr, f"{kind} attribute"))
+    if not cleaned:
+        raise DeduplicationConfigError(f"At least one attribute is required for {kind} deduplication")
+    return cleaned
+
+
+@dataclass
+class NodeRule:
+    label: str
+    match_attributes: List[str]
+
+
+@dataclass
+class RelationshipRule:
+    type: str
+    match_attributes: List[str]
+
+
+def _build_key_expression(identifier: str, attributes: Sequence[str]) -> str:
+    parts = [f"coalesce(toString({identifier}.`{attr}`), '')" for attr in attributes]
+    if len(parts) == 1:
+        return parts[0]
+    return " + '|' + ".join(parts)
+
+
+def _normalise_node_rules(raw: Any) -> List[NodeRule]:
+    if not raw:
+        return []
+    if not isinstance(raw, list):
+        raise DeduplicationConfigError("node_rules must be an array")
+    rules: List[NodeRule] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            raise DeduplicationConfigError("Each node rule must be an object")
+        label = _validate_identifier(entry.get('label'), 'Node label')
+        attributes = entry.get('match_attributes') or entry.get('matchAttributes')
+        if attributes is None:
+            raise DeduplicationConfigError(f"Node rule for label '{label}' must define match_attributes")
+        rules.append(NodeRule(label=label, match_attributes=_validate_attributes(attributes, f"node '{label}'")))
+    return rules
+
+
+def _normalise_relationship_rules(raw: Any) -> List[RelationshipRule]:
+    if not raw:
+        return []
+    if not isinstance(raw, list):
+        raise DeduplicationConfigError("relationship_rules must be an array")
+    rules: List[RelationshipRule] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            raise DeduplicationConfigError("Each relationship rule must be an object")
+        rel_type = _validate_identifier(entry.get('type'), 'Relationship type')
+        attributes = entry.get('match_attributes') or entry.get('matchAttributes')
+        if attributes is None:
+            raise DeduplicationConfigError(
+                f"Relationship rule for type '{rel_type}' must define match_attributes"
+            )
+        rules.append(
+            RelationshipRule(type=rel_type, match_attributes=_validate_attributes(attributes, f"relationship '{rel_type}'"))
+        )
+    return rules
+
+
+def _fetch_node_duplicates(tx, rule: NodeRule):
+    key_expr = _build_key_expression('n', rule.match_attributes)
+    query = f"""
+    MATCH (n:`{rule.label}`)
+    WITH {key_expr} AS dedup_key, collect(n) AS nodes
+    WHERE size(nodes) > 1 AND dedup_key <> ''
+    RETURN dedup_key AS key, [node IN nodes | id(node)] AS node_ids, size(nodes) AS count
+    ORDER BY count DESC, key ASC
+    """
+    return list(tx.run(query).data())
+
+
+def _merge_node_group(tx, node_ids: Sequence[int]):
+    if len(node_ids) < 2:
+        return None
+    query = """
+    MATCH (n) WHERE id(n) IN $node_ids
+    WITH collect(n) AS nodes
+    CALL apoc.refactor.mergeNodes(
+      nodes,
+      {properties:'combine', mergeRels:true, mergeRelsProperties:'combine', produceAlerts:false}
+    ) YIELD node
+    RETURN id(node) AS canonical_id
+    """
+    record = tx.run(query, node_ids=list(node_ids)).single()
+    return record['canonical_id'] if record else None
+
+
+def _fetch_relationship_duplicates(tx, rule: RelationshipRule):
+    key_expr = _build_key_expression('r', rule.match_attributes)
+    query = f"""
+    MATCH (start)-[r:`{rule.type}`]->(end)
+    WITH id(start) AS start_id, id(end) AS end_id, {key_expr} AS dedup_key, collect(r) AS relationships
+    WHERE size(relationships) > 1 AND dedup_key <> ''
+    RETURN start_id, end_id, dedup_key AS key, [rel IN relationships | id(rel)] AS relationship_ids, size(relationships) AS count
+    ORDER BY count DESC, key ASC
+    """
+    return list(tx.run(query).data())
+
+
+def _merge_relationship_group(tx, relationship_ids: Sequence[int]):
+    if len(relationship_ids) < 2:
+        return None
+    query = """
+    MATCH ()-[r]->() WHERE id(r) IN $relationship_ids
+    WITH collect(r) AS rels
+    CALL apoc.refactor.mergeRelationships(rels, {properties:'combine'}) YIELD rel
+    RETURN id(rel) AS canonical_id
+    """
+    record = tx.run(query, relationship_ids=list(relationship_ids)).single()
+    return record['canonical_id'] if record else None
+
+
+def _load_config() -> Dict[str, Any]:
+    try:
+        raw = json.load(sys.stdin)
+    except json.JSONDecodeError as exc:
+        raise DeduplicationConfigError(f"Invalid JSON configuration: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise DeduplicationConfigError('Configuration must be a JSON object')
+    return raw
+
+
+def _connect_driver() -> Driver:
+    uri = os.environ.get('NEO4J_URI')
+    user = os.environ.get('NEO4J_USER')
+    password = os.environ.get('NEO4J_PASSWORD')
+    if not uri or not user or not password:
+        raise DeduplicationConfigError('NEO4J_URI, NEO4J_USER, and NEO4J_PASSWORD environment variables must be set')
+    return GraphDatabase.driver(uri, auth=(user, password))
+
+
+def run_deduplication(driver: Driver, config: Dict[str, Any]) -> Dict[str, Any]:
+    dry_run = bool(config.get('dry_run', False))
+    database = config.get('database')
+    node_rules = _normalise_node_rules(config.get('node_rules') or config.get('nodeRules'))
+    relationship_rules = _normalise_relationship_rules(
+        config.get('relationship_rules') or config.get('relationshipRules')
+    )
+
+    if not node_rules and not relationship_rules:
+        raise DeduplicationConfigError('At least one node_rules or relationship_rules entry must be provided')
+
+    summary: Dict[str, Any] = {
+        'operation_id': config.get('operation_id') or str(uuid.uuid4()),
+        'dry_run': dry_run,
+        'started_at': datetime.now(timezone.utc).isoformat(),
+        'node_summary': {
+            'rules': [],
+            'groups': [],
+            'total_groups': 0,
+            'duplicates_identified': 0,
+            'merged': 0,
+        },
+        'relationship_summary': {
+            'rules': [],
+            'groups': [],
+            'total_groups': 0,
+            'duplicates_identified': 0,
+            'merged': 0,
+        },
+        'logs': [],
+    }
+
+    def _with_session() -> Any:
+        return driver.session(database=database) if database else driver.session()
+
+    try:
+        with _with_session() as session:
+            for rule in node_rules:
+                summary['node_summary']['rules'].append({'label': rule.label, 'match_attributes': rule.match_attributes})
+                duplicates = session.execute_read(_fetch_node_duplicates, rule)
+                summary['node_summary']['total_groups'] += len(duplicates)
+                for group in duplicates:
+                    summary['node_summary']['duplicates_identified'] += group['count']
+                    group_info = {
+                        'label': rule.label,
+                        'key': group['key'],
+                        'node_ids': group['node_ids'],
+                        'count': group['count'],
+                    }
+                    if not dry_run:
+                        canonical_id = session.execute_write(_merge_node_group, group['node_ids'])
+                        group_info['canonical_node_id'] = canonical_id
+                        summary['node_summary']['merged'] += max(group['count'] - 1, 0)
+                        summary['logs'].append(
+                            f"Merged {group['count']} nodes with key '{group['key']}' on label {rule.label}"
+                        )
+                    else:
+                        summary['logs'].append(
+                            f"Identified {group['count']} duplicate nodes with key '{group['key']}' on label {rule.label}"
+                        )
+                    summary['node_summary']['groups'].append(group_info)
+
+            for rule in relationship_rules:
+                summary['relationship_summary']['rules'].append(
+                    {'type': rule.type, 'match_attributes': rule.match_attributes}
+                )
+                duplicates = session.execute_read(_fetch_relationship_duplicates, rule)
+                summary['relationship_summary']['total_groups'] += len(duplicates)
+                for group in duplicates:
+                    summary['relationship_summary']['duplicates_identified'] += group['count']
+                    group_info = {
+                        'type': rule.type,
+                        'key': group['key'],
+                        'start_id': group['start_id'],
+                        'end_id': group['end_id'],
+                        'relationship_ids': group['relationship_ids'],
+                        'count': group['count'],
+                    }
+                    if not dry_run:
+                        canonical_id = session.execute_write(
+                            _merge_relationship_group, group['relationship_ids']
+                        )
+                        group_info['canonical_relationship_id'] = canonical_id
+                        summary['relationship_summary']['merged'] += max(group['count'] - 1, 0)
+                        summary['logs'].append(
+                            f"Merged {group['count']} relationships with key '{group['key']}' on type {rule.type}"
+                        )
+                    else:
+                        summary['logs'].append(
+                            f"Identified {group['count']} duplicate relationships with key '{group['key']}' on type {rule.type}"
+                        )
+                    summary['relationship_summary']['groups'].append(group_info)
+    except ClientError as exc:  # Typically raised when APOC is unavailable
+        raise DeduplicationExecutionError(str(exc)) from exc
+
+    summary['completed_at'] = datetime.now(timezone.utc).isoformat()
+    return summary
+
+
+def main() -> int:
+    try:
+        config = _load_config()
+        driver = _connect_driver()
+        try:
+            result = run_deduplication(driver, config)
+        finally:
+            driver.close()
+        json.dump(result, sys.stdout)
+        sys.stdout.flush()
+        return 0
+    except (DeduplicationConfigError, DeduplicationExecutionError) as exc:
+        print(json.dumps({'error': str(exc)}), file=sys.stderr)
+        return 1
+    except Exception as exc:  # pragma: no cover - defensive guard
+        print(json.dumps({'error': f'Unexpected failure: {exc}'}), file=sys.stderr)
+        return 2
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/server/python/tests/test_graph_deduplication.py
+++ b/server/python/tests/test_graph_deduplication.py
@@ -1,0 +1,100 @@
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# Ensure the script module is importable
+MODULE_ROOT = Path(__file__).resolve().parents[1]
+if str(MODULE_ROOT) not in sys.path:
+    sys.path.append(str(MODULE_ROOT))
+
+import graph_deduplication as dedup  # noqa: E402  pylint: disable=wrong-import-position
+
+
+def test_validate_identifier_rejects_invalid():
+    with pytest.raises(dedup.DeduplicationConfigError):
+        dedup._validate_identifier('Bad Label!', 'label')  # pylint: disable=protected-access
+
+
+@pytest.mark.parametrize(
+    'attributes,expected',
+    [
+        (['externalId'], "coalesce(toString(n.`externalId`), '')"),
+        (
+            ['externalId', 'name'],
+            "coalesce(toString(n.`externalId`), '') + '|' + coalesce(toString(n.`name`), '')",
+        ),
+    ],
+)
+def test_build_key_expression(attributes, expected):
+    expr = dedup._build_key_expression('n', attributes)  # pylint: disable=protected-access
+    assert expr == expected
+
+
+def test_normalise_node_rules_supports_camel_case():
+    rules = dedup._normalise_node_rules(
+        [{'label': 'Person', 'matchAttributes': ['externalId', 'name']}]
+    )  # pylint: disable=protected-access
+    assert len(rules) == 1
+    assert rules[0].label == 'Person'
+    assert rules[0].match_attributes == ['externalId', 'name']
+
+
+def test_run_deduplication_merges_groups():
+    node_groups = {
+        'Person': [
+            {'key': 'abc', 'node_ids': [1, 2], 'count': 2},
+        ]
+    }
+    relationship_groups = {
+        'ASSOCIATED_WITH': [
+            {'key': 'rel', 'start_id': 1, 'end_id': 3, 'relationship_ids': [11, 12], 'count': 2},
+        ]
+    }
+
+    session = MagicMock()
+
+    def execute_read(func, rule):
+        if isinstance(rule, dedup.NodeRule):
+            tx = MagicMock()
+            tx.run.return_value.data.return_value = node_groups.get(rule.label, [])
+            return func(tx, rule)
+        tx = MagicMock()
+        tx.run.return_value.data.return_value = relationship_groups.get(rule.type, [])
+        return func(tx, rule)
+
+    def execute_write(func, identifiers):
+        tx = MagicMock()
+        tx.run.return_value.single.return_value = {'canonical_id': 99}
+        return func(tx, identifiers)
+
+    session.execute_read.side_effect = execute_read
+    session.execute_write.side_effect = execute_write
+
+    @contextmanager
+    def session_cm(*_args, **_kwargs):
+        yield session
+
+    driver = MagicMock()
+    driver.session.side_effect = session_cm
+
+    result = dedup.run_deduplication(
+        driver,
+        {
+            'node_rules': [{'label': 'Person', 'match_attributes': ['externalId']}],
+            'relationship_rules': [{'type': 'ASSOCIATED_WITH', 'match_attributes': ['sourceId']}],
+        },
+    )
+
+    assert result['node_summary']['merged'] == 1
+    assert result['relationship_summary']['merged'] == 1
+    assert any('Merged 2 nodes' in entry for entry in result['logs'])
+    assert any('Merged 2 relationships' in entry for entry in result['logs'])
+
+
+def test_run_deduplication_requires_rules():
+    driver = MagicMock()
+    with pytest.raises(dedup.DeduplicationConfigError):
+        dedup.run_deduplication(driver, {})

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -90,6 +90,7 @@ requests==2.32.5
 python-dotenv==1.1.1
 pyyaml==6.0.2
 psutil==7.0.0
+neo4j==5.25.0
 
 # Language Detection
 langdetect==1.0.9

--- a/server/src/graphql/resolvers/deduplication.ts
+++ b/server/src/graphql/resolvers/deduplication.ts
@@ -1,0 +1,182 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { trace, SpanStatusCode, Span } from '@opentelemetry/api';
+
+interface NodeRuleInput {
+  label: string;
+  matchAttributes: string[];
+}
+
+interface RelationshipRuleInput {
+  type: string;
+  matchAttributes: string[];
+}
+
+interface GraphDeduplicationInput {
+  nodeRules?: NodeRuleInput[] | null;
+  relationshipRules?: RelationshipRuleInput[] | null;
+  dryRun?: boolean | null;
+  database?: string | null;
+  context?: Record<string, unknown> | null;
+}
+
+const tracer = trace.getTracer('graph-deduplication');
+
+function formatRules(
+  rules: NodeRuleInput[] | RelationshipRuleInput[] | null | undefined,
+  key: 'label' | 'type',
+) {
+  if (!Array.isArray(rules) || rules.length === 0) {
+    return [];
+  }
+  return rules.map((rule) => {
+    const values = Array.isArray(rule.matchAttributes)
+      ? rule.matchAttributes.filter((value) => typeof value === 'string' && value.trim().length > 0)
+      : [];
+
+    if (values.length === 0) {
+      throw new Error(`Rule for ${key} '${rule[key]}' must include at least one match attribute`);
+    }
+
+    return {
+      [key]: rule[key],
+      match_attributes: values,
+    };
+  });
+}
+
+function runPythonDeduplication(pythonPath: string, scriptPath: string, payload: Record<string, unknown>, span: Span) {
+  return new Promise<any>((resolve, reject) => {
+    const child = spawn(pythonPath, [scriptPath], { stdio: ['pipe', 'pipe', 'pipe'] });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data: Buffer) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data: Buffer) => {
+      const message = data.toString();
+      stderr += message;
+      span.addEvent('graph.dedup.stderr', { 'graph.dedup.stderr_chunk': message });
+    });
+
+    child.on('error', (error) => {
+      reject(error);
+    });
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        const errorMessage = stderr || stdout || `Deduplication script exited with code ${code}`;
+        reject(new Error(errorMessage.trim()));
+        return;
+      }
+
+      try {
+        const parsed = stdout ? JSON.parse(stdout) : {};
+        resolve(parsed);
+      } catch (error) {
+        reject(new Error(`Failed to parse deduplication response: ${(error as Error).message}`));
+      }
+    });
+
+    child.stdin.write(JSON.stringify(payload));
+    child.stdin.end();
+  });
+}
+
+export const graphDeduplicationResolvers = {
+  Mutation: {
+    async runGraphDeduplication(_: unknown, args: { input: GraphDeduplicationInput }, ctx: any) {
+      const pythonExecutable = process.env.PYTHON_PATH || 'python3';
+      const scriptPath = path.join(process.cwd(), 'server', 'python', 'graph_deduplication.py');
+      const input = args?.input || {};
+      const dryRun = Boolean(input.dryRun);
+      const operationId = randomUUID();
+
+      const span = tracer.startSpan('graph.runGraphDeduplication', {
+        attributes: {
+          'graph.dedup.operation_id': operationId,
+          'graph.dedup.dry_run': dryRun,
+          'graph.dedup.triggered_by': ctx?.user?.id ?? 'anonymous',
+          'graph.dedup.tenant': ctx?.user?.tenantId ?? ctx?.tenantId ?? 'unknown',
+        },
+      });
+
+      try {
+        const nodeRules = formatRules(input.nodeRules, 'label');
+        const relationshipRules = formatRules(input.relationshipRules, 'type');
+
+        if (nodeRules.length === 0 && relationshipRules.length === 0) {
+          throw new Error('At least one deduplication rule must be provided');
+        }
+
+        const payload: Record<string, unknown> = {
+          operation_id: operationId,
+          dry_run: dryRun,
+          node_rules: nodeRules,
+          relationship_rules: relationshipRules,
+        };
+
+        if (input.database) {
+          payload.database = input.database;
+        }
+
+        const contextData: Record<string, unknown> = {
+          triggered_by: ctx?.user?.id,
+          tenant_id: ctx?.user?.tenantId ?? ctx?.tenantId,
+          request_id: ctx?.req?.id,
+        };
+
+        if (input.context && typeof input.context === 'object') {
+          Object.assign(contextData, input.context);
+        }
+
+        payload.context = contextData;
+
+        const result = await runPythonDeduplication(pythonExecutable, scriptPath, payload, span);
+
+        const nodeSummary = result?.node_summary ?? {};
+        const relationshipSummary = result?.relationship_summary ?? {};
+        const mergedNodes = nodeSummary?.merged ?? 0;
+        const mergedRelationships = relationshipSummary?.merged ?? 0;
+
+        span.setAttribute('graph.dedup.nodes.merged', mergedNodes);
+        span.setAttribute('graph.dedup.relationships.merged', mergedRelationships);
+        span.setAttribute('graph.dedup.node_groups', nodeSummary?.total_groups ?? 0);
+        span.setAttribute('graph.dedup.relationship_groups', relationshipSummary?.total_groups ?? 0);
+
+        const logs = Array.isArray(result?.logs) ? result.logs : [];
+        logs.slice(0, 5).forEach((entry: string, index: number) => {
+          span.addEvent('graph.dedup.log', { 'log.index': index, 'log.message': entry });
+        });
+
+        span.addEvent('graph.dedup.completed', {
+          'graph.dedup.operation_id': result?.operation_id ?? operationId,
+          'graph.dedup.merged_nodes': mergedNodes,
+          'graph.dedup.merged_relationships': mergedRelationships,
+        });
+
+        return {
+          operationId: result?.operation_id ?? operationId,
+          dryRun: Boolean(result?.dry_run ?? dryRun),
+          startedAt: result?.started_at ?? new Date().toISOString(),
+          completedAt: result?.completed_at ?? new Date().toISOString(),
+          mergedNodes,
+          mergedRelationships,
+          nodeSummary,
+          relationshipSummary,
+          logs,
+        };
+      } catch (error) {
+        span.recordException(error as Error);
+        span.setStatus({ code: SpanStatusCode.ERROR, message: (error as Error).message });
+        throw error;
+      } finally {
+        span.end();
+      }
+    },
+  },
+};

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -12,6 +12,7 @@ import { triggerN8nFlow } from '../../integrations/n8n.js';
 import { checkN8nTriggerAllowed } from '../../integrations/n8n-policy.js';
 import { isEnabled as flagEnabled } from '../../featureFlags/flagsmith.js';
 import { doclingResolvers } from './docling.ts';
+import { graphDeduplicationResolvers } from './deduplication';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -63,6 +64,7 @@ const resolvers = {
     // Production core resolvers
     ...coreResolvers.Mutation,
     ...doclingResolvers.Mutation,
+    ...graphDeduplicationResolvers.Mutation,
 
     // Legacy resolvers (will be phased out)
     ...entityResolvers.Mutation,

--- a/server/src/graphql/schema/crudSchema.ts
+++ b/server/src/graphql/schema/crudSchema.ts
@@ -320,6 +320,36 @@ export const crudTypeDefs = gql`
     endDate: DateTime
   }
 
+  input NodeDeduplicationRuleInput {
+    label: String!
+    matchAttributes: [String!]!
+  }
+
+  input RelationshipDeduplicationRuleInput {
+    type: String!
+    matchAttributes: [String!]!
+  }
+
+  input GraphDeduplicationInput {
+    nodeRules: [NodeDeduplicationRuleInput!]
+    relationshipRules: [RelationshipDeduplicationRuleInput!]
+    dryRun: Boolean = false
+    database: String
+    context: JSON
+  }
+
+  type GraphDeduplicationResult {
+    operationId: ID!
+    dryRun: Boolean!
+    startedAt: DateTime!
+    completedAt: DateTime!
+    mergedNodes: Int!
+    mergedRelationships: Int!
+    nodeSummary: JSON!
+    relationshipSummary: JSON!
+    logs: [String!]!
+  }
+
   # Core Queries
   type Query {
     # Entity queries
@@ -400,6 +430,9 @@ export const crudTypeDefs = gql`
     deleteInvestigation(id: ID!): Boolean!
     assignUserToInvestigation(investigationId: ID!, userId: ID!): Investigation!
     unassignUserFromInvestigation(investigationId: ID!, userId: ID!): Investigation!
+
+    # Graph maintenance
+    runGraphDeduplication(input: GraphDeduplicationInput!): GraphDeduplicationResult!
 
     # Authentication mutations (placeholder - handled separately)
     login(email: String!, password: String!): AuthPayload!


### PR DESCRIPTION
## Summary
- add a configurable Neo4j graph deduplication script and supporting pytest coverage
- expose a GraphQL mutation that calls the deduplication script and emits OpenTelemetry spans
- document how to run the deduplication workflow and add the Neo4j driver dependency

## Testing
- pytest server/python/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d72cba921c8333aca1d77ef9cd5dfc