### PR TITLE
feat: add prompt diff impact lab toolkit

### DIFF
--- a/sdk/__init__.py
+++ b/sdk/__init__.py
@@ -1,0 +1,1 @@
+"""SDK namespace package."""

--- a/sdk/pdil/README.md
+++ b/sdk/pdil/README.md
@@ -1,0 +1,49 @@
+# Prompt Diff Impact Lab (PDIL)
+
+PDIL is a hybrid Python/TypeScript toolkit for evaluating prompt revisions
+against golden datasets. It provides deterministic replays with seed control,
+risk-aware scoring, and a dashboard that ranks risky diffs by business impact.
+
+## Features
+
+- Deterministic golden set replays with pluggable model endpoint adapters.
+- Failure taxonomy heuristics that tag regressions as omissions, schema
+  mismatches, partial matches, or incorrect responses.
+- Risk-weighted regression scoring that combines severity, business impact, and
+  coverage delta penalties.
+- TypeScript dashboard utilities for turning replay JSON into a sortable HTML
+  report that highlights the riskiest diffs.
+
+## Layout
+
+```
+sdk/pdil/
+  adapters.py      # Model endpoint abstractions and reference adapters
+  cli.py           # CLI entry point for running golden set replays
+  models.py        # Dataclasses shared across the toolkit
+  replay.py        # Deterministic replay engine
+  risk.py          # Risk scoring implementation
+  taxonomy.py      # Failure classification helpers
+  README.md
+  examples/
+    golden_sample.json
+  dashboard/
+    package.json
+    tsconfig.json
+    src/
+      index.ts
+      dashboard.ts
+      ranking.ts
+      types.ts
+    README.md
+```
+
+## Running replays
+
+```
+python -m sdk.pdil.cli sdk/pdil/examples/golden_sample.json v1 v2 \
+  --seed 123 --adapter template --output pdil-report.json
+```
+
+The resulting JSON file can be rendered into an HTML dashboard via the
+TypeScript utilities in `dashboard/`.

--- a/sdk/pdil/__init__.py
+++ b/sdk/pdil/__init__.py
@@ -1,0 +1,26 @@
+"""Prompt Diff Impact Lab (PDIL) core package."""
+
+from .models import (
+    GoldenCase,
+    GoldenSet,
+    PromptDiffOutcome,
+    PromptRun,
+    ReplayReport,
+)
+from .adapters import ModelAdapter, EchoAdapter, TemplateAdapter
+from .replay import PromptDiffRunner
+from .risk import RiskAssessor, RiskAssessment
+
+__all__ = [
+    "GoldenCase",
+    "GoldenSet",
+    "PromptDiffOutcome",
+    "PromptRun",
+    "ReplayReport",
+    "ModelAdapter",
+    "EchoAdapter",
+    "TemplateAdapter",
+    "PromptDiffRunner",
+    "RiskAssessor",
+    "RiskAssessment",
+]

--- a/sdk/pdil/adapters.py
+++ b/sdk/pdil/adapters.py
@@ -1,0 +1,52 @@
+"""Model endpoint adapters for PDIL."""
+
+from __future__ import annotations
+
+import abc
+import hashlib
+import json
+import random
+from typing import Dict, Optional
+
+
+class ModelAdapter(abc.ABC):
+    """Interface for model provider integrations."""
+
+    name: str
+    supports_seed_control: bool = True
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+    @abc.abstractmethod
+    def generate(self, prompt: str, seed: Optional[int] = None, **kwargs: object) -> str:
+        """Return a response for the prompt."""
+
+
+class EchoAdapter(ModelAdapter):
+    """Basic adapter that echoes prompts with deterministic noise for tests."""
+
+    def __init__(self) -> None:
+        super().__init__("echo")
+
+    def generate(self, prompt: str, seed: Optional[int] = None, **kwargs: object) -> str:
+        seed_value = seed if seed is not None else 0
+        token = hashlib.sha1(prompt.encode("utf-8")).hexdigest()[:8]
+        return f"{prompt.strip()} ::{seed_value}:{token}::"
+
+
+class TemplateAdapter(ModelAdapter):
+    """Adapter that simulates templated completions with seeded sampling."""
+
+    def __init__(self, templates: Optional[Dict[str, str]] = None) -> None:
+        super().__init__("template")
+        self.templates = templates or {}
+
+    def generate(self, prompt: str, seed: Optional[int] = None, **kwargs: object) -> str:
+        seed_value = seed if seed is not None else 0
+        rng = random.Random(seed_value + hash(prompt))
+        base = self.templates.get(prompt, prompt)
+        variants = base.split("|")
+        choice = variants[rng.randrange(len(variants))]
+        payload = {"seed": seed_value, "selected": choice.strip()}
+        return json.dumps(payload, sort_keys=True)

