### PR TITLE
feat: add model usage ledger SDK and API

### DIFF
--- a/ga-graphai/packages/prov-ledger/package.json
+++ b/ga-graphai/packages/prov-ledger/package.json
@@ -12,10 +12,15 @@
     "test:record": "node --loader ts-node/esm ./tests/record.test.ts"
   },
   "dependencies": {
-    "common-types": "file:../common-types"
+    "common-types": "file:../common-types",
+    "better-sqlite3": "^9.4.0",
+    "express": "^4.19.2"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",
+    "@types/express": "^4.17.21",
+    "@types/supertest": "^2.0.16",
+    "supertest": "^7.1.1",
     "ts-node": "^10.9.2",
     "typescript": "5.4.5",
     "vitest": "1.6.0"

--- a/ga-graphai/packages/prov-ledger/src/index.ts
+++ b/ga-graphai/packages/prov-ledger/src/index.ts
@@ -22,6 +22,8 @@ import {
   normalizeWorkflow,
 } from 'common-types';
 
+export * from './mul-ledger';
+
 // ============================================================================
 // SIMPLE PROVENANCE LEDGER - From HEAD
 // ============================================================================

--- a/ga-graphai/packages/prov-ledger/src/mul-ledger.ts
+++ b/ga-graphai/packages/prov-ledger/src/mul-ledger.ts
@@ -1,0 +1,463 @@
+import Database from 'better-sqlite3';
+import { createHash, createHmac, randomUUID } from 'node:crypto';
+import { performance } from 'node:perf_hooks';
+import express, { Router } from 'express';
+
+export interface ModelUsageEventInput {
+  model: string;
+  version: string;
+  datasetLineageId: string;
+  consentScope: string;
+  dpBudgetSpend: number;
+  policyHash: string;
+  outputArtifactIds: string[];
+  eventId?: string;
+  timestamp?: string;
+}
+
+export interface ModelUsageEventRecord extends ModelUsageEventInput {
+  eventId: string;
+  timestamp: string;
+  previousHash: string | null;
+  hash: string;
+  sequence: number;
+}
+
+export interface LedgerQueryOptions {
+  model?: string;
+  datasetLineageId?: string;
+  policyHash?: string;
+  limit?: number;
+  after?: string;
+}
+
+export interface IntegrityCheckFailure {
+  index: number;
+  eventId: string;
+  reason: 'PREVIOUS_HASH_MISMATCH' | 'HASH_MISMATCH';
+}
+
+export interface IntegrityCheckResult {
+  ok: boolean;
+  failure?: IntegrityCheckFailure;
+}
+
+export interface CompliancePackTotals {
+  events: number;
+  dpBudgetSpend: number;
+}
+
+export interface CompliancePack {
+  month: string;
+  generatedAt: string;
+  headHash: string | null;
+  totals: CompliancePackTotals;
+  digest: string;
+  events: ModelUsageEventRecord[];
+}
+
+export interface CompliancePackSignature {
+  algorithm: string;
+  keyId: string;
+  value: string;
+}
+
+export interface SignedCompliancePack {
+  pack: CompliancePack;
+  signature: CompliancePackSignature;
+  payload: string;
+}
+
+export interface CompliancePackSigner {
+  keyId: string;
+  secret: string | Buffer;
+  algorithm?: 'HS256' | 'SHA256';
+}
+
+export interface LedgerServerOptions {
+  signer: CompliancePackSigner;
+}
+
+export class ModelUsageLedger {
+  protected readonly db: Database.Database;
+  private readonly insertStatement: Database.Statement;
+  private readonly headStatement: Database.Statement;
+  private readonly monthStatement: Database.Statement;
+
+  constructor(path: string = ':memory:') {
+    this.db = new Database(path);
+    this.db.pragma('journal_mode = WAL');
+    this.initialize();
+    this.insertStatement = this.db.prepare(`
+      INSERT INTO ledger_entries (
+        event_id,
+        timestamp,
+        model,
+        version,
+        dataset_lineage_id,
+        consent_scope,
+        dp_budget_spend,
+        policy_hash,
+        output_artifact_ids,
+        previous_hash,
+        entry_hash
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    this.headStatement = this.db.prepare(
+      'SELECT entry_hash AS hash FROM ledger_entries ORDER BY sequence DESC LIMIT 1'
+    );
+    this.monthStatement = this.db.prepare(`
+      SELECT
+        sequence,
+        event_id,
+        timestamp,
+        model,
+        version,
+        dataset_lineage_id AS datasetLineageId,
+        consent_scope AS consentScope,
+        dp_budget_spend AS dpBudgetSpend,
+        policy_hash AS policyHash,
+        output_artifact_ids AS outputArtifactIds,
+        previous_hash AS previousHash,
+        entry_hash AS hash
+      FROM ledger_entries
+      WHERE timestamp >= ? AND timestamp < ?
+      ORDER BY sequence ASC
+    `);
+  }
+
+  private initialize(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS ledger_entries (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_id TEXT NOT NULL UNIQUE,
+        timestamp TEXT NOT NULL,
+        model TEXT NOT NULL,
+        version TEXT NOT NULL,
+        dataset_lineage_id TEXT NOT NULL,
+        consent_scope TEXT NOT NULL,
+        dp_budget_spend REAL NOT NULL,
+        policy_hash TEXT NOT NULL,
+        output_artifact_ids TEXT NOT NULL,
+        previous_hash TEXT,
+        entry_hash TEXT NOT NULL
+      );
+    `);
+  }
+
+  appendEvent(event: ModelUsageEventInput): ModelUsageEventRecord {
+    const timestamp = normaliseTimestamp(event.timestamp);
+    const eventId = event.eventId ?? randomUUID();
+    const previousHash = this.getHeadHash();
+    const hash = computeHash({
+      eventId,
+      timestamp,
+      model: event.model,
+      version: event.version,
+      datasetLineageId: event.datasetLineageId,
+      consentScope: event.consentScope,
+      dpBudgetSpend: event.dpBudgetSpend,
+      policyHash: event.policyHash,
+      outputArtifactIds: event.outputArtifactIds,
+      previousHash: previousHash ?? undefined
+    });
+
+    const payloadJson = JSON.stringify(event.outputArtifactIds ?? []);
+    const info = this.insertStatement.run(
+      eventId,
+      timestamp,
+      event.model,
+      event.version,
+      event.datasetLineageId,
+      event.consentScope,
+      event.dpBudgetSpend,
+      event.policyHash,
+      payloadJson,
+      previousHash ?? null,
+      hash
+    );
+
+    return {
+      model: event.model,
+      version: event.version,
+      datasetLineageId: event.datasetLineageId,
+      consentScope: event.consentScope,
+      dpBudgetSpend: event.dpBudgetSpend,
+      policyHash: event.policyHash,
+      outputArtifactIds: [...event.outputArtifactIds],
+      eventId,
+      timestamp,
+      previousHash: previousHash ?? null,
+      hash,
+      sequence: Number(info.lastInsertRowid)
+    };
+  }
+
+  getHeadHash(): string | null {
+    const result = this.headStatement.get() as { hash?: string } | undefined;
+    return result?.hash ?? null;
+  }
+
+  queryEvents(options: LedgerQueryOptions = {}): ModelUsageEventRecord[] {
+    const clauses: string[] = [];
+    const params: any[] = [];
+    if (options.model) {
+      clauses.push('model = ?');
+      params.push(options.model);
+    }
+    if (options.datasetLineageId) {
+      clauses.push('dataset_lineage_id = ?');
+      params.push(options.datasetLineageId);
+    }
+    if (options.policyHash) {
+      clauses.push('policy_hash = ?');
+      params.push(options.policyHash);
+    }
+    if (options.after) {
+      clauses.push('timestamp > ?');
+      params.push(options.after);
+    }
+    const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
+    const limit = options.limit && options.limit > 0 ? options.limit : 200;
+    const statement = this.db.prepare(
+      `SELECT sequence, event_id, timestamp, model, version, dataset_lineage_id, consent_scope, dp_budget_spend, policy_hash, output_artifact_ids, previous_hash, entry_hash FROM ledger_entries ${where} ORDER BY sequence DESC LIMIT ?`
+    );
+    const rows = statement.all(...params, limit) as any[];
+    return rows.map(mapRow);
+  }
+
+  verifyIntegrity(): IntegrityCheckResult {
+    const rows = this.db
+      .prepare(
+        `SELECT sequence, event_id, timestamp, model, version, dataset_lineage_id, consent_scope, dp_budget_spend, policy_hash, output_artifact_ids, previous_hash, entry_hash FROM ledger_entries ORDER BY sequence ASC`
+      )
+      .all() as any[];
+
+    let previousHash: string | null = null;
+    for (let index = 0; index < rows.length; index += 1) {
+      const row = rows[index];
+      if (row.previous_hash !== previousHash) {
+        return {
+          ok: false,
+          failure: {
+            index,
+            eventId: row.event_id,
+            reason: 'PREVIOUS_HASH_MISMATCH'
+          }
+        };
+      }
+      const recalculated = computeHash({
+        eventId: row.event_id,
+        timestamp: row.timestamp,
+        model: row.model,
+        version: row.version,
+        datasetLineageId: row.dataset_lineage_id,
+        consentScope: row.consent_scope,
+        dpBudgetSpend: row.dp_budget_spend,
+        policyHash: row.policy_hash,
+        outputArtifactIds: JSON.parse(row.output_artifact_ids),
+        previousHash: row.previous_hash ?? undefined
+      });
+      if (recalculated !== row.entry_hash) {
+        return {
+          ok: false,
+          failure: {
+            index,
+            eventId: row.event_id,
+            reason: 'HASH_MISMATCH'
+          }
+        };
+      }
+      previousHash = row.entry_hash;
+    }
+
+    return { ok: true };
+  }
+
+  exportMonthlyCompliancePack(month: string, signer: CompliancePackSigner): SignedCompliancePack {
+    const { start, end } = monthRange(month);
+    const rows = this.monthStatement.all(start, end) as any[];
+    const events = rows.map(mapRow);
+    const totals = events.reduce<CompliancePackTotals>(
+      (agg, row) => ({
+        events: agg.events + 1,
+        dpBudgetSpend: agg.dpBudgetSpend + row.dpBudgetSpend
+      }),
+      { events: 0, dpBudgetSpend: 0 }
+    );
+
+    const digest = hashEvents(events);
+    const pack: CompliancePack = {
+      month,
+      generatedAt: new Date().toISOString(),
+      headHash: events.at(-1)?.hash ?? this.getHeadHash(),
+      totals,
+      digest,
+      events
+    };
+
+    const payload = JSON.stringify(pack);
+    const signature = signPayload(payload, signer);
+
+    return {
+      pack,
+      signature,
+      payload
+    };
+  }
+}
+
+export class MulLedgerSdk {
+  constructor(private readonly ledger: ModelUsageLedger) {}
+
+  logEvent(event: ModelUsageEventInput): ModelUsageEventRecord {
+    return this.ledger.appendEvent(event);
+  }
+
+  benchmark(iterations = 100, factory?: () => ModelUsageEventInput): number {
+    const samples: number[] = [];
+    for (let index = 0; index < iterations; index += 1) {
+      const start = performance.now();
+      this.logEvent(factory ? factory() : defaultEvent());
+      const duration = performance.now() - start;
+      samples.push(duration);
+    }
+    return samples.reduce((sum, value) => sum + value, 0) / samples.length;
+  }
+}
+
+export function createLedgerRouter(
+  ledger: ModelUsageLedger,
+  options: LedgerServerOptions
+): Router {
+  const router = express.Router();
+  router.use(express.json());
+
+  router.post('/events', (req, res) => {
+    const record = ledger.appendEvent(req.body as ModelUsageEventInput);
+    res.status(201).json(record);
+  });
+
+  router.get('/events', (req, res) => {
+    const events = ledger.queryEvents({
+      model: req.query.model as string | undefined,
+      datasetLineageId: req.query.datasetLineageId as string | undefined,
+      policyHash: req.query.policyHash as string | undefined,
+      limit: req.query.limit ? Number(req.query.limit) : undefined,
+      after: req.query.after as string | undefined
+    });
+    res.json({ events });
+  });
+
+  router.get('/integrity', (req, res) => {
+    const result = ledger.verifyIntegrity();
+    if (result.ok) {
+      res.json({ ok: true });
+      return;
+    }
+    res.status(409).json(result);
+  });
+
+  router.get('/compliance-pack', (req, res) => {
+    const { month } = req.query;
+    if (!month || typeof month !== 'string') {
+      res.status(400).json({ error: 'month query param required' });
+      return;
+    }
+    const pack = ledger.exportMonthlyCompliancePack(month, options.signer);
+    res.json(pack);
+  });
+
+  return router;
+}
+
+function normaliseTimestamp(value?: string): string {
+  if (value) {
+    return new Date(value).toISOString();
+  }
+  return new Date().toISOString();
+}
+
+function computeHash(
+  data: Omit<ModelUsageEventRecord, 'sequence'> & { previousHash?: string | null }
+): string {
+  const hash = createHash('sha256');
+  hash.update(data.eventId);
+  hash.update(data.timestamp);
+  hash.update(data.model);
+  hash.update(data.version);
+  hash.update(data.datasetLineageId);
+  hash.update(data.consentScope);
+  hash.update(String(data.dpBudgetSpend));
+  hash.update(data.policyHash);
+  hash.update(JSON.stringify(data.outputArtifactIds));
+  if (data.previousHash) {
+    hash.update(data.previousHash);
+  }
+  return hash.digest('hex');
+}
+
+function mapRow(row: any): ModelUsageEventRecord {
+  return {
+    eventId: row.event_id ?? row.eventId,
+    timestamp: row.timestamp,
+    model: row.model,
+    version: row.version,
+    datasetLineageId: row.datasetLineageId ?? row.dataset_lineage_id,
+    consentScope: row.consentScope ?? row.consent_scope,
+    dpBudgetSpend: Number(row.dpBudgetSpend ?? row.dp_budget_spend),
+    policyHash: row.policyHash ?? row.policy_hash,
+    outputArtifactIds: Array.isArray(row.outputArtifactIds)
+      ? row.outputArtifactIds
+      : JSON.parse(row.output_artifact_ids ?? row.outputArtifactIds ?? '[]'),
+    previousHash: row.previousHash ?? row.previous_hash ?? null,
+    hash: row.hash ?? row.entry_hash,
+    sequence: Number(row.sequence)
+  };
+}
+
+function monthRange(month: string): { start: string; end: string } {
+  const [year, monthPart] = month.split('-').map(Number);
+  if (!year || !monthPart || monthPart < 1 || monthPart > 12) {
+    throw new Error(`Invalid month format: ${month}`);
+  }
+  const start = new Date(Date.UTC(year, monthPart - 1, 1));
+  const end = new Date(Date.UTC(year, monthPart, 1));
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+function hashEvents(events: ModelUsageEventRecord[]): string {
+  const hash = createHash('sha256');
+  hash.update(JSON.stringify(events));
+  return hash.digest('hex');
+}
+
+function signPayload(payload: string, signer: CompliancePackSigner): CompliancePackSignature {
+  const algorithm = signer.algorithm ?? 'HS256';
+  if (algorithm === 'HS256') {
+    const value = createHmac('sha256', signer.secret).update(payload).digest('hex');
+    return {
+      algorithm,
+      keyId: signer.keyId,
+      value
+    };
+  }
+  const value = createHash('sha256').update(payload).digest('hex');
+  return {
+    algorithm,
+    keyId: signer.keyId,
+    value
+  };
+}
+
+function defaultEvent(): ModelUsageEventInput {
+  return {
+    model: 'default-model',
+    version: '1.0.0',
+    datasetLineageId: 'ds-1',
+    consentScope: 'general',
+    dpBudgetSpend: 0,
+    policyHash: 'policy',
+    outputArtifactIds: []
+  };
+}

--- a/ga-graphai/packages/prov-ledger/tests/mul-ledger.test.ts
+++ b/ga-graphai/packages/prov-ledger/tests/mul-ledger.test.ts
@@ -1,0 +1,143 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import supertest from 'supertest';
+import express from 'express';
+import {
+  ModelUsageLedger,
+  MulLedgerSdk,
+  createLedgerRouter,
+  CompliancePackSigner
+} from '../src/mul-ledger';
+
+const signer: CompliancePackSigner = {
+  keyId: 'test-key',
+  secret: 'secret'
+};
+
+describe('ModelUsageLedger', () => {
+  it('maintains hash integrity across appended events', () => {
+    const ledger = new ModelUsageLedger(':memory:');
+    const first = ledger.appendEvent({
+      model: 'gaia',
+      version: '1.0.0',
+      datasetLineageId: 'dl-001',
+      consentScope: 'research',
+      dpBudgetSpend: 2.5,
+      policyHash: 'policy-a',
+      outputArtifactIds: ['art-1']
+    });
+    const second = ledger.appendEvent({
+      model: 'gaia',
+      version: '1.0.1',
+      datasetLineageId: 'dl-001',
+      consentScope: 'research',
+      dpBudgetSpend: 1.5,
+      policyHash: 'policy-b',
+      outputArtifactIds: ['art-2']
+    });
+
+    expect(second.previousHash).toBe(first.hash);
+    const integrity = ledger.verifyIntegrity();
+    expect(integrity.ok).toBe(true);
+  });
+
+  it('detects tampering via integrity check', () => {
+    const ledger = new ModelUsageLedger(':memory:');
+    const record = ledger.appendEvent({
+      model: 'gaia',
+      version: '1.0.0',
+      datasetLineageId: 'dl-001',
+      consentScope: 'research',
+      dpBudgetSpend: 1,
+      policyHash: 'policy',
+      outputArtifactIds: []
+    });
+
+    const db = (ledger as any).db;
+    db.prepare('UPDATE ledger_entries SET dp_budget_spend = 99 WHERE event_id = ?').run(record.eventId);
+
+    const integrity = ledger.verifyIntegrity();
+    expect(integrity.ok).toBe(false);
+    expect(integrity.failure?.reason).toBe('HASH_MISMATCH');
+  });
+
+  it('exports monthly compliance pack with exact totals', () => {
+    const ledger = new ModelUsageLedger(':memory:');
+    ledger.appendEvent({
+      model: 'gaia',
+      version: '1.0.0',
+      datasetLineageId: 'dl-001',
+      consentScope: 'research',
+      dpBudgetSpend: 2,
+      policyHash: 'policy-a',
+      outputArtifactIds: [],
+      timestamp: '2024-05-05T00:00:00.000Z'
+    });
+    ledger.appendEvent({
+      model: 'gaia',
+      version: '1.0.1',
+      datasetLineageId: 'dl-002',
+      consentScope: 'analytics',
+      dpBudgetSpend: 3,
+      policyHash: 'policy-b',
+      outputArtifactIds: [],
+      timestamp: '2024-05-06T00:00:00.000Z'
+    });
+
+    const pack = ledger.exportMonthlyCompliancePack('2024-05', signer);
+    expect(pack.pack.totals.events).toBe(2);
+    expect(pack.pack.totals.dpBudgetSpend).toBe(5);
+    expect(pack.pack.digest).toBeDefined();
+    const digestRecalc = createHash('sha256')
+      .update(JSON.stringify(pack.pack.events))
+      .digest('hex');
+    expect(pack.pack.digest).toBe(digestRecalc);
+  });
+});
+
+describe('Ledger API', () => {
+  it('accepts writes and queries through HTTP', async () => {
+    const ledger = new ModelUsageLedger(':memory:');
+    const app = express();
+    app.use('/', createLedgerRouter(ledger, { signer }));
+    const request = supertest(app);
+
+    const response = await request.post('/events').send({
+      model: 'gaia',
+      version: '1.0.0',
+      datasetLineageId: 'dl-001',
+      consentScope: 'research',
+      dpBudgetSpend: 1.2,
+      policyHash: 'policy',
+      outputArtifactIds: []
+    });
+    expect(response.status).toBe(201);
+
+    const list = await request.get('/events');
+    expect(list.body.events.length).toBe(1);
+
+    const integrity = await request.get('/integrity');
+    expect(integrity.body.ok).toBe(true);
+
+    const pack = await request.get('/compliance-pack').query({ month: '2024-05' });
+    expect(pack.status).toBe(200);
+    expect(pack.body.signature.value).toBeDefined();
+  });
+});
+
+describe('MulLedgerSdk', () => {
+  it('logs events with negligible overhead', () => {
+    const ledger = new ModelUsageLedger(':memory:');
+    const sdk = new MulLedgerSdk(ledger);
+    const average = sdk.benchmark(30, () => ({
+      model: 'gaia',
+      version: '1.0.0',
+      datasetLineageId: 'dl-001',
+      consentScope: 'research',
+      dpBudgetSpend: 0.5,
+      policyHash: 'policy',
+      outputArtifactIds: []
+    }));
+    expect(average).toBeLessThan(5);
+  });
+});

--- a/sdk/python/maestro_sdk/mul_ledger/__init__.py
+++ b/sdk/python/maestro_sdk/mul_ledger/__init__.py
@@ -1,0 +1,107 @@
+"""Model Usage Ledger SDK for Python."""
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Any, Dict, Iterable, List, Optional
+import json
+import time
+
+import httpx
+
+
+@dataclass
+class ModelUsageEvent:
+    """Data structure describing a single model usage event."""
+
+    model: str
+    version: str
+    dataset_lineage_id: str
+    consent_scope: str
+    dp_budget_spend: float
+    policy_hash: str
+    output_artifact_ids: Iterable[str]
+    event_id: Optional[str] = None
+    timestamp: Optional[str] = None
+
+    def to_payload(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["output_artifact_ids"] = list(self.output_artifact_ids)
+        return data
+
+
+class MulLedgerClient:
+    """Client for interacting with the MUL ledger HTTP API."""
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        client: Optional[httpx.Client] = None,
+        timeout: float = 5.0,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = client or httpx.Client(base_url=self._base_url, timeout=timeout)
+        self._owns_client = client is None
+
+    def __enter__(self) -> "MulLedgerClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def log_event(self, event: ModelUsageEvent) -> Dict[str, Any]:
+        response = self._client.post("/events", json=event.to_payload())
+        response.raise_for_status()
+        return response.json()
+
+    def query_events(self, **filters: Any) -> List[Dict[str, Any]]:
+        response = self._client.get("/events", params=filters)
+        response.raise_for_status()
+        payload = response.json()
+        events = payload.get("events")
+        if isinstance(events, list):
+            return events
+        raise ValueError("Unexpected response payload for events query")
+
+    def integrity_status(self) -> Dict[str, Any]:
+        response = self._client.get("/integrity")
+        if response.status_code == 409:
+            return response.json()
+        response.raise_for_status()
+        return response.json()
+
+    def export_monthly_compliance_pack(self, month: str) -> Dict[str, Any]:
+        response = self._client.get("/compliance-pack", params={"month": month})
+        response.raise_for_status()
+        return response.json()
+
+    def benchmark_log_event(self, event: ModelUsageEvent, iterations: int = 25) -> float:
+        durations: List[float] = []
+        for _ in range(iterations):
+            start = time.perf_counter()
+            self.log_event(event)
+            durations.append(time.perf_counter() - start)
+        return sum(durations) / len(durations)
+
+
+class MockTransportFactory:
+    """Utilities for creating mock transports during testing."""
+
+    @staticmethod
+    def create(responses: Dict[str, Dict[str, Any]]) -> httpx.MockTransport:
+        def handler(request: httpx.Request) -> httpx.Response:
+            key = f"{request.method} {request.url.path}"
+            data = responses.get(key)
+            if data is None:
+                return httpx.Response(404, json={"error": "not found"})
+            body = data.get("json")
+            if callable(body):
+                body = body(json.loads(request.content.decode("utf-8")))
+            return httpx.Response(data.get("status", 200), json=body)
+
+        return httpx.MockTransport(handler)
+

--- a/sdk/python/test/test_mul_ledger.py
+++ b/sdk/python/test/test_mul_ledger.py
@@ -1,0 +1,76 @@
+import json
+from typing import List
+
+import httpx
+
+from maestro_sdk.mul_ledger import ModelUsageEvent, MulLedgerClient
+
+
+def build_transport(log: List[dict]) -> httpx.MockTransport:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/events":
+            body = json.loads(request.content.decode("utf-8"))
+            record = {
+                **body,
+                "eventId": body.get("event_id", "evt-" + str(len(log) + 1)),
+                "hash": "hash-value",
+                "previousHash": log[-1]["hash"] if log else None,
+                "sequence": len(log) + 1,
+            }
+            log.append(record)
+            return httpx.Response(201, json=record)
+        if request.method == "GET" and request.url.path == "/events":
+            return httpx.Response(200, json={"events": list(log)})
+        if request.method == "GET" and request.url.path == "/integrity":
+            return httpx.Response(200, json={"ok": True})
+        if request.method == "GET" and request.url.path == "/compliance-pack":
+            return httpx.Response(
+                200,
+                json={
+                    "pack": {
+                        "totals": {
+                            "events": len(log),
+                            "dpBudgetSpend": sum(item["dp_budget_spend"] for item in log),
+                        }
+                    },
+                    "signature": {"value": "sig"},
+                    "payload": "{}",
+                },
+            )
+        return httpx.Response(404, json={"error": "not found"})
+
+    return httpx.MockTransport(handler)
+
+
+def test_python_sdk_logs_and_queries_quickly() -> None:
+    log: List[dict] = []
+    transport = build_transport(log)
+    http_client = httpx.Client(transport=transport, base_url="http://ledger.local")
+    client = MulLedgerClient("http://ledger.local", client=http_client)
+
+    event = ModelUsageEvent(
+        model="gaia",
+        version="1.0.0",
+        dataset_lineage_id="dl-001",
+        consent_scope="research",
+        dp_budget_spend=0.5,
+        policy_hash="policy",
+        output_artifact_ids=[],
+    )
+
+    record = client.log_event(event)
+    assert record["model"] == event.model
+    events = client.query_events()
+    assert len(events) == 1
+
+    integrity = client.integrity_status()
+    assert integrity["ok"] is True
+
+    pack = client.export_monthly_compliance_pack("2024-05")
+    assert pack["signature"]["value"] == "sig"
+
+    average = client.benchmark_log_event(event, iterations=10)
+    assert average < 0.005
+
+    http_client.close()
+


### PR DESCRIPTION
## Summary
- implement a SQLite-backed model usage ledger with integrity verification, API router, and compliance pack signing
- add Vitest coverage for the new ledger plus API, tamper detection, and SDK benchmarks
- provide Python client utilities for the ledger HTTP API with supporting tests

## Testing
- npm test (fails: legacy provenance ledger tests expect older signatures)
- PYTHONPATH=. pytest (fails: existing maestro SDK tests require unavailable AuthenticatedClient token mock)


------
https://chatgpt.com/codex/tasks/task_e_68d73926b288833392fdfdfb237e8b77