### PR TITLE
feat: add federated t-secure metrics aggregator

### DIFF
--- a/ftma/core/field.h
+++ b/ftma/core/field.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <cstdint>
+
+namespace ftma {
+
+class Field {
+ public:
+  static constexpr std::uint64_t kModulus = 2305843009213693951ULL;  // 2^61 - 1
+
+  static std::uint64_t Add(std::uint64_t a, std::uint64_t b) {
+    unsigned __int128 sum = static_cast<unsigned __int128>(a) +
+                            static_cast<unsigned __int128>(b);
+    return static_cast<std::uint64_t>(sum % kModulus);
+  }
+
+  static std::uint64_t Sub(std::uint64_t a, std::uint64_t b) {
+    unsigned __int128 base = static_cast<unsigned __int128>(kModulus) + a;
+    unsigned __int128 diff = base - static_cast<unsigned __int128>(b % kModulus);
+    return static_cast<std::uint64_t>(diff % kModulus);
+  }
+
+  static std::uint64_t Mul(std::uint64_t a, std::uint64_t b) {
+    unsigned __int128 prod = static_cast<unsigned __int128>(a) *
+                             static_cast<unsigned __int128>(b);
+    return static_cast<std::uint64_t>(prod % kModulus);
+  }
+
+  static std::uint64_t Pow(std::uint64_t base, std::uint64_t exp) {
+    std::uint64_t result = 1ULL;
+    std::uint64_t cur = base % kModulus;
+    while (exp > 0) {
+      if (exp & 1ULL) {
+        result = Mul(result, cur);
+      }
+      cur = Mul(cur, cur);
+      exp >>= 1ULL;
+    }
+    return result;
+  }
+
+  static std::uint64_t Inverse(std::uint64_t value) {
+    if (value == 0ULL) {
+      return 0ULL;
+    }
+    return Pow(value, kModulus - 2ULL);
+  }
+
+  static int64_t ToSigned(std::uint64_t value) {
+    if (value > kModulus / 2ULL) {
+      return static_cast<int64_t>(value) - static_cast<int64_t>(kModulus);
+    }
+    return static_cast<int64_t>(value);
+  }
+
+  static std::uint64_t FromSigned(int64_t value) {
+    int64_t mod = static_cast<int64_t>(kModulus);
+    int64_t adjusted = ((value % mod) + mod) % mod;
+    return static_cast<std::uint64_t>(adjusted);
+  }
+};
+
+}  // namespace ftma