--- a/sdk/pdil/cli.py
+++ b/sdk/pdil/cli.py
@@ -1,0 +1,86 @@
+"""Command line interface for PDIL."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict
+
+from .adapters import EchoAdapter, ModelAdapter, TemplateAdapter
+from .models import GoldenSet
+from .replay import PromptDiffRunner, load_golden_set
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prompt Diff Impact Lab")
+    parser.add_argument("golden_set", type=Path, help="Path to the golden set JSON file")
+    parser.add_argument("baseline", type=str, help="Baseline prompt version key")
+    parser.add_argument("candidate", type=str, help="Candidate prompt version key")
+    parser.add_argument("--seed", type=int, default=0, help="Base seed for deterministic replays")
+    parser.add_argument("--adapter", type=str, default="echo", choices=["echo", "template"], help="Adapter to use")
+    parser.add_argument("--template-map", type=Path, help="Optional template mapping JSON")
+    parser.add_argument("--shuffle", action="store_true", help="Shuffle case order before replay")
+    parser.add_argument("--output", type=Path, help="Write replay report JSON to this path")
+    return parser
+
+
+def _adapter_from_args(args: argparse.Namespace) -> Dict[str, ModelAdapter]:
+    if args.adapter == "echo":
+        return {args.baseline: EchoAdapter(), args.candidate: EchoAdapter()}
+    if args.adapter == "template":
+        template_map = {}
+        if args.template_map:
+            template_map = json.loads(args.template_map.read_text())
+        adapter = TemplateAdapter(template_map)
+        return {args.baseline: adapter, args.candidate: adapter}
+    raise ValueError(f"Unsupported adapter: {args.adapter}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    golden_set: GoldenSet = load_golden_set(args.golden_set)
+    adapters = _adapter_from_args(args)
+    runner = PromptDiffRunner(golden_set, adapters)
+    report = runner.run(args.baseline, args.candidate, seed=args.seed, shuffle=args.shuffle)
+    serialized = serialize_report(report)
+    if args.output:
+        args.output.write_text(json.dumps(serialized, indent=2))
+    else:
+        print(json.dumps(serialized, indent=2))
+    return 0
+
+
+def serialize_report(report) -> dict:
+    return {
+        "seed": report.seed,
+        "assessment": {
+            "total_risk": report.assessment.total_risk,
+            "coverage_delta": report.assessment.coverage_delta,
+            "taxonomy_counts": report.assessment.taxonomy_counts,
+            "regressions": [outcome.case.case_id for outcome in report.assessment.regressions],
+        },
+        "outcomes": [
+            {
+                "case_id": outcome.case.case_id,
+                "baseline": {
+                    "passed": outcome.baseline.passed,
+                    "taxonomy": outcome.baseline.taxonomy,
+                    "severity": outcome.baseline.severity,
+                },
+                "candidate": {
+                    "passed": outcome.candidate.passed,
+                    "taxonomy": outcome.candidate.taxonomy,
+                    "severity": outcome.candidate.severity,
+                },
+                "coverage_delta": outcome.coverage_delta,
+                "business_impact": outcome.case.business_impact,
+            }
+            for outcome in report.outcomes
+        ],
+    }
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sdk/pdil/dashboard/README.md
+++ b/sdk/pdil/dashboard/README.md
@@ -1,0 +1,27 @@
+# PDIL Dashboard Utilities
+
+This package contains a lightweight TypeScript toolkit that converts PDIL replay
+reports into an HTML dashboard. The dashboard ranks risky prompt diffs by
+business impact and highlights regressions that should be triaged.
+
+## Usage
+
+```
+npm install
+npm run build
+node dist/index.js --input ../../pdil-report.json --output ../../pdil-dashboard.html
+```
+
+During development you can run the script with `ts-node` instead of compiling:
+
+```
+npx ts-node src/index.ts --input ../../pdil-report.json
+```
+
+The generated HTML includes:
+
+- Coverage delta summary and aggregate risk score.
+- Table of cases sorted by risk contributions, including severity, taxonomy and
+  business impact.
+- Regression badges and tag annotations to help reviewers filter high priority
+  failures.

--- a/sdk/pdil/dashboard/package.json
+++ b/sdk/pdil/dashboard/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "pdil-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p .",
+    "lint": "eslint src --ext .ts",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "yargs": "^17.7.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/yargs": "^17.0.32",
+    "typescript": "^5.4.5"
+  }
+}

--- a/sdk/pdil/dashboard/src/dashboard.ts
+++ b/sdk/pdil/dashboard/src/dashboard.ts
@@ -1,0 +1,72 @@
+import { rankOutcomes } from "./ranking.js";
+import { ReplayReport } from "./types.js";
+
+export function renderDashboard(report: ReplayReport): string {
+  const ranked = rankOutcomes(report);
+  const rows = ranked
+    .map((outcome) => renderRow(outcome))
+    .join("\n");
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Prompt Diff Impact Lab</title>
+    <style>
+      body { font-family: system-ui, sans-serif; margin: 2rem; background: #fafafa; }
+      h1 { margin-bottom: 0.5rem; }
+      table { border-collapse: collapse; width: 100%; margin-top: 1.5rem; }
+      th, td { border: 1px solid #ccc; padding: 0.5rem 0.75rem; text-align: left; }
+      th { background: #f1f1f1; }
+      tr:nth-child(even) { background: #fff; }
+      .regression { color: #b30000; font-weight: 600; }
+      .badge { display: inline-block; padding: 0.125rem 0.5rem; border-radius: 0.5rem; font-size: 0.75rem; margin-left: 0.5rem; }
+      .badge.regression { background: #ffe1e1; color: #b30000; }
+      .badge.passed { background: #e8f5e9; color: #1b5e20; }
+    </style>
+  </head>
+  <body>
+    <h1>Prompt Diff Impact Lab</h1>
+    <p><strong>Seed:</strong> ${report.seed}</p>
+    <p>
+      <strong>Total Risk:</strong> ${report.assessment.total_risk.toFixed(4)}<br />
+      <strong>Coverage Delta:</strong> ${report.assessment.coverage_delta.toFixed(4)}
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>Case</th>
+          <th>Taxonomy</th>
+          <th>Business Impact</th>
+          <th>Risk Contribution</th>
+          <th>Baseline</th>
+          <th>Candidate</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${rows}
+      </tbody>
+    </table>
+  </body>
+</html>`;
+}
+
+function renderRow(outcome: ReturnType<typeof rankOutcomes>[number]): string {
+  const regression = outcome.baseline.passed && !outcome.candidate.passed;
+  const statusBadge = regression
+    ? '<span class="badge regression">Regression</span>'
+    : '<span class="badge passed">Pass</span>';
+  return `<tr>
+    <td>${outcome.case_id} ${statusBadge}</td>
+    <td>${outcome.taxonomy}</td>
+    <td>${outcome.business_impact.toFixed(2)}</td>
+    <td>${outcome.risk_contribution.toFixed(4)}</td>
+    <td>${renderRun(outcome.baseline)}</td>
+    <td>${renderRun(outcome.candidate)}</td>
+  </tr>`;
+}
+
+function renderRun(run: { passed: boolean; taxonomy: string | null; severity: number }): string {
+  const badge = run.passed ? "✅" : "⚠️";
+  const taxonomy = run.taxonomy ?? "passed";
+  return `${badge} ${taxonomy} (sev ${run.severity.toFixed(2)})`;
+}

--- a/sdk/pdil/dashboard/src/index.ts
+++ b/sdk/pdil/dashboard/src/index.ts
@@ -1,0 +1,55 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { renderDashboard } from "./dashboard.js";
+import { ReplayReport } from "./types.js";
+
+interface Args {
+  input: string;
+  output?: string;
+}
+
+async function loadReport(filePath: string): Promise<ReplayReport> {
+  const content = await fs.readFile(filePath, "utf8");
+  return JSON.parse(content) as ReplayReport;
+}
+
+async function writeOutput(html: string, target?: string): Promise<void> {
+  if (!target) {
+    process.stdout.write(html);
+    return;
+  }
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  await fs.writeFile(target, html, "utf8");
+}
+
+export async function main(argv = hideBin(process.argv)): Promise<void> {
+  const args = (await yargs(argv)
+    .option("input", {
+      alias: "i",
+      demandOption: true,
+      describe: "Path to PDIL replay JSON",
+      type: "string",
+    })
+    .option("output", {
+      alias: "o",
+      describe: "Optional output HTML path",
+      type: "string",
+    })
+    .strict()
+    .help()
+    .parse()) as Args;
+
+  const report = await loadReport(args.input);
+  const html = renderDashboard(report);
+  await writeOutput(html, args.output);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/sdk/pdil/dashboard/src/ranking.ts
+++ b/sdk/pdil/dashboard/src/ranking.ts
@@ -1,0 +1,20 @@
+import { OutcomeSummary, RankedOutcome, ReplayReport } from "./types.js";
+
+export function rankOutcomes(report: ReplayReport): RankedOutcome[] {
+  return report.outcomes
+    .map((outcome) => toRankedOutcome(outcome))
+    .sort((a, b) => b.risk_contribution - a.risk_contribution);
+}
+
+function toRankedOutcome(outcome: OutcomeSummary): RankedOutcome {
+  const taxonomy = outcome.candidate.taxonomy ?? "passed";
+  const regressionPenalty = outcome.baseline.passed && !outcome.candidate.passed ? 1.5 : 1;
+  const failurePenalty = outcome.candidate.passed ? 0 : outcome.candidate.severity * regressionPenalty;
+  const coveragePenalty = outcome.coverage_delta < 0 ? Math.abs(outcome.coverage_delta) * 5 : 0;
+  const riskContribution = (failurePenalty + coveragePenalty) * outcome.business_impact;
+  return {
+    ...outcome,
+    risk_contribution: Number(riskContribution.toFixed(4)),
+    taxonomy,
+  };
+}

--- a/sdk/pdil/dashboard/src/types.ts
+++ b/sdk/pdil/dashboard/src/types.ts
@@ -1,0 +1,31 @@
+export interface PromptRunSummary {
+  passed: boolean;
+  taxonomy: string | null;
+  severity: number;
+}
+
+export interface OutcomeSummary {
+  case_id: string;
+  baseline: PromptRunSummary;
+  candidate: PromptRunSummary;
+  coverage_delta: number;
+  business_impact: number;
+}
+
+export interface ReplayAssessment {
+  total_risk: number;
+  coverage_delta: number;
+  taxonomy_counts: Record<string, number>;
+  regressions: string[];
+}
+
+export interface ReplayReport {
+  seed: number;
+  assessment: ReplayAssessment;
+  outcomes: OutcomeSummary[];
+}
+
+export interface RankedOutcome extends OutcomeSummary {
+  risk_contribution: number;
+  taxonomy: string;
+}

--- a/sdk/pdil/dashboard/tsconfig.json
+++ b/sdk/pdil/dashboard/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/sdk/pdil/examples/golden_sample.json
+++ b/sdk/pdil/examples/golden_sample.json
@@ -1,0 +1,64 @@
+{
+  "cases": [
+    {
+      "case_id": "billing-refund",
+      "prompts": {
+        "v1": "Explain the refund policy for premium users.",
+        "v2": "Explain the refund policy for premium plan customers clearly."
+      },
+      "expected_response": "Premium users receive refunds within 3 business days after approval.",
+      "business_impact": 3.0,
+      "coverage_tags": ["billing", "refunds"],
+      "failure_severity": {
+        "omission": 2.0,
+        "incorrect": 1.5,
+        "partial": 1.2,
+        "schema": 1.0,
+        "default": 1.0
+      },
+      "metadata": {
+        "notes": "High risk scenario due to regulatory commitments."
+      }
+    },
+    {
+      "case_id": "safety-commitment",
+      "prompts": {
+        "v1": "Respond to abusive language with a de-escalation statement.",
+        "v2": "Provide a calm response to abusive language while reiterating policy."
+      },
+      "expected_response": "We do not tolerate abusive language. Let's keep our conversation respectful.",
+      "business_impact": 4.5,
+      "coverage_tags": ["safety"],
+      "failure_severity": {
+        "omission": 3.0,
+        "incorrect": 2.5,
+        "partial": 1.8,
+        "schema": 1.0,
+        "default": 1.5
+      },
+      "metadata": {
+        "notes": "Safety regressions carry higher risk weighting."
+      }
+    },
+    {
+      "case_id": "upsell-offer",
+      "prompts": {
+        "v1": "Suggest an add-on for the standard plan.",
+        "v2": "Offer a relevant add-on for the standard plan customer profile."
+      },
+      "expected_response": "Consider upgrading to the productivity toolkit add-on for collaboration features.",
+      "business_impact": 1.5,
+      "coverage_tags": ["upsell"],
+      "failure_severity": {
+        "omission": 1.0,
+        "incorrect": 1.0,
+        "partial": 0.8,
+        "schema": 0.5,
+        "default": 1.0
+      },
+      "metadata": {
+        "notes": "Moderate impact scenario focused on revenue growth."
+      }
+    }
+  ]
+}

--- a/sdk/pdil/models.py
+++ b/sdk/pdil/models.py
@@ -1,0 +1,108 @@
+"""Core data models for the Prompt Diff Impact Lab (PDIL)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+
+@dataclass
+class GoldenCase:
+    """Represents a single evaluation scenario in the golden set."""
+
+    case_id: str
+    prompts: Dict[str, str]
+    expected_response: str
+    business_impact: float = 1.0
+    coverage_tags: List[str] = field(default_factory=list)
+    failure_severity: Dict[str, float] = field(default_factory=dict)
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def severity_for(self, taxonomy: str) -> float:
+        return self.failure_severity.get(taxonomy, self.failure_severity.get("default", 1.0))
+
+
+@dataclass
+class PromptRun:
+    """Captures the result of running a prompt version through a model."""
+
+    prompt_version: str
+    model_name: str
+    response: str
+    passed: bool
+    taxonomy: Optional[str]
+    severity: float
+
+
+@dataclass
+class PromptDiffOutcome:
+    """Compares baseline and candidate outputs for a golden case."""
+
+    case: GoldenCase
+    baseline: PromptRun
+    candidate: PromptRun
+
+    @property
+    def coverage_delta(self) -> float:
+        return float(self.candidate.passed) - float(self.baseline.passed)
+
+    @property
+    def regression_detected(self) -> bool:
+        return self.baseline.passed and not self.candidate.passed
+
+
+@dataclass
+class GoldenSet:
+    """Collection of golden cases with helper lookups."""
+
+    cases: List[GoldenCase]
+
+    def by_tag(self) -> Dict[str, List[GoldenCase]]:
+        tags: Dict[str, List[GoldenCase]] = {}
+        for case in self.cases:
+            for tag in case.coverage_tags or ["__untagged__"]:
+                tags.setdefault(tag, []).append(case)
+        return tags
+
+    @classmethod
+    def from_iterable(cls, cases: Iterable[GoldenCase]) -> "GoldenSet":
+        return cls(list(cases))
+
+
+@dataclass
+class RiskAssessment:
+    """Summary of risk metrics for a prompt diff."""
+
+    total_risk: float
+    coverage_delta: float
+    taxonomy_counts: Dict[str, int]
+    regressions: List[PromptDiffOutcome]
+
+
+@dataclass
+class ReplayReport:
+    """Complete report produced by a PDIL replay run."""
+
+    seed: int
+    outcomes: List[PromptDiffOutcome]
+    assessment: RiskAssessment
+
+    def regression_cases(self) -> List[str]:
+        return [outcome.case.case_id for outcome in self.outcomes if outcome.regression_detected]
+
+    def coverage_by_tag(self) -> Dict[str, float]:
+        tagged = {}
+        for tag, cases in GoldenSet(self.cases_from_outcomes()).by_tag().items():
+            total = len(cases)
+            passed = sum(1 for case in cases if self._candidate_pass(case.case_id))
+            tagged[tag] = passed / total if total else 0.0
+        return tagged
+
+    def _candidate_pass(self, case_id: str) -> bool:
+        for outcome in self.outcomes:
+            if outcome.case.case_id == case_id:
+                return outcome.candidate.passed
+        return False
+
+    def cases_from_outcomes(self) -> List[GoldenCase]:
+        return [outcome.case for outcome in self.outcomes]

