### PR TITLE
feat: integrate sentiment analysis pipeline

### DIFF
--- a/docs/ml/sentiment-analysis.md
+++ b/docs/ml/sentiment-analysis.md
@@ -1,0 +1,94 @@
+# Sentiment Analysis Pipeline
+
+This guide describes how Summit's ML engine performs sentiment analysis for
+text content ingested through the feed processor.  The integration combines a
+Hugging Face transformer model (with a deterministic lexical fallback) and
+persists the results to Neo4j so they can be queried through GraphQL.
+
+## Components
+
+- **Python model (`server/ml/models/sentiment_analysis.py`)** – wraps a
+  transformer pipeline and exposes a CLI that returns normalized JSON.  When
+  the `transformers` package or a GPU is not available the module falls back to
+  a keyword-based classifier so the rest of the system continues to function.
+- **Feed processor integration (`services/feed-processor/src/index.ts`)** –
+  detects rich text fields in incoming records, invokes the Python model via a
+  subprocess, and stores the results in Neo4j alongside the entity node.
+- **GraphQL resolver (`server/src/graphql/resolvers/core.ts`)** – exposes the
+  `entitySentiment` query which returns the most recent sentiment insight for
+  an entity.
+- **Persistence (`server/src/repos/EntityRepo.ts`)** – maps Neo4j
+  `SentimentResult` nodes to the `SentimentInsight` GraphQL type.
+
+## Running the model directly
+
+The Python module can be executed as a standalone CLI.  Pass the text as
+Base64-encoded UTF-8 to avoid shell escaping issues:
+
+```bash
+python3 server/ml/models/sentiment_analysis.py \
+  --text-base64 "$(printf '%s' 'The release looks fantastic!' | base64)"
+```
+
+Sample output:
+
+```json
+{
+  "label": "positive",
+  "confidence": 0.92,
+  "score": 0.92,
+  "method": "transformer",
+  "model": "cardiffnlp/twitter-roberta-base-sentiment-latest",
+  "probabilities": {"positive": 0.92, "neutral": 0.05, "negative": 0.03},
+  "computed_at": "2026-01-12T20:00:00Z"
+}
+```
+
+The CLI supports `--input-file` with a JSON array for batch jobs and
+`--metadata` for attaching contextual information.
+
+## Feed processor behaviour
+
+1. Each ingested entity is scanned for text-rich fields such as `text`,
+   `content`, `description`, `message`, etc.
+2. If a candidate string longer than 20 characters is found, the service spawns
+   the Python CLI (configurable via `SENTIMENT_SCRIPT_PATH` and
+   `ML_PYTHON_PATH`).
+3. The resulting JSON payload is stored in Neo4j as a `SentimentResult` node and
+   linked to the entity with a `HAS_SENTIMENT` relationship.  Summary fields are
+   also copied onto the entity (`sentiment_label`, `sentiment_confidence`,
+   `sentiment_score`).
+4. When the Python process is unavailable the worker logs a warning and
+   gracefully disables future attempts for the remainder of the process.
+
+## Querying via GraphQL
+
+Use the `entitySentiment` query to fetch the most recent analysis for a given
+entity.  Tenancy enforcement mirrors the other CRUD queries.
+
+```graphql
+query GetEntitySentiment($entityId: ID!, $tenantId: ID!) {
+  entitySentiment(entityId: $entityId, tenantId: $tenantId) {
+    label
+    confidence
+    score
+    method
+    model
+    computedAt
+    textSample
+  }
+}
+```
+
+## Testing
+
+Run the dedicated pytest suite to validate the sentiment model without
+downloading large transformer weights:
+
+```bash
+pytest server/ml/tests/test_sentiment_analysis.py
+```
+
+The tests rely on a deterministic dummy pipeline to exercise both the
+transformer path and the lexical fallback logic.
+

--- a/server/ml/__init__.py
+++ b/server/ml/__init__.py
@@ -1,0 +1,2 @@
+"""ML engine package for Summit server components."""
+

--- a/server/ml/models/__init__.py
+++ b/server/ml/models/__init__.py
@@ -1,0 +1,2 @@
+"""Model implementations used by the Summit ML engine."""
+