--- a/ftma/core/protocol.cpp
+++ b/ftma/core/protocol.cpp
@@ -1,0 +1,259 @@
+#include "protocol.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+
+namespace ftma {
+
+namespace {
+
+std::uint64_t MixSeed(std::uint64_t a, std::uint64_t b, std::uint64_t c) {
+  if (a > b) {
+    std::swap(a, b);
+  }
+  std::uint64_t seed = a;
+  seed ^= b + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+  seed ^= c + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+  return seed;
+}
+
+}  // namespace
+
+FtmaCoordinator::FtmaCoordinator(std::size_t num_clients, std::size_t threshold,
+                                 std::size_t metric_dimension, std::uint64_t scale)
+    : num_clients_(num_clients),
+      threshold_(threshold),
+      metric_dimension_(metric_dimension),
+      vector_dimension_(metric_dimension * 2),
+      scale_(scale),
+      prng_(std::random_device{}()),
+      shamir_(threshold, num_clients),
+      clients_(num_clients) {
+  if (threshold == 0 || threshold > num_clients) {
+    throw std::invalid_argument("Threshold must be between 1 and num_clients");
+  }
+  if (metric_dimension == 0) {
+    throw std::invalid_argument("Metric dimension must be positive");
+  }
+  if (scale == 0) {
+    throw std::invalid_argument("Scale must be non-zero");
+  }
+}
+
+std::vector<std::uint64_t> FtmaCoordinator::GeneratePersonalMask() {
+  std::vector<std::uint64_t> mask(vector_dimension_, 0ULL);
+  std::uniform_int_distribution<std::uint64_t> dist(0, Field::kModulus - 1ULL);
+  for (auto& value : mask) {
+    value = dist(prng_);
+  }
+  return mask;
+}
+
+std::vector<std::uint64_t> FtmaCoordinator::GeneratePairwiseMask(
+    std::uint64_t seed) const {
+  std::mt19937_64 prng(seed);
+  std::uniform_int_distribution<std::uint64_t> dist(0, Field::kModulus - 1ULL);
+  std::vector<std::uint64_t> mask(vector_dimension_, 0ULL);
+  for (auto& value : mask) {
+    value = dist(prng);
+  }
+  return mask;
+}
+
+std::vector<std::uint64_t> FtmaCoordinator::BuildPayload(
+    const std::vector<double>& metrics, std::vector<std::uint64_t>& personal_mask,
+    std::unordered_map<std::size_t, std::uint64_t>& pairwise_seeds,
+    std::size_t client_id) {
+  if (metrics.size() != metric_dimension_) {
+    throw std::invalid_argument("Metric vector dimension mismatch");
+  }
+  std::vector<std::uint64_t> scaled(vector_dimension_, 0ULL);
+  for (std::size_t i = 0; i < metric_dimension_; ++i) {
+    double value = metrics[i];
+    double scaled_value = std::round(value * static_cast<double>(scale_));
+    int64_t scaled_int = static_cast<int64_t>(scaled_value);
+    std::uint64_t field_value = Field::FromSigned(scaled_int);
+    scaled[i] = field_value;
+    __int128 square_int = static_cast<__int128>(scaled_int) *
+                          static_cast<__int128>(scaled_int);
+    __int128 modulus = static_cast<__int128>(Field::kModulus);
+    square_int %= modulus;
+    if (square_int < 0) {
+      square_int += modulus;
+    }
+    scaled[i + metric_dimension_] =
+        static_cast<std::uint64_t>(square_int);
+  }
+
+  personal_mask = GeneratePersonalMask();
+
+  std::vector<std::vector<std::uint64_t>> mask_shares =
+      shamir_.ShareVector(personal_mask, prng_);
+
+  for (std::size_t recipient = 0; recipient < num_clients_; ++recipient) {
+    if (recipient == client_id) {
+      continue;
+    }
+    clients_[recipient].incoming_shares[client_id] = mask_shares[recipient];
+  }
+
+  std::vector<std::uint64_t> payload = scaled;
+  for (std::size_t i = 0; i < vector_dimension_; ++i) {
+    payload[i] = Field::Add(payload[i], personal_mask[i]);
+  }
+
+  for (std::size_t other = 0; other < num_clients_; ++other) {
+    if (other == client_id) {
+      continue;
+    }
+    std::uint64_t seed = MixSeed(static_cast<std::uint64_t>(client_id + 1),
+                                 static_cast<std::uint64_t>(other + 1),
+                                 static_cast<std::uint64_t>(scale_));
+    pairwise_seeds[other] = seed;
+    std::vector<std::uint64_t> mask = GeneratePairwiseMask(seed);
+    bool client_smaller = client_id < other;
+    for (std::size_t i = 0; i < vector_dimension_; ++i) {
+      if (client_smaller) {
+        payload[i] = Field::Add(payload[i], mask[i]);
+      } else {
+        payload[i] = Field::Sub(payload[i], mask[i]);
+      }
+    }
+  }
+
+  return payload;
+}
+
+std::vector<std::uint64_t> FtmaCoordinator::RegisterClient(
+    std::size_t client_id, const std::vector<double>& metrics) {
+  if (client_id >= num_clients_) {
+    throw std::out_of_range("Client id out of range");
+  }
+  ClientState& state = clients_[client_id];
+  if (state.registered) {
+    throw std::runtime_error("Client already registered");
+  }
+  state.original_metrics = metrics;
+  state.masked_payload = BuildPayload(metrics, state.personal_mask,
+                                      state.pairwise_seeds, client_id);
+  state.registered = true;
+  return state.masked_payload;
+}
+
+AggregationResult FtmaCoordinator::Finalize(
+    const std::vector<std::size_t>& active_clients) {
+  if (active_clients.size() < threshold_) {
+    throw std::runtime_error("Not enough active clients to satisfy threshold");
+  }
+  for (std::size_t id : active_clients) {
+    if (id >= num_clients_ || !clients_[id].registered) {
+      throw std::runtime_error("Active client not registered");
+    }
+  }
+  std::vector<std::uint64_t> aggregate(vector_dimension_, 0ULL);
+  std::size_t participants = 0;
+  for (std::size_t id = 0; id < num_clients_; ++id) {
+    if (!clients_[id].registered) {
+      continue;
+    }
+    ++participants;
+    const auto& payload = clients_[id].masked_payload;
+    for (std::size_t i = 0; i < vector_dimension_; ++i) {
+      aggregate[i] = Field::Add(aggregate[i], payload[i]);
+    }
+  }
+
+  for (std::size_t id : active_clients) {
+    const auto& mask = clients_[id].personal_mask;
+    for (std::size_t i = 0; i < vector_dimension_; ++i) {
+      aggregate[i] = Field::Sub(aggregate[i], mask[i]);
+    }
+  }
+
+  std::vector<bool> is_active(num_clients_, false);
+  for (std::size_t id : active_clients) {
+    is_active[id] = true;
+  }
+
+  for (std::size_t dropout = 0; dropout < num_clients_; ++dropout) {
+    if (is_active[dropout] || !clients_[dropout].registered) {
+      continue;
+    }
+    std::vector<std::vector<std::uint64_t>> collected;
+    std::vector<std::uint64_t> coords;
+    collected.reserve(active_clients.size());
+    coords.reserve(active_clients.size());
+    for (std::size_t id : active_clients) {
+      auto it = clients_[id].incoming_shares.find(dropout);
+      if (it != clients_[id].incoming_shares.end()) {
+        collected.push_back(it->second);
+        coords.push_back(static_cast<std::uint64_t>(id + 1));
+      }
+    }
+    if (collected.size() < threshold_) {
+      throw std::runtime_error("Insufficient shares to reconstruct dropout mask");
+    }
+    std::vector<std::vector<std::uint64_t>> truncated(collected.begin(),
+                                                      collected.begin() + threshold_);
+    std::vector<std::uint64_t> coord_subset(coords.begin(), coords.begin() + threshold_);
+    std::vector<std::uint64_t> mask = shamir_.Reconstruct(coord_subset, truncated);
+    for (std::size_t i = 0; i < vector_dimension_; ++i) {
+      aggregate[i] = Field::Sub(aggregate[i], mask[i]);
+    }
+  }
+
+  for (std::size_t missing = 0; missing < num_clients_; ++missing) {
+    if (clients_[missing].registered || is_active[missing]) {
+      continue;
+    }
+    for (std::size_t id : active_clients) {
+      auto seed_it = clients_[id].pairwise_seeds.find(missing);
+      if (seed_it == clients_[id].pairwise_seeds.end()) {
+        continue;
+      }
+      std::vector<std::uint64_t> mask_vec = GeneratePairwiseMask(seed_it->second);
+      bool survivor_smaller = id < missing;
+      for (std::size_t i = 0; i < vector_dimension_; ++i) {
+        if (survivor_smaller) {
+          aggregate[i] = Field::Sub(aggregate[i], mask_vec[i]);
+        } else {
+          aggregate[i] = Field::Add(aggregate[i], mask_vec[i]);
+        }
+      }
+    }
+  }
+
+  if (participants == 0) {
+    throw std::runtime_error("No registered participants to aggregate");
+  }
+
+  AggregationResult result;
+  result.participants = participants;
+  result.survivors = active_clients.size();
+  result.threshold = threshold_;
+  result.sum.resize(metric_dimension_);
+  result.mean.resize(metric_dimension_);
+  result.variance.resize(metric_dimension_);
+
+  for (std::size_t i = 0; i < metric_dimension_; ++i) {
+    std::uint64_t sum_component = aggregate[i];
+    std::uint64_t sumsq_component = aggregate[i + metric_dimension_];
+    double sum_value = static_cast<double>(Field::ToSigned(sum_component)) /
+                       static_cast<double>(scale_);
+    double sumsq_value = static_cast<double>(Field::ToSigned(sumsq_component)) /
+                         (static_cast<double>(scale_) * static_cast<double>(scale_));
+    result.sum[i] = sum_value;
+    double mean = sum_value / static_cast<double>(participants);
+    double variance =
+        std::max(0.0, sumsq_value / static_cast<double>(participants) -
+                           mean * mean);
+    result.mean[i] = mean;
+    result.variance[i] = variance;
+  }
+
+  return result;
+}
+
+}  // namespace ftma