--- a/sdk/pdil/replay.py
+++ b/sdk/pdil/replay.py
@@ -1,0 +1,115 @@
+"""Golden set replay engine for PDIL."""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from .adapters import ModelAdapter
+from .models import GoldenCase, GoldenSet, PromptDiffOutcome, PromptRun, ReplayReport
+from .risk import RiskAssessor
+from .taxonomy import classify_failure
+
+
+@dataclass
+class SeedController:
+    """Deterministic seed generator for replay sessions."""
+
+    base_seed: int
+
+    def for_case(self, case_id: str, prompt_version: str) -> int:
+        return abs(hash((self.base_seed, case_id, prompt_version))) % (2**32)
+
+
+class PromptDiffRunner:
+    """Runs prompt versions against a golden set and computes outcomes."""
+
+    def __init__(
+        self,
+        golden_set: GoldenSet,
+        adapters: Dict[str, ModelAdapter],
+        risk_assessor: Optional[RiskAssessor] = None,
+    ) -> None:
+        self.golden_set = golden_set
+        self.adapters = adapters
+        self.risk_assessor = risk_assessor or RiskAssessor()
+
+    def run(
+        self,
+        baseline_version: str,
+        candidate_version: str,
+        *,
+        seed: int = 0,
+        shuffle: bool = False,
+    ) -> ReplayReport:
+        controller = SeedController(seed)
+        outcomes: List[PromptDiffOutcome] = []
+        cases = list(self.golden_set.cases)
+        if shuffle:
+            rng = random.Random(seed)
+            rng.shuffle(cases)
+        for case in cases:
+            baseline_prompt = case.prompts.get(baseline_version)
+            candidate_prompt = case.prompts.get(candidate_version)
+            if baseline_prompt is None or candidate_prompt is None:
+                raise KeyError(f"Prompt version missing for case {case.case_id}")
+            baseline_run = self._execute(case, baseline_version, baseline_prompt, controller)
+            candidate_run = self._execute(case, candidate_version, candidate_prompt, controller)
+            outcomes.append(PromptDiffOutcome(case=case, baseline=baseline_run, candidate=candidate_run))
+        assessment = self.risk_assessor.assess(outcomes)
+        return ReplayReport(seed=seed, outcomes=outcomes, assessment=assessment)
+
+    def _execute(
+        self,
+        case: GoldenCase,
+        prompt_version: str,
+        prompt: str,
+        controller: SeedController,
+    ) -> PromptRun:
+        adapter = self._adapter_for(prompt_version)
+        seed = controller.for_case(case.case_id, prompt_version) if adapter.supports_seed_control else None
+        response = adapter.generate(prompt, seed=seed)
+        passed, taxonomy = classify_failure(case, response)
+        severity = case.severity_for(taxonomy or "default")
+        return PromptRun(
+            prompt_version=prompt_version,
+            model_name=adapter.name,
+            response=response,
+            passed=passed,
+            taxonomy=taxonomy,
+            severity=severity,
+        )
+
+    def _adapter_for(self, prompt_version: str) -> ModelAdapter:
+        adapter = self.adapters.get(prompt_version)
+        if adapter is None:
+            if len(set(self.adapters.values())) == 1:
+                # Single adapter shared by all versions.
+                return next(iter(self.adapters.values()))
+            raise KeyError(f"No adapter configured for version '{prompt_version}'")
+        return adapter
+
+
+def load_golden_set(path: Path) -> GoldenSet:
+    payload = json.loads(path.read_text())
+    cases = [_case_from_dict(item) for item in payload.get("cases", [])]
+    return GoldenSet(cases)
+
+
+def load_cases(cases: Iterable[Dict[str, object]]) -> GoldenSet:
+    return GoldenSet([_case_from_dict(item) for item in cases])
+
+
+def _case_from_dict(item: Dict[str, object]) -> GoldenCase:
+    return GoldenCase(
+        case_id=str(item["case_id"]),
+        prompts=dict(item["prompts"]),
+        expected_response=str(item["expected_response"]),
+        business_impact=float(item.get("business_impact", 1.0)),
+        coverage_tags=list(item.get("coverage_tags", [])),
+        failure_severity=dict(item.get("failure_severity", {})),
+        metadata=dict(item.get("metadata", {})),
+    )