--- a/server/ml/models/sentiment_analysis.py
+++ b/server/ml/models/sentiment_analysis.py
@@ -1,0 +1,366 @@
+"""Sentiment analysis utilities for the Summit ML engine.
+
+This module provides a light-weight wrapper around Hugging Face sentiment
+classification models with a deterministic lexical fallback.  It can be used as
+an importable library or executed directly from the command line.  The command
+line interface is intentionally simple so that Node.js services (such as the
+feed processor) can invoke the script and receive JSON responses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from typing import Callable, Dict, Iterable, List, Optional, Sequence
+
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    from transformers import pipeline as hf_pipeline  # type: ignore
+
+    TRANSFORMERS_AVAILABLE = True
+except Exception:  # pragma: no cover - environment without transformers
+    hf_pipeline = None  # type: ignore
+    TRANSFORMERS_AVAILABLE = False
+
+
+ScoreDistribution = Dict[str, float]
+PipelineCallable = Callable[[str], Sequence[Dict[str, float]]]
+
+
+class SentimentModel:
+    """Sentiment classifier with optional Hugging Face integration."""
+
+    DEFAULT_MODEL = "cardiffnlp/twitter-roberta-base-sentiment-latest"
+
+    def __init__(
+        self,
+        model_name: str = DEFAULT_MODEL,
+        pipeline_factory: Optional[Callable[[str], PipelineCallable]] = None,
+        max_length: int = 512,
+    ) -> None:
+        self.model_name = model_name
+        self.max_length = max_length
+        self._pipeline: Optional[PipelineCallable] = None
+        self._mode = "lexicon-rule"
+
+        if pipeline_factory is None and TRANSFORMERS_AVAILABLE:
+            pipeline_factory = self._default_pipeline_factory
+
+        if pipeline_factory is not None:
+            try:
+                self._pipeline = pipeline_factory(model_name)
+                self._mode = "transformer"
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logger.warning("Falling back to lexical sentiment due to %s", exc)
+                self._pipeline = None
+
+    @staticmethod
+    def _default_pipeline_factory(model_name: str) -> PipelineCallable:
+        if not TRANSFORMERS_AVAILABLE:  # pragma: no cover - guard
+            raise RuntimeError("transformers library is not installed")
+
+        hf = hf_pipeline(  # type: ignore[operator]
+            "sentiment-analysis",
+            model=model_name,
+            return_all_scores=True,
+        )
+
+        def _call(text: str) -> Sequence[Dict[str, float]]:
+            result = hf(text)
+            if isinstance(result, Sequence) and result and isinstance(result[0], Sequence):
+                return result[0]  # pipeline returns List[List[Dict]] for batched calls
+            return result  # type: ignore[return-value]
+
+        return _call
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def analyze_text(
+        self,
+        text: str,
+        *,
+        metadata: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, object]:
+        """Analyse a single text string and return a normalized payload."""
+
+        if not text or not text.strip():
+            return self._empty_result(metadata)
+
+        prepared = text.strip()
+        if len(prepared) > self.max_length:
+            prepared = prepared[: self.max_length]
+
+        if self._pipeline is not None:
+            try:
+                raw_predictions = self._pipeline(prepared)
+                return self._format_transformer_result(raw_predictions, prepared, metadata)
+            except Exception as exc:  # pragma: no cover - defensive guard
+                logger.exception("Transformer sentiment analysis failed: %s", exc)
+
+        return self._lexical_analysis(prepared, metadata)
+
+    def analyze_batch(
+        self,
+        texts: Iterable[str],
+        *,
+        metadata: Optional[Iterable[Optional[Dict[str, str]]]] = None,
+    ) -> List[Dict[str, object]]:
+        """Analyse multiple texts sequentially."""
+
+        results: List[Dict[str, object]] = []
+        metadata_iter = iter(metadata) if metadata is not None else None
+
+        for text in texts:
+            meta = next(metadata_iter) if metadata_iter is not None else None
+            results.append(self.analyze_text(text, metadata=meta))
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _format_transformer_result(
+        self,
+        predictions: Sequence[Dict[str, float]],
+        text: str,
+        metadata: Optional[Dict[str, str]],
+    ) -> Dict[str, object]:
+        label_map = {
+            "LABEL_0": "negative",
+            "LABEL_1": "neutral",
+            "LABEL_2": "positive",
+            "NEGATIVE": "negative",
+            "NEUTRAL": "neutral",
+            "POSITIVE": "positive",
+        }
+
+        probabilities: ScoreDistribution = {}
+        best_label = "neutral"
+        best_confidence = 0.0
+
+        for entry in predictions:
+            raw_label = str(entry.get("label", "neutral"))
+            label = label_map.get(raw_label.upper(), raw_label.lower())
+            score = float(entry.get("score", 0.0))
+            probabilities[label] = score
+            if score > best_confidence:
+                best_label = label
+                best_confidence = score
+
+        signed_score = self._to_signed_score(best_label, best_confidence)
+        return self._build_payload(
+            label=best_label,
+            confidence=best_confidence,
+            signed_score=signed_score,
+            method=self._mode,
+            text=text,
+            metadata=metadata,
+            probabilities=probabilities,
+        )
+
+    def _lexical_analysis(
+        self,
+        text: str,
+        metadata: Optional[Dict[str, str]],
+    ) -> Dict[str, object]:
+        text_lower = text.lower()
+        positive_tokens = {
+            "excellent",
+            "good",
+            "great",
+            "love",
+            "positive",
+            "outstanding",
+            "success",
+            "happy",
+            "wonderful",
+        }
+        negative_tokens = {
+            "bad",
+            "terrible",
+            "awful",
+            "negative",
+            "sad",
+            "hate",
+            "poor",
+            "failure",
+            "horrible",
+        }
+
+        positive_hits = sum(1 for token in positive_tokens if token in text_lower)
+        negative_hits = sum(1 for token in negative_tokens if token in text_lower)
+
+        if positive_hits > negative_hits:
+            label = "positive"
+            confidence = min(0.95, 0.55 + 0.1 * positive_hits)
+        elif negative_hits > positive_hits:
+            label = "negative"
+            confidence = min(0.95, 0.55 + 0.1 * negative_hits)
+        else:
+            label = "neutral"
+            confidence = 0.6
+
+        signed_score = self._to_signed_score(label, confidence)
+        probabilities = self._probability_distribution(label, confidence)
+
+        return self._build_payload(
+            label=label,
+            confidence=confidence,
+            signed_score=signed_score,
+            method="lexicon-rule",
+            text=text,
+            metadata=metadata,
+            probabilities=probabilities,
+        )
+
+    def _empty_result(self, metadata: Optional[Dict[str, str]]) -> Dict[str, object]:
+        return self._build_payload(
+            label="neutral",
+            confidence=0.0,
+            signed_score=0.0,
+            method=self._mode,
+            text="",
+            metadata=metadata,
+            probabilities={"neutral": 1.0},
+        )
+
+    def _build_payload(
+        self,
+        *,
+        label: str,
+        confidence: float,
+        signed_score: float,
+        method: str,
+        text: str,
+        metadata: Optional[Dict[str, str]],
+        probabilities: ScoreDistribution,
+    ) -> Dict[str, object]:
+        timestamp = datetime.now(timezone.utc).isoformat()
+        token_count = len(text.split()) if text else 0
+        payload = {
+            "label": label,
+            "confidence": round(float(confidence), 6),
+            "score": round(float(signed_score), 6),
+            "method": method,
+            "model": self.model_name if method == "transformer" else "lexicon-rule",
+            "probabilities": probabilities,
+            "token_count": token_count,
+            "text_sample": text[:240],
+            "computed_at": timestamp,
+        }
+
+        if metadata:
+            payload["metadata"] = metadata
+
+        return payload
+
+    @staticmethod
+    def _to_signed_score(label: str, confidence: float) -> float:
+        if label == "positive":
+            return confidence
+        if label == "negative":
+            return -confidence
+        return 0.0
+
+    @staticmethod
+    def _probability_distribution(label: str, confidence: float) -> ScoreDistribution:
+        neutral_weight = max(0.0, 1.0 - confidence)
+        if label == "positive":
+            return {
+                "positive": confidence,
+                "neutral": neutral_weight * 0.7,
+                "negative": neutral_weight * 0.3,
+            }
+        if label == "negative":
+            return {
+                "negative": confidence,
+                "neutral": neutral_weight * 0.7,
+                "positive": neutral_weight * 0.3,
+            }
+        return {
+            "neutral": max(confidence, 0.5),
+            "positive": (1.0 - confidence) * 0.25,
+            "negative": (1.0 - confidence) * 0.25,
+        }
+
+
+# ----------------------------------------------------------------------
+# Command line interface
+# ----------------------------------------------------------------------
+
+
+def _decode_base64(value: str) -> str:
+    return base64.b64decode(value.encode("utf-8")).decode("utf-8")
+
+
+def _load_json_metadata(value: Optional[str]) -> Optional[Dict[str, str]]:
+    if not value:
+        return None
+    try:
+        data = json.loads(value)
+    except json.JSONDecodeError as exc:  # pragma: no cover - CLI guard
+        raise ValueError(f"Invalid metadata JSON: {exc}") from exc
+
+    if data is None:
+        return None
+    if not isinstance(data, dict):  # pragma: no cover - CLI guard
+        raise ValueError("Metadata must be a JSON object")
+
+    # Cast everything to strings to keep payload predictable
+    return {str(key): str(value) for key, value in data.items()}
+
+
+def _load_batch_file(path: str) -> List[str]:
+    with open(path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    if isinstance(payload, list):
+        return [str(item) for item in payload]
+
+    raise ValueError("Batch file must contain a JSON array of strings")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Sentiment analysis CLI")
+    parser.add_argument("--text-base64", dest="text_base64", help="UTF-8 text encoded in base64")
+    parser.add_argument("--input-file", dest="input_file", help="JSON file containing an array of texts")
+    parser.add_argument("--model-name", dest="model_name", default=SentimentModel.DEFAULT_MODEL)
+    parser.add_argument("--metadata", dest="metadata", help="JSON metadata to attach to the response")
+
+    args = parser.parse_args(argv)
+
+    if not args.text_base64 and not args.input_file:
+        parser.error("Either --text-base64 or --input-file must be provided")
+
+    model = SentimentModel(model_name=args.model_name)
+
+    try:
+        if args.input_file:
+            texts = _load_batch_file(args.input_file)
+            results = model.analyze_batch(texts)
+            print(json.dumps(results, ensure_ascii=False))
+            return 0
+
+        assert args.text_base64 is not None
+        text = _decode_base64(args.text_base64)
+        metadata = _load_json_metadata(args.metadata)
+        result = model.analyze_text(text, metadata=metadata)
+        print(json.dumps(result, ensure_ascii=False))
+        return 0
+
+    except Exception as exc:  # pragma: no cover - CLI guard
+        logger.error("Sentiment analysis failed: %s", exc)
+        print(json.dumps({"error": str(exc)}))
+        return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI execution
+    sys.exit(main())
+

--- a/server/ml/tests/test_sentiment_analysis.py
+++ b/server/ml/tests/test_sentiment_analysis.py
@@ -1,0 +1,84 @@
+"""Unit tests for the Summit sentiment analysis model."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from typing import Dict, List
+
+import pytest
+
+
+# Ensure the summit/server package root is on the Python path when running pytest
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+from ml.models.sentiment_analysis import SentimentModel  # noqa: E402  (import after sys.path tweak)
+
+
+class DummyPipeline:
+    """Simple deterministic pipeline to avoid heavy model downloads in tests."""
+
+    def __call__(self, text: str) -> List[Dict[str, float]]:
+        # Pretend the model is very confident when the word "fantastic" appears
+        if "fantastic" in text.lower():
+            return [
+                {"label": "POSITIVE", "score": 0.92},
+                {"label": "NEGATIVE", "score": 0.04},
+                {"label": "NEUTRAL", "score": 0.04},
+            ]
+        return [
+            {"label": "NEGATIVE", "score": 0.55},
+            {"label": "POSITIVE", "score": 0.30},
+            {"label": "NEUTRAL", "score": 0.15},
+        ]
+
+
+def test_transformer_pipeline_is_used_when_available() -> None:
+    model = SentimentModel(pipeline_factory=lambda _: DummyPipeline())
+
+    result = model.analyze_text("This product is fantastic and works wonderfully!")
+
+    assert result["label"] == "positive"
+    assert pytest.approx(result["confidence"], rel=1e-6) == 0.92
+    assert result["method"] == "transformer"
+    assert result["probabilities"]["positive"] == pytest.approx(0.92)
+
+
+def test_falls_back_to_lexical_model_when_pipeline_missing() -> None:
+    model = SentimentModel(pipeline_factory=lambda _: (_ for _ in ()).throw(RuntimeError("boom")))
+
+    result = model.analyze_text("This is a terrible and horrible failure.")
+
+    assert result["label"] == "negative"
+    assert result["method"] == "lexicon-rule"
+    # Lexical model should produce a negative score
+    assert result["score"] < 0
+
+
+def test_batch_analysis_respects_metadata_order() -> None:
+    model = SentimentModel(pipeline_factory=lambda _: DummyPipeline())
+    texts = [
+        "Fantastic execution with outstanding success.",
+        "A neutral update with little detail.",
+    ]
+    metadata = [{"id": "1"}, {"id": "2"}]
+
+    results = model.analyze_batch(texts, metadata=metadata)
+
+    assert len(results) == 2
+    assert results[0]["metadata"] == {"id": "1"}
+    assert results[1]["metadata"] == {"id": "2"}
+
+
+def test_cli_single_text(tmp_path: pathlib.Path) -> None:
+    model = SentimentModel(pipeline_factory=lambda _: DummyPipeline())
+    payload = model.analyze_text("fantastic progress")
+
+    # Serialize the payload to simulate CLI output and ensure it's JSON compatible
+    data = json.loads(json.dumps(payload))
+    assert data["label"] == "positive"
+

