### PR TITLE
feat: add synthetic entity graph forge generator

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,7 @@ passlib[bcrypt]==1.7.4
 python-dotenv==1.1.*
 httpx==0.28.*
 jinja2==3.1.*
+networkx==3.4.*
+numpy==1.26.*
+pandas==2.2.*
+pyarrow==18.1.*

--- a/segf/README.md
+++ b/segf/README.md
@@ -1,0 +1,65 @@
+# Synthetic Entity Graph Forge (SEGF)
+
+SEGF is a synthetic data generator tailored for graph-centric fraud analytics
+prototyping. It produces lifecycled entity populations, rich event streams, and
+explicit graph motifs such as coordinated fraud rings. Outputs include
+columnar tables (Parquet) and a `GraphML` network that can be ingested into
+network tooling and GNN stacks.
+
+## Features
+
+- **Entities** – users, devices, and merchants with configurable population
+  sizes, lifecycle spans, and behavioural segments.
+- **Temporal events** – signup, transaction, and chargeback events emitted from
+  lifecycle periods with stochastic intensity control.
+- **Fraud motifs** – optional fraud rings that share devices and merchants to
+  recreate synthetic collusion patterns.
+- **Concept drift** – drift windows alter event frequencies and chargeback risk
+  with explicit labelling for supervised degradation experiments.
+- **Deterministic runs** – seeds guarantee reproducibility across generations.
+- **Validation** – built-in validator compares generated corpora against target
+  ratios, drift multipliers, and reproducibility requirements.
+
+## Quick start
+
+```python
+from pathlib import Path
+
+from segf import (
+    DriftScenario,
+    SegfConfig,
+    SyntheticEntityGraphForge,
+    TargetStats,
+    SegfValidator,
+)
+
+config = SegfConfig(
+    drift_scenarios=[
+        DriftScenario(name="holiday_spike", start_day=20, end_day=35, fraud_multiplier=1.4, chargeback_multiplier=2.0),
+    ],
+)
+forge = SyntheticEntityGraphForge(config)
+result = forge.generate()
+result.write(Path("./segf-output"))
+
+validator = SegfValidator(
+    TargetStats(
+        expected_user_fraud_ratio=config.population.fraud_user_ratio,
+        expected_chargeback_rate=config.events.chargeback_prob_fraud * 0.5,
+        expected_daily_transactions=config.events.daily_txn_rate_legit,
+        drift_windows={"holiday_spike": {"chargeback_multiplier": 2.0}},
+    )
+)
+report = validator.evaluate(users=result.users, events=result.events, lifecycles=result.lifecycles)
+print(report.within_tolerance)
+```
+
+## Repository layout
+
+- `config.py` – dataclasses for generator configuration.
+- `generator.py` – end-to-end graph and event synthesis logic.
+- `validator.py` – scoring utilities for realism and reproducibility.
+- `notebooks/` – starter notebooks for exploring baseline and drift scenarios.
+- `tests/` – pytest coverage for deterministic generation and validation.
+
+See the notebooks for end-to-end walkthroughs and drift experiments.

--- a/segf/__init__.py
+++ b/segf/__init__.py
@@ -1,0 +1,26 @@
+"""Synthetic Entity Graph Forge (SEGF) package exports."""
+
+from .config import (
+    DriftScenario,
+    EventConfig,
+    FraudRingConfig,
+    LifecycleConfig,
+    PopulationConfig,
+    SegfConfig,
+    TargetStats,
+)
+from .generator import GenerationResult, SyntheticEntityGraphForge
+from .validator import SegfValidator
+
+__all__ = [
+    "DriftScenario",
+    "EventConfig",
+    "FraudRingConfig",
+    "LifecycleConfig",
+    "PopulationConfig",
+    "SegfConfig",
+    "TargetStats",
+    "GenerationResult",
+    "SyntheticEntityGraphForge",
+    "SegfValidator",
+]

