### PR TITLE
feat: add governance SLO monitoring service

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,4 @@ passlib[bcrypt]==1.7.4
 python-dotenv==1.1.*
 httpx==0.28.*
 jinja2==3.1.*
+prometheus-client==0.20.*

--- a/services/gslo/__init__.py
+++ b/services/gslo/__init__.py
@@ -1,0 +1,5 @@
+"""Governance SLO monitoring service package."""
+
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/services/gslo/alerting.py
+++ b/services/gslo/alerting.py
@@ -1,0 +1,91 @@
+"""Burn-rate monitoring utilities for governance SLOs."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from .config import BurnRateConfig
+from .metrics import SLO_GAUGES, get_burn_rate_gauge
+from .models import BurnRateAlert, SLOSnapshot
+from .service import GovernanceSLOService
+
+
+class BurnRateMonitor:
+    """Periodically evaluates SLO performance and raises burn-rate alerts."""
+
+    def __init__(
+        self,
+        service: GovernanceSLOService,
+        config: BurnRateConfig,
+    ) -> None:
+        self._service = service
+        self._config = config
+        self._alerts: Dict[str, BurnRateAlert] = {}
+        self._breach_started: Dict[str, datetime] = {}
+        self._task: Optional[asyncio.Task] = None
+        self._stopped = asyncio.Event()
+
+    async def start(self) -> None:
+        if self._task is not None:
+            return
+        self._stopped.clear()
+        self._task = asyncio.create_task(self._run_loop())
+
+    async def stop(self) -> None:
+        if self._task is None:
+            return
+        self._stopped.set()
+        await self._task
+        self._task = None
+
+    async def _run_loop(self) -> None:
+        interval = self._config.evaluation_interval.total_seconds()
+        while not self._stopped.is_set():
+            snapshot = await self._service.snapshot()
+            self._evaluate_snapshot(snapshot)
+            try:
+                await asyncio.wait_for(self._stopped.wait(), timeout=interval)
+            except asyncio.TimeoutError:
+                continue
+
+    def _evaluate_snapshot(self, snapshot: SLOSnapshot) -> None:
+        thresholds = self._service.thresholds
+        metrics = {
+            "time_to_block_seconds": (snapshot.time_to_block_seconds, thresholds.time_to_block_seconds),
+            "false_negative_rate": (snapshot.false_negative_rate, thresholds.false_negative_rate),
+            "decision_freshness_seconds": (
+                snapshot.decision_freshness_seconds,
+                thresholds.decision_freshness_seconds,
+            ),
+            "appeal_latency_seconds": (snapshot.appeal_latency_seconds, thresholds.appeal_latency_seconds),
+        }
+
+        now = snapshot.collected_at
+        for slo_name, (value, target) in metrics.items():
+            if slo_name in SLO_GAUGES:
+                SLO_GAUGES[slo_name].set(value)
+            if target <= 0:
+                continue
+            burn_rate = value / target if target else 0.0
+            get_burn_rate_gauge(slo_name).set(burn_rate)
+            if burn_rate > 1:
+                start = self._breach_started.setdefault(slo_name, now)
+                if now - start >= self._config.alert_window:
+                    self._alerts[slo_name] = BurnRateAlert(
+                        slo_name=slo_name,
+                        burn_rate=burn_rate,
+                        triggered_at=start,
+                        details={
+                            "observed": f"{value:.2f}",
+                            "target": f"{target:.2f}",
+                        },
+                    )
+            else:
+                self._breach_started.pop(slo_name, None)
+                self._alerts.pop(slo_name, None)
+
+    def get_alerts(self) -> List[BurnRateAlert]:
+        return sorted(self._alerts.values(), key=lambda alert: alert.triggered_at)
+

--- a/services/gslo/app.py
+++ b/services/gslo/app.py
@@ -1,0 +1,220 @@
+"""FastAPI application for the Governance SLO monitor."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from pydantic import BaseModel
+
+from .alerting import BurnRateMonitor
+from .config import DEFAULT_BURN_RATE, DEFAULT_THRESHOLDS, BurnRateConfig, SLOThresholds
+from .metrics import REDMetricsMiddleware, metrics_response
+from .models import (
+    AppealEvent,
+    BlockEvent,
+    BurnRateAlert,
+    CanaryEvent,
+    DashboardPayload,
+    DecisionEvent,
+    PolicyCommit,
+    SLOSnapshot,
+    SyntheticSchedule,
+    TimeseriesPoint,
+    ViolationEvent,
+)
+from .service import GovernanceSLOService
+from .synthetic import SyntheticTrafficGenerator
+
+
+def create_app(
+    thresholds: SLOThresholds = DEFAULT_THRESHOLDS,
+    burn_config: BurnRateConfig = DEFAULT_BURN_RATE,
+    synthetic_schedule: SyntheticSchedule = SyntheticSchedule(),
+) -> FastAPI:
+    """Instantiate the Governance SLO monitoring service application."""
+
+    service = GovernanceSLOService(
+        thresholds=thresholds,
+        history_retention=burn_config.history_retention,
+    )
+    burn_monitor = BurnRateMonitor(service, burn_config)
+    traffic = SyntheticTrafficGenerator(service, synthetic_schedule)
+
+    app = FastAPI(title="Governance SLO Monitor", version="1.0.0")
+    app.add_middleware(REDMetricsMiddleware)
+
+    @app.on_event("startup")
+    async def _startup() -> None:
+        await burn_monitor.start()
+        await traffic.start()
+
+    @app.on_event("shutdown")
+    async def _shutdown() -> None:
+        await burn_monitor.stop()
+        await traffic.stop()
+
+    @app.get("/healthz")
+    async def healthcheck() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/metrics")
+    def metrics():
+        return metrics_response()
+
+    @app.get("/slo", response_model=SLOSnapshot)
+    async def get_slo_snapshot() -> SLOSnapshot:
+        return await service.snapshot()
+
+    @app.get("/alerts", response_model=List[BurnRateAlert])
+    async def get_alerts() -> List[BurnRateAlert]:
+        return burn_monitor.get_alerts()
+
+    @app.get("/dashboard.json", response_model=DashboardPayload)
+    async def dashboard_json() -> DashboardPayload:
+        return await service.get_dashboard_payload(burn_monitor.get_alerts())
+
+    @app.get("/dashboard", response_class=HTMLResponse)
+    async def dashboard() -> HTMLResponse:
+        payload = await service.get_dashboard_payload(burn_monitor.get_alerts())
+        return HTMLResponse(render_dashboard(payload))
+
+    @app.post("/events/violation", status_code=202)
+    async def post_violation(event: ViolationEvent) -> dict[str, str]:
+        await service.record_violation(event)
+        return {"status": "queued"}
+
+    @app.post("/events/block", status_code=202)
+    async def post_block(event: BlockEvent) -> dict[str, str]:
+        await service.record_block(event)
+        return {"status": "processed"}
+
+    @app.post("/events/canary", status_code=202)
+    async def post_canary(event: CanaryEvent) -> dict[str, str]:
+        await service.seed_canary(event)
+        return {"status": "seeded"}
+
+    @app.post("/events/decision", status_code=202)
+    async def post_decision(event: DecisionEvent) -> dict[str, str]:
+        await service.record_decision(event)
+        return {"status": "recorded"}
+
+    @app.post("/events/policy", status_code=202)
+    async def post_policy(commit: PolicyCommit) -> dict[str, str]:
+        await service.record_policy_commit(commit)
+        return {"status": "updated"}
+
+    @app.post("/events/appeal", status_code=202)
+    async def post_appeal(event: AppealEvent) -> dict[str, str]:
+        await service.file_appeal(event)
+        return {"status": "filed"}
+
+    class AppealResolution(BaseModel):
+        appeal_id: str
+        resolved_at: Optional[datetime] = None
+
+    @app.post("/events/appeal/resolve", status_code=202)
+    async def resolve_appeal(event: AppealResolution) -> dict[str, str]:
+        await service.resolve_appeal(event.appeal_id, event.resolved_at)
+        return {"status": "closed"}
+
+    return app
+
+
+def render_dashboard(payload: DashboardPayload) -> str:
+    """Render a time-series dashboard for the four governance SLOs."""
+
+    def serialize_series(points: List[TimeseriesPoint]) -> list[dict[str, float | str]]:
+        return [{"x": point.ts.isoformat(), "y": point.value} for point in points]
+
+    history = {
+        name: serialize_series(points)
+        for name, points in payload.history.items()
+    }
+    history_json = json.dumps(history)
+    snapshot = payload.snapshot
+    alerts = [alert.model_dump() for alert in payload.alerts]
+    alerts_json = json.dumps(alerts)
+
+    return f"""
+<!DOCTYPE html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\" />
+    <title>Governance SLO Monitor</title>
+    <script src=\"https://cdn.jsdelivr.net/npm/chart.js\"></script>
+    <script src=\"https://cdn.jsdelivr.net/npm/luxon@3.4.4/build/global/luxon.min.js\"></script>
+    <script src=\"https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@1.4.0\"></script>
+    <style>
+      body {{ font-family: Arial, sans-serif; margin: 2rem; background-color: #f7f7f7; }}
+      h1 {{ margin-bottom: 0.5rem; }}
+      .slo-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem; }}
+      .card {{ background: white; border-radius: 8px; padding: 1rem; box-shadow: 0 1px 4px rgba(0,0,0,0.1); }}
+      canvas {{ width: 100%; height: 220px; }}
+      .alerts {{ margin-top: 2rem; }}
+      .alert {{ background: #ffe7e7; border: 1px solid #f5a9a9; padding: 0.75rem; border-radius: 6px; margin-bottom: 0.5rem; }}
+    </style>
+  </head>
+  <body>
+    <h1>Governance SLO Monitor</h1>
+    <p>Snapshot captured at {snapshot.collected_at.isoformat()}.</p>
+    <div class=\"slo-grid\">
+      <div class=\"card\"><canvas id=\"time_to_block_seconds\"></canvas></div>
+      <div class=\"card\"><canvas id=\"false_negative_rate\"></canvas></div>
+      <div class=\"card\"><canvas id=\"decision_freshness_seconds\"></canvas></div>
+      <div class=\"card\"><canvas id=\"appeal_latency_seconds\"></canvas></div>
+    </div>
+    <div class=\"alerts\">
+      <h2>Active Burn-Rate Alerts</h2>
+      <div id=\"alerts-container\"></div>
+    </div>
+    <script>
+      const history = {history_json};
+      const alerts = {alerts_json};
+      const sloNames = [
+        {{ id: 'time_to_block_seconds', label: 'Time to Block (s)' }},
+        {{ id: 'false_negative_rate', label: 'False Negative Rate' }},
+        {{ id: 'decision_freshness_seconds', label: 'Decision Freshness (s)' }},
+        {{ id: 'appeal_latency_seconds', label: 'Appeal Latency (s)' }}
+      ];
+      sloNames.forEach((cfg) => {{
+        const ctx = document.getElementById(cfg.id);
+        new Chart(ctx, {{
+          type: 'line',
+          data: {{
+            datasets: [{{
+              label: cfg.label,
+              data: history[cfg.id] || [],
+              fill: false,
+              borderColor: '#2563eb',
+              tension: 0.3,
+            }}],
+          }},
+          options: {{
+            parsing: false,
+            scales: {{ x: {{ type: 'time', time: {{ parser: true, tooltipFormat: 'MMM d HH:mm:ss' }} }} }},
+            plugins: {{
+              legend: {{ display: true }},
+            }},
+          }},
+        }});
+      }});
+      const alertsContainer = document.getElementById('alerts-container');
+      if (alerts.length === 0) {{
+        alertsContainer.innerHTML = '<p>No active burn-rate alerts.</p>';
+      }} else {{
+        alerts.forEach((alert) => {{
+          const div = document.createElement('div');
+          div.className = 'alert';
+          div.innerHTML = '<strong>' + alert.slo_name + '</strong> burn rate <strong>' +
+            alert.burn_rate.toFixed(2) + '</strong> since ' + alert.triggered_at;
+          alertsContainer.appendChild(div);
+        }});
+      }}
+    </script>
+  </body>
+</html>
+"""

