### PR TITLE
feat: add TESQ sandbox package

### DIFF
--- a/tools/tesq/package.json
+++ b/tools/tesq/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "tesq",
+  "version": "0.1.0",
+  "description": "Tool Execution Sandbox & Quotas (TESQ) for running LLM-invoked tools safely.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "test": "vitest run",
+    "redteam": "ts-node src/redteam.ts"
+  },
+  "keywords": [
+    "sandbox",
+    "llm",
+    "security",
+    "quotas"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "eslint": "^8.57.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.2",
+    "vitest": "^1.6.0"
+  }
+}

--- a/tools/tesq/src/audit.ts
+++ b/tools/tesq/src/audit.ts
@@ -1,0 +1,30 @@
+import { randomUUID } from 'crypto';
+import { AuditEvent } from './types';
+
+export class AuditLog {
+  private events: AuditEvent[] = [];
+
+  public record(
+    type: AuditEvent['type'],
+    metadata: Record<string, unknown>,
+    parentId?: string
+  ): AuditEvent {
+    const event: AuditEvent = {
+      id: randomUUID(),
+      type,
+      parentId,
+      timestamp: Date.now(),
+      metadata
+    };
+    this.events.push(event);
+    return event;
+  }
+
+  public getEvents(): AuditEvent[] {
+    return [...this.events];
+  }
+
+  public findChildren(parentId: string): AuditEvent[] {
+    return this.events.filter((event) => event.parentId === parentId);
+  }
+}

--- a/tools/tesq/src/index.ts
+++ b/tools/tesq/src/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './audit';
+export * from './quota';
+export * from './policy';
+export * from './sandbox';