--- a/ftma/core/protocol.h
+++ b/ftma/core/protocol.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <unordered_map>
+#include <vector>
+
+#include "field.h"
+#include "shamir.h"
+
+namespace ftma {
+
+struct AggregationResult {
+  std::vector<double> sum;
+  std::vector<double> mean;
+  std::vector<double> variance;
+  std::size_t participants;
+  std::size_t survivors;
+  std::size_t threshold;
+};
+
+class FtmaCoordinator {
+ public:
+  FtmaCoordinator(std::size_t num_clients, std::size_t threshold,
+                  std::size_t metric_dimension, std::uint64_t scale);
+
+  std::vector<std::uint64_t> RegisterClient(
+      std::size_t client_id, const std::vector<double>& metrics);
+
+  AggregationResult Finalize(const std::vector<std::size_t>& active_clients);
+
+  std::size_t dimension() const { return metric_dimension_; }
+
+ private:
+  struct ClientState {
+    bool registered = false;
+    std::vector<std::uint64_t> masked_payload;
+    std::vector<std::uint64_t> personal_mask;
+    std::unordered_map<std::size_t, std::vector<std::uint64_t>> incoming_shares;
+    std::unordered_map<std::size_t, std::uint64_t> pairwise_seeds;
+    std::vector<double> original_metrics;
+  };
+
+  std::vector<std::uint64_t> BuildPayload(
+      const std::vector<double>& metrics, std::vector<std::uint64_t>& personal_mask,
+      std::unordered_map<std::size_t, std::uint64_t>& pairwise_seeds,
+      std::size_t client_id);
+
+  std::vector<std::uint64_t> GeneratePersonalMask();
+
+  std::vector<std::uint64_t> GeneratePairwiseMask(std::uint64_t seed) const;
+
+  std::size_t num_clients_;
+  std::size_t threshold_;
+  std::size_t metric_dimension_;
+  std::size_t vector_dimension_;
+  std::uint64_t scale_;
+  std::mt19937_64 prng_;
+  Shamir shamir_;
+  std::vector<ClientState> clients_;
+};
+
+}  // namespace ftma