--- a/services/gslo/config.py
+++ b/services/gslo/config.py
@@ -1,0 +1,46 @@
+"""Configuration models for the Governance SLO monitor."""
+
+from datetime import timedelta
+from pydantic import BaseModel, Field
+
+
+class SLOThresholds(BaseModel):
+    """Target objectives for governance control SLOs."""
+
+    time_to_block_seconds: float = Field(
+        120.0,
+        description="Maximum acceptable mean seconds between violation detection and block action.",
+    )
+    false_negative_rate: float = Field(
+        0.01,
+        description="Maximum tolerated false-negative rate for seeded governance canaries.",
+    )
+    decision_freshness_seconds: float = Field(
+        3600.0,
+        description="Maximum acceptable age in seconds of the policy commit applied to a decision.",
+    )
+    appeal_latency_seconds: float = Field(
+        86_400.0,
+        description="Maximum acceptable mean seconds to close an appeal on a governance decision.",
+    )
+
+
+class BurnRateConfig(BaseModel):
+    """Configuration for burn-rate alerting logic."""
+
+    evaluation_interval: timedelta = Field(
+        default=timedelta(seconds=30),
+        description="How often to recompute SLO metrics for alerting.",
+    )
+    alert_window: timedelta = Field(
+        default=timedelta(minutes=2),
+        description="Window within which burn rate must exceed 1.0 to raise an alert.",
+    )
+    history_retention: timedelta = Field(
+        default=timedelta(hours=6),
+        description="Duration for which time-series metric snapshots are retained for dashboards.",
+    )
+
+
+DEFAULT_THRESHOLDS = SLOThresholds()
+DEFAULT_BURN_RATE = BurnRateConfig()

