### PR TITLE
feat: add preregistered experiment registry service

### DIFF
--- a/sdk/prer-python/README.md
+++ b/sdk/prer-python/README.md
@@ -1,0 +1,25 @@
+# PRER Python SDK
+
+```python
+from prer_client import PrerClient
+
+client = PrerClient(base_url="http://localhost:3000", default_actor="analyst@company")
+
+experiment = client.create_experiment(
+    {
+        "name": "Hero CTA",
+        "hypothesis": "New CTA boosts clicks",
+        "metrics": [
+            {"name": "click_through", "baselineRate": 0.12, "minDetectableEffect": 0.015}
+        ],
+        "stopRule": {"maxDurationDays": 14, "maxUnits": 10000},
+        "analysisPlan": {
+            "method": "difference-in-proportions",
+            "alpha": 0.05,
+            "desiredPower": 0.8,
+        },
+    }
+)
+
+client.start_experiment(experiment["id"])
+```

--- a/sdk/prer-python/prer_client/__init__.py
+++ b/sdk/prer-python/prer_client/__init__.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import requests
+
+
+@dataclass
+class PrerClient:
+    base_url: str
+    default_actor: Optional[str] = None
+    session: requests.Session = requests.Session()
+
+    def _url(self, path: str) -> str:
+        return f"{self.base_url.rstrip('/')}{path}"
+
+    def create_experiment(self, payload: Dict[str, Any], actor: Optional[str] = None) -> Dict[str, Any]:
+        resolved_actor = actor or self._require_actor()
+        response = self.session.post(
+            self._url("/experiments"), json={**payload, "actor": resolved_actor}, timeout=10
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def start_experiment(self, experiment_id: str, actor: Optional[str] = None) -> Dict[str, Any]:
+        resolved_actor = actor or self._require_actor()
+        response = self.session.post(
+            self._url(f"/experiments/{experiment_id}/start"),
+            json={"actor": resolved_actor},
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def ingest_result(
+        self, experiment_id: str, metric: str, variant: str, value: float, actor: Optional[str] = None
+    ) -> Dict[str, Any]:
+        resolved_actor = actor or self._require_actor()
+        response = self.session.post(
+            self._url(f"/experiments/{experiment_id}/results"),
+            json={
+                "metric": metric,
+                "variant": variant,
+                "value": value,
+                "actor": resolved_actor,
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def export_preregistration(self, experiment_id: str, actor: Optional[str] = None) -> Dict[str, Any]:
+        resolved_actor = actor or self._require_actor()
+        response = self.session.post(
+            self._url(f"/experiments/{experiment_id}/export"),
+            json={"actor": resolved_actor},
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def _require_actor(self) -> str:
+        if not self.default_actor:
+            raise ValueError("Actor must be provided when no default_actor is set.")
+        return self.default_actor

--- a/sdk/prer-python/pyproject.toml
+++ b/sdk/prer-python/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "prer-sdk"
+version = "0.1.0"
+description = "Python helper for the PRER service"
+requires-python = ">=3.10"
+dependencies = ["requests>=2.32.0"]
+
+[build-system]
+requires = ["setuptools>=65"]
+build-backend = "setuptools.build_meta"

--- a/sdk/prer-ts/README.md
+++ b/sdk/prer-ts/README.md
@@ -1,0 +1,24 @@
+# PRER TypeScript SDK
+
+A lightweight wrapper around the PRER service REST API.
+
+```ts
+import { PrerClient } from '@summit/prer-sdk';
+
+const client = new PrerClient({
+  baseUrl: 'http://localhost:3000',
+  defaultActor: 'analyst@company'
+});
+
+const experiment = await client.createExperiment({
+  name: 'Hero CTA',
+  hypothesis: 'New CTA boosts clicks',
+  metrics: [
+    { name: 'click_through', baselineRate: 0.12, minDetectableEffect: 0.015 }
+  ],
+  stopRule: { maxDurationDays: 14, maxUnits: 10000 },
+  analysisPlan: { method: 'difference-in-proportions', alpha: 0.05, desiredPower: 0.8 }
+});
+
+await client.startExperiment(experiment.id);
+```

--- a/sdk/prer-ts/package.json
+++ b/sdk/prer-ts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@summit/prer-sdk",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.12",
+    "typescript": "^5.4.5"
+  }
+}

--- a/sdk/prer-ts/src/index.ts
+++ b/sdk/prer-ts/src/index.ts
@@ -1,0 +1,107 @@
+import fetch from 'node-fetch';
+
+type Fetch = typeof fetch;
+
+export interface PrerClientOptions {
+  baseUrl: string;
+  fetchImpl?: Fetch;
+  defaultActor?: string;
+}
+
+export interface CreateExperimentInput {
+  name: string;
+  hypothesis: string;
+  metrics: Array<{
+    name: string;
+    baselineRate: number;
+    minDetectableEffect: number;
+  }>;
+  stopRule: {
+    maxDurationDays: number;
+    maxUnits?: number;
+  };
+  analysisPlan: {
+    method: 'difference-in-proportions';
+    alpha: number;
+    desiredPower: number;
+  };
+  actor?: string;
+}
+
+export interface ResultIngestInput {
+  metric: string;
+  variant: string;
+  value: number;
+  actor?: string;
+}
+
+export class PrerClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: Fetch;
+  private readonly defaultActor?: string;
+
+  constructor(options: PrerClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, '');
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.defaultActor = options.defaultActor;
+  }
+
+  async createExperiment(input: CreateExperimentInput) {
+    const actor = input.actor ?? this.requireActor();
+    const response = await this.fetchImpl(`${this.baseUrl}/experiments`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...input, actor })
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to create experiment: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  async startExperiment(id: string, actor?: string) {
+    const resolvedActor = actor ?? this.requireActor();
+    const response = await this.fetchImpl(`${this.baseUrl}/experiments/${id}/start`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ actor: resolvedActor })
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to start experiment: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  async ingestResult(id: string, input: ResultIngestInput) {
+    const actor = input.actor ?? this.requireActor();
+    const response = await this.fetchImpl(`${this.baseUrl}/experiments/${id}/results`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ...input, actor })
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to ingest result: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  async exportPreregistration(id: string, actor?: string) {
+    const resolvedActor = actor ?? this.requireActor();
+    const response = await this.fetchImpl(`${this.baseUrl}/experiments/${id}/export`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ actor: resolvedActor })
+    });
+    if (!response.ok) {
+      throw new Error(`Failed to export preregistration: ${response.status} ${response.statusText}`);
+    }
+    return response.json();
+  }
+
+  private requireActor(): string {
+    if (!this.defaultActor) {
+      throw new Error('Actor must be provided when no defaultActor is configured.');
+    }
+    return this.defaultActor;
+  }
+}

