### PR TITLE
Add workflow-engine load testing automation assets

### DIFF
--- a/docs/workflows/grafana-workflow-load-test.json
+++ b/docs/workflows/grafana-workflow-load-test.json
@@ -1,0 +1,213 @@
+{
+  "id": null,
+  "uid": "argo-workflows-load",
+  "title": "Argo Workflow Load Test Overview",
+  "tags": ["k6", "argo", "load-testing"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 1,
+  "refresh": "10s",
+  "panels": [
+    {
+      "type": "row",
+      "title": "Load Generation",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 }
+    },
+    {
+      "type": "timeseries",
+      "title": "Active Virtual Users",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 1 },
+      "targets": [
+        {
+          "expr": "sum(k6_vus{service=\"k6-load-test\"})",
+          "legendFormat": "VU Count"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "HTTP Request Rate",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 1 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_reqs_total{service=\"k6-load-test\"}[1m]))",
+          "legendFormat": "req/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": { "unit": "req/s" },
+        "overrides": []
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Workflow Submission Duration (p95)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 9 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(workflow_submission_duration_bucket[5m])))",
+          "legendFormat": "p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ms",
+          "decimals": 0
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Workflow Status Duration (p95)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 9 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(workflow_status_duration_bucket[5m])))",
+          "legendFormat": "p95"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "decimals": 0
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Workflow Error Rate",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 17 },
+      "targets": [
+        {
+          "expr": "sum(rate(workflow_errors_total[5m]))",
+          "legendFormat": "errors/s"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "req/s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.05 },
+              { "color": "red", "value": 0.1 }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Workflow Completion Status",
+      "gridPos": { "h": 6, "w": 10, "x": 6, "y": 17 },
+      "targets": [
+        {
+          "expr": "sum by (status) (increase(workflow_status_total[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Workflow Engine CPU",
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 17 },
+      "targets": [
+        {
+          "expr": "rate(container_cpu_usage_seconds_total{pod=~\"workflow-engine.*\"}[5m])",
+          "legendFormat": "CPU"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "cores",
+          "decimals": 2
+        }
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Workflow Engine Memory",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 23 },
+      "targets": [
+        {
+          "expr": "container_memory_working_set_bytes{pod=~\"workflow-engine.*\"}",
+          "legendFormat": "{{pod}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes",
+          "decimals": 0
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Completed Workflows",
+      "gridPos": { "h": 6, "w": 6, "x": 12, "y": 23 },
+      "targets": [
+        {
+          "expr": "sum(increase(workflow_status_total{status=\"Succeeded\"}[5m]))",
+          "legendFormat": "Succeeded"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Failed Workflows",
+      "gridPos": { "h": 6, "w": 6, "x": 18, "y": 23 },
+      "targets": [
+        {
+          "expr": "sum(increase(workflow_status_total{status=~\"Failed|Error\"}[5m]))",
+          "legendFormat": "Failed"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "namespace",
+        "type": "query",
+        "datasource": "Prometheus",
+        "refresh": 1,
+        "query": "label_values(workflow_status_total, namespace)",
+        "current": {
+          "text": "argo",
+          "value": "argo"
+        }
+      }
+    ]
+  }
+}

--- a/docs/workflows/k6-argo-workflow-load-test.js
+++ b/docs/workflows/k6-argo-workflow-load-test.js
@@ -1,0 +1,149 @@
+import http from 'k6/http';
+import { check, sleep } from 'k6';
+import { Trend, Rate, Counter } from 'k6/metrics';
+
+const workflowSubmissionDuration = new Trend('workflow_submission_duration');
+const workflowStatusDuration = new Trend('workflow_status_duration');
+const workflowErrors = new Rate('workflow_errors');
+const workflowRetries = new Counter('workflow_retries');
+
+const BASE_URL = __ENV.ARGO_BASE_URL || 'http://localhost:2746';
+const WORKFLOW_TEMPLATE = __ENV.WORKFLOW_TEMPLATE || 'stress-test-dag';
+const TOKEN = __ENV.ARGO_TOKEN || '';
+const MAX_STATUS_POLLS = Number(__ENV.MAX_STATUS_POLLS || 120);
+const STATUS_POLL_INTERVAL = Number(__ENV.STATUS_POLL_INTERVAL || 5);
+const MAX_RETRIES = Number(__ENV.MAX_RETRIES || 3);
+
+export const options = {
+  scenarios: {
+    submit_and_watch: {
+      executor: 'ramping-arrival-rate',
+      startRate: Number(__ENV.START_RATE || 5),
+      stages: JSON.parse(
+        __ENV.STAGES ||
+          JSON.stringify([
+            { target: 20, duration: '2m' },
+            { target: 60, duration: '5m' },
+            { target: 0, duration: '1m' },
+          ]),
+      ),
+      preAllocatedVUs: Number(__ENV.PREALLOCATED_VUS || 100),
+      maxVUs: Number(__ENV.MAX_VUS || 500),
+      exec: 'submitAndWatchWorkflow',
+    },
+  },
+  thresholds: {
+    workflow_errors: ['rate<0.05'],
+    http_req_duration: ['p(95)<2000', 'avg<1000'],
+    workflow_submission_duration: ['p(95)<1500'],
+    workflow_status_duration: ['p(95)<30000'],
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)'],
+  setupTimeout: '5m',
+};
+
+function authHeaders() {
+  const headers = { 'Content-Type': 'application/json' };
+  if (TOKEN) {
+    headers.Authorization = `Bearer ${TOKEN}`;
+  }
+  return headers;
+}
+
+function submitWorkflow() {
+  const payload = JSON.stringify({
+    namespace: __ENV.ARGO_NAMESPACE || 'argo',
+    resourceKind: 'Workflow',
+    resourceName: WORKFLOW_TEMPLATE,
+  });
+
+  const res = http.post(
+    `${BASE_URL}/api/v1/workflows/${__ENV.ARGO_NAMESPACE || 'argo'}/submit`,
+    payload,
+    { headers: authHeaders(), tags: { name: 'workflow_submit' } },
+  );
+
+  workflowSubmissionDuration.add(res.timings.duration);
+
+  const ok = check(res, {
+    'submitted workflow successfully': (r) => r.status === 200,
+  });
+
+  if (!ok) {
+    workflowErrors.add(1);
+    return null;
+  }
+
+  const responseBody = res.json();
+  return responseBody && responseBody.metadata && responseBody.metadata.name
+    ? responseBody.metadata.name
+    : null;
+}
+
+function getWorkflowStatus(name) {
+  let attempt = 0;
+  const namespace = __ENV.ARGO_NAMESPACE || 'argo';
+  const url = `${BASE_URL}/api/v1/workflows/${namespace}/${name}`;
+  let statusResponse;
+
+  while (attempt < MAX_STATUS_POLLS) {
+    statusResponse = http.get(url, {
+      headers: authHeaders(),
+      tags: { name: 'workflow_status' },
+    });
+
+    workflowStatusDuration.add(statusResponse.timings.duration);
+
+    if (statusResponse.status !== 200) {
+      workflowErrors.add(1);
+      attempt += 1;
+      workflowRetries.add(1);
+      sleep(STATUS_POLL_INTERVAL);
+      continue;
+    }
+
+    const phase = statusResponse.json('status.phase');
+    if (phase === 'Succeeded' || phase === 'Failed' || phase === 'Error') {
+      return phase;
+    }
+
+    attempt += 1;
+    sleep(STATUS_POLL_INTERVAL);
+  }
+
+  return 'Timeout';
+}
+
+export function setup() {
+  if (!TOKEN) {
+    console.warn('Running without authentication token; ensure Argo API allows anonymous access.');
+  }
+}
+
+export function submitAndWatchWorkflow() {
+  let attempt = 0;
+  let workflowName;
+
+  while (attempt < MAX_RETRIES && !workflowName) {
+    workflowName = submitWorkflow();
+    if (workflowName) {
+      break;
+    }
+    attempt += 1;
+    workflowRetries.add(1);
+    sleep(1);
+  }
+
+  if (!workflowName) {
+    workflowErrors.add(1);
+    return;
+  }
+
+  const phase = getWorkflowStatus(workflowName);
+
+  check(phase, {
+    'workflow completed successfully': (p) => p === 'Succeeded',
+  }) || workflowErrors.add(1);
+
+  sleep(Number(__ENV.PAUSE_BETWEEN_WORKFLOWS || 1));
+}

--- a/docs/workflows/prometheus-workflow-load-test.yml
+++ b/docs/workflows/prometheus-workflow-load-test.yml
@@ -1,0 +1,60 @@
+# Prometheus configuration for collecting metrics during Argo Workflow load tests.
+# Scrapes K6 metrics, Argo Workflow controller, and the workflow-engine service.
+
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'k6'
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - 'k6:6565'
+        labels:
+          service: 'k6-load-test'
+          component: 'load-generator'
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: instance
+        replacement: 'k6-runner'
+
+  - job_name: 'argo-workflows-controller'
+    metrics_path: /metrics
+    scheme: http
+    static_configs:
+      - targets:
+          - 'argo-workflows-controller:9090'
+        labels:
+          namespace: 'argo'
+          service: 'argo-workflows-controller'
+
+  - job_name: 'workflow-engine'
+    metrics_path: /metrics
+    scheme: http
+    static_configs:
+      - targets:
+          - 'workflow-engine:8080'
+        labels:
+          namespace: 'argo'
+          service: 'workflow-engine'
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'go_gc_duration_seconds.*'
+        action: drop
+      - source_labels: [__name__]
+        regex: 'process_(virtual_memory_bytes|open_fds)'
+        action: keep
+
+remote_write:
+  - url: '${PROM_REMOTE_WRITE_URL:http://prometheus:9090/api/v1/write}'
+    # Optional basic auth for remote storage or Thanos
+    basic_auth:
+      username: '${PROM_REMOTE_WRITE_USERNAME:}'
+      password: '${PROM_REMOTE_WRITE_PASSWORD:}'
+    queue_config:
+      max_samples_per_send: 2000
+      batch_send_deadline: 10s
+      min_backoff: 1s
+      max_backoff: 30s

--- a/docs/workflows/workflow-engine-load-testing-guide.md
+++ b/docs/workflows/workflow-engine-load-testing-guide.md
@@ -1,0 +1,154 @@
+# Workflow Engine Load Testing Guide
+
+This guide describes how to run automated load tests against the workflow-engine using [k6](https://k6.io), capture metrics in Prometheus, and visualize live results in Grafana.
+
+## Overview
+
+The workflow-engine drives Summit's orchestration by dispatching Argo Workflows. The provided automation simulates concurrent workflow submissions, records system behavior, and highlights bottlenecks. The toolkit includes:
+
+- [`k6-argo-workflow-load-test.js`](./k6-argo-workflow-load-test.js): parameterized k6 script that submits and monitors workflows via the Argo Workflows API.
+- [`prometheus-workflow-load-test.yml`](./prometheus-workflow-load-test.yml): scrape configuration for k6, the Argo controller, and the workflow-engine.
+- [`grafana-workflow-load-test.json`](./grafana-workflow-load-test.json): Grafana dashboard focused on load, latency, and reliability metrics.
+
+## Prerequisites
+
+1. **Argo Workflows access**
+   - API endpoint reachable from the k6 runner (default `http://localhost:2746`).
+   - Service account token with permission to submit workflows (set `ARGO_TOKEN`).
+   - Target namespace (default `argo`) and workflow template name to submit (`WORKFLOW_TEMPLATE`).
+2. **k6 >= 0.46** with the [Prometheus remote write output](https://grafana.com/docs/k6/latest/results-output/prometheus-remote-write/).
+3. **Prometheus** with write permissions to a storage backend or remote write endpoint.
+4. **Grafana** with access to the Prometheus data source.
+5. Optional: Kubernetes cluster context if deploying the helper components via manifests/Helm.
+
+## Architecture
+
+```text
+┌────────┐       submit       ┌────────────────┐       metrics        ┌────────────┐
+│  k6    │ ───────────────▶  │ Argo API/WS    │ ───────────────────▶ │ Prometheus │
+│ script │ ◀──── status ───── │ workflow-engine│                      │  (remote)  │
+└────────┘                    └────────────────┘                      └─────┬──────┘
+        │                                                               │
+        └────────── Grafana dashboard (PromQL queries) ◀─────────────────┘
+```
+
+## k6 Execution
+
+### Environment variables
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `ARGO_BASE_URL` | Base URL of the Argo Workflows API server. | `http://localhost:2746` |
+| `ARGO_NAMESPACE` | Namespace for workflow submissions. | `argo` |
+| `ARGO_TOKEN` | Bearer token used for API authentication. | _empty_ |
+| `WORKFLOW_TEMPLATE` | Template name to submit. | `stress-test-dag` |
+| `START_RATE` | Initial workflow submissions per second. | `5` |
+| `STAGES` | JSON array describing the ramping arrival rate stages. | `[{"target":20,"duration":"2m"},{"target":60,"duration":"5m"},{"target":0,"duration":"1m"}]` |
+| `PREALLOCATED_VUS` | Preallocated virtual users. | `100` |
+| `MAX_VUS` | Maximum virtual users allowed during the test. | `500` |
+| `MAX_STATUS_POLLS` | Maximum polls for workflow completion. | `120` |
+| `STATUS_POLL_INTERVAL` | Seconds between status checks. | `5` |
+| `MAX_RETRIES` | Submission retries before flagging an error. | `3` |
+| `PAUSE_BETWEEN_WORKFLOWS` | Delay between iterations. | `1` |
+
+### Run locally with Prometheus remote write
+
+```bash
+k6 run \
+  --out prometheus-remote-write=${PROM_REMOTE_WRITE_URL:-http://localhost:9090/api/v1/write} \
+  docs/workflows/k6-argo-workflow-load-test.js
+```
+
+If Prometheus requires authentication, export `PROM_REMOTE_WRITE_USERNAME` and `PROM_REMOTE_WRITE_PASSWORD` before running.
+
+### Running inside Kubernetes
+
+1. Package the script into a ConfigMap:
+   ```bash
+   kubectl create configmap k6-argo-script \
+     --from-file=docs/workflows/k6-argo-workflow-load-test.js \
+     --dry-run=client -o yaml | kubectl apply -f -
+   ```
+2. Deploy a k6 job (example snippet):
+   ```yaml
+   apiVersion: batch/v1
+   kind: Job
+   metadata:
+     name: k6-argo-load-test
+   spec:
+     template:
+       spec:
+         serviceAccountName: argo-workflow-tester
+         restartPolicy: Never
+         containers:
+           - name: k6
+             image: grafana/k6:0.49.0
+             args:
+               - run
+               - --out
+               - prometheus-remote-write=$(PROM_REMOTE_WRITE_URL)
+               - /scripts/k6-argo-workflow-load-test.js
+             envFrom:
+               - secretRef:
+                   name: argo-api-credentials
+             env:
+               - name: PROM_REMOTE_WRITE_URL
+                 value: http://prometheus.monitoring:9090/api/v1/write
+             volumeMounts:
+               - name: k6-script
+                 mountPath: /scripts
+         volumes:
+           - name: k6-script
+             configMap:
+               name: k6-argo-script
+   ```
+3. Monitor the job logs for threshold violations.
+
+## Prometheus Setup
+
+Merge [`prometheus-workflow-load-test.yml`](./prometheus-workflow-load-test.yml) with your existing Prometheus configuration. For a standalone instance:
+
+```bash
+cat docs/workflows/prometheus-workflow-load-test.yml >> /etc/prometheus/prometheus.yml
+systemctl restart prometheus
+```
+
+Ensure DNS or hostnames resolve to the k6 runner, Argo controller (`argo-workflows-controller:9090`), and workflow-engine service (`workflow-engine:8080`). Adjust scrape intervals and authentication to match production settings.
+
+## Grafana Dashboard Import
+
+1. Open Grafana → **Dashboards** → **Import**.
+2. Upload [`grafana-workflow-load-test.json`](./grafana-workflow-load-test.json) or paste the JSON definition.
+3. Choose the Prometheus data source that receives the k6 metrics.
+4. Save the dashboard into a folder such as `Load Tests`.
+
+Key visualizations include:
+
+- Virtual users vs. request rate to verify target load.
+- Workflow submission and completion latency (p95).
+- Error rate and completion distribution to spot failures.
+- Workflow engine resource consumption (CPU/memory).
+
+## Test Lifecycle
+
+1. **Plan**: Align load stages with anticipated peak throughput and define success thresholds beyond the defaults.
+2. **Dry Run**: Execute a short (5–10 min) test to validate connectivity and dashboards.
+3. **Soak Test**: Increase stage durations to observe resource saturation and memory growth.
+4. **Analyze**: Use Prometheus queries and Grafana annotations to correlate errors with system events.
+5. **Iterate**: Tune the workflow-engine concurrency, queue depth, and Argo controller settings based on findings.
+
+## Troubleshooting
+
+| Symptom | Possible Cause | Resolution |
+| --- | --- | --- |
+| `401 Unauthorized` on submit | Missing or incorrect `ARGO_TOKEN`. | Refresh the service account token, verify API server audience. |
+| Workflows stuck in `Pending` | Insufficient workflow-engine capacity or Kubernetes quota. | Scale the workflow-engine deployment and review pod quotas. |
+| Prometheus missing k6 metrics | Incorrect `--out` URL or network policy blocking port 6565. | Validate the remote write endpoint and network connectivity. |
+| Grafana panels show `No data` | Dashboard PromQL queries don't match metric labels. | Confirm scrape config labels (`service="k6-load-test"`) and namespace filter. |
+
+## Next Steps
+
+- Integrate k6 execution into CI by running staged loads nightly and alerting on threshold breaches.
+- Expand the script with additional checks (e.g., verifying workflow outputs or artifacts).
+- Store historical runs in a time-series database (Prometheus + Thanos) to track performance trends over time.
+


### PR DESCRIPTION
## Summary
- add a k6 script that ramps workflow submissions against the Argo API and captures reliability trends
- provide Prometheus scrape configuration and Grafana dashboard tuned for workflow-engine load testing
- document setup and execution steps for automated workflow load tests

## Testing
- not run (documentation and configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68d72d08e5f4833399cd436a16885651