--- a/services/gslo/metrics.py
+++ b/services/gslo/metrics.py
@@ -1,0 +1,94 @@
+"""Prometheus metrics and middleware for the Governance SLO service."""
+
+from __future__ import annotations
+
+import time
+from typing import Dict
+
+from fastapi import Request, Response
+from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, Counter, Gauge, Histogram, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+
+REGISTRY = CollectorRegistry()
+
+REQUEST_COUNT = Counter(
+    "gslo_requests_total",
+    "Total number of requests received by the Governance SLO service.",
+    labelnames=("method", "path"),
+    registry=REGISTRY,
+)
+
+REQUEST_ERRORS = Counter(
+    "gslo_request_errors_total",
+    "Total number of error responses emitted by the Governance SLO service.",
+    labelnames=("method", "path"),
+    registry=REGISTRY,
+)
+
+REQUEST_LATENCY = Histogram(
+    "gslo_request_latency_seconds",
+    "Latency of HTTP requests served by the Governance SLO service.",
+    labelnames=("method", "path"),
+    registry=REGISTRY,
+)
+
+SLO_GAUGES: Dict[str, Gauge] = {
+    "time_to_block_seconds": Gauge(
+        "gslo_time_to_block_seconds",
+        "Mean seconds from violation detection to block action.",
+        registry=REGISTRY,
+    ),
+    "false_negative_rate": Gauge(
+        "gslo_false_negative_rate",
+        "False negative rate observed on seeded canary violations.",
+        registry=REGISTRY,
+    ),
+    "decision_freshness_seconds": Gauge(
+        "gslo_decision_freshness_seconds",
+        "Mean seconds between policy commit publication and decision execution.",
+        registry=REGISTRY,
+    ),
+    "appeal_latency_seconds": Gauge(
+        "gslo_appeal_latency_seconds",
+        "Mean seconds to resolve governance appeals.",
+        registry=REGISTRY,
+    ),
+}
+
+BURN_RATE_GAUGES: Dict[str, Gauge] = {}
+
+
+def get_burn_rate_gauge(name: str) -> Gauge:
+    if name not in BURN_RATE_GAUGES:
+        BURN_RATE_GAUGES[name] = Gauge(
+            f"gslo_{name}_burn_rate",
+            f"Burn rate for the {name} SLO.",
+            registry=REGISTRY,
+        )
+    return BURN_RATE_GAUGES[name]
+
+
+class REDMetricsMiddleware(BaseHTTPMiddleware):
+    """Middleware that records RED metrics for FastAPI endpoints."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[override]
+        method = request.method
+        path = request.url.path
+        REQUEST_COUNT.labels(method=method, path=path).inc()
+        start = time.perf_counter()
+        try:
+            response = await call_next(request)
+            if response.status_code >= 500:
+                REQUEST_ERRORS.labels(method=method, path=path).inc()
+            return response
+        except Exception:
+            REQUEST_ERRORS.labels(method=method, path=path).inc()
+            raise
+        finally:
+            duration = time.perf_counter() - start
+            REQUEST_LATENCY.labels(method=method, path=path).observe(duration)
+
+
+def metrics_response() -> Response:
+    payload = generate_latest(REGISTRY)
+    return Response(content=payload, media_type=CONTENT_TYPE_LATEST)

--- a/services/gslo/models.py
+++ b/services/gslo/models.py
@@ -1,0 +1,133 @@
+"""Data models for the Governance SLO monitor service."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class ViolationEvent(BaseModel):
+    """Represents the detection of a policy violation."""
+
+    violation_id: str = Field(..., description="Unique identifier for the detected violation.")
+    detected_at: datetime = Field(
+        default_factory=lambda: datetime.utcnow(),
+        description="Timestamp when the violation was detected.",
+    )
+    control: Optional[str] = Field(
+        default=None,
+        description="Governance control or policy guardrail that triggered the violation.",
+    )
+
+
+class BlockEvent(BaseModel):
+    """Represents the enforcement action taken to block a violation."""
+
+    violation_id: str = Field(..., description="Identifier correlating to the detected violation.")
+    blocked_at: datetime = Field(
+        default_factory=lambda: datetime.utcnow(),
+        description="Timestamp when the block action was executed.",
+    )
+    control: Optional[str] = Field(default=None, description="Control executing the block action.")
+    reason: Optional[str] = Field(default=None, description="Optional free-form reason for the block.")
+
+
+class CanaryEvent(BaseModel):
+    """Represents a seeded canary used to detect false negatives."""
+
+    canary_id: str = Field(..., description="Identifier for the seeded canary event.")
+    violation_id: str = Field(..., description="Synthetic violation identifier tied to the canary.")
+    injected_at: datetime = Field(
+        default_factory=lambda: datetime.utcnow(),
+        description="Timestamp when the canary violation was injected.",
+    )
+    blocked: bool = Field(
+        default=False,
+        description="Whether the canary violation was successfully blocked by the governance plane.",
+    )
+    blocked_at: Optional[datetime] = Field(
+        default=None,
+        description="Timestamp when the canary was blocked, if applicable.",
+    )
+
+
+class PolicyCommit(BaseModel):
+    """Represents the policy commit used for a governance decision."""
+
+    commit_sha: str = Field(..., description="Git commit SHA for the policy snapshot.")
+    published_at: datetime = Field(
+        default_factory=lambda: datetime.utcnow(),
+        description="Time when the policy commit was published to governance controls.",
+    )
+
+
+class DecisionEvent(BaseModel):
+    """Represents a governance decision made under a specific policy commit."""
+
+    decision_id: str = Field(..., description="Identifier for the recorded decision.")
+    policy_sha: str = Field(..., description="Commit SHA the decision evaluated against.")
+    decided_at: datetime = Field(
+        default_factory=lambda: datetime.utcnow(),
+        description="Timestamp when the decision occurred.",
+    )
+
+
+class AppealEvent(BaseModel):
+    """Represents the lifecycle of an appeal on a governance decision."""
+
+    appeal_id: str = Field(..., description="Unique identifier for the appeal.")
+    decision_id: str = Field(..., description="Decision associated with the appeal.")
+    filed_at: datetime = Field(
+        default_factory=lambda: datetime.utcnow(),
+        description="Timestamp when the appeal was filed.",
+    )
+    resolved_at: Optional[datetime] = Field(
+        default=None,
+        description="Timestamp when the appeal received a final decision.",
+    )
+    outcome: Optional[str] = Field(default=None, description="Outcome of the appeal.")
+
+
+class TimeseriesPoint(BaseModel):
+    """Single point for a time-series metric."""
+
+    ts: datetime
+    value: float
+
+
+class SLOSnapshot(BaseModel):
+    """Snapshot of current SLO performance metrics."""
+
+    collected_at: datetime = Field(default_factory=lambda: datetime.utcnow())
+    time_to_block_seconds: float
+    false_negative_rate: float
+    decision_freshness_seconds: float
+    appeal_latency_seconds: float
+
+
+class BurnRateAlert(BaseModel):
+    """Represents an active burn-rate alert for a specific SLO."""
+
+    slo_name: str
+    burn_rate: float
+    triggered_at: datetime
+    details: Dict[str, str] = Field(default_factory=dict)
+
+
+class DashboardPayload(BaseModel):
+    """Response model for the dashboard endpoint."""
+
+    snapshot: SLOSnapshot
+    history: Dict[str, List[TimeseriesPoint]]
+    alerts: List[BurnRateAlert]
+
+
+class SyntheticSchedule(BaseModel):
+    """Configuration for the synthetic traffic generator."""
+
+    violation_interval_seconds: float = 15.0
+    canary_interval_seconds: float = 45.0
+    appeal_interval_seconds: float = 60.0
+    policy_refresh_interval_seconds: float = 90.0