--- a/sdk/prer-ts/tsconfig.json
+++ b/sdk/prer-ts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "Node"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/services/prer/README.md
+++ b/services/prer/README.md
@@ -1,0 +1,48 @@
+# PRER Service
+
+The Pre-Registered Experiment Registry (PRER) service enables teams to lock A/B test
+analysis plans before shipping variants. It exposes a REST API for preregistration,
+experiment lifecycle management, tamper-evident exports, and guarded result
+ingestion.
+
+## Features
+
+- Register experiments with hypotheses, metric definitions, stop rules, and analysis plans.
+- Auto-generate classical power calculations for two-proportion tests.
+- Lock preregistered hypotheses once an experiment starts; attempts to change them are
+  rejected and added to the audit trail.
+- Export preregistration bundles with SHA-256 digests for offline verification.
+- Ingest experiment results while rejecting any metrics that were not preregistered.
+
+## Running the service
+
+```bash
+cd services/prer
+npm install
+npm run dev
+```
+
+The service listens on `PORT` (defaults to `3000`).
+
+## Key API routes
+
+| Method | Route                           | Description |
+| ------ | ------------------------------- | ----------- |
+| POST   | `/experiments`                  | Create a preregistered experiment. |
+| POST   | `/experiments/:id/start`        | Mark experiment as running and lock the plan. |
+| PUT    | `/experiments/:id/hypothesis`   | Attempt to update the hypothesis (rejected once locked). |
+| POST   | `/experiments/:id/export`       | Produce a cryptographically verifiable preregistration bundle. |
+| POST   | `/experiments/:id/results`      | Ingest metric results (rejects unregistered metrics). |
+| GET    | `/experiments/:id/audit`        | Retrieve the audit log. |
+
+## Offline export verification
+
+Each export returns the serialized preregistration document and its SHA-256 digest.
+Offline verification simply recomputes the digest:
+
+```bash
+echo "<payload>" | shasum -a 256
+```
+
+Matching hashes confirm integrity and the recorded export timestamp provides temporal
+anchoring for the preregistration record.

