### PR TITLE
feat: add reproducible notebook freezer tooling

### DIFF
--- a/.github/workflows/rnf.yml
+++ b/.github/workflows/rnf.yml
@@ -1,0 +1,19 @@
+name: RNF Replay Check
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  replay:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Validate RNF bundles
+        run: |
+          python -m pip install --upgrade pip
+          python -m tools.notebook_freezer ci-check --root .

--- a/tests/notebook_freezer/test_rnf.py
+++ b/tests/notebook_freezer/test_rnf.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.notebook_freezer.cli import cache_key, diff, freeze, replay
+
+
+class NotebookFreezerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.tmp_path = Path(self.tmp.name)
+        self.notebook = self.tmp_path / "demo.ipynb"
+        self._write_notebook(self.notebook)
+
+    def _write_notebook(self, path: Path) -> None:
+        notebook = {
+            "cells": [
+                {
+                    "cell_type": "markdown",
+                    "id": "intro",
+                    "source": ["# Demo"],
+                },
+                {
+                    "cell_type": "code",
+                    "execution_count": 1,
+                    "id": "code-cell",
+                    "source": ["x = 1\n", "print('hello world')\n", "x"],
+                    "outputs": [
+                        {
+                            "output_type": "stream",
+                            "name": "stdout",
+                            "text": "hello world\n",
+                        },
+                        {
+                            "output_type": "execute_result",
+                            "data": {"text/plain": "1"},
+                        },
+                    ],
+                },
+            ],
+            "metadata": {"language_info": {"name": "python", "version": "3"}},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+        path.write_text(json.dumps(notebook, indent=2), encoding="utf-8")
+
+    def test_freeze_produces_manifest_and_artifacts(self) -> None:
+        manifest_path = freeze(self.notebook, None, data=[])
+        bundle_dir = manifest_path.parent
+        self.assertTrue((bundle_dir / "manifest.json").exists())
+        self.assertTrue((bundle_dir / "environment" / "requirements.lock").exists())
+        self.assertTrue((bundle_dir / "artifacts" / "cell-0001.json").exists())
+        key = cache_key(bundle_dir)
+        self.assertIsInstance(key, str)
+        self.assertTrue(key)
+
+    def test_replay_matches_expected_outputs(self) -> None:
+        manifest_path = freeze(self.notebook, None, data=[])
+        bundle_dir = manifest_path.parent
+        replay_dir = replay(bundle_dir)
+        report = json.loads((replay_dir / "report.json").read_text(encoding="utf-8"))
+        self.assertTrue(report["success"])
+
+    def test_diff_highlights_changes(self) -> None:
+        manifest_path = freeze(self.notebook, None, data=[])
+        bundle_dir = manifest_path.parent
+        clone_dir = self.tmp_path / "clone.rnf"
+        shutil.copytree(bundle_dir, clone_dir)
+        artifact = clone_dir / "artifacts" / "cell-0001.json"
+        payload = json.loads(artifact.read_text(encoding="utf-8"))
+        payload["outputs"][0]["text"] = "changed\n"
+        artifact.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        diff_text = diff(bundle_dir, clone_dir)
+        self.assertIn("changed", diff_text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,5 @@
+"""Utility namespace for Summit tools."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/tools/notebook_freezer/README.md
+++ b/tools/notebook_freezer/README.md
@@ -1,0 +1,32 @@
+# Reproducible Notebook Freezer (RNF)
+
+RNF builds deterministic bundles from executed Jupyter notebooks. A bundle captures:
+
+- A copy of the notebook with its execution order.
+- A `pip freeze` environment lock with a checksum.
+- Fingerprints for optional datasets.
+- Normalised per-cell outputs.
+- A standalone `replay.py` script that re-executes the notebook and verifies that
+  the regenerated artifacts match the frozen outputs.
+
+## Commands
+
+Run the CLI with `python -m tools.notebook_freezer <command>`.
+
+- `freeze <notebook.ipynb>` — create a `<notebook>.rnf` bundle.
+  - `--output <path>` overrides the bundle directory.
+  - `--data <paths...>` fingerprints additional files or directories.
+  - `--archive` produces a `.zip` archive alongside the bundle directory.
+- `replay <bundle>` — execute the notebook and verify outputs.
+- `diff <bundle-a> <bundle-b>` — render a unified diff of output changes.
+- `cache-key <bundle>` — print the cache key derived from the notebook, data, and
+  environment hashes.
+- `ci-check` — replay every `*.rnf` bundle in the repository to block
+  nondeterministic outputs in CI.
+
+## Replay contract
+
+The generated `replay.py` imports the CLI and executes the `replay` command.
+Replay runs record a report under `<bundle>/replays/<timestamp>/report.json` and
+fail fast if any artifact hash differs. The same hashing routine is exposed by
+`cache-key`, making cache invalidation deterministic.

--- a/tools/notebook_freezer/__init__.py
+++ b/tools/notebook_freezer/__init__.py
@@ -1,0 +1,9 @@
+"""Reproducible Notebook Freezer (RNF) package."""
+
+from __future__ import annotations
+
+__all__ = [
+    "__version__",
+]
+
+__version__ = "0.1.0"

--- a/tools/notebook_freezer/__main__.py
+++ b/tools/notebook_freezer/__main__.py
@@ -1,0 +1,9 @@
+"""Module entry point for `python -m tools.notebook_freezer`."""
+
+from __future__ import annotations
+
+from .cli import main
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tools/notebook_freezer/bundle.py
+++ b/tools/notebook_freezer/bundle.py
@@ -1,0 +1,246 @@
+"""Bundle creation logic for the Reproducible Notebook Freezer."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from .utils import (
+    dumps_json,
+    ensure_clean_dir,
+    normalise_output,
+    notebook_cells,
+    normalize_text,
+    sha256_bytes,
+    sha256_file,
+    utcnow,
+    write_json,
+)
+
+
+@dataclass
+class DataFingerprint:
+    path: str
+    sha256: str
+    size: int
+
+
+@dataclass
+class CellArtifact:
+    index: int
+    id: Optional[str]
+    execution_count: Optional[int]
+    source_hash: str
+    artifact_path: Path
+    artifact_sha: str
+    output_types: List[str]
+
+
+class NotebookBundler:
+    """Create deterministic RNF bundles from notebooks."""
+
+    def __init__(
+        self,
+        notebook_path: Path,
+        bundle_root: Path,
+        data_paths: Iterable[Path] | None = None,
+    ) -> None:
+        self.notebook_path = notebook_path
+        self.bundle_root = bundle_root
+        self.data_paths = list(data_paths or [])
+
+    def run(self, archive: bool = False) -> Path:
+        ensure_clean_dir(self.bundle_root)
+        notebook = self._load_notebook()
+        self._copy_notebook()
+        _, environment_hash = self._capture_environment()
+        data_manifest, data_hash = self._fingerprint_data()
+        cell_artifacts = self._materialize_artifacts(notebook)
+        manifest = self._build_manifest(
+            notebook=notebook,
+            environment_hash=environment_hash,
+            data_manifest=data_manifest,
+            data_hash=data_hash,
+            artifacts=cell_artifacts,
+        )
+        manifest_path = self.bundle_root / "manifest.json"
+        write_json(manifest_path, manifest)
+        self._write_replay_script()
+        if archive:
+            self._create_archive()
+        return manifest_path
+
+    # ------------------------------------------------------------------
+    def _load_notebook(self) -> Dict[str, Any]:
+        with self.notebook_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def _copy_notebook(self) -> None:
+        dest = self.bundle_root / "source" / self.notebook_path.name
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(self.notebook_path, dest)
+
+    def _capture_environment(self) -> tuple[str, str]:
+        """Capture pip freeze output and write the requirements lock file."""
+        try:
+            result = subprocess.run(
+                [sys.executable, "-m", "pip", "freeze"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise RuntimeError("Unable to capture pip environment") from exc
+        requirements = result.stdout.strip()
+        env_dir = self.bundle_root / "environment"
+        env_dir.mkdir(parents=True, exist_ok=True)
+        lock_file = env_dir / "requirements.lock"
+        lock_file.write_text(requirements + "\n", encoding="utf-8")
+        return requirements, sha256_bytes(requirements.encode("utf-8"))
+
+    def _fingerprint_data(self) -> tuple[Dict[str, Any], Optional[str]]:
+        if not self.data_paths:
+            manifest = {"files": [], "sha256": None}
+            write_json(self.bundle_root / "data" / "manifest.json", manifest)
+            return manifest, None
+        entries: List[DataFingerprint] = []
+        for path in sorted(self.data_paths):
+            if not path.exists():
+                raise FileNotFoundError(f"Data path {path} does not exist")
+            if path.is_dir():
+                for file_path in sorted(path.rglob("*")):
+                    if file_path.is_file():
+                        entries.append(self._fingerprint_file(path, file_path))
+            elif path.is_file():
+                entries.append(self._fingerprint_file(path.parent, path))
+        serialised = [entry.__dict__ for entry in entries]
+        combined_hash = sha256_bytes(dumps_json(serialised).encode("utf-8"))
+        data_manifest = {"files": serialised, "sha256": combined_hash}
+        write_json(self.bundle_root / "data" / "manifest.json", data_manifest)
+        return data_manifest, combined_hash
+
+    def _fingerprint_file(self, base: Path, file_path: Path) -> DataFingerprint:
+        rel = file_path.relative_to(base)
+        digest = sha256_file(file_path)
+        size = file_path.stat().st_size
+        return DataFingerprint(path=str(rel).replace("\\", "/"), sha256=digest, size=size)
+
+    def _materialize_artifacts(self, notebook: Dict[str, Any]) -> List[CellArtifact]:
+        artifacts_dir = self.bundle_root / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        cell_artifacts: List[CellArtifact] = []
+        for index, cell in notebook_cells(notebook):
+            if cell.get("cell_type") != "code":
+                continue
+            outputs = [normalise_output(item) for item in cell.get("outputs", [])]
+            payload = {
+                "index": index,
+                "id": cell.get("id"),
+                "execution_count": cell.get("execution_count"),
+                "outputs": outputs,
+            }
+            content = dumps_json(payload).encode("utf-8")
+            sha = sha256_bytes(content)
+            filename = artifacts_dir / f"cell-{index:04d}.json"
+            filename.write_bytes(content + b"\n")
+            cell_artifacts.append(
+                CellArtifact(
+                    index=index,
+                    id=cell.get("id"),
+                    execution_count=cell.get("execution_count"),
+                    source_hash=sha256_bytes(normalize_text(cell.get("source", "")).encode("utf-8")),
+                    artifact_path=filename.relative_to(self.bundle_root),
+                    artifact_sha=sha,
+                    output_types=[item["type"] for item in outputs],
+                )
+            )
+        return cell_artifacts
+
+    def _build_manifest(
+        self,
+        notebook: Dict[str, Any],
+        environment_hash: str,
+        data_manifest: Dict[str, Any],
+        data_hash: Optional[str],
+        artifacts: List[CellArtifact],
+    ) -> Dict[str, Any]:
+        notebook_copy = self.bundle_root / "source" / self.notebook_path.name
+        notebook_hash = sha256_file(notebook_copy)
+        cell_entries = [
+            {
+                "index": artifact.index,
+                "id": artifact.id,
+                "execution_count": artifact.execution_count,
+                "source_sha256": artifact.source_hash,
+                "artifact": {
+                    "path": str(artifact.artifact_path).replace("\\", "/"),
+                    "sha256": artifact.artifact_sha,
+                    "output_types": artifact.output_types,
+                },
+            }
+            for artifact in artifacts
+        ]
+        cache_payload = {
+            "environment": environment_hash,
+            "notebook": notebook_hash,
+            "data": data_hash,
+            "cells": [artifact.source_hash for artifact in artifacts],
+        }
+        cache_key = sha256_bytes(dumps_json(cache_payload).encode("utf-8"))
+        manifest: Dict[str, Any] = {
+            "schema_version": 1,
+            "created_at": utcnow(),
+            "notebook": {
+                "path": f"source/{self.notebook_path.name}",
+                "sha256": notebook_hash,
+                "cell_count": len(list(notebook_cells(notebook))),
+            },
+            "environment": {
+                "path": "environment/requirements.lock",
+                "sha256": environment_hash,
+            },
+            "data": data_manifest,
+            "cells": cell_entries,
+            "cache_key": cache_key,
+        }
+        return manifest
+
+    def _write_replay_script(self) -> None:
+        script_path = self.bundle_root / "replay.py"
+        script_path.write_text(REPLAY_TEMPLATE, encoding="utf-8")
+
+    def _create_archive(self) -> None:
+        archive_path = shutil.make_archive(str(self.bundle_root), "zip", root_dir=self.bundle_root)
+        # Ensure reproducible timestamp metadata by touching the archive file.
+        Path(archive_path).touch()
+
+
+REPLAY_TEMPLATE = """#!/usr/bin/env python3
+\"\"\"RNF bundle replayer.\"\"\"
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools.notebook_freezer.cli import replay as replay_cmd  # type: ignore  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Replay an RNF bundle")
+    parser.add_argument("bundle", nargs="?", default=str(Path(__file__).resolve().parent))
+    args = parser.parse_args()
+    replay_cmd(Path(args.bundle))
+
+
+if __name__ == "__main__":
+    main()
+"""

--- a/tools/notebook_freezer/cli.py
+++ b/tools/notebook_freezer/cli.py
@@ -1,0 +1,108 @@
+"""Command line interface for the Reproducible Notebook Freezer."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+from .bundle import NotebookBundler
+from .diff_viewer import BundleDiff
+from .replay import NotebookReplayer
+from .utils import read_json
+
+
+def freeze(notebook: Path, output: Path | None, data: Iterable[Path], archive: bool = False) -> Path:
+    bundle_root = output or notebook.with_suffix(".rnf")
+    bundler = NotebookBundler(notebook, bundle_root, data_paths=data)
+    manifest = bundler.run(archive=archive)
+    print(str(manifest))
+    return manifest
+
+
+def replay(bundle: Path) -> Path:
+    bundle_path = bundle
+    if bundle_path.is_file() and bundle_path.name == "manifest.json":
+        bundle_path = bundle_path.parent
+    replayer = NotebookReplayer(bundle_path)
+    replay_dir = replayer.run()
+    print(str(replay_dir))
+    return replay_dir
+
+
+def diff(lhs: Path, rhs: Path) -> str:
+    lhs_dir = lhs.parent if lhs.is_file() and lhs.name == "manifest.json" else lhs
+    rhs_dir = rhs.parent if rhs.is_file() and rhs.name == "manifest.json" else rhs
+    viewer = BundleDiff(lhs_dir, rhs_dir)
+    text = viewer.render()
+    print(text)
+    return text
+
+
+def cache_key(bundle: Path) -> str:
+    manifest = read_json(bundle / "manifest.json")
+    key = manifest.get("cache_key", "")
+    print(key)
+    return key
+
+
+def ci_check(root: Path) -> None:
+    manifests: List[Path] = list(root.rglob("manifest.json"))
+    bundles = [manifest.parent for manifest in manifests if manifest.parent.name.endswith(".rnf")]
+    success = True
+    for bundle in bundles:
+        try:
+            NotebookReplayer(bundle).run()
+        except Exception as exc:  # noqa: BLE001
+            success = False
+            print(f"Replay failed for {bundle}: {exc}", file=sys.stderr)
+    if not success:
+        raise SystemExit("RNF replay check failed")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Reproducible Notebook Freezer")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    freeze_cmd = sub.add_parser("freeze", help="Freeze a notebook into an RNF bundle")
+    freeze_cmd.add_argument("notebook", type=Path)
+    freeze_cmd.add_argument("--output", type=Path)
+    freeze_cmd.add_argument("--data", type=Path, nargs="*", default=[])
+    freeze_cmd.add_argument("--archive", action="store_true")
+
+    replay_cmd = sub.add_parser("replay", help="Replay a bundle")
+    replay_cmd.add_argument("bundle", type=Path)
+
+    diff_cmd = sub.add_parser("diff", help="Show output differences between bundles")
+    diff_cmd.add_argument("lhs", type=Path)
+    diff_cmd.add_argument("rhs", type=Path)
+
+    cache_cmd = sub.add_parser("cache-key", help="Print cache key for bundle")
+    cache_cmd.add_argument("bundle", type=Path)
+
+    ci_cmd = sub.add_parser("ci-check", help="Replay all bundles to ensure determinism")
+    ci_cmd.add_argument("--root", type=Path, default=Path("."))
+
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "freeze":
+        freeze(args.notebook, args.output, args.data, archive=args.archive)
+    elif args.command == "replay":
+        replay(args.bundle)
+    elif args.command == "diff":
+        diff(args.lhs, args.rhs)
+    elif args.command == "cache-key":
+        cache_key(args.bundle)
+    elif args.command == "ci-check":
+        ci_check(args.root)
+    else:  # pragma: no cover
+        parser.error(f"Unknown command {args.command}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/notebook_freezer/diff_viewer.py
+++ b/tools/notebook_freezer/diff_viewer.py
@@ -1,0 +1,56 @@
+"""Diff utilities for RNF bundles."""
+
+from __future__ import annotations
+
+import difflib
+from pathlib import Path
+from typing import Dict, List
+
+from .utils import read_json
+
+
+class BundleDiff:
+    def __init__(self, lhs: Path, rhs: Path) -> None:
+        self.lhs = lhs
+        self.rhs = rhs
+
+    def render(self) -> str:
+        lhs_manifest = read_json(self.lhs / "manifest.json")
+        rhs_manifest = read_json(self.rhs / "manifest.json")
+        lhs_cells = {cell["index"]: cell for cell in lhs_manifest.get("cells", [])}
+        rhs_cells = {cell["index"]: cell for cell in rhs_manifest.get("cells", [])}
+        shared_indices = sorted(set(lhs_cells) | set(rhs_cells))
+        diffs: List[str] = []
+        for index in shared_indices:
+            lhs_cell = lhs_cells.get(index)
+            rhs_cell = rhs_cells.get(index)
+            if not lhs_cell or not rhs_cell:
+                diffs.append(f"Cell {index}: added" if rhs_cell else f"Cell {index}: removed")
+                continue
+            lhs_path = self.lhs / lhs_cell["artifact"]["path"]
+            rhs_path = self.rhs / rhs_cell["artifact"]["path"]
+            lhs_payload = read_json(lhs_path)
+            rhs_payload = read_json(rhs_path)
+            if lhs_payload == rhs_payload:
+                continue
+            lhs_text = self._pretty(lhs_payload)
+            rhs_text = self._pretty(rhs_payload)
+            diff = difflib.unified_diff(
+                lhs_text.splitlines(),
+                rhs_text.splitlines(),
+                fromfile=f"lhs cell {index}",
+                tofile=f"rhs cell {index}",
+                lineterm="",
+            )
+            diffs.extend(diff)
+        return "\n".join(diffs) if diffs else "No differences detected"
+
+    def _pretty(self, payload: Dict) -> str:  # type: ignore[override]
+        return read_json_to_text(payload)
+
+
+def read_json_to_text(payload: Dict) -> str:
+    """Return deterministic text from a JSON payload."""
+    import json
+
+    return json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True)

--- a/tools/notebook_freezer/replay.py
+++ b/tools/notebook_freezer/replay.py
@@ -1,0 +1,155 @@
+"""Replay logic for RNF bundles."""
+
+from __future__ import annotations
+
+import ast
+import io
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .utils import dumps_json, read_json, sha256_bytes, utcnow, write_json
+
+
+@dataclass
+class ReplayResult:
+    index: int
+    expected_sha: str
+    actual_sha: str
+    match: bool
+    difference: Optional[str]
+
+
+class NotebookReplayer:
+    def __init__(self, bundle_path: Path) -> None:
+        self.bundle_path = bundle_path
+        self.manifest = read_json(bundle_path / "manifest.json")
+
+    def run(self, output_dir: Optional[Path] = None) -> Path:
+        self._validate_environment()
+        replay_dir = output_dir or (self.bundle_path / "replays" / utcnow().replace(":", "-"))
+        artifacts_dir = replay_dir / "artifacts"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        source_path = self.bundle_path / self.manifest["notebook"]["path"]
+        notebook = json.loads(source_path.read_text(encoding="utf-8"))
+        results: List[ReplayResult] = []
+        for cell_meta in self.manifest.get("cells", []):
+            index = cell_meta["index"]
+            expected_path = self.bundle_path / cell_meta["artifact"]["path"]
+            expected_payload = read_json(expected_path)
+            actual_payload = self._execute_cell(notebook["cells"][index], index)
+            actual_path = artifacts_dir / expected_path.name
+            actual_path.write_text(dumps_json(actual_payload) + "\n", encoding="utf-8")
+            expected_sha = cell_meta["artifact"]["sha256"]
+            actual_sha = sha256_bytes(dumps_json(actual_payload).encode("utf-8"))
+            difference = None
+            if expected_sha != actual_sha:
+                difference = self._build_diff(expected_payload, actual_payload)
+            results.append(ReplayResult(index, expected_sha, actual_sha, expected_sha == actual_sha, difference))
+        report = {
+            "bundle": str(self.bundle_path),
+            "run_at": utcnow(),
+            "results": [result.__dict__ for result in results],
+            "success": all(result.match for result in results),
+        }
+        write_json(replay_dir / "report.json", report)
+        if not report["success"]:
+            raise RuntimeError("Replay detected nondeterministic outputs")
+        return replay_dir
+
+    # ------------------------------------------------------------------
+    def _validate_environment(self) -> None:
+        env = self.manifest.get("environment", {})
+        expected = env.get("sha256")
+        if not expected:
+            return
+        result = subprocess.run(
+            [sys.executable, "-m", "pip", "freeze"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        actual = sha256_bytes(result.stdout.strip().encode("utf-8"))
+        if actual != expected:
+            raise RuntimeError(
+                "Environment hash mismatch. Expected "
+                f"{expected}, observed {actual}. Install the pinned requirements"
+            )
+
+    def _execute_cell(self, cell: Dict[str, Any], index: int) -> Dict[str, Any]:
+        if cell.get("cell_type") != "code":
+            return {"index": index, "outputs": []}
+        code = "".join(cell.get("source", []))
+        module = ast.parse(code, mode="exec")
+        body = module.body
+        last_expr = None
+        if body and isinstance(body[-1], ast.Expr):
+            last_expr = ast.Expression(body[-1].value)
+            body = body[:-1]
+        exec_code = ast.Module(body=body, type_ignores=[])
+        globals_ns: Dict[str, Any] = {"__name__": "__main__"}
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        outputs: List[Dict[str, Any]] = []
+
+        def display(*objects: Any) -> None:
+            for obj in objects:
+                outputs.append(
+                    {
+                        "type": "display_data",
+                        "data": {"text/plain": repr(obj)},
+                    }
+                )
+
+        globals_ns["display"] = display
+        exec_bytes = compile(exec_code, filename="<cell>", mode="exec") if body else None
+        expr_bytes = compile(last_expr, filename="<cell>", mode="eval") if last_expr else None
+        with redirect(stdout=stdout, stderr=stderr):
+            if exec_bytes is not None:
+                exec(exec_bytes, globals_ns)
+            result = None
+            if expr_bytes is not None:
+                result = eval(expr_bytes, globals_ns)
+        stdout_text = stdout.getvalue()
+        stderr_text = stderr.getvalue()
+        if stdout_text:
+            outputs.append({"type": "stream", "name": "stdout", "text": stdout_text})
+        if stderr_text:
+            outputs.append({"type": "stream", "name": "stderr", "text": stderr_text})
+        if expr_bytes is not None and result is not None:
+            outputs.append({"type": "execute_result", "data": {"text/plain": repr(result)}})
+        payload = {
+            "index": index,
+            "id": cell.get("id"),
+            "execution_count": cell.get("execution_count"),
+            "outputs": outputs,
+        }
+        return payload
+
+    def _build_diff(self, expected: Dict[str, Any], actual: Dict[str, Any]) -> str:
+        return json.dumps({"expected": expected, "actual": actual}, indent=2, ensure_ascii=False)
+
+
+class redirect:
+    """Context manager capturing stdout/stderr without importing contextlib."""
+
+    def __init__(self, stdout: io.StringIO, stderr: io.StringIO) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self._prev_stdout = None
+        self._prev_stderr = None
+
+    def __enter__(self) -> "redirect":
+        self._prev_stdout = sys.stdout
+        self._prev_stderr = sys.stderr
+        sys.stdout = self.stdout
+        sys.stderr = self.stderr
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        sys.stdout = self._prev_stdout  # type: ignore[assignment]
+        sys.stderr = self._prev_stderr  # type: ignore[assignment]
+

--- a/tools/notebook_freezer/utils.py
+++ b/tools/notebook_freezer/utils.py
@@ -1,0 +1,140 @@
+"""Utility helpers for the Reproducible Notebook Freezer."""
+
+from __future__ import annotations
+
+import contextlib
+import datetime as _dt
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Tuple
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def utcnow() -> str:
+    """Return a UTC timestamp in ISO format with millisecond precision."""
+    now = _dt.datetime.now(tz=_dt.timezone.utc)
+    return now.replace(microsecond=(now.microsecond // 1000) * 1000).strftime(ISO_FORMAT)
+
+
+def sha256_bytes(data: bytes) -> str:
+    """Return the hex digest for the given bytes."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    """Return the sha256 digest for a file."""
+    h = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def dumps_json(data: Any) -> str:
+    """Serialise JSON using deterministic ordering and UTF-8 encoding."""
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def write_json(path: Path, data: Any) -> None:
+    """Write JSON to a file using deterministic formatting."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(dumps_json(data) + "\n", encoding="utf-8")
+
+
+def read_json(path: Path) -> Any:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def ensure_clean_dir(path: Path) -> None:
+    """Ensure a directory exists and is empty."""
+    if path.exists():
+        if any(path.iterdir()):
+            raise FileExistsError(f"Bundle target {path} is not empty")
+    else:
+        path.mkdir(parents=True, exist_ok=False)
+
+
+def normalize_text(value: Any) -> str:
+    if isinstance(value, list):
+        return "".join(value)
+    if value is None:
+        return ""
+    return str(value)
+
+
+def normalise_output(output: Dict[str, Any]) -> Dict[str, Any]:
+    """Simplify notebook output cells into a deterministic JSON shape."""
+    otype = output.get("output_type")
+    if otype == "stream":
+        return {
+            "type": "stream",
+            "name": output.get("name", "stdout"),
+            "text": normalize_text(output.get("text", "")),
+        }
+    if otype in {"execute_result", "display_data"}:
+        data = output.get("data", {})
+        cleaned: Dict[str, Any] = {}
+        for key in sorted(data):
+            value = data[key]
+            if isinstance(value, list):
+                cleaned[key] = "".join(str(item) for item in value)
+            else:
+                cleaned[key] = value
+        return {
+            "type": otype,
+            "data": cleaned,
+        }
+    if otype == "error":
+        return {
+            "type": "error",
+            "ename": output.get("ename"),
+            "evalue": output.get("evalue"),
+            "traceback": output.get("traceback", []),
+        }
+    # Fallback to a deterministic representation.
+    return {
+        "type": otype or "unknown",
+        "raw": output,
+    }
+
+
+def notebook_cells(notebook: Dict[str, Any]) -> Iterator[Tuple[int, Dict[str, Any]]]:
+    for index, cell in enumerate(notebook.get("cells", [])):
+        yield index, cell
+
+
+@contextlib.contextmanager
+def change_cwd(path: Path) -> Iterator[None]:
+    """Context manager that temporarily changes the working directory."""
+    prev = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev)
+
+
+def flatten_paths(paths: Iterable[Path]) -> List[Path]:
+    files: List[Path] = []
+    for path in paths:
+        if path.is_dir():
+            for sub in sorted(path.rglob("*")):
+                if sub.is_file():
+                    files.append(sub)
+        elif path.is_file():
+            files.append(path)
+    return files
+
+
+def relative_to(paths: Iterable[Path], root: Path) -> List[Path]:
+    result: List[Path] = []
+    for path in paths:
+        try:
+            result.append(path.relative_to(root))
+        except ValueError:
+            result.append(Path("..") / path.resolve())
+    return result


### PR DESCRIPTION
## Summary
- add a reusable RNF CLI that freezes notebooks into deterministic bundles with environment locks and per-cell artifacts
- provide replay, diff, and cache-key helpers plus documentation for the bundle format
- enforce determinism with unit tests and a CI workflow that replays every committed bundle

## Testing
- python -m unittest tests.notebook_freezer.test_rnf

------
https://chatgpt.com/codex/tasks/task_e_68d73e240b388333b6b0cc822fc0bb1a