--- a/tools/tesq/src/policy.ts
+++ b/tools/tesq/src/policy.ts
@@ -1,0 +1,265 @@
+import { TenantQuotaManager } from './quota';
+import {
+  PolicyDecision,
+  PolicyQuotaRule,
+  TenantId,
+  TenantPolicy,
+  ToolDefinition,
+  ToolInvocationRequest
+} from './types';
+
+const DEFAULT_OUTPUT_LIMIT = 64 * 1024; // 64 KiB
+
+function createEmptyPolicy(tenantId: TenantId): TenantPolicy {
+  return {
+    tenantId,
+    quotas: new Map(),
+    allowAllSyscalls: false,
+    allowedSyscalls: new Set(),
+    deniedSyscalls: new Set(),
+    allowAllNetwork: false,
+    deniedAllNetwork: false,
+    allowedNetworkDestinations: new Set(),
+    outputMaxBytes: DEFAULT_OUTPUT_LIMIT
+  };
+}
+
+function clonePolicy(policy: TenantPolicy, tenantId?: TenantId): TenantPolicy {
+  return {
+    tenantId: tenantId ?? policy.tenantId,
+    quotas: new Map(policy.quotas),
+    allowAllSyscalls: policy.allowAllSyscalls,
+    allowedSyscalls: new Set(policy.allowedSyscalls),
+    deniedSyscalls: new Set(policy.deniedSyscalls),
+    allowAllNetwork: policy.allowAllNetwork,
+    deniedAllNetwork: policy.deniedAllNetwork,
+    allowedNetworkDestinations: new Set(policy.allowedNetworkDestinations),
+    outputMaxBytes: policy.outputMaxBytes
+  };
+}
+
+export class PolicyEngine {
+  private policies: Map<TenantId, TenantPolicy> = new Map();
+
+  constructor(
+    policySource: string,
+    private readonly quotaManager?: TenantQuotaManager
+  ) {
+    this.load(policySource);
+  }
+
+  public load(policySource: string) {
+    this.policies.clear();
+    const sanitized = policySource.replace(/\r/g, '');
+    const lines = sanitized.split('\n');
+    let currentPolicy: TenantPolicy | null = null;
+
+    for (const rawLine of lines) {
+      const line = rawLine.replace(/#.*/, '').trim();
+      if (!line) {
+        continue;
+      }
+
+      if (/^tenant\s+/i.test(line) && line.endsWith('{')) {
+        const match = line.match(/^tenant\s+([\w*\-]+)\s*\{$/i);
+        if (!match) {
+          throw new Error(`Invalid tenant declaration: ${rawLine}`);
+        }
+        currentPolicy = createEmptyPolicy(match[1]);
+        this.policies.set(currentPolicy.tenantId, currentPolicy);
+        continue;
+      }
+
+      if (line === '}') {
+        currentPolicy = null;
+        continue;
+      }
+
+      if (!currentPolicy) {
+        throw new Error(`Statement outside tenant block: ${rawLine}`);
+      }
+
+      this.parseStatement(currentPolicy, line.replace(/;$/, ''));
+    }
+
+    if (this.quotaManager) {
+      for (const policy of this.policies.values()) {
+        for (const [toolName, rule] of policy.quotas.entries()) {
+          this.quotaManager.registerLimit(policy.tenantId, toolName, rule);
+        }
+      }
+    }
+  }
+
+  private parseStatement(policy: TenantPolicy, statement: string) {
+    if (/^quota\s+/i.test(statement)) {
+      this.parseQuota(policy, statement);
+      return;
+    }
+
+    if (/^allow_syscalls\s+/i.test(statement)) {
+      const value = statement.replace(/^allow_syscalls\s+/i, '').trim();
+      if (value.toLowerCase() === 'any') {
+        policy.allowAllSyscalls = true;
+        return;
+      }
+      value.split(',').map((s) => s.trim()).filter(Boolean).forEach((syscall) => {
+        policy.allowedSyscalls.add(syscall);
+      });
+      return;
+    }
+
+    if (/^deny_syscalls\s+/i.test(statement)) {
+      const value = statement.replace(/^deny_syscalls\s+/i, '').trim();
+      value.split(',').map((s) => s.trim()).filter(Boolean).forEach((syscall) => {
+        policy.deniedSyscalls.add(syscall);
+      });
+      return;
+    }
+
+    if (/^allow_network\s+/i.test(statement)) {
+      const value = statement.replace(/^allow_network\s+/i, '').trim();
+      if (value.toLowerCase() === 'any') {
+        policy.allowAllNetwork = true;
+        return;
+      }
+      value.split(',').map((s) => s.trim()).filter(Boolean).forEach((destination) => {
+        policy.allowedNetworkDestinations.add(destination);
+      });
+      return;
+    }
+
+    if (/^deny_network\s+/i.test(statement)) {
+      const value = statement.replace(/^deny_network\s+/i, '').trim();
+      if (value.toLowerCase() === 'all') {
+        policy.deniedAllNetwork = true;
+        return;
+      }
+      value.split(',').map((s) => s.trim()).filter(Boolean).forEach((destination) => {
+        policy.allowedNetworkDestinations.delete(destination);
+      });
+      return;
+    }
+
+    if (/^output_max\s+/i.test(statement)) {
+      const value = statement.replace(/^output_max\s+/i, '').trim();
+      const limit = Number.parseInt(value, 10);
+      if (Number.isNaN(limit) || limit <= 0) {
+        throw new Error(`Invalid output_max value: ${statement}`);
+      }
+      policy.outputMaxBytes = limit;
+      return;
+    }
+
+    throw new Error(`Unrecognized policy statement: ${statement}`);
+  }
+
+  private parseQuota(policy: TenantPolicy, statement: string) {
+    const match = statement.match(/^quota\s+(\S+)\s+(\d+)(?:\s+per\s+([\w\-]+))?$/i);
+    if (!match) {
+      throw new Error(`Invalid quota statement: ${statement}`);
+    }
+    const [, toolName, limitStr, window] = match;
+    const limit = Number.parseInt(limitStr, 10);
+    if (Number.isNaN(limit) || limit < 0) {
+      throw new Error(`Invalid quota limit in statement: ${statement}`);
+    }
+    const rule: PolicyQuotaRule = {
+      limit,
+      window: window ?? undefined
+    };
+    policy.quotas.set(toolName, rule);
+  }
+
+  public getPolicyForTenant(tenantId: TenantId): TenantPolicy {
+    if (this.policies.has(tenantId)) {
+      return clonePolicy(this.policies.get(tenantId)!);
+    }
+
+    if (this.policies.has('*')) {
+      const base = this.policies.get('*')!;
+      return clonePolicy(base, tenantId);
+    }
+
+    if (this.policies.has('default')) {
+      const base = this.policies.get('default')!;
+      return clonePolicy(base, tenantId);
+    }
+
+    return createEmptyPolicy(tenantId);
+  }
+
+  public evaluate(
+    request: ToolInvocationRequest,
+    tool: ToolDefinition,
+    quotaManager: TenantQuotaManager
+  ): PolicyDecision {
+    const policy = this.getPolicyForTenant(request.tenantId);
+
+    const requiredSyscalls = tool.metadata.requiredSyscalls ?? [];
+    for (const syscall of requiredSyscalls) {
+      if (policy.deniedSyscalls.has(syscall)) {
+        return {
+          allowed: false,
+          reason: `Syscall ${syscall} denied by policy`,
+          policy
+        };
+      }
+      if (!policy.allowAllSyscalls && !policy.allowedSyscalls.has(syscall)) {
+        return {
+          allowed: false,
+          reason: `Syscall ${syscall} not allowlisted`,
+          policy
+        };
+      }
+    }
+
+    const networkDestinations = tool.metadata.networkDestinations ?? [];
+    if (policy.deniedAllNetwork && networkDestinations.length > 0) {
+      return {
+        allowed: false,
+        reason: 'Network egress denied by policy',
+        policy
+      };
+    }
+
+    if (!policy.allowAllNetwork) {
+      for (const destination of networkDestinations) {
+        if (!policy.allowedNetworkDestinations.has(destination)) {
+          return {
+            allowed: false,
+            reason: `Network destination ${destination} not allowlisted`,
+            policy
+          };
+        }
+      }
+    }
+
+    const maxOutput = tool.metadata.maxOutputBytes;
+    if (maxOutput && maxOutput > policy.outputMaxBytes) {
+      return {
+        allowed: false,
+        reason: `Tool output budget ${maxOutput} exceeds policy limit ${policy.outputMaxBytes}`,
+        policy
+      };
+    }
+
+    const quotaRule = policy.quotas.get(tool.name);
+    if (quotaRule && !quotaManager.checkAndConsume(request.tenantId, tool.name, quotaRule.limit)) {
+      return {
+        allowed: false,
+        reason: `Quota exceeded for ${tool.name}`,
+        policy
+      };
+    }
+
+    return {
+      allowed: true,
+      policy
+    };
+  }
+
+  public listPolicies(): TenantPolicy[] {
+    return Array.from(this.policies.values()).map((policy) => clonePolicy(policy));
+  }
+}

--- a/tools/tesq/src/quota.ts
+++ b/tools/tesq/src/quota.ts
@@ -1,0 +1,54 @@
+import { PolicyQuotaRule, TenantId } from './types';
+
+interface QuotaUsage {
+  limit: number;
+  used: number;
+}
+
+export class TenantQuotaManager {
+  private usage: Map<TenantId, Map<string, QuotaUsage>> = new Map();
+
+  public registerLimit(tenantId: TenantId, toolName: string, rule: PolicyQuotaRule) {
+    if (!this.usage.has(tenantId)) {
+      this.usage.set(tenantId, new Map());
+    }
+    const tenantUsage = this.usage.get(tenantId)!;
+    const existing = tenantUsage.get(toolName);
+    if (!existing || existing.limit !== rule.limit) {
+      tenantUsage.set(toolName, { limit: rule.limit, used: existing?.used ?? 0 });
+    }
+  }
+
+  public checkAndConsume(tenantId: TenantId, toolName: string, limit: number): boolean {
+    if (!this.usage.has(tenantId)) {
+      this.usage.set(tenantId, new Map());
+    }
+    const tenantUsage = this.usage.get(tenantId)!;
+    let usage = tenantUsage.get(toolName);
+    if (!usage) {
+      usage = { limit, used: 0 };
+      tenantUsage.set(toolName, usage);
+    } else if (usage.limit !== limit) {
+      usage.limit = limit;
+    }
+
+    if (usage.used >= usage.limit) {
+      return false;
+    }
+
+    usage.used += 1;
+    return true;
+  }
+
+  public getUsage(tenantId: TenantId, toolName: string): Readonly<QuotaUsage> | undefined {
+    return this.usage.get(tenantId)?.get(toolName);
+  }
+
+  public reset(tenantId?: TenantId) {
+    if (tenantId) {
+      this.usage.delete(tenantId);
+      return;
+    }
+    this.usage.clear();
+  }
+}

--- a/tools/tesq/src/redteam.ts
+++ b/tools/tesq/src/redteam.ts
@@ -1,0 +1,140 @@
+import { Sandbox } from './sandbox';
+import { ToolDefinition, ToolInvocationRequest } from './types';
+
+const policyDSL = `
+# Global defaults
+tenant * {
+  quota safe-tool 2 per window
+  quota sandbox-breaker 1 per window
+  allow_syscalls read,write
+  deny_syscalls exec,spawn
+  deny_network all
+  output_max 2048
+}
+
+# Hardened tenant with tighter limits
+tenant redteam {
+  quota safe-tool 1 per window
+  quota sandbox-breaker 1 per window
+  allow_syscalls read
+  deny_syscalls exec,spawn
+  deny_network all
+  output_max 512
+}
+`;
+
+const safeTool: ToolDefinition = {
+  name: 'safe-tool',
+  metadata: {
+    description: 'Echoes the payload in a controlled manner.',
+    requiredSyscalls: ['read'],
+    maxOutputBytes: 256
+  },
+  handler: async (request, context) => {
+    context.appendLog('safe-tool invoked');
+    const message = String(request.payload['message'] ?? '');
+    context.createArtifact({
+      name: `echo-${request.id}.txt`,
+      mediaType: 'text/plain',
+      content: message
+    });
+    return {
+      stdout: message.toUpperCase()
+    };
+  }
+};
+
+const sandboxBreaker: ToolDefinition = {
+  name: 'sandbox-breaker',
+  metadata: {
+    description: 'Attempts a series of sandbox escape primitives.',
+    requiredSyscalls: ['read'],
+    maxOutputBytes: 128
+  },
+  handler: async (request, context) => {
+    const attempts: string[] = [];
+
+    try {
+      context.appendLog('Attempting forbidden syscall exec');
+      context.requestSyscall('exec');
+    } catch (error) {
+      attempts.push(`syscall: ${(error as Error).message}`);
+    }
+
+    try {
+      context.appendLog('Attempting forbidden network egress');
+      await context.fetch('https://evil.example.com/loot');
+    } catch (error) {
+      attempts.push(`network: ${(error as Error).message}`);
+    }
+
+    try {
+      context.appendLog('Attempting to overflow output budget');
+      const payload = 'x'.repeat(context.getRemainingOutputBudget() + 1);
+      context.createArtifact({
+        name: 'overflow.txt',
+        mediaType: 'text/plain',
+        content: payload
+      });
+    } catch (error) {
+      attempts.push(`output: ${(error as Error).message}`);
+    }
+
+    const message = attempts.join('; ');
+    throw new Error(`Red-team attempts blocked: ${message}`);
+  }
+};
+
+async function runHarness(): Promise<Sandbox> {
+  const sandbox = new Sandbox({ policySource: policyDSL });
+  sandbox.registerTool(safeTool);
+  sandbox.registerTool(sandboxBreaker);
+
+  const requests: ToolInvocationRequest[] = [
+    {
+      id: 'req-safe-1',
+      tenantId: 'default',
+      toolName: 'safe-tool',
+      payload: { message: 'hello world' }
+    },
+    {
+      id: 'req-safe-2',
+      tenantId: 'default',
+      toolName: 'safe-tool',
+      payload: { message: 'hello world' }
+    },
+    {
+      id: 'req-breaker-1',
+      tenantId: 'redteam',
+      toolName: 'sandbox-breaker',
+      payload: {}
+    }
+  ];
+
+  for (const request of requests) {
+    const result = await sandbox.run(request);
+    console.log('---');
+    console.log(`Request ${request.id} allowed=${result.allowed}`);
+    if (result.allowed) {
+      console.log('stdout:', result.result?.stdout);
+    } else {
+      console.log('denied reason:', result.decision.reason);
+    }
+  }
+
+  console.log('Audit Trail:');
+  for (const event of sandbox.getAuditLog().getEvents()) {
+    console.log(JSON.stringify(event));
+  }
+
+  return sandbox;
+}
+
+if (require.main === module) {
+  runHarness().catch((error) => {
+    console.error('Harness failed', error);
+    process.exit(1);
+  });
+}
+
+export { runHarness };

--- a/tools/tesq/src/sandbox.ts
+++ b/tools/tesq/src/sandbox.ts
@@ -1,0 +1,344 @@
+import { AuditLog } from './audit';
+import { PolicyEngine } from './policy';
+import { TenantQuotaManager } from './quota';
+import {
+  SandboxContext,
+  SandboxRunResult,
+  SandboxArtifact,
+  TenantPolicy,
+  ToolDefinition,
+  ToolExecutionResult,
+  ToolInvocationRequest
+} from './types';
+
+class GuardedSandboxContext implements SandboxContext {
+  private readonly artifacts: SandboxArtifact[] = [];
+  private readonly logs: string[] = [];
+  private consumedBytes = 0;
+
+  constructor(
+    private readonly policy: TenantPolicy,
+    private readonly auditLog: AuditLog,
+    private readonly parentId: string
+  ) {}
+
+  requestSyscall(syscall: string): void {
+    if (
+      this.policy.deniedSyscalls.has(syscall) ||
+      (!this.policy.allowAllSyscalls && !this.policy.allowedSyscalls.has(syscall))
+    ) {
+      this.auditLog.record(
+        'violation',
+        {
+          kind: 'syscall',
+          syscall,
+          message: `Denied syscall ${syscall}`
+        },
+        this.parentId
+      );
+      throw new Error(`Syscall ${syscall} denied by policy`);
+    }
+    this.auditLog.record(
+      'tool-execution',
+      {
+        stage: 'syscall',
+        syscall
+      },
+      this.parentId
+    );
+  }
+
+  async fetch(target: string): Promise<string> {
+    let destination: string;
+    try {
+      const url = new URL(target);
+      const port = url.port || (url.protocol === 'https:' ? '443' : '80');
+      destination = `${url.hostname}:${port}`;
+    } catch (error) {
+      throw new Error(`Invalid URL ${target}: ${(error as Error).message}`);
+    }
+
+    if (this.policy.deniedAllNetwork) {
+      this.auditLog.record(
+        'violation',
+        {
+          kind: 'network',
+          destination,
+          message: 'Network egress denied by policy'
+        },
+        this.parentId
+      );
+      throw new Error('Network egress denied by policy');
+    }
+
+    if (!this.policy.allowAllNetwork) {
+      const hostAllowed = this.policy.allowedNetworkDestinations.has(destination);
+      const hostnameAllowed = this.policy.allowedNetworkDestinations.has(destination.split(':')[0]);
+      if (!hostAllowed && !hostnameAllowed) {
+        this.auditLog.record(
+          'violation',
+          {
+            kind: 'network',
+            destination,
+            message: 'Network destination not allowlisted'
+          },
+          this.parentId
+        );
+        throw new Error(`Network destination ${destination} not allowlisted`);
+      }
+    }
+
+    this.auditLog.record(
+      'tool-execution',
+      {
+        stage: 'network-egress',
+        destination
+      },
+      this.parentId
+    );
+
+    return `Egress to ${destination} suppressed in sandbox`;
+  }
+
+  createArtifact(artifact: SandboxArtifact): void {
+    const size = Buffer.byteLength(artifact.content, 'utf8');
+    this.ensureBudget(size, `artifact ${artifact.name}`);
+    this.artifacts.push(artifact);
+    this.consumedBytes += size;
+    this.auditLog.record(
+      'artifact',
+      {
+        name: artifact.name,
+        mediaType: artifact.mediaType,
+        size
+      },
+      this.parentId
+    );
+  }
+
+  appendLog(message: string): void {
+    this.logs.push(message);
+  }
+
+  getRemainingOutputBudget(): number {
+    return Math.max(this.policy.outputMaxBytes - this.consumedBytes, 0);
+  }
+
+  getArtifacts(): SandboxArtifact[] {
+    return [...this.artifacts];
+  }
+
+  getLogs(): string[] {
+    return [...this.logs];
+  }
+
+  getConsumedBytes(): number {
+    return this.consumedBytes;
+  }
+
+  ensureBudget(size: number, context: string) {
+    if (this.consumedBytes + size > this.policy.outputMaxBytes) {
+      this.auditLog.record(
+        'violation',
+        {
+          kind: 'output',
+          context,
+          message: 'Output budget exceeded'
+        },
+        this.parentId
+      );
+      throw new Error('Output budget exceeded');
+    }
+  }
+}
+
+function normalizeResult(
+  rawResult: ToolExecutionResult | undefined,
+  context: GuardedSandboxContext,
+  policy: TenantPolicy,
+  auditLog: AuditLog,
+  toolEventId: string
+): ToolExecutionResult {
+  const result: ToolExecutionResult = {
+    stdout: rawResult?.stdout,
+    artifacts: [],
+    logs: []
+  };
+
+  let remaining = policy.outputMaxBytes - context.getConsumedBytes();
+
+  if (rawResult?.stdout) {
+    const size = Buffer.byteLength(rawResult.stdout, 'utf8');
+    if (size > remaining) {
+      auditLog.record(
+        'violation',
+        {
+          kind: 'output',
+          context: 'stdout',
+          message: 'Output budget exceeded'
+        },
+        toolEventId
+      );
+      throw new Error('Output budget exceeded');
+    }
+    remaining -= size;
+    result.stdout = rawResult.stdout;
+  }
+
+  const combinedArtifacts: SandboxArtifact[] = [];
+  for (const artifact of context.getArtifacts()) {
+    combinedArtifacts.push(artifact);
+  }
+
+  if (rawResult?.artifacts) {
+    for (const artifact of rawResult.artifacts) {
+      const size = Buffer.byteLength(artifact.content, 'utf8');
+      if (size > remaining) {
+        auditLog.record(
+          'violation',
+          {
+            kind: 'output',
+            context: `artifact ${artifact.name}`,
+            message: 'Output budget exceeded'
+          },
+          toolEventId
+        );
+        throw new Error('Output budget exceeded');
+      }
+      remaining -= size;
+      combinedArtifacts.push(artifact);
+      auditLog.record(
+        'artifact',
+        {
+          name: artifact.name,
+          mediaType: artifact.mediaType,
+          size
+        },
+        toolEventId
+      );
+    }
+  }
+
+  result.artifacts = combinedArtifacts;
+  result.logs = [...(rawResult?.logs ?? []), ...context.getLogs()];
+  return result;
+}
+
+export interface SandboxOptions {
+  policySource: string;
+  auditLog?: AuditLog;
+  quotaManager?: TenantQuotaManager;
+}
+
+export class Sandbox {
+  private readonly tools: Map<string, ToolDefinition> = new Map();
+  private readonly auditLog: AuditLog;
+  private readonly quotaManager: TenantQuotaManager;
+  private readonly policyEngine: PolicyEngine;
+
+  constructor(options: SandboxOptions) {
+    this.auditLog = options.auditLog ?? new AuditLog();
+    this.quotaManager = options.quotaManager ?? new TenantQuotaManager();
+    this.policyEngine = new PolicyEngine(options.policySource, this.quotaManager);
+  }
+
+  public registerTool(tool: ToolDefinition) {
+    this.tools.set(tool.name, tool);
+  }
+
+  public getAuditLog(): AuditLog {
+    return this.auditLog;
+  }
+
+  public async run(request: ToolInvocationRequest): Promise<SandboxRunResult> {
+    const requestEvent = this.auditLog.record('request', {
+      requestId: request.id,
+      tenantId: request.tenantId,
+      toolName: request.toolName
+    });
+
+    const tool = this.tools.get(request.toolName);
+    const policy = this.policyEngine.getPolicyForTenant(request.tenantId);
+
+    if (!tool) {
+      this.auditLog.record(
+        'violation',
+        {
+          kind: 'tool',
+          message: `Tool ${request.toolName} is not registered`
+        },
+        requestEvent.id
+      );
+      return {
+        allowed: false,
+        decision: {
+          allowed: false,
+          reason: `Tool ${request.toolName} is not registered`,
+          policy
+        }
+      };
+    }
+
+    const decision = this.policyEngine.evaluate(request, tool, this.quotaManager);
+    if (!decision.allowed) {
+      this.auditLog.record(
+        'violation',
+        {
+          kind: 'policy',
+          reason: decision.reason
+        },
+        requestEvent.id
+      );
+      return {
+        allowed: false,
+        decision
+      };
+    }
+
+    const toolEvent = this.auditLog.record(
+      'tool-execution',
+      {
+        stage: 'start',
+        toolName: tool.name
+      },
+      requestEvent.id
+    );
+
+    const context = new GuardedSandboxContext(decision.policy, this.auditLog, toolEvent.id);
+
+    try {
+      const rawResult = await tool.handler(request, context);
+      const result = normalizeResult(rawResult, context, decision.policy, this.auditLog, toolEvent.id);
+      this.auditLog.record(
+        'tool-execution',
+        {
+          stage: 'finish',
+          toolName: tool.name
+        },
+        toolEvent.id
+      );
+      return {
+        allowed: true,
+        result,
+        decision
+      };
+    } catch (error) {
+      this.auditLog.record(
+        'violation',
+        {
+          kind: 'runtime',
+          message: (error as Error).message
+        },
+        toolEvent.id
+      );
+      return {
+        allowed: false,
+        decision: {
+          allowed: false,
+          reason: (error as Error).message,
+          policy: decision.policy
+        }
+      };
+    }
+  }
+}

--- a/tools/tesq/src/types.ts
+++ b/tools/tesq/src/types.ts
@@ -1,0 +1,83 @@
+export type TenantId = string;
+
+export interface ToolInvocationRequest {
+  id: string;
+  tenantId: TenantId;
+  toolName: string;
+  payload: Record<string, unknown>;
+}
+
+export interface SandboxArtifact {
+  name: string;
+  mediaType: string;
+  content: string;
+}
+
+export interface ToolExecutionResult {
+  stdout?: string;
+  artifacts?: SandboxArtifact[];
+  logs?: string[];
+}
+
+export interface ToolMetadata {
+  description: string;
+  requiredSyscalls?: string[];
+  networkDestinations?: string[];
+  maxOutputBytes?: number;
+}
+
+export type ToolHandler = (
+  request: ToolInvocationRequest,
+  context: SandboxContext
+) => Promise<ToolExecutionResult> | ToolExecutionResult;
+
+export interface ToolDefinition {
+  name: string;
+  metadata: ToolMetadata;
+  handler: ToolHandler;
+}
+
+export interface SandboxContext {
+  requestSyscall: (syscall: string) => void;
+  fetch: (target: string) => Promise<string>;
+  createArtifact: (artifact: SandboxArtifact) => void;
+  appendLog: (message: string) => void;
+  getRemainingOutputBudget: () => number;
+}
+
+export interface PolicyQuotaRule {
+  limit: number;
+  window?: string;
+}
+
+export interface TenantPolicy {
+  tenantId: TenantId;
+  quotas: Map<string, PolicyQuotaRule>;
+  allowAllSyscalls: boolean;
+  allowedSyscalls: Set<string>;
+  deniedSyscalls: Set<string>;
+  allowAllNetwork: boolean;
+  deniedAllNetwork: boolean;
+  allowedNetworkDestinations: Set<string>;
+  outputMaxBytes: number;
+}
+
+export interface PolicyDecision {
+  allowed: boolean;
+  reason?: string;
+  policy: TenantPolicy;
+}
+
+export interface AuditEvent {
+  id: string;
+  type: 'request' | 'tool-execution' | 'artifact' | 'violation';
+  parentId?: string;
+  timestamp: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface SandboxRunResult {
+  allowed: boolean;
+  result?: ToolExecutionResult;
+  decision: PolicyDecision;
+}

--- a/tools/tesq/tests/sandbox.spec.ts
+++ b/tools/tesq/tests/sandbox.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { Sandbox } from '../src/sandbox';
+import { ToolDefinition, ToolInvocationRequest } from '../src/types';
+import { runHarness } from '../src/redteam';
+
+const policy = `
+tenant * {
+  quota safe-tool 2 per batch
+  quota sandbox-breaker 1 per batch
+  allow_syscalls read,write
+  deny_syscalls exec,spawn
+  deny_network all
+  output_max 2048
+}
+`;
+
+describe('TESQ Sandbox', () => {
+  let sandbox: Sandbox;
+
+  const safeTool: ToolDefinition = {
+    name: 'safe-tool',
+    metadata: {
+      description: 'Echo payload',
+      requiredSyscalls: ['read'],
+      maxOutputBytes: 256
+    },
+    handler: async (request, context) => {
+      const message = String(request.payload['message'] ?? '');
+      context.createArtifact({
+        name: `echo-${request.id}.txt`,
+        mediaType: 'text/plain',
+        content: message
+      });
+      return {
+        stdout: message.toUpperCase(),
+        logs: ['echo complete']
+      };
+    }
+  };
+
+  const sandboxBreaker: ToolDefinition = {
+    name: 'sandbox-breaker',
+    metadata: {
+      description: 'Attempt escape',
+      requiredSyscalls: ['read'],
+      maxOutputBytes: 128
+    },
+    handler: async (_request, context) => {
+      context.appendLog('probing sandbox');
+      const failures: string[] = [];
+      try {
+        context.requestSyscall('exec');
+      } catch (error) {
+        failures.push((error as Error).message);
+      }
+
+      try {
+        await context.fetch('https://forbidden.example.com');
+      } catch (error) {
+        failures.push((error as Error).message);
+      }
+
+      try {
+        const payload = 'x'.repeat(context.getRemainingOutputBudget() + 1);
+        context.createArtifact({
+          name: 'overflow.txt',
+          mediaType: 'text/plain',
+          content: payload
+        });
+      } catch (error) {
+        failures.push((error as Error).message);
+      }
+
+      throw new Error(`Red-team attempts blocked: ${failures.join('; ')}`);
+    }
+  };
+
+  beforeEach(() => {
+    sandbox = new Sandbox({ policySource: policy });
+    sandbox.registerTool(safeTool);
+    sandbox.registerTool(sandboxBreaker);
+  });
+
+  it('allows safe tools within quota and enforces output caps', async () => {
+    const request: ToolInvocationRequest = {
+      id: 'safe-1',
+      tenantId: 'tenant-a',
+      toolName: 'safe-tool',
+      payload: { message: 'hello' }
+    };
+
+    const first = await sandbox.run(request);
+    expect(first.allowed).toBe(true);
+    expect(first.result?.artifacts).toHaveLength(1);
+    expect(first.result?.stdout).toBe('HELLO');
+
+    const second = await sandbox.run({ ...request, id: 'safe-2' });
+    expect(second.allowed).toBe(true);
+
+    const third = await sandbox.run({ ...request, id: 'safe-3' });
+    expect(third.allowed).toBe(false);
+    expect(third.decision.reason).toContain('Quota exceeded');
+  });
+
+  it('blocks unauthorized syscalls, network egress, and output overflow attempts', async () => {
+    const result = await sandbox.run({
+      id: 'breaker-1',
+      tenantId: 'tenant-a',
+      toolName: 'sandbox-breaker',
+      payload: {}
+    });
+
+    expect(result.allowed).toBe(false);
+    expect(result.decision.reason).toContain('Red-team attempts blocked');
+
+    const violations = sandbox
+      .getAuditLog()
+      .getEvents()
+      .filter((event) => event.type === 'violation');
+
+    expect(violations.some((v) => v.metadata['kind'] === 'syscall')).toBe(true);
+    expect(violations.some((v) => v.metadata['kind'] === 'network')).toBe(true);
+    expect(violations.some((v) => v.metadata['kind'] === 'output')).toBe(true);
+  });
+
+  it('produces deterministic outcomes for identical requests', async () => {
+    const request: ToolInvocationRequest = {
+      id: 'deterministic',
+      tenantId: 'tenant-a',
+      toolName: 'safe-tool',
+      payload: { message: 'deterministic' }
+    };
+
+    const sandboxA = new Sandbox({ policySource: policy });
+    sandboxA.registerTool(safeTool);
+    const sandboxB = new Sandbox({ policySource: policy });
+    sandboxB.registerTool(safeTool);
+
+    const [first, second] = await Promise.all([
+      sandboxA.run(request),
+      sandboxB.run(request)
+    ]);
+
+    expect(first.allowed).toBe(second.allowed);
+    expect(first.decision.reason ?? null).toBe(second.decision.reason ?? null);
+  });
+
+  it('red-team harness seeds escape attempts that are contained and logged', async () => {
+    const harnessSandbox = await runHarness();
+    const breakerEvents = harnessSandbox
+      .getAuditLog()
+      .getEvents()
+      .filter((event) => event.metadata['toolName'] === 'sandbox-breaker');
+
+    expect(breakerEvents.length).toBeGreaterThan(0);
+    const violationKinds = new Set(
+      harnessSandbox
+        .getAuditLog()
+        .getEvents()
+        .filter((event) => event.type === 'violation')
+        .map((event) => event.metadata['kind'])
+    );
+
+    expect(violationKinds.has('syscall')).toBe(true);
+    expect(violationKinds.has('network')).toBe(true);
+    expect(violationKinds.has('output')).toBe(true);
+  });
+});

--- a/tools/tesq/tsconfig.json
+++ b/tools/tesq/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "moduleResolution": "node",
+    "module": "CommonJS",
+    "target": "ES2020",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/tools/tesq/vitest.config.ts
+++ b/tools/tesq/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.spec.ts']
+  }
+});


### PR DESCRIPTION
## Summary
- add a new `tools/tesq` package that ships the TESQ sandbox runtime, policy DSL parser, and audit log plumbing for LLM-invoked tools
- implement guarded syscall/network/output enforcement with deterministic quotas plus a bundled red-team harness that exercises escape attempts
- cover TESQ with Vitest specs that validate quota enforcement, containment, determinism, and harness auditing

## Testing
- npm test (tools/tesq)


------
https://chatgpt.com/codex/tasks/task_e_68d74081db648333bc6ebef134a52d2c