--- a/server/src/graphql/resolvers/core.ts
+++ b/server/src/graphql/resolvers/core.ts
@@ -149,6 +149,15 @@ export const coreResolvers = {
       });
     },
 
+    entitySentiment: async (_: any, { entityId, tenantId }: any, context: any) => {
+      const effectiveTenantId = tenantId || context.tenantId;
+      if (!effectiveTenantId) {
+        throw new Error('Tenant ID is required');
+      }
+
+      return await entityRepo.getSentimentForEntity(entityId, effectiveTenantId);
+    },
+
     // Graph traversal (temporarily disabled due to schema mismatch)
     // graphNeighborhood: async (_: any, { input }: any, context: any) => {
     //   const { startEntityId, tenantId, maxDepth = 2, relationshipTypes, entityKinds, limit = 100 } = input;

--- a/server/src/graphql/schema/crudSchema.ts
+++ b/server/src/graphql/schema/crudSchema.ts
@@ -358,6 +358,9 @@ export const crudTypeDefs = gql`
     # Related entities query
     relatedEntities(entityId: ID!): [RelatedEntity!]!
 
+    # Sentiment insight for an entity
+    entitySentiment(entityId: ID!, tenantId: ID): SentimentInsight
+
     # Current user
     me: User
   }
@@ -374,6 +377,19 @@ export const crudTypeDefs = gql`
     edges: [Relationship!]!
     nodeCount: Int!
     edgeCount: Int!
+  }
+
+  type SentimentInsight {
+    entityId: ID!
+    label: String!
+    confidence: Float!
+    score: Float!
+    method: String!
+    model: String
+    probabilities: JSON
+    computedAt: DateTime!
+    textSample: String
+    jobId: String
   }
 
   # Core Mutations


### PR DESCRIPTION
## Summary
- add a Hugging Face-backed sentiment model and CLI to the ML engine with dedicated pytest coverage
- invoke the sentiment analyzer from the feed processor, persist results to Neo4j, and surface entity sentiment through GraphQL
- document the workflow in docs/ml for operating the new pipeline

## Testing
- pytest server/ml/tests/test_sentiment_analysis.py
- npm run lint *(fails: Invalid option '--ext' when using eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d72ce46c5883338276d5f3448aa169