--- a/sdk/pdil/risk.py
+++ b/sdk/pdil/risk.py
@@ -1,0 +1,43 @@
+"""Risk scoring utilities."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable
+
+from .models import PromptDiffOutcome, RiskAssessment
+
+
+@dataclass
+class RiskAssessor:
+    """Computes risk metrics for prompt diffs."""
+
+    coverage_weight: float = 5.0
+
+    def assess(self, outcomes: Iterable[PromptDiffOutcome]) -> RiskAssessment:
+        outcomes = list(outcomes)
+        taxonomy_counts = Counter()
+        total_risk = 0.0
+        coverage_delta = 0.0
+        regressions = []
+        for outcome in outcomes:
+            coverage_delta += outcome.coverage_delta
+            if outcome.candidate.passed:
+                continue
+            taxonomy = outcome.candidate.taxonomy or "unknown"
+            taxonomy_counts[taxonomy] += 1
+            severity = outcome.case.severity_for(taxonomy)
+            weighted = severity * outcome.case.business_impact
+            if outcome.regression_detected:
+                weighted *= 1.5
+                regressions.append(outcome)
+            total_risk += weighted
+        normalized_coverage = coverage_delta / max(len(outcomes), 1)
+        total_risk += self.coverage_weight * max(0.0, -normalized_coverage)
+        return RiskAssessment(
+            total_risk=round(total_risk, 4),
+            coverage_delta=round(normalized_coverage, 4),
+            taxonomy_counts=dict(taxonomy_counts),
+            regressions=regressions,
+        )

--- a/sdk/pdil/taxonomy.py
+++ b/sdk/pdil/taxonomy.py
@@ -1,0 +1,32 @@
+"""Failure taxonomy heuristics."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional, Tuple
+
+from .models import GoldenCase
+
+
+def classify_failure(case: GoldenCase, response: str) -> Tuple[bool, Optional[str]]:
+    """Return whether the response passes and the taxonomy label if it fails."""
+
+    expected = case.expected_response.strip()
+    normalized = response.strip()
+    if normalized == expected:
+        return True, None
+    if not normalized:
+        return False, "omission"
+    if expected.lower() in normalized.lower():
+        return False, "partial"
+    if looks_like_json(expected) and looks_like_json(normalized):
+        return False, "schema"
+    return False, "incorrect"
+
+
+def looks_like_json(payload: str) -> bool:
+    try:
+        json.loads(payload)
+    except Exception:
+        return False
+    return True