--- a/services/gslo/service.py
+++ b/services/gslo/service.py
@@ -1,0 +1,162 @@
+"""Core governance SLO aggregation logic."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from datetime import datetime, timedelta
+from statistics import fmean
+from typing import Deque, Dict, Iterable, List, Optional
+
+from .config import SLOThresholds
+from .models import (
+    AppealEvent,
+    BlockEvent,
+    CanaryEvent,
+    DecisionEvent,
+    DashboardPayload,
+    BurnRateAlert,
+    PolicyCommit,
+    SLOSnapshot,
+    TimeseriesPoint,
+    ViolationEvent,
+)
+
+
+def _mean(values: Iterable[float]) -> float:
+    """Return the mean of the values or 0 when empty."""
+
+    vals = list(values)
+    return fmean(vals) if vals else 0.0
+
+
+class GovernanceSLOService:
+    """In-memory governance SLO aggregation service."""
+
+    def __init__(
+        self,
+        thresholds: SLOThresholds,
+        history_retention: timedelta,
+    ) -> None:
+        self._thresholds = thresholds
+        self._history_retention = history_retention
+        self._lock = asyncio.Lock()
+
+        self._violations: Dict[str, ViolationEvent] = {}
+        self._canaries: Dict[str, CanaryEvent] = {}
+        self._policy_commits: Dict[str, PolicyCommit] = {}
+        self._appeals_open: Dict[str, AppealEvent] = {}
+
+        self._block_durations: Deque[float] = deque(maxlen=5000)
+        self._decision_freshness: Deque[float] = deque(maxlen=5000)
+        self._appeal_latencies: Deque[float] = deque(maxlen=5000)
+
+        self._canary_total = 0
+        self._canary_blocked = 0
+
+        self._history: Dict[str, Deque[TimeseriesPoint]] = {
+            "time_to_block_seconds": deque(),
+            "false_negative_rate": deque(),
+            "decision_freshness_seconds": deque(),
+            "appeal_latency_seconds": deque(),
+        }
+
+    async def record_violation(self, event: ViolationEvent) -> None:
+        async with self._lock:
+            self._violations[event.violation_id] = event
+
+    async def record_block(self, event: BlockEvent) -> None:
+        async with self._lock:
+            violation = self._violations.pop(event.violation_id, None)
+            if violation is None:
+                return
+            duration = (event.blocked_at - violation.detected_at).total_seconds()
+            if duration >= 0:
+                self._block_durations.append(duration)
+
+            # Mark any associated canary as blocked
+            for canary in self._canaries.values():
+                if canary.violation_id == event.violation_id and not canary.blocked:
+                    canary.blocked = True
+                    canary.blocked_at = event.blocked_at
+                    self._canary_blocked += 1
+
+    async def seed_canary(self, event: CanaryEvent) -> None:
+        async with self._lock:
+            self._canaries[event.canary_id] = event
+            self._canary_total += 1
+            self._violations[event.violation_id] = ViolationEvent(
+                violation_id=event.violation_id,
+                detected_at=event.injected_at,
+                control="seeded-canary",
+            )
+
+    async def record_policy_commit(self, commit: PolicyCommit) -> None:
+        async with self._lock:
+            self._policy_commits[commit.commit_sha] = commit
+
+    async def record_decision(self, decision: DecisionEvent) -> None:
+        async with self._lock:
+            commit = self._policy_commits.get(decision.policy_sha)
+            if commit is None:
+                return
+            freshness = (decision.decided_at - commit.published_at).total_seconds()
+            if freshness >= 0:
+                self._decision_freshness.append(freshness)
+
+    async def file_appeal(self, appeal: AppealEvent) -> None:
+        async with self._lock:
+            self._appeals_open[appeal.appeal_id] = appeal
+
+    async def resolve_appeal(self, appeal_id: str, resolved_at: Optional[datetime] = None) -> None:
+        async with self._lock:
+            appeal = self._appeals_open.pop(appeal_id, None)
+            if appeal is None:
+                return
+            resolved_time = resolved_at or datetime.utcnow()
+            latency = (resolved_time - appeal.filed_at).total_seconds()
+            if latency >= 0:
+                self._appeal_latencies.append(latency)
+
+    async def snapshot(self) -> SLOSnapshot:
+        async with self._lock:
+            snapshot = SLOSnapshot(
+                time_to_block_seconds=_mean(self._block_durations),
+                false_negative_rate=self._compute_false_negative_rate(),
+                decision_freshness_seconds=_mean(self._decision_freshness),
+                appeal_latency_seconds=_mean(self._appeal_latencies),
+            )
+            self._append_history(snapshot)
+            return snapshot
+
+    def _compute_false_negative_rate(self) -> float:
+        if self._canary_total == 0:
+            return 0.0
+        missed = self._canary_total - self._canary_blocked
+        return missed / float(self._canary_total)
+
+    def _append_history(self, snapshot: SLOSnapshot) -> None:
+        for key in self._history:
+            value = getattr(snapshot, key)
+            series = self._history[key]
+            series.append(TimeseriesPoint(ts=snapshot.collected_at, value=value))
+            self._prune_history(series, snapshot.collected_at)
+
+    def _prune_history(self, series: Deque[TimeseriesPoint], now: datetime) -> None:
+        while series and now - series[0].ts > self._history_retention:
+            series.popleft()
+
+    async def get_history(self) -> Dict[str, List[TimeseriesPoint]]:
+        async with self._lock:
+            return {key: list(points) for key, points in self._history.items()}
+
+    async def get_dashboard_payload(
+        self, alerts: Optional[List[BurnRateAlert]] = None
+    ) -> DashboardPayload:
+        snapshot = await self.snapshot()
+        history = await self.get_history()
+        return DashboardPayload(snapshot=snapshot, history=history, alerts=alerts or [])
+
+    @property
+    def thresholds(self) -> SLOThresholds:
+        return self._thresholds

--- a/services/gslo/synthetic.py
+++ b/services/gslo/synthetic.py
@@ -1,0 +1,165 @@
+"""Synthetic traffic generator for the governance SLO monitor."""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from collections import deque
+from datetime import datetime, timedelta
+from typing import Deque, List
+from uuid import uuid4
+
+from .models import (
+    AppealEvent,
+    BlockEvent,
+    CanaryEvent,
+    DecisionEvent,
+    PolicyCommit,
+    SyntheticSchedule,
+    ViolationEvent,
+)
+from .service import GovernanceSLOService
+
+
+class SyntheticTrafficGenerator:
+    """Injects synthetic violations, canaries, and appeals on a schedule."""
+
+    def __init__(
+        self,
+        service: GovernanceSLOService,
+        schedule: SyntheticSchedule,
+    ) -> None:
+        self._service = service
+        self._schedule = schedule
+        self._rng = random.Random()
+        self._stop = asyncio.Event()
+        self._tasks: List[asyncio.Task[None]] = []
+        self._decisions: Deque[str] = deque(maxlen=512)
+        self._current_commit = PolicyCommit(commit_sha=self._new_commit_sha())
+        self._policy_lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        if self._tasks:
+            return
+        await self._service.record_policy_commit(self._current_commit)
+        self._stop.clear()
+        self._tasks = [
+            asyncio.create_task(self._run_violation_stream()),
+            asyncio.create_task(self._run_canary_stream()),
+            asyncio.create_task(self._run_appeal_stream()),
+            asyncio.create_task(self._run_policy_refresher()),
+        ]
+
+    async def stop(self) -> None:
+        if not self._tasks:
+            return
+        self._stop.set()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        self._tasks.clear()
+
+    async def _run_violation_stream(self) -> None:
+        interval = self._schedule.violation_interval_seconds
+        while not self._stop.is_set():
+            violation_id = str(uuid4())
+            detected_at = datetime.utcnow()
+            await self._service.record_violation(
+                ViolationEvent(
+                    violation_id=violation_id,
+                    detected_at=detected_at,
+                    control=self._rng.choice(["geo", "content", "compliance"]),
+                )
+            )
+            block_delay = self._rng.uniform(10, 240)
+            asyncio.create_task(self._complete_block(violation_id, detected_at, block_delay))
+            await self._record_decision(detected_at + timedelta(seconds=block_delay))
+            await self._sleep(interval)
+
+    async def _complete_block(self, violation_id: str, detected_at: datetime, delay: float) -> None:
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=delay)
+            return
+        except asyncio.TimeoutError:
+            pass
+        await self._service.record_block(
+            BlockEvent(
+                violation_id=violation_id,
+                blocked_at=detected_at + timedelta(seconds=delay),
+                control="auto-blocker",
+            )
+        )
+
+    async def _record_decision(self, decided_at: datetime) -> None:
+        async with self._policy_lock:
+            commit_sha = self._current_commit.commit_sha
+        decision_id = str(uuid4())
+        await self._service.record_decision(
+            DecisionEvent(
+                decision_id=decision_id,
+                policy_sha=commit_sha,
+                decided_at=decided_at,
+            )
+        )
+        self._decisions.append(decision_id)
+
+    async def _run_canary_stream(self) -> None:
+        interval = self._schedule.canary_interval_seconds
+        while not self._stop.is_set():
+            violation_id = f"canary-{uuid4()}"
+            canary = CanaryEvent(canary_id=str(uuid4()), violation_id=violation_id)
+            await self._service.seed_canary(canary)
+            # 20% chance to simulate a false negative (no block)
+            if self._rng.random() < 0.8:
+                delay = self._rng.uniform(15, 90)
+                asyncio.create_task(self._complete_block(violation_id, canary.injected_at, delay))
+            await self._sleep(interval)
+
+    async def _run_appeal_stream(self) -> None:
+        interval = self._schedule.appeal_interval_seconds
+        while not self._stop.is_set():
+            if not self._decisions:
+                await self._sleep(interval)
+                continue
+            decision_id = self._rng.choice(list(self._decisions))
+            appeal_id = str(uuid4())
+            filed_at = datetime.utcnow()
+            await self._service.file_appeal(
+                AppealEvent(
+                    appeal_id=appeal_id,
+                    decision_id=decision_id,
+                    filed_at=filed_at,
+                )
+            )
+            resolve_delay = self._rng.uniform(120, 3600)
+            asyncio.create_task(self._resolve_appeal(appeal_id, filed_at, resolve_delay))
+            await self._sleep(interval)
+
+    async def _run_policy_refresher(self) -> None:
+        interval = self._schedule.policy_refresh_interval_seconds
+        while not self._stop.is_set():
+            await self._sleep(interval)
+            async with self._policy_lock:
+                self._current_commit = PolicyCommit(
+                    commit_sha=self._new_commit_sha(),
+                    published_at=datetime.utcnow(),
+                )
+                await self._service.record_policy_commit(self._current_commit)
+
+    async def _resolve_appeal(self, appeal_id: str, filed_at: datetime, delay: float) -> None:
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=delay)
+            return
+        except asyncio.TimeoutError:
+            pass
+        await self._service.resolve_appeal(
+            appeal_id,
+            resolved_at=filed_at + timedelta(seconds=delay),
+        )
+
+    async def _sleep(self, seconds: float) -> None:
+        try:
+            await asyncio.wait_for(self._stop.wait(), timeout=seconds)
+        except asyncio.TimeoutError:
+            return
+
+    def _new_commit_sha(self) -> str:
+        return uuid4().hex[:12]


### PR DESCRIPTION
## Summary
- build a dedicated FastAPI-based Governance SLO monitor service with REST endpoints, dashboard views, and policy event ingestion models
- implement in-memory aggregation, burn-rate alerting, and a synthetic traffic generator to continuously exercise block/allow controls and appeals
- expose RED metrics for observability and add the prometheus client dependency needed for exporting telemetry

## Testing
- python -m compileall services/gslo

------
https://chatgpt.com/codex/tasks/task_e_68d73d3b453c8333a05e27cd4af8e09e