--- a/services/prer/package.json
+++ b/services/prer/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "prer-service",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "jstat": "^1.9.6",
+    "uuid": "^9.0.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.12",
+    "@types/uuid": "^9.0.7",
+    "@types/jest": "^29.5.12",
+    "ts-node-dev": "^2.0.0",
+    "typescript": "^5.4.5",
+    "vitest": "^1.6.0"
+  }
+}

--- a/services/prer/src/exporter.ts
+++ b/services/prer/src/exporter.ts
@@ -1,0 +1,33 @@
+import { createHash } from 'crypto';
+import type { Experiment } from './types.js';
+
+export function serializeExperimentForExport(experiment: Experiment): string {
+  return JSON.stringify(
+    {
+      id: experiment.id,
+      name: experiment.name,
+      hypothesis: experiment.hypothesis,
+      metrics: experiment.metrics,
+      stopRule: experiment.stopRule,
+      analysisPlan: experiment.analysisPlan,
+      powerAnalysis: experiment.powerAnalysis,
+      createdAt: experiment.createdAt,
+      lockedAt: experiment.lockedAt ?? null,
+      status: experiment.status,
+      auditLog: experiment.auditLog,
+      results: experiment.results
+    },
+    null,
+    2
+  );
+}
+
+export function createExportDigest(payload: string): string {
+  return createHash('sha256').update(payload).digest('hex');
+}
+
+export function buildExportBundle(experiment: Experiment) {
+  const payload = serializeExperimentForExport(experiment);
+  const digest = createExportDigest(payload);
+  return { payload, digest };
+}