--- a/ftma/core/shamir.cpp
+++ b/ftma/core/shamir.cpp
@@ -1,0 +1,87 @@
+#include "shamir.h"
+
+#include <stdexcept>
+
+namespace ftma {
+
+namespace {
+
+std::vector<std::uint64_t> BuildPolynomial(std::uint64_t constant,
+                                           std::size_t degree,
+                                           std::mt19937_64& prng) {
+  std::vector<std::uint64_t> coeffs(degree + 1);
+  coeffs[0] = constant;
+  std::uniform_int_distribution<std::uint64_t> dist(0, Field::kModulus - 1ULL);
+  for (std::size_t i = 1; i <= degree; ++i) {
+    coeffs[i] = dist(prng);
+  }
+  return coeffs;
+}
+
+std::uint64_t Evaluate(const std::vector<std::uint64_t>& coeffs,
+                       std::uint64_t x) {
+  std::uint64_t result = 0ULL;
+  std::uint64_t power = 1ULL;
+  for (std::size_t i = 0; i < coeffs.size(); ++i) {
+    std::uint64_t term = Field::Mul(coeffs[i], power);
+    result = Field::Add(result, term);
+    power = Field::Mul(power, x % Field::kModulus);
+  }
+  return result;
+}
+
+}  // namespace
+
+std::vector<std::vector<std::uint64_t>> Shamir::ShareVector(
+    const std::vector<std::uint64_t>& secret, std::mt19937_64& prng) const {
+  if (threshold_ == 0 || threshold_ > num_participants_) {
+    throw std::invalid_argument("Invalid Shamir threshold");
+  }
+  std::vector<std::vector<std::uint64_t>> shares(num_participants_,
+                                                 std::vector<std::uint64_t>(secret.size(), 0ULL));
+  for (std::size_t component = 0; component < secret.size(); ++component) {
+    std::vector<std::uint64_t> coeffs =
+        BuildPolynomial(secret[component], threshold_ - 1, prng);
+    for (std::size_t participant = 0; participant < num_participants_; ++participant) {
+      std::uint64_t x = static_cast<std::uint64_t>(participant + 1);
+      shares[participant][component] = Evaluate(coeffs, x);
+    }
+  }
+  return shares;
+}
+
+std::vector<std::uint64_t> Shamir::Reconstruct(
+    const std::vector<std::uint64_t>& x_coords,
+    const std::vector<std::vector<std::uint64_t>>& shares) const {
+  if (shares.size() != x_coords.size()) {
+    throw std::invalid_argument("Share and coordinate sizes differ");
+  }
+  if (shares.size() < threshold_) {
+    throw std::invalid_argument("Insufficient shares to reconstruct secret");
+  }
+  std::size_t vector_size = shares[0].size();
+  std::vector<std::uint64_t> secret(vector_size, 0ULL);
+  for (std::size_t comp = 0; comp < vector_size; ++comp) {
+    std::uint64_t value = 0ULL;
+    for (std::size_t i = 0; i < shares.size(); ++i) {
+      std::uint64_t numerator = 1ULL;
+      std::uint64_t denominator = 1ULL;
+      for (std::size_t j = 0; j < shares.size(); ++j) {
+        if (i == j) {
+          continue;
+        }
+        std::uint64_t xi = x_coords[i] % Field::kModulus;
+        std::uint64_t xj = x_coords[j] % Field::kModulus;
+        numerator = Field::Mul(numerator, Field::Sub(0ULL, xj));
+        denominator = Field::Mul(denominator, Field::Sub(xi, xj));
+      }
+      std::uint64_t lagrange =
+          Field::Mul(numerator, Field::Inverse(denominator));
+      value = Field::Add(value, Field::Mul(shares[i][comp], lagrange));
+    }
+    secret[comp] = value;
+  }
+  return secret;
+}
+
+}  // namespace ftma