--- a/tests/pdil/test_pdil.py
+++ b/tests/pdil/test_pdil.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from sdk.pdil.adapters import EchoAdapter, TemplateAdapter
+from sdk.pdil.cli import serialize_report
+from sdk.pdil.models import GoldenCase, GoldenSet
+from sdk.pdil.replay import PromptDiffRunner, SeedController
+from sdk.pdil.risk import RiskAssessor
+
+
+def build_case(case_id: str, expected: str, *, impact: float, severity: float) -> GoldenCase:
+    return GoldenCase(
+        case_id=case_id,
+        prompts={"v1": expected, "v2": expected},
+        expected_response=expected,
+        business_impact=impact,
+        failure_severity={"incorrect": severity, "default": severity},
+    )
+
+
+def test_replays_are_deterministic() -> None:
+    golden = GoldenSet.from_iterable(
+        [
+            build_case("case-a", "alpha", impact=1.0, severity=1.0),
+            build_case("case-b", "beta", impact=1.0, severity=1.0),
+        ]
+    )
+    adapter = EchoAdapter()
+    runner = PromptDiffRunner(golden, {"v1": adapter, "v2": adapter})
+
+    first = runner.run("v1", "v2", seed=123)
+    second = runner.run("v1", "v2", seed=123)
+
+    assert json.dumps(serialize_report(first), sort_keys=True) == json.dumps(
+        serialize_report(second), sort_keys=True
+    )
+
+
+def test_risk_score_correlates_with_severity() -> None:
+    high_severity = build_case("high", "{\"selected\":\"ok\"}", impact=2.0, severity=3.0)
+    low_severity = build_case("low", "{\"selected\":\"ok\"}", impact=2.0, severity=1.0)
+
+    golden = GoldenSet.from_iterable([high_severity, low_severity])
+    adapter = TemplateAdapter({
+        high_severity.expected_response: "wrong",
+        low_severity.expected_response: "wrong",
+    })
+    runner = PromptDiffRunner(golden, {"v1": adapter, "v2": adapter}, risk_assessor=RiskAssessor())
+    report = runner.run("v1", "v2", seed=77)
+
+    contributions = {outcome.case.case_id: outcome.candidate.severity for outcome in report.outcomes}
+    assert contributions["high"] > contributions["low"]
+    assert report.assessment.total_risk > 0
+
+
+def test_regressions_flagged_in_report() -> None:
+    seed = 11
+    baseline_adapter = EchoAdapter()
+    candidate_adapter = TemplateAdapter({"critical": "wrong"})
+    controller = SeedController(seed)
+    expected_response = baseline_adapter.generate(
+        "critical",
+        seed=controller.for_case("fail", "v1"),
+    )
+
+    failing = GoldenCase(
+        case_id="fail",
+        prompts={"v1": "critical", "v2": "critical"},
+        expected_response=expected_response,
+        business_impact=2.0,
+        failure_severity={"incorrect": 2.0, "default": 2.0},
+    )
+
+    golden = GoldenSet.from_iterable([failing])
+    runner = PromptDiffRunner(golden, {"v1": baseline_adapter, "v2": candidate_adapter})
+    report = runner.run("v1", "v2", seed=seed)
+    regression_ids = report.assessment.regressions
+    assert any(outcome.case.case_id == "fail" for outcome in regression_ids)


### PR DESCRIPTION
## Summary
- add the Prompt Diff Impact Lab (PDIL) python package with deterministic replay engine, failure taxonomy, and risk scoring
- ship a TypeScript dashboard utility that renders PDIL replay JSON into a ranked HTML report
- seed the toolkit with sample golden cases, CLI entry point, and unit tests to lock deterministic seeds and risk correlations

## Testing
- pytest tests/pdil -q

------
https://chatgpt.com/codex/tasks/task_e_68d73febd22083339b421653eb9f48f7