--- a/services/prer/src/index.ts
+++ b/services/prer/src/index.ts
@@ -1,0 +1,154 @@
+import express from 'express';
+import { z } from 'zod';
+import { ExperimentStore } from './store.js';
+import { buildExportBundle } from './exporter.js';
+
+const app = express();
+app.use(express.json());
+
+const store = new ExperimentStore();
+
+const metricSchema = z.object({
+  name: z.string().min(1),
+  baselineRate: z.number().min(0).max(1),
+  minDetectableEffect: z.number()
+});
+
+const stopRuleSchema = z.object({
+  maxDurationDays: z.number().int().positive(),
+  maxUnits: z.number().int().positive().optional()
+});
+
+const analysisPlanSchema = z.object({
+  method: z.literal('difference-in-proportions'),
+  alpha: z.number().min(0).max(1),
+  desiredPower: z.number().min(0).max(1)
+});
+
+const actorSchema = z.object({
+  actor: z.string().min(1)
+});
+
+app.post('/experiments', (req, res) => {
+  const schema = z
+    .object({
+      name: z.string().min(1),
+      hypothesis: z.string().min(1),
+      metrics: z.array(metricSchema).min(1),
+      stopRule: stopRuleSchema,
+      analysisPlan: analysisPlanSchema,
+      actor: z.string().min(1)
+    })
+    .strict();
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json(parsed.error);
+  }
+
+  try {
+    const { actor, ...rest } = parsed.data;
+    const experiment = store.createExperiment(rest, actor);
+    return res.status(201).json(experiment);
+  } catch (err) {
+    return res.status(400).json({ message: (err as Error).message });
+  }
+});
+
+app.get('/experiments/:id', (req, res) => {
+  const experiment = store.getExperiment(req.params.id);
+  if (!experiment) {
+    return res.status(404).json({ message: 'Not found' });
+  }
+  return res.json(experiment);
+});
+
+app.post('/experiments/:id/start', (req, res) => {
+  const parsed = actorSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json(parsed.error);
+  }
+  try {
+    const experiment = store.startExperiment(req.params.id, parsed.data.actor);
+    return res.json(experiment);
+  } catch (err) {
+    return res.status(404).json({ message: (err as Error).message });
+  }
+});
+
+app.put('/experiments/:id/hypothesis', (req, res) => {
+  const schema = actorSchema.merge(z.object({ hypothesis: z.string().min(1) }));
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json(parsed.error);
+  }
+
+  try {
+    store.attemptHypothesisUpdate(req.params.id, parsed.data.hypothesis, parsed.data.actor);
+    return res.json(store.getExperiment(req.params.id));
+  } catch (err) {
+    return res.status(409).json({ message: (err as Error).message });
+  }
+});
+
+app.post('/experiments/:id/export', (req, res) => {
+  const parsed = actorSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json(parsed.error);
+  }
+  try {
+    const experiment = store.getExperiment(req.params.id);
+    if (!experiment) {
+      return res.status(404).json({ message: 'Not found' });
+    }
+    const bundle = buildExportBundle(experiment);
+    store.recordExport(req.params.id, bundle);
+    store.appendAudit(req.params.id, {
+      actor: parsed.data.actor,
+      action: 'EXPORT_PREREGISTRATION',
+      detail: 'Generated preregistration bundle.',
+      status: 'SUCCESS'
+    });
+    return res.json(bundle);
+  } catch (err) {
+    return res.status(400).json({ message: (err as Error).message });
+  }
+});
+
+app.get('/experiments/:id/audit', (req, res) => {
+  const experiment = store.getExperiment(req.params.id);
+  if (!experiment) {
+    return res.status(404).json({ message: 'Not found' });
+  }
+  return res.json(experiment.auditLog);
+});
+
+app.post('/experiments/:id/results', (req, res) => {
+  const schema = z
+    .object({
+      metric: z.string().min(1),
+      variant: z.string().min(1),
+      value: z.number(),
+      actor: z.string().min(1)
+    })
+    .strict();
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json(parsed.error);
+  }
+  try {
+    const experiment = store.addResult(
+      req.params.id,
+      parsed.data.metric,
+      { variant: parsed.data.variant, value: parsed.data.value },
+      parsed.data.actor
+    );
+    return res.json({ status: 'accepted', results: experiment.results[parsed.data.metric] });
+  } catch (err) {
+    return res.status(409).json({ message: (err as Error).message });
+  }
+});
+
+const port = process.env.PORT ?? 3000;
+app.listen(port, () => {
+  console.log(`PRER service listening on port ${port}`);
+});

--- a/services/prer/src/power.ts
+++ b/services/prer/src/power.ts
@@ -1,0 +1,60 @@
+import { jStat } from 'jstat';
+import type { AnalysisPlan, MetricDefinition, PowerCalculation } from './types.js';
+
+export function calculatePowerForMetric(
+  metric: MetricDefinition,
+  plan: AnalysisPlan
+): PowerCalculation {
+  if (plan.method !== 'difference-in-proportions') {
+    throw new Error(`Unsupported method: ${plan.method}`);
+  }
+
+  const { baselineRate, minDetectableEffect } = metric;
+  if (minDetectableEffect === 0) {
+    throw new Error('minDetectableEffect must be non-zero');
+  }
+
+  const alpha = plan.alpha;
+  const desiredPower = plan.desiredPower;
+
+  if (alpha <= 0 || alpha >= 1) {
+    throw new Error('alpha must be between 0 and 1');
+  }
+
+  if (desiredPower <= 0 || desiredPower >= 1) {
+    throw new Error('desiredPower must be between 0 and 1');
+  }
+
+  const p1 = baselineRate;
+  const p2 = baselineRate + minDetectableEffect;
+
+  if (p2 <= 0 || p2 >= 1) {
+    throw new Error('baselineRate + minDetectableEffect must be between 0 and 1');
+  }
+
+  const pooled = (p1 + p2) / 2;
+  const zAlpha = jStat.normal.inv(1 - alpha / 2, 0, 1);
+  const zBeta = jStat.normal.inv(desiredPower, 0, 1);
+  const numerator =
+    zAlpha * Math.sqrt(2 * pooled * (1 - pooled)) +
+    zBeta * Math.sqrt(p1 * (1 - p1) + p2 * (1 - p2));
+  const perVariant = Math.ceil((numerator * numerator) / (minDetectableEffect * minDetectableEffect));
+  const total = perVariant * 2;
+
+  return {
+    variantSampleSize: perVariant,
+    totalSampleSize: total,
+    baselineRate,
+    minDetectableEffect
+  };
+}
+
+export function buildPowerAnalysis(
+  metrics: MetricDefinition[],
+  plan: AnalysisPlan
+): Record<string, PowerCalculation> {
+  return metrics.reduce<Record<string, PowerCalculation>>((acc, metric) => {
+    acc[metric.name] = calculatePowerForMetric(metric, plan);
+    return acc;
+  }, {});
+}