--- a/ftma/core/shamir.h
+++ b/ftma/core/shamir.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "field.h"
+
+namespace ftma {
+
+class Shamir {
+ public:
+  Shamir(std::size_t threshold, std::size_t num_participants)
+      : threshold_(threshold), num_participants_(num_participants) {}
+
+  std::vector<std::vector<std::uint64_t>> ShareVector(
+      const std::vector<std::uint64_t>& secret, std::mt19937_64& prng) const;
+
+  std::vector<std::uint64_t> Reconstruct(
+      const std::vector<std::uint64_t>& x_coords,
+      const std::vector<std::vector<std::uint64_t>>& shares) const;
+
+ private:
+  std::size_t threshold_;
+  std::size_t num_participants_;
+};
+
+}  // namespace ftma

--- a/ftma/python/CMakeLists.txt
+++ b/ftma/python/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.18)
+project(ftma LANGUAGES CXX)
+
+find_package(pybind11 CONFIG REQUIRED)
+
+set(FTMA_CORE_SOURCES
+    ../core/protocol.cpp
+    ../core/shamir.cpp
+)
+
+pybind11_add_module(ftma_core bindings.cpp ${FTMA_CORE_SOURCES})
+
+target_include_directories(ftma_core
+    PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/../core
+)
+
+target_compile_features(ftma_core PRIVATE cxx_std_17)
+
+install(TARGETS ftma_core LIBRARY DESTINATION .)

--- a/ftma/python/README.md
+++ b/ftma/python/README.md
@@ -1,0 +1,5 @@
+# Federated T-Secure Metrics Aggregator (FTMA)
+
+This package provides Python bindings for the FTMA C++ core, enabling
+threshold-secure aggregation of federated metrics with dropout resilience and
+support for integer and fixed-point real statistics.

--- a/ftma/python/bindings.cpp
+++ b/ftma/python/bindings.cpp
@@ -1,0 +1,26 @@
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include "../core/protocol.h"
+
+namespace py = pybind11;
+
+PYBIND11_MODULE(ftma_core, m) {
+  py::class_<ftma::AggregationResult>(m, "AggregationResult")
+      .def_readonly("sum", &ftma::AggregationResult::sum)
+      .def_readonly("mean", &ftma::AggregationResult::mean)
+      .def_readonly("variance", &ftma::AggregationResult::variance)
+      .def_readonly("participants", &ftma::AggregationResult::participants)
+      .def_readonly("survivors", &ftma::AggregationResult::survivors)
+      .def_readonly("threshold", &ftma::AggregationResult::threshold);
+
+  py::class_<ftma::FtmaCoordinator>(m, "FtmaCoordinator")
+      .def(py::init<std::size_t, std::size_t, std::size_t, std::uint64_t>(),
+           py::arg("num_clients"), py::arg("threshold"),
+           py::arg("metric_dimension"), py::arg("scale") = 1000000ULL)
+      .def("register_client", &ftma::FtmaCoordinator::RegisterClient,
+           py::arg("client_id"), py::arg("metrics"))
+      .def("finalize", &ftma::FtmaCoordinator::Finalize,
+           py::arg("active_clients"))
+      .def_property_readonly("dimension", &ftma::FtmaCoordinator::dimension);
+}