--- a/segf/config.py
+++ b/segf/config.py
@@ -1,0 +1,104 @@
+"""Configuration objects for the Synthetic Entity Graph Forge (SEGF)."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Dict, List, Optional
+
+
+@dataclass
+class PopulationConfig:
+    """High level controls for the entity population."""
+
+    n_users: int = 5_000
+    n_merchants: int = 350
+    avg_devices_per_user: float = 1.6
+    avg_merchants_per_user: float = 3.2
+    fraud_user_ratio: float = 0.08
+
+
+@dataclass
+class LifecycleConfig:
+    """Controls for lifecycle timing measured in days from an anchor date."""
+
+    horizon_days: int = 90
+    signup_window_days: int = 14
+    mean_active_span_days: float = 45.0
+    std_active_span_days: float = 12.0
+    churn_reactivation_probability: float = 0.1
+
+
+@dataclass
+class EventConfig:
+    """Controls for transactional activity."""
+
+    daily_txn_rate_legit: float = 0.35
+    daily_txn_rate_fraud: float = 0.55
+    chargeback_prob_legit: float = 0.01
+    chargeback_prob_fraud: float = 0.35
+    base_amount: float = 82.0
+    amount_std: float = 18.0
+
+
+@dataclass
+class FraudRingConfig:
+    """Configuration for optional fraud ring motifs."""
+
+    enabled: bool = True
+    ring_count: int = 6
+    min_ring_size: int = 3
+    max_ring_size: int = 10
+    shared_device_ratio: float = 0.65
+    shared_merchant_ratio: float = 0.55
+
+
+@dataclass
+class DriftScenario:
+    """Represents a concept-drift window where behaviour deviates from baseline."""
+
+    name: str
+    start_day: int
+    end_day: int
+    fraud_multiplier: float = 1.2
+    legit_multiplier: float = 0.8
+    chargeback_multiplier: float = 1.5
+    description: str = ""
+
+    def to_range(self) -> range:
+        return range(self.start_day, self.end_day + 1)
+
+
+@dataclass
+class TargetStats:
+    """Target statistics for validating generated corpora."""
+
+    expected_user_fraud_ratio: float
+    expected_chargeback_rate: float
+    expected_daily_transactions: float
+    drift_windows: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    tolerance: float = 0.05
+
+
+@dataclass
+class SegfConfig:
+    """Primary configuration bundle for generation runs."""
+
+    population: PopulationConfig = field(default_factory=PopulationConfig)
+    lifecycle: LifecycleConfig = field(default_factory=LifecycleConfig)
+    events: EventConfig = field(default_factory=EventConfig)
+    fraud_rings: FraudRingConfig = field(default_factory=FraudRingConfig)
+    drift_scenarios: List[DriftScenario] = field(default_factory=list)
+    anchor_date: date = field(default_factory=date.today)
+    metadata: Dict[str, str] = field(default_factory=dict)
+    random_seed: Optional[int] = 7
+
+
+__all__ = [
+    "PopulationConfig",
+    "LifecycleConfig",
+    "EventConfig",
+    "FraudRingConfig",
+    "DriftScenario",
+    "TargetStats",
+    "SegfConfig",
+]

--- a/segf/generator.py
+++ b/segf/generator.py
@@ -1,0 +1,481 @@
+"""Core generation logic for Synthetic Entity Graph Forge (SEGF)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+
+from .config import (
+    DriftScenario,
+    EventConfig,
+    FraudRingConfig,
+    LifecycleConfig,
+    PopulationConfig,
+    SegfConfig,
+)
+
+
+@dataclass
+class GenerationResult:
+    """Artifacts produced by a generation run."""
+
+    users: pd.DataFrame
+    devices: pd.DataFrame
+    merchants: pd.DataFrame
+    lifecycles: pd.DataFrame
+    events: pd.DataFrame
+    graph: nx.MultiDiGraph
+
+    def write(self, output_dir: Path) -> None:
+        """Persist tables as Parquet and the entity graph as GraphML."""
+
+        output_dir.mkdir(parents=True, exist_ok=True)
+        tables = {
+            "users": self.users,
+            "devices": self.devices,
+            "merchants": self.merchants,
+            "lifecycles": self.lifecycles,
+            "events": self.events,
+        }
+        for name, frame in tables.items():
+            frame.to_parquet(output_dir / f"{name}.parquet", index=False)
+
+        nx.write_graphml(self.graph, output_dir / "entity_graph.graphml")
+
+
+class SyntheticEntityGraphForge:
+    """Generator for synthetic multi-entity graphs with temporal dynamics."""
+
+    def __init__(self, config: Optional[SegfConfig] = None, *, seed: Optional[int] = None) -> None:
+        self.config = config or SegfConfig()
+        self.rng = np.random.default_rng(seed if seed is not None else self.config.random_seed)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def generate(self) -> GenerationResult:
+        population = self.config.population
+        lifecycle = self.config.lifecycle
+        events_cfg = self.config.events
+        fraud_cfg = self.config.fraud_rings
+
+        users = self._create_users(population, lifecycle)
+        merchants = self._create_merchants(population)
+        device_records, user_device_edges = self._assign_devices(users, population, fraud_cfg)
+        merchant_links = self._assign_merchants(users, merchants, population, fraud_cfg)
+        lifecycles = self._build_lifecycles(users, lifecycle)
+        events = self._generate_events(users, lifecycles, merchant_links, events_cfg)
+        graph = self._build_graph(users, device_records, merchants, user_device_edges, events)
+
+        return GenerationResult(
+            users=users,
+            devices=device_records,
+            merchants=merchants,
+            lifecycles=lifecycles,
+            events=events,
+            graph=graph,
+        )
+
+    def generate_to(self, output_dir: Path) -> GenerationResult:
+        """Helper that generates and immediately writes artifacts."""
+
+        result = self.generate()
+        result.write(output_dir)
+        return result
+
+    # ------------------------------------------------------------------
+    # Entity creation helpers
+    # ------------------------------------------------------------------
+    def _create_users(self, population: PopulationConfig, lifecycle: LifecycleConfig) -> pd.DataFrame:
+        n_users = population.n_users
+        user_ids = [f"user_{idx:06d}" for idx in range(n_users)]
+        fraud_cutoff = int(np.round(n_users * population.fraud_user_ratio))
+        fraud_user_ids = set(self.rng.choice(user_ids, size=fraud_cutoff, replace=False)) if fraud_cutoff else set()
+
+        signup_offsets = self.rng.integers(0, lifecycle.signup_window_days + 1, size=n_users)
+        segments = self.rng.choice(["retail", "smb", "enterprise"], p=[0.7, 0.25, 0.05], size=n_users)
+
+        users = pd.DataFrame(
+            {
+                "user_id": user_ids,
+                "signup_day": signup_offsets,
+                "segment": segments,
+                "is_fraud": [uid in fraud_user_ids for uid in user_ids],
+                "fraud_ring_id": None,
+            }
+        )
+
+        if population.fraud_user_ratio and self.config.fraud_rings.enabled:
+            users = self._inject_fraud_rings(users, self.config.fraud_rings)
+
+        return users
+
+    def _create_merchants(self, population: PopulationConfig) -> pd.DataFrame:
+        n_merchants = population.n_merchants
+        merchant_ids = [f"merchant_{idx:05d}" for idx in range(n_merchants)]
+        categories = ["electronics", "apparel", "grocery", "marketplace", "travel", "gaming"]
+        category_probs = np.array([0.18, 0.22, 0.2, 0.17, 0.13, 0.1])
+        merchant_segments = self.rng.choice(categories, size=n_merchants, p=category_probs)
+        risk_scores = np.clip(self.rng.normal(0.35, 0.18, size=n_merchants), 0, 1)
+
+        merchants = pd.DataFrame(
+            {
+                "merchant_id": merchant_ids,
+                "category": merchant_segments,
+                "risk_score": risk_scores,
+                "is_ring_merchant": False,
+            }
+        )
+        return merchants
+
+    def _assign_devices(
+        self,
+        users: pd.DataFrame,
+        population: PopulationConfig,
+        fraud_cfg: FraudRingConfig,
+    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+        device_records: List[Dict[str, object]] = []
+        edges: List[Dict[str, object]] = []
+        device_index = 0
+
+        os_choices = ["ios", "android", "windows", "macos"]
+        os_probs = np.array([0.42, 0.4, 0.1, 0.08])
+
+        def _new_device(owner: str, ring_id: Optional[str] = None) -> str:
+            nonlocal device_index
+            device_id = f"device_{device_index:06d}"
+            device_index += 1
+            device_records.append(
+                {
+                    "device_id": device_id,
+                    "os": self.rng.choice(os_choices, p=os_probs),
+                    "trust_score": float(np.clip(self.rng.normal(0.6, 0.15), 0, 1)),
+                    "ring_id": ring_id,
+                }
+            )
+            edges.append(
+                {
+                    "user_id": owner,
+                    "device_id": device_id,
+                    "relation": "uses",
+                    "ring_id": ring_id,
+                }
+            )
+            return device_id
+
+        # Non ring users get devices first
+        for user_row in users.itertuples():
+            if user_row.fraud_ring_id:
+                continue
+            device_count = max(1, self.rng.poisson(population.avg_devices_per_user))
+            for _ in range(device_count):
+                _new_device(user_row.user_id)
+
+        # Fraud ring participants share devices to create the motif
+        if fraud_cfg.enabled:
+            grouped = users.dropna(subset=["fraud_ring_id"]).groupby("fraud_ring_id")
+            for ring_id, group in grouped:
+                ring_size = len(group)
+                shared_count = max(1, int(np.ceil(population.avg_devices_per_user * fraud_cfg.shared_device_ratio)))
+                first_member = group.user_id.iloc[0]
+                shared_devices = [
+                    _new_device(owner=first_member, ring_id=ring_id) for _ in range(shared_count)
+                ]
+                for member in group.itertuples():
+                    # add shared edges for all members
+                    for device_id in shared_devices:
+                        if member.user_id == first_member:
+                            continue
+                        edges.append(
+                            {
+                                "user_id": member.user_id,
+                                "device_id": device_id,
+                                "relation": "uses",
+                                "ring_id": ring_id,
+                            }
+                        )
+                    personal_device_count = max(
+                        0,
+                        int(np.round(population.avg_devices_per_user)) - shared_count,
+                    )
+                    for _ in range(personal_device_count):
+                        _new_device(member.user_id, ring_id=ring_id)
+
+        devices_df = pd.DataFrame(device_records)
+        edges_df = pd.DataFrame(edges)
+        return devices_df, edges_df
+
+    def _assign_merchants(
+        self,
+        users: pd.DataFrame,
+        merchants: pd.DataFrame,
+        population: PopulationConfig,
+        fraud_cfg: FraudRingConfig,
+    ) -> Dict[str, List[str]]:
+        merchant_links: Dict[str, List[str]] = {uid: [] for uid in users.user_id}
+
+        base_merchants = merchants[~merchants["is_ring_merchant"]].merchant_id.tolist()
+
+        for user_row in users.itertuples():
+            merchant_count = max(1, self.rng.poisson(population.avg_merchants_per_user))
+            merchant_count = min(merchant_count, len(base_merchants))
+            chosen = self.rng.choice(base_merchants, size=merchant_count, replace=False)
+            merchant_links[user_row.user_id] = list(chosen)
+
+        if fraud_cfg.enabled:
+            ring_groups = users.dropna(subset=["fraud_ring_id"]).groupby("fraud_ring_id")
+            for ring_id, group in ring_groups:
+                shared_count = max(1, int(np.ceil(population.avg_merchants_per_user * fraud_cfg.shared_merchant_ratio)))
+                shared_merchants = [
+                    f"merchant_ring_{ring_id}_{idx}"
+                    for idx in range(shared_count)
+                ]
+                # Append shared merchants to merchant table
+                for merch_id in shared_merchants:
+                    merchants.loc[len(merchants)] = {
+                        "merchant_id": merch_id,
+                        "category": "ring-front",
+                        "risk_score": float(np.clip(self.rng.normal(0.85, 0.05), 0, 1)),
+                        "is_ring_merchant": True,
+                    }
+
+                for member in group.itertuples():
+                    merchant_links[member.user_id].extend(shared_merchants)
+
+        return merchant_links
+
+    def _build_lifecycles(self, users: pd.DataFrame, lifecycle: LifecycleConfig) -> pd.DataFrame:
+        lifecycle_records: List[Dict[str, object]] = []
+        horizon = lifecycle.horizon_days
+
+        for user_row in users.itertuples():
+            active_start = int(user_row.signup_day)
+            span = max(1, int(np.round(self.rng.normal(lifecycle.mean_active_span_days, lifecycle.std_active_span_days))))
+            active_end = min(horizon, active_start + span)
+            lifecycle_records.append(
+                {
+                    "user_id": user_row.user_id,
+                    "period_index": 0,
+                    "start_day": active_start,
+                    "end_day": active_end,
+                }
+            )
+
+            if self.rng.random() < lifecycle.churn_reactivation_probability and active_end < horizon:
+                rest_days = self.rng.integers(3, 14)
+                restart_day = min(horizon, active_end + rest_days)
+                re_span = max(1, int(np.round(self.rng.normal(lifecycle.mean_active_span_days / 2, lifecycle.std_active_span_days / 2))))
+                lifecycle_records.append(
+                    {
+                        "user_id": user_row.user_id,
+                        "period_index": 1,
+                        "start_day": restart_day,
+                        "end_day": min(horizon, restart_day + re_span),
+                    }
+                )
+
+        return pd.DataFrame(lifecycle_records)
+
+    def _generate_events(
+        self,
+        users: pd.DataFrame,
+        lifecycles: pd.DataFrame,
+        merchant_links: Dict[str, List[str]],
+        events_cfg: EventConfig,
+    ) -> pd.DataFrame:
+        event_records: List[Dict[str, object]] = []
+        event_id = 0
+        anchor = datetime.combine(self.config.anchor_date, datetime.min.time())
+
+        drift_index = self._create_drift_index(self.config.drift_scenarios)
+
+        for user_row in users.itertuples():
+            # Signup event
+            signup_timestamp = anchor + timedelta(days=int(user_row.signup_day), hours=float(self.rng.uniform(0, 24)))
+            event_records.append(
+                {
+                    "event_id": event_id,
+                    "event_type": "signup",
+                    "user_id": user_row.user_id,
+                    "related_id": None,
+                    "timestamp": signup_timestamp,
+                    "amount": None,
+                    "is_fraud": bool(user_row.is_fraud),
+                    "drift_tag": None,
+                }
+            )
+            event_id += 1
+
+            user_periods = lifecycles[lifecycles.user_id == user_row.user_id]
+            for period in user_periods.itertuples():
+                for day in range(period.start_day, period.end_day + 1):
+                    multipliers = drift_index.get(day, {})
+                    drift_tag = multipliers.get("tag")
+                    rate_multiplier = multipliers.get("fraud_multiplier" if user_row.is_fraud else "legit_multiplier", 1.0)
+                    chargeback_multiplier = multipliers.get("chargeback_multiplier", 1.0)
+
+                    base_rate = events_cfg.daily_txn_rate_fraud if user_row.is_fraud else events_cfg.daily_txn_rate_legit
+                    txn_count = self.rng.poisson(max(base_rate * rate_multiplier, 0))
+                    if txn_count == 0:
+                        continue
+
+                    chargeback_prob = np.clip(
+                        (events_cfg.chargeback_prob_fraud if user_row.is_fraud else events_cfg.chargeback_prob_legit)
+                        * chargeback_multiplier,
+                        0,
+                        1,
+                    )
+
+                    user_merchants = merchant_links[user_row.user_id]
+                    for _ in range(txn_count):
+                        merchant_id = self.rng.choice(user_merchants)
+                        amount = max(
+                            1.0,
+                            float(
+                                self.rng.normal(events_cfg.base_amount, events_cfg.amount_std)
+                                * (1.05 if user_row.is_fraud else 1.0)
+                                * rate_multiplier
+                            ),
+                        )
+                        timestamp = anchor + timedelta(
+                            days=day,
+                            hours=float(self.rng.uniform(0, 24)),
+                            minutes=float(self.rng.uniform(0, 60)),
+                        )
+                        txn_event_id = event_id
+                        event_records.append(
+                            {
+                                "event_id": txn_event_id,
+                                "event_type": "transaction",
+                                "user_id": user_row.user_id,
+                                "related_id": merchant_id,
+                                "timestamp": timestamp,
+                                "amount": amount,
+                                "is_fraud": bool(user_row.is_fraud),
+                                "drift_tag": drift_tag,
+                            }
+                        )
+                        event_id += 1
+
+                        if self.rng.random() < chargeback_prob:
+                            chargeback_timestamp = timestamp + timedelta(days=float(self.rng.uniform(3, 30)))
+                            event_records.append(
+                                {
+                                    "event_id": event_id,
+                                    "event_type": "chargeback",
+                                    "user_id": user_row.user_id,
+                                    "related_id": txn_event_id,
+                                    "timestamp": chargeback_timestamp,
+                                    "amount": -amount,
+                                    "is_fraud": bool(user_row.is_fraud),
+                                    "drift_tag": drift_tag,
+                                }
+                            )
+                            event_id += 1
+
+        events_df = pd.DataFrame(event_records)
+        return events_df.sort_values("timestamp").reset_index(drop=True)
+
+    def _build_graph(
+        self,
+        users: pd.DataFrame,
+        devices: pd.DataFrame,
+        merchants: pd.DataFrame,
+        device_edges: pd.DataFrame,
+        events: pd.DataFrame,
+    ) -> nx.MultiDiGraph:
+        graph = nx.MultiDiGraph()
+
+        for row in users.itertuples():
+            graph.add_node(
+                row.user_id,
+                type="user",
+                segment=row.segment,
+                is_fraud=bool(row.is_fraud),
+                signup_day=int(row.signup_day),
+                fraud_ring_id=row.fraud_ring_id,
+            )
+
+        for row in devices.itertuples():
+            graph.add_node(
+                row.device_id,
+                type="device",
+                os=row.os,
+                trust_score=float(row.trust_score),
+                ring_id=row.ring_id,
+            )
+
+        for row in merchants.itertuples():
+            graph.add_node(
+                row.merchant_id,
+                type="merchant",
+                category=row.category,
+                risk_score=float(row.risk_score),
+                is_ring_merchant=bool(row.is_ring_merchant),
+            )
+
+        for edge in device_edges.itertuples():
+            graph.add_edge(edge.user_id, edge.device_id, relation=edge.relation, ring_id=edge.ring_id)
+
+        txn_events = events[events.event_type == "transaction"]
+        txn_counts = txn_events.groupby(["user_id", "related_id"]).size().reset_index(name="txn_count")
+        for row in txn_counts.itertuples():
+            graph.add_edge(row.user_id, row.related_id, relation="transacts_with", weight=int(row.txn_count))
+
+        return graph
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _inject_fraud_rings(self, users: pd.DataFrame, fraud_cfg: FraudRingConfig) -> pd.DataFrame:
+        fraud_users = users[users.is_fraud]
+        available_users = fraud_users.user_id.tolist()
+        if not available_users:
+            return users
+
+        ring_assignments: Dict[str, str] = {}
+        ring_counter = 0
+
+        while available_users and ring_counter < fraud_cfg.ring_count:
+            ring_size = min(
+                len(available_users),
+                self.rng.integers(fraud_cfg.min_ring_size, fraud_cfg.max_ring_size + 1),
+            )
+            if ring_size < fraud_cfg.min_ring_size:
+                break
+            selected = list(self.rng.choice(available_users, size=ring_size, replace=False))
+            ring_id = f"ring_{ring_counter:03d}"
+            for uid in selected:
+                ring_assignments[uid] = ring_id
+                available_users.remove(uid)
+            ring_counter += 1
+
+        users = users.copy()
+        users["fraud_ring_id"] = users.user_id.map(ring_assignments)
+        users["fraud_ring_id"] = users["fraud_ring_id"].where(users["fraud_ring_id"].notna(), None)
+        return users
+
+    def _create_drift_index(self, scenarios: Iterable[DriftScenario]) -> Dict[int, Dict[str, object]]:
+        drift_index: Dict[int, Dict[str, object]] = {}
+        for scenario in scenarios:
+            for day in scenario.to_range():
+                entry = drift_index.setdefault(day, {"tags": set()})
+                entry["tags"].add(scenario.name)
+                entry["fraud_multiplier"] = entry.get("fraud_multiplier", 1.0) * scenario.fraud_multiplier
+                entry["legit_multiplier"] = entry.get("legit_multiplier", 1.0) * scenario.legit_multiplier
+                entry["chargeback_multiplier"] = entry.get("chargeback_multiplier", 1.0) * scenario.chargeback_multiplier
+
+        for day, entry in drift_index.items():
+            if entry["tags"]:
+                entry["tag"] = "|".join(sorted(entry["tags"]))
+            else:
+                entry["tag"] = None
+        return drift_index
+
+
+__all__ = ["SyntheticEntityGraphForge", "GenerationResult"]

--- a/segf/notebooks/01_getting_started.ipynb
+++ b/segf/notebooks/01_getting_started.ipynb
@@ -1,0 +1,65 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SEGF: Getting Started\n",
+    "Generate your first synthetic entity graph and inspect the outputs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "from segf import DriftScenario, SegfConfig, SegfValidator, SyntheticEntityGraphForge, TargetStats\n",
+    "\n",
+    "config = SegfConfig(\n",
+    "    drift_scenarios=[\n",
+    "        DriftScenario(\n",
+    "            name=\"promo_push\", start_day=12, end_day=22, fraud_multiplier=1.25, chargeback_multiplier=1.8\n",
+    "        )\n",
+    "    ]\n",
+    ")\n",
+    "forge = SyntheticEntityGraphForge(config)\n",
+    "result = forge.generate()\n",
+    "result.write(Path(\"./segf-sample-output\"))\n",
+    "\n",
+    "validator = SegfValidator(\n",
+    "    TargetStats(\n",
+    "        expected_user_fraud_ratio=config.population.fraud_user_ratio,\n",
+    "        expected_chargeback_rate=config.events.chargeback_prob_fraud * 0.5,\n",
+    "        expected_daily_transactions=config.events.daily_txn_rate_legit,\n",
+    "        drift_windows={\"promo_push\": {\"chargeback_multiplier\": 1.8}},\n",
+    "    )\n",
+    ")\n",
+    "report = validator.evaluate(users=result.users, events=result.events, lifecycles=result.lifecycles)\n",
+    "report"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use `result.graph` with NetworkX, or open the Parquet files in your notebook to explore the generated data."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/segf/notebooks/02_drift_scenarios.ipynb
+++ b/segf/notebooks/02_drift_scenarios.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Analysing Drift Scenarios\n",
+    "Quantify how configured drift windows impact downstream metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "from segf import DriftScenario, SegfConfig, SegfValidator, SyntheticEntityGraphForge, TargetStats\n",
+    "\n",
+    "config = SegfConfig(\n",
+    "    drift_scenarios=[\n",
+    "        DriftScenario(name=\"holiday_spike\", start_day=15, end_day=25, fraud_multiplier=1.5, chargeback_multiplier=2.2),\n",
+    "        DriftScenario(name=\"post_holiday_lull\", start_day=26, end_day=40, fraud_multiplier=0.6, legit_multiplier=0.7),\n",
+    "    ]\n",
+    ")\n",
+    "forge = SyntheticEntityGraphForge(config)\n",
+    "result = forge.generate()\n",
+    "\n",
+    "baseline_validator = SegfValidator(\n",
+    "    TargetStats(\n",
+    "        expected_user_fraud_ratio=config.population.fraud_user_ratio,\n",
+    "        expected_chargeback_rate=config.events.chargeback_prob_fraud * 0.5,\n",
+    "        expected_daily_transactions=config.events.daily_txn_rate_legit,\n",
+    "        drift_windows={\n",
+    "            \"holiday_spike\": {\"chargeback_multiplier\": 2.2},\n",
+    "            \"post_holiday_lull\": {\"txn_multiplier\": 0.7},\n",
+    "        },\n",
+    "        tolerance=0.15,\n",
+    "    )\n",
+    ")\n",
+    "report = baseline_validator.evaluate(users=result.users, events=result.events, lifecycles=result.lifecycles)\n",
+    "pd.DataFrame(report.drift_metrics).T\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The resulting frame surfaces multipliers against the baseline rates for each named drift window."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/segf/tests/test_segf.py
+++ b/segf/tests/test_segf.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from segf import (
+    DriftScenario,
+    PopulationConfig,
+    SegfConfig,
+    SegfValidator,
+    SyntheticEntityGraphForge,
+    TargetStats,
+)
+
+
+def test_seed_reproducibility():
+    config = SegfConfig(
+        population=PopulationConfig(n_users=200, n_merchants=30),
+        drift_scenarios=[DriftScenario(name="spike", start_day=5, end_day=10)],
+        random_seed=42,
+    )
+
+    forge_a = SyntheticEntityGraphForge(config, seed=config.random_seed)
+    forge_b = SyntheticEntityGraphForge(config, seed=config.random_seed)
+
+    result_a = forge_a.generate()
+    result_b = forge_b.generate()
+
+    assert result_a.users.equals(result_b.users)
+    assert result_a.events.equals(result_b.events)
+
+
+def test_validator_matches_targets():
+    config = SegfConfig(
+        population=PopulationConfig(n_users=150, n_merchants=25, fraud_user_ratio=0.1),
+        drift_scenarios=[
+            DriftScenario(name="holiday", start_day=10, end_day=15, fraud_multiplier=1.4, chargeback_multiplier=1.6)
+        ],
+        random_seed=99,
+    )
+    forge = SyntheticEntityGraphForge(config)
+    result = forge.generate()
+
+    txn_events = result.events[result.events.event_type == "transaction"]
+    chargebacks = result.events[result.events.event_type == "chargeback"]
+    chargeback_rate = len(chargebacks) / len(txn_events) if len(txn_events) else 0.0
+    horizon = result.lifecycles.end_day.max() - result.lifecycles.start_day.min() + 1
+    daily_txn = len(txn_events) / horizon
+
+    scenario_events = result.events[result.events.drift_tag == "holiday"]
+    scenario_txns = scenario_events[scenario_events.event_type == "transaction"]
+    scenario_cbs = scenario_events[scenario_events.event_type == "chargeback"]
+    scenario_cb_rate = (
+        len(scenario_cbs) / len(scenario_txns) if len(scenario_txns) and chargeback_rate else chargeback_rate
+    )
+
+    validator = SegfValidator(
+        TargetStats(
+            expected_user_fraud_ratio=result.users.is_fraud.mean(),
+            expected_chargeback_rate=chargeback_rate,
+            expected_daily_transactions=daily_txn,
+            drift_windows={
+                "holiday": {
+                    "chargeback_multiplier": (scenario_cb_rate / chargeback_rate) if chargeback_rate else 1.0
+                }
+            },
+            tolerance=0.05,
+        )
+    )
+
+    report = validator.evaluate(users=result.users, events=result.events, lifecycles=result.lifecycles)
+    assert report.within_tolerance
+    assert "holiday" in report.drift_metrics

--- a/segf/validator.py
+++ b/segf/validator.py
@@ -1,0 +1,167 @@
+"""Validator utilities for SEGF outputs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import numpy as np
+import pandas as pd
+
+from .config import TargetStats
+
+
+@dataclass
+class ValidationReport:
+    """Structured report of validation metrics."""
+
+    metrics: Dict[str, float]
+    drift_metrics: Dict[str, Dict[str, float]]
+    within_tolerance: bool
+    messages: List[str]
+
+
+class SegfValidator:
+    """Validator that scores generated corpora against target statistics."""
+
+    def __init__(self, target: TargetStats) -> None:
+        self.target = target
+
+    def evaluate(
+        self,
+        *,
+        users: pd.DataFrame,
+        events: pd.DataFrame,
+        lifecycles: Optional[pd.DataFrame] = None,
+    ) -> ValidationReport:
+        """Compute deviation scores against configured targets."""
+
+        metrics = self._compute_global_metrics(users, events, lifecycles)
+        drift_metrics = self._compute_drift_metrics(events, metrics)
+
+        within_tolerance = True
+        messages: List[str] = []
+
+        def _check(metric_key: str, actual: float, expected: float) -> None:
+            nonlocal within_tolerance
+            delta = abs(actual - expected)
+            threshold = self.target.tolerance * expected if expected else self.target.tolerance
+            if delta > threshold:
+                within_tolerance = False
+                messages.append(
+                    f"{metric_key} deviates by {delta:.4f} (expected {expected:.4f}, actual {actual:.4f})."
+                )
+
+        _check("fraud_ratio", metrics["fraud_ratio"], self.target.expected_user_fraud_ratio)
+        _check("chargeback_rate", metrics["chargeback_rate"], self.target.expected_chargeback_rate)
+        _check("daily_transactions", metrics["daily_transactions"], self.target.expected_daily_transactions)
+
+        for drift_name, scenario_metrics in drift_metrics.items():
+            expectations = self.target.drift_windows.get(drift_name, {})
+            if not expectations:
+                continue
+            for key, expected_value in expectations.items():
+                actual_value = scenario_metrics.get(key)
+                if actual_value is None:
+                    continue
+                _check(f"{drift_name}.{key}", actual_value, expected_value)
+
+        return ValidationReport(metrics=metrics, drift_metrics=drift_metrics, within_tolerance=within_tolerance, messages=messages)
+
+    def validate_reproducibility(self, config, runs: int = 2) -> bool:
+        """Confirm deterministic outputs for fixed seeds."""
+
+        if runs < 2:
+            raise ValueError("runs must be >= 2 for reproducibility checks")
+
+        from copy import deepcopy
+
+        from .generator import SyntheticEntityGraphForge
+
+        digests: List[str] = []
+        for _ in range(runs):
+            cfg = deepcopy(config)
+            if cfg.random_seed is None:
+                raise ValueError("SegfConfig.random_seed must be set for reproducibility validation")
+            forge = SyntheticEntityGraphForge(cfg, seed=cfg.random_seed)
+            result = forge.generate()
+            digests.append(self._digest(result))
+        return all(d == digests[0] for d in digests[1:])
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _compute_global_metrics(
+        self,
+        users: pd.DataFrame,
+        events: pd.DataFrame,
+        lifecycles: Optional[pd.DataFrame],
+    ) -> Dict[str, float]:
+        fraud_ratio = float(users.is_fraud.mean()) if not users.empty else 0.0
+        transactions = events[events.event_type == "transaction"]
+        chargebacks = events[events.event_type == "chargeback"]
+
+        chargeback_rate = float(len(chargebacks) / len(transactions)) if len(transactions) else 0.0
+
+        if lifecycles is not None and not lifecycles.empty:
+            horizon_days = int(lifecycles.end_day.max() - lifecycles.start_day.min() + 1)
+        else:
+            if events.empty:
+                horizon_days = 1
+            else:
+                span = (events.timestamp.max() - events.timestamp.min()).days
+                horizon_days = max(span, 1)
+        daily_transactions = float(len(transactions) / horizon_days) if horizon_days else 0.0
+
+        return {
+            "fraud_ratio": fraud_ratio,
+            "chargeback_rate": chargeback_rate,
+            "daily_transactions": daily_transactions,
+            "transactions": float(len(transactions)),
+            "chargebacks": float(len(chargebacks)),
+            "horizon_days": float(horizon_days),
+        }
+
+    def _compute_drift_metrics(
+        self,
+        events: pd.DataFrame,
+        global_metrics: Dict[str, float],
+    ) -> Dict[str, Dict[str, float]]:
+        txn_events = events[events.event_type == "transaction"]
+        cb_events = events[events.event_type == "chargeback"]
+        baseline_txn_rate = global_metrics.get("daily_transactions", 0.0)
+        baseline_cb_rate = global_metrics.get("chargeback_rate", 0.0)
+
+        metrics: Dict[str, Dict[str, float]] = {}
+        if "drift_tag" not in events.columns:
+            return metrics
+
+        tags = events["drift_tag"].dropna().unique()
+        for tag in tags:
+            tag_txn_filter = txn_events["drift_tag"].fillna("").str.contains(tag)
+            tag_cb_filter = cb_events["drift_tag"].fillna("").str.contains(tag)
+            tag_txns = txn_events[tag_txn_filter]
+            tag_cbs = cb_events[tag_cb_filter]
+            txn_rate = float(len(tag_txns)) / global_metrics.get("horizon_days", 1.0)
+            cb_rate = float(len(tag_cbs) / len(tag_txns)) if len(tag_txns) else 0.0
+            metrics[tag] = {
+                "txn_multiplier": (txn_rate / baseline_txn_rate) if baseline_txn_rate else np.nan,
+                "chargeback_multiplier": (cb_rate / baseline_cb_rate) if baseline_cb_rate else np.nan,
+                "txn_rate": txn_rate,
+                "chargeback_rate": cb_rate,
+            }
+        return metrics
+
+    def _digest(self, result) -> str:
+        """Stable hash over key result tables for reproducibility checks."""
+
+        import hashlib
+
+        users_bytes = result.users.sort_values("user_id").to_csv(index=False).encode()
+        events_bytes = result.events.sort_values("event_id").head(100).to_csv(index=False).encode()
+        hasher = hashlib.sha256()
+        hasher.update(users_bytes)
+        hasher.update(events_bytes)
+        return hasher.hexdigest()
+
+
+__all__ = ["SegfValidator", "ValidationReport"]


### PR DESCRIPTION
## Summary
- add the segf package for generating synthetic entity graphs with lifecycle events, fraud rings, and Parquet/GraphML export
- provide validator utilities, documentation, and starter notebooks for drift and imbalance scenarios
- add pytest coverage for reproducibility plus supporting data science dependencies

## Testing
- pytest segf/tests/test_segf.py


------
https://chatgpt.com/codex/tasks/task_e_68d7404a673c8333a745198f8ac2ffa9