--- a/services/prer/src/store.ts
+++ b/services/prer/src/store.ts
@@ -1,0 +1,164 @@
+import { randomUUID } from 'crypto';
+import { buildPowerAnalysis } from './power.js';
+import type {
+  AnalysisPlan,
+  AuditEntry,
+  Experiment,
+  MetricDefinition,
+  PowerCalculation,
+  StopRule
+} from './types.js';
+
+export class ExperimentStore {
+  private experiments = new Map<string, Experiment>();
+
+  createExperiment(
+    payload: {
+      name: string;
+      hypothesis: string;
+      metrics: MetricDefinition[];
+      stopRule: StopRule;
+      analysisPlan: AnalysisPlan;
+    },
+    actor: string
+  ): Experiment {
+    const id = randomUUID();
+    const powerAnalysis = buildPowerAnalysis(payload.metrics, payload.analysisPlan);
+    const experiment: Experiment = {
+      id,
+      name: payload.name,
+      hypothesis: payload.hypothesis,
+      metrics: payload.metrics,
+      stopRule: payload.stopRule,
+      analysisPlan: payload.analysisPlan,
+      status: 'registered',
+      createdAt: new Date().toISOString(),
+      powerAnalysis,
+      auditLog: [],
+      exports: [],
+      results: {}
+    };
+    this.experiments.set(id, experiment);
+    this.appendAudit(id, {
+      actor,
+      action: 'CREATE_EXPERIMENT',
+      detail: 'Experiment preregistered with locked plan.',
+      status: 'SUCCESS'
+    });
+    return experiment;
+  }
+
+  getExperiment(id: string): Experiment | undefined {
+    return this.experiments.get(id);
+  }
+
+  listExperiments(): Experiment[] {
+    return Array.from(this.experiments.values());
+  }
+
+  startExperiment(id: string, actor: string): Experiment {
+    const experiment = this.requireExperiment(id);
+    if (experiment.status === 'running') {
+      return experiment;
+    }
+
+    experiment.status = 'running';
+    experiment.lockedAt = new Date().toISOString();
+    this.appendAudit(id, {
+      actor,
+      action: 'START_EXPERIMENT',
+      detail: 'Experiment marked as running and analysis plan locked.',
+      status: 'SUCCESS'
+    });
+    return experiment;
+  }
+
+  attemptHypothesisUpdate(id: string, newHypothesis: string, actor: string): string {
+    const experiment = this.requireExperiment(id);
+    if (experiment.status === 'running' || experiment.lockedAt) {
+      this.appendAudit(id, {
+        actor,
+        action: 'UPDATE_HYPOTHESIS',
+        detail: 'Rejected: hypotheses cannot change once the test is running.',
+        status: 'REJECTED'
+      });
+      throw new Error('Hypothesis changes are locked once the experiment has started.');
+    }
+
+    experiment.hypothesis = newHypothesis;
+    this.appendAudit(id, {
+      actor,
+      action: 'UPDATE_HYPOTHESIS',
+      detail: 'Hypothesis updated prior to lock.',
+      status: 'SUCCESS'
+    });
+    return newHypothesis;
+  }
+
+  appendAudit(
+    id: string,
+    entry: Omit<AuditEntry, 'at'>
+  ): AuditEntry {
+    const experiment = this.requireExperiment(id);
+    const fullEntry: AuditEntry = {
+      ...entry,
+      at: new Date().toISOString()
+    };
+    experiment.auditLog.push(fullEntry);
+    return fullEntry;
+  }
+
+  recordExport(id: string, record: { digest: string; payload: string }): Experiment {
+    const experiment = this.requireExperiment(id);
+    const exportEntry = {
+      id: randomUUID(),
+      createdAt: new Date().toISOString(),
+      ...record
+    };
+    experiment.exports.push(exportEntry);
+    return experiment;
+  }
+
+  addResult(
+    id: string,
+    metric: string,
+    result: { variant: string; value: number },
+    actor: string
+  ): Experiment {
+    const experiment = this.requireExperiment(id);
+    const metricRegistered = experiment.metrics.some((m) => m.name === metric);
+    if (!metricRegistered) {
+      this.appendAudit(id, {
+        actor,
+        action: 'INGEST_RESULT',
+        detail: `Rejected metric ${metric}: not pre-registered.`,
+        status: 'REJECTED'
+      });
+      throw new Error(`Metric ${metric} is not registered for this experiment.`);
+    }
+
+    if (!experiment.results[metric]) {
+      experiment.results[metric] = [];
+    }
+    experiment.results[metric].push(result);
+    this.appendAudit(id, {
+      actor,
+      action: 'INGEST_RESULT',
+      detail: `Recorded result for metric ${metric}.`,
+      status: 'SUCCESS'
+    });
+    return experiment;
+  }
+
+  getPowerAnalysis(id: string): Record<string, PowerCalculation> {
+    return this.requireExperiment(id).powerAnalysis;
+  }
+
+  private requireExperiment(id: string): Experiment {
+    const experiment = this.experiments.get(id);
+    if (!experiment) {
+      throw new Error('Experiment not found');
+    }
+    return experiment;
+  }
+}