--- a/ftma/python/ftma/__init__.py
+++ b/ftma/python/ftma/__init__.py
@@ -1,0 +1,62 @@
+"""Python helpers for the Federated T-Secure Metrics Aggregator."""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+ftma_core = importlib.import_module("ftma_core")
+
+
+@dataclass(frozen=True)
+class AggregationResult:
+    """Typed wrapper around the C++ aggregation result."""
+
+    sum: List[float]
+    mean: List[float]
+    variance: List[float]
+    participants: int
+    survivors: int
+    threshold: int
+
+
+class Coordinator:
+    """High-level coordinator orchestrating FTMA sessions."""
+
+    def __init__(self, num_clients: int, threshold: int, metric_dimension: int, scale: int = 1_000_000) -> None:
+        if threshold <= 0 or threshold > num_clients:
+            raise ValueError("threshold must be within (0, num_clients]")
+        self._core = ftma_core.FtmaCoordinator(num_clients, threshold, metric_dimension, scale)
+        self._num_clients = num_clients
+        self._dimension = metric_dimension
+        self._scale = scale
+
+    @property
+    def dimension(self) -> int:
+        return self._dimension
+
+    @property
+    def scale(self) -> int:
+        return self._scale
+
+    def register_client(self, client_id: int, metrics: Sequence[float]) -> List[int]:
+        if len(metrics) != self._dimension:
+            raise ValueError("metrics dimension mismatch")
+        masked = self._core.register_client(client_id, list(metrics))
+        return [int(value) for value in masked]
+
+    def finalize(self, active_clients: Iterable[int]) -> AggregationResult:
+        active_list = list(active_clients)
+        core_result = self._core.finalize(active_list)
+        return AggregationResult(
+            sum=list(core_result.sum),
+            mean=list(core_result.mean),
+            variance=list(core_result.variance),
+            participants=core_result.participants,
+            survivors=core_result.survivors,
+            threshold=core_result.threshold,
+        )
+
+
+__all__ = ["AggregationResult", "Coordinator"]

--- a/ftma/python/ftma/benchmark.py
+++ b/ftma/python/ftma/benchmark.py
@@ -1,0 +1,69 @@
+"""Latency and scalability benchmarks for the FTMA coordinator."""
+
+from __future__ import annotations
+
+import argparse
+import random
+import statistics
+import time
+from typing import Dict, Iterable, List
+
+from . import Coordinator
+
+
+def _generate_updates(num_clients: int, dimension: int) -> List[List[float]]:
+    rng = random.Random(9876)
+    return [[rng.uniform(-5.0, 5.0) for _ in range(dimension)] for _ in range(num_clients)]
+
+
+def run_benchmark(num_clients: int, threshold: int, dimension: int, runs: int = 25) -> Dict[str, float]:
+    updates = _generate_updates(num_clients, dimension)
+    coordinator = Coordinator(num_clients, threshold, dimension)
+    for idx, metrics in enumerate(updates):
+        coordinator.register_client(idx, metrics)
+
+    active = list(range(num_clients))
+    latencies: List[float] = []
+    for _ in range(runs):
+        start = time.perf_counter()
+        coordinator.finalize(active)
+        latencies.append(time.perf_counter() - start)
+
+    mean_latency = statistics.mean(latencies)
+    stddev = statistics.pstdev(latencies)
+    ci95 = 1.96 * stddev / (len(latencies) ** 0.5)
+
+    return {
+        "num_clients": float(num_clients),
+        "threshold": float(threshold),
+        "dimension": float(dimension),
+        "mean_latency_s": mean_latency,
+        "std_latency_s": stddev,
+        "ci95_s": ci95,
+    }
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="FTMA latency benchmark")
+    parser.add_argument("--clients", type=int, nargs="*", default=[32, 64, 128])
+    parser.add_argument("--dimension", type=int, default=4)
+    parser.add_argument("--runs", type=int, default=25)
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    rows = []
+    for clients in args.clients:
+        threshold = max(3, int(0.7 * clients))
+        row = run_benchmark(clients, threshold, args.dimension, runs=args.runs)
+        rows.append(row)
+
+    header = "clients\tthreshold\tdimension\tmean_latency_s\tci95_s"
+    print(header)
+    for row in rows:
+        print(
+            f"{int(row['num_clients'])}\t{int(row['threshold'])}\t{int(row['dimension'])}\t"
+            f"{row['mean_latency_s']:.6f}\t{row['ci95_s']:.6f}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/ftma/python/ftma/server.py
+++ b/ftma/python/ftma/server.py
@@ -1,0 +1,116 @@
+"""Reference HTTP server exposing the FTMA coordinator."""
+
+from __future__ import annotations
+
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Dict, Tuple
+
+from . import Coordinator
+
+
+class FtmaRequestHandler(BaseHTTPRequestHandler):
+    coordinator: Coordinator | None = None
+
+    def _json_response(self, status: HTTPStatus, payload: Dict) -> None:
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(status.value)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        if self.path != "/status":
+            self._json_response(HTTPStatus.NOT_FOUND, {"error": "not found"})
+            return
+        coord = self.__class__.coordinator
+        if coord is None:
+            self._json_response(HTTPStatus.SERVICE_UNAVAILABLE, {"status": "uninitialized"})
+            return
+        self._json_response(
+            HTTPStatus.OK,
+            {
+                "status": "ready",
+                "dimension": coord.dimension,
+                "scale": coord.scale,
+            },
+        )
+
+    def do_POST(self) -> None:  # noqa: N802 - required by BaseHTTPRequestHandler
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            self._json_response(HTTPStatus.BAD_REQUEST, {"error": "invalid JSON"})
+            return
+
+        if self.path == "/register":
+            self._handle_register(payload)
+        elif self.path == "/finalize":
+            self._handle_finalize(payload)
+        else:
+            self._json_response(HTTPStatus.NOT_FOUND, {"error": "not found"})
+
+    def _handle_register(self, payload: Dict) -> None:
+        coord = self.__class__.coordinator
+        if coord is None:
+            self._json_response(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "coordinator not configured"})
+            return
+        try:
+            client_id = int(payload["client_id"])
+            metrics = [float(v) for v in payload["metrics"]]
+        except (KeyError, TypeError, ValueError):
+            self._json_response(HTTPStatus.BAD_REQUEST, {"error": "invalid register payload"})
+            return
+        try:
+            masked = coord.register_client(client_id, metrics)
+        except Exception as exc:  # pragma: no cover - defensive
+            self._json_response(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+        self._json_response(HTTPStatus.OK, {"masked": masked})
+
+    def _handle_finalize(self, payload: Dict) -> None:
+        coord = self.__class__.coordinator
+        if coord is None:
+            self._json_response(HTTPStatus.SERVICE_UNAVAILABLE, {"error": "coordinator not configured"})
+            return
+        try:
+            active = [int(v) for v in payload["active_clients"]]
+        except (KeyError, TypeError, ValueError):
+            self._json_response(HTTPStatus.BAD_REQUEST, {"error": "invalid finalize payload"})
+            return
+        try:
+            result = coord.finalize(active)
+        except Exception as exc:  # pragma: no cover - defensive
+            self._json_response(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            return
+        self._json_response(
+            HTTPStatus.OK,
+            {
+                "sum": result.sum,
+                "mean": result.mean,
+                "variance": result.variance,
+                "participants": result.participants,
+                "survivors": result.survivors,
+            },
+        )
+
+
+def serve(host: str = "127.0.0.1", port: int = 8080, *, num_clients: int, threshold: int, dimension: int, scale: int = 1_000_000) -> Tuple[str, int]:
+    """Start the FTMA reference server and return the bound address."""
+
+    FtmaRequestHandler.coordinator = Coordinator(num_clients, threshold, dimension, scale)
+    server = ThreadingHTTPServer((host, port), FtmaRequestHandler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover - interactive use
+        pass
+    finally:
+        server.server_close()
+    return server.server_address
+
+
+__all__ = ["serve", "FtmaRequestHandler"]

--- a/ftma/python/ftma/tests/test_ftma.py
+++ b/ftma/python/ftma/tests/test_ftma.py
@@ -1,0 +1,113 @@
+import math
+import random
+
+import numpy as np
+import pytest
+
+from ftma import Coordinator
+
+
+def centralized_statistics(vectors):
+    arr = np.array(vectors, dtype=float)
+    sums = arr.sum(axis=0)
+    means = sums / arr.shape[0]
+    variances = arr.var(axis=0)
+    return sums.tolist(), means.tolist(), variances.tolist()
+
+
+def quantize_vectors(vectors, scale):
+    return [[round(value * scale) / scale for value in vec] for vec in vectors]
+
+
+def test_secure_aggregation_matches_centralized():
+    random.seed(42)
+    num_clients = 8
+    threshold = 5
+    dimension = 3
+    coordinator = Coordinator(num_clients, threshold, dimension, scale=1_000_000)
+
+    updates = []
+    for client_id in range(num_clients):
+        metrics = [random.uniform(-10.0, 10.0) for _ in range(dimension)]
+        updates.append(metrics)
+        masked = coordinator.register_client(client_id, metrics)
+        assert len(masked) == dimension * 2
+
+    active_clients = [0, 1, 2, 4, 5, 6]
+    quantized = quantize_vectors(updates, coordinator.scale)
+    expected_sum, expected_mean, expected_var = centralized_statistics(quantized)
+
+    result = coordinator.finalize(active_clients)
+
+    assert result.participants == num_clients
+    assert result.survivors == len(active_clients)
+    for idx in range(dimension):
+        assert math.isclose(result.sum[idx], expected_sum[idx], rel_tol=1e-6, abs_tol=1e-6)
+        assert math.isclose(result.mean[idx], expected_mean[idx], rel_tol=1e-6, abs_tol=1e-6)
+        assert math.isclose(result.variance[idx], expected_var[idx], rel_tol=1e-6, abs_tol=1e-6)
+
+
+def test_dropout_resilience_multiple_clients():
+    num_clients = 10
+    threshold = 6
+    dimension = 2
+    coordinator = Coordinator(num_clients, threshold, dimension, scale=1_000)
+
+    updates = []
+    rng = random.Random(1337)
+    for client_id in range(num_clients):
+        metrics = [rng.randint(-50, 50) for _ in range(dimension)]
+        updates.append(metrics)
+        coordinator.register_client(client_id, metrics)
+
+    active_clients = [0, 1, 3, 4, 6, 7, 9]
+    quantized = quantize_vectors(updates, coordinator.scale)
+    expected_sum, expected_mean, expected_var = centralized_statistics(quantized)
+
+    result = coordinator.finalize(active_clients)
+
+    assert result.participants == num_clients
+    assert result.survivors == len(active_clients)
+    for idx in range(dimension):
+        assert math.isclose(result.sum[idx], expected_sum[idx], rel_tol=1e-6, abs_tol=1e-6)
+        assert math.isclose(result.mean[idx], expected_mean[idx], rel_tol=1e-6, abs_tol=1e-6)
+        assert math.isclose(result.variance[idx], expected_var[idx], rel_tol=1e-6, abs_tol=1e-6)
+
+
+def test_threshold_enforced():
+    num_clients = 5
+    threshold = 4
+    dimension = 1
+    coordinator = Coordinator(num_clients, threshold, dimension)
+
+    for client_id in range(num_clients):
+        coordinator.register_client(client_id, [float(client_id + 1)])
+
+    with pytest.raises(RuntimeError):
+        coordinator.finalize([0, 1])
+
+
+def test_handles_unregistered_clients():
+    num_clients = 6
+    threshold = 4
+    dimension = 2
+    coordinator = Coordinator(num_clients, threshold, dimension, scale=1_000)
+
+    updates = []
+    rng = random.Random(2024)
+    for client_id in range(4):
+        metrics = [rng.uniform(-3.0, 3.0) for _ in range(dimension)]
+        updates.append(metrics)
+        coordinator.register_client(client_id, metrics)
+
+    quantized = quantize_vectors(updates, coordinator.scale)
+    expected_sum, expected_mean, expected_var = centralized_statistics(quantized)
+
+    result = coordinator.finalize([0, 1, 2, 3])
+
+    assert result.participants == 4
+    assert result.survivors == 4
+    for idx in range(dimension):
+        assert math.isclose(result.sum[idx], expected_sum[idx], rel_tol=1e-6, abs_tol=1e-6)
+        assert math.isclose(result.mean[idx], expected_mean[idx], rel_tol=1e-6, abs_tol=1e-6)
+        assert math.isclose(result.variance[idx], expected_var[idx], rel_tol=1e-6, abs_tol=1e-6)

--- a/ftma/python/pyproject.toml
+++ b/ftma/python/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["scikit-build-core>=0.5.1", "pybind11>=2.11"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "ftma"
+version = "0.1.0"
+authors = [{name = "Summit Labs"}]
+description = "Federated T-Secure Metrics Aggregator"
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: C++",
+  "Operating System :: OS Independent"
+]
+
+[project.optional-dependencies]
+dev = ["pytest", "numpy", "scipy"]
+
+[project.urls]
+Homepage = "https://example.com/ftma"
+
+[tool.scikit-build]
+wheel.expand-macos-universal-tags = true
+cmake.version = ">=3.18"


### PR DESCRIPTION
## Summary
- add C++ FTMA core implementing double-masked t-of-n secure aggregation with Shamir reconstruction
- expose bindings, Python helpers, HTTP reference server, and benchmarking utilities with CI-ready tests
- add pytest-based differential tests validating dropout handling and accuracy against centralized statistics

## Testing
- python -m pip install --upgrade pip
- pip install -e ftma/python[dev]
- pytest ftma/python/ftma/tests -q
- python -m ftma.benchmark --clients 16 32 --dimension 3 --runs 5

------
https://chatgpt.com/codex/tasks/task_e_68d732de9fa883338ca5989632fd6bd2