--- a/services/prer/src/types.ts
+++ b/services/prer/src/types.ts
@@ -1,0 +1,56 @@
+export interface MetricDefinition {
+  name: string;
+  baselineRate: number;
+  minDetectableEffect: number;
+}
+
+export interface StopRule {
+  maxDurationDays: number;
+  maxUnits?: number;
+}
+
+export interface AnalysisPlan {
+  method: 'difference-in-proportions';
+  alpha: number;
+  desiredPower: number;
+}
+
+export interface PowerCalculation {
+  variantSampleSize: number;
+  totalSampleSize: number;
+  baselineRate: number;
+  minDetectableEffect: number;
+}
+
+export type AuditStatus = 'SUCCESS' | 'REJECTED';
+
+export interface AuditEntry {
+  at: string;
+  actor: string;
+  action: string;
+  status: AuditStatus;
+  detail: string;
+}
+
+export interface ExportRecord {
+  id: string;
+  createdAt: string;
+  digest: string;
+  payload: string;
+}
+
+export interface Experiment {
+  id: string;
+  name: string;
+  hypothesis: string;
+  metrics: MetricDefinition[];
+  stopRule: StopRule;
+  analysisPlan: AnalysisPlan;
+  status: 'draft' | 'registered' | 'running' | 'completed';
+  createdAt: string;
+  lockedAt?: string;
+  powerAnalysis: Record<string, PowerCalculation>;
+  auditLog: AuditEntry[];
+  exports: ExportRecord[];
+  results: Record<string, Array<{ variant: string; value: number }>>;
+}

--- a/services/prer/tests/experiment-store.test.ts
+++ b/services/prer/tests/experiment-store.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { ExperimentStore } from '../src/store.js';
+import type { AnalysisPlan, MetricDefinition, StopRule } from '../src/types.js';
+import { buildExportBundle, createExportDigest } from '../src/exporter.js';
+
+const actor = 'qa@prer';
+const stopRule: StopRule = { maxDurationDays: 14, maxUnits: 10000 };
+const analysisPlan: AnalysisPlan = {
+  method: 'difference-in-proportions',
+  alpha: 0.05,
+  desiredPower: 0.8
+};
+
+const metrics: MetricDefinition[] = [
+  { name: 'activation_rate', baselineRate: 0.1, minDetectableEffect: 0.02 }
+];
+
+describe('ExperimentStore', () => {
+  it('rejects hypothesis changes after experiment start and logs audit entries', () => {
+    const store = new ExperimentStore();
+    const experiment = store.createExperiment(
+      {
+        name: 'Onboarding funnel',
+        hypothesis: 'Shorter form improves activation',
+        metrics,
+        stopRule,
+        analysisPlan
+      },
+      actor
+    );
+
+    store.startExperiment(experiment.id, actor);
+
+    expect(() =>
+      store.attemptHypothesisUpdate(
+        experiment.id,
+        'Different hypothesis',
+        'malicious@corp'
+      )
+    ).toThrowError('Hypothesis changes are locked once the experiment has started.');
+
+    const auditLog = store.getExperiment(experiment.id)!.auditLog;
+    const rejection = auditLog.find((entry) => entry.action === 'UPDATE_HYPOTHESIS');
+    expect(rejection).toBeDefined();
+    expect(rejection?.status).toBe('REJECTED');
+    expect(rejection?.actor).toBe('malicious@corp');
+  });
+
+  it('blocks ingestion for unregistered metrics', () => {
+    const store = new ExperimentStore();
+    const experiment = store.createExperiment(
+      {
+        name: 'Pricing page',
+        hypothesis: 'New layout improves conversion',
+        metrics,
+        stopRule,
+        analysisPlan
+      },
+      actor
+    );
+
+    expect(() =>
+      store.addResult(experiment.id, 'revenue', { variant: 'B', value: 42 }, actor)
+    ).toThrowError('Metric revenue is not registered for this experiment.');
+  });
+
+  it('produces exports that can be verified offline', () => {
+    const store = new ExperimentStore();
+    const experiment = store.createExperiment(
+      {
+        name: 'Copy test',
+        hypothesis: 'Button copy increases clicks',
+        metrics,
+        stopRule,
+        analysisPlan
+      },
+      actor
+    );
+
+    const bundle = buildExportBundle(experiment);
+    const offlineDigest = createExportDigest(bundle.payload);
+    expect(bundle.digest).toEqual(offlineDigest);
+  });
+});

--- a/services/prer/tests/power.test.ts
+++ b/services/prer/tests/power.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { calculatePowerForMetric } from '../src/power.js';
+
+describe('power calculations', () => {
+  it('matches analytical baseline for two-proportion test', () => {
+    const result = calculatePowerForMetric(
+      {
+        name: 'activation_rate',
+        baselineRate: 0.1,
+        minDetectableEffect: 0.02
+      },
+      {
+        method: 'difference-in-proportions',
+        alpha: 0.05,
+        desiredPower: 0.8
+      }
+    );
+
+    // Analytical calculators report ~3841 samples per variant for these parameters.
+    expect(result.variantSampleSize).toBe(3841);
+    expect(result.totalSampleSize).toBe(7682);
+  });
+});

--- a/services/prer/tsconfig.json
+++ b/services/prer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/services/prer/vitest.config.ts
+++ b/services/prer/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts']
+  }
+});


### PR DESCRIPTION
## Summary
- add a dedicated PRER service with preregistration endpoints, audit logging, exports, and guarded ingestion
- generate classical power analyses for registered metrics and lock hypotheses after experiments begin
- ship companion TypeScript and Python SDKs for integrating with the PRER HTTP API

## Testing
- npm test (from services/prer)


------
https://chatgpt.com/codex/tasks/task_e_68d73fcd5ad4833398a12c0738e7ee0a