### PR TITLE
feat: add stochastic actor awareness simulation

### DIFF
--- a/server/src/services/StochasticActorAwareness.ts
+++ b/server/src/services/StochasticActorAwareness.ts
@@ -1,0 +1,187 @@
+export interface ActorSignal {
+  actor: string;
+  sightings?: number;
+  confidence?: number;
+  recencyDays?: number;
+  severity?: number;
+  capability?: number;
+  influence?: number;
+  exposure?: number;
+}
+
+export interface ActorAwarenessOptions {
+  sampleCount?: number;
+  recencyHalfLifeDays?: number;
+  sightingSaturation?: number;
+  noiseFloor?: number;
+  uncertaintyAmplifier?: number;
+  explorationWeight?: number;
+  summaryLimit?: number;
+}
+
+export interface ActorAwarenessResult {
+  actor: string;
+  probability: number;
+  meanScore: number;
+  volatility: number;
+  baseWeight: number;
+  awarenessScore: number;
+  confidence: number;
+  dominanceCount: number;
+}
+
+/**
+ * Performs Monte Carlo style sampling over threat actor signals to surface
+ * which groups deserve analyst attention. The stochastic approach mixes
+ * deterministic scoring with noise so that frequently sighted but lower
+ * confidence actors still receive some exploration.
+ */
+export class StochasticActorAwareness {
+  private readonly random: () => number;
+
+  constructor(random: () => number = Math.random) {
+    this.random = random;
+  }
+
+  runSimulation(
+    signals: ActorSignal[],
+    options: ActorAwarenessOptions = {},
+  ): ActorAwarenessResult[] {
+    if (!signals || signals.length === 0) {
+      return [];
+    }
+
+    const sampleCount = Math.max(1, Math.min(options.sampleCount ?? 500, 10000));
+    const halfLife = options.recencyHalfLifeDays ?? 14;
+    const saturation = options.sightingSaturation ?? 5;
+    const noiseFloor = options.noiseFloor ?? 0.05;
+    const uncertaintyAmplifier = options.uncertaintyAmplifier ?? 0.35;
+    const explorationWeight = options.explorationWeight ?? 0.1;
+
+    const baseScores = signals.map((signal) =>
+      this.computeBaseScore(signal, halfLife, saturation),
+    );
+    const epsilon = 1e-6;
+    const totalBase = baseScores.reduce((sum, score) => sum + score, 0);
+    const normalizedBase = baseScores.map(
+      (score) => (score + epsilon) / (totalBase + epsilon * baseScores.length),
+    );
+
+    const wins = new Array(signals.length).fill(0);
+    const totals = new Array(signals.length).fill(0);
+    const squaredTotals = new Array(signals.length).fill(0);
+
+    for (let sample = 0; sample < sampleCount; sample += 1) {
+      let bestIndex = 0;
+      let bestScore = -Infinity;
+
+      for (let index = 0; index < signals.length; index += 1) {
+        const signal = signals[index];
+        const confidence = this.clamp(signal.confidence ?? 0.5);
+        const variability = noiseFloor + (1 - confidence) * uncertaintyAmplifier;
+        const noise = (this.nextRandom() * 2 - 1) * variability;
+        const exploration = explorationWeight
+          ? this.nextRandom() * explorationWeight
+          : 0;
+        const score = Math.max(0, normalizedBase[index] + noise + exploration);
+        totals[index] += score;
+        squaredTotals[index] += score * score;
+        if (score > bestScore) {
+          bestScore = score;
+          bestIndex = index;
+        }
+      }
+
+      wins[bestIndex] += 1;
+    }
+
+    const results = signals.map((signal, index) => {
+      const probability = wins[index] / sampleCount;
+      const meanScore = totals[index] / sampleCount;
+      const variance = Math.max(
+        0,
+        squaredTotals[index] / sampleCount - meanScore * meanScore,
+      );
+      const volatility = Math.sqrt(variance);
+      const baseWeight = normalizedBase[index];
+      const awarenessScore = this.clamp(0.6 * probability + 0.4 * meanScore);
+
+      return {
+        actor: signal.actor,
+        probability,
+        meanScore,
+        volatility,
+        baseWeight,
+        awarenessScore,
+        confidence: this.clamp(signal.confidence ?? 0.5),
+        dominanceCount: wins[index],
+      };
+    });
+
+    return results.sort((a, b) => b.awarenessScore - a.awarenessScore);
+  }
+
+  buildSummary(results: ActorAwarenessResult[], limit = 3): string {
+    if (!results || results.length === 0) {
+      return 'No actor signals provided for awareness simulation.';
+    }
+
+    const focus = results.slice(0, limit);
+    const breakdown = focus
+      .map(
+        (entry) =>
+          `${entry.actor}: ${(entry.awarenessScore * 100).toFixed(1)} awareness score, ${(entry.probability * 100).toFixed(1)}% dominant`,
+      )
+      .join('; ');
+
+    return `Stochastic actor awareness highlights ${focus[0].actor} as the leading threat focus. ${breakdown}.`;
+  }
+
+  private nextRandom(): number {
+    const value = this.random();
+    if (value === 1) {
+      return 0.999999;
+    }
+    if (value === 0) {
+      return 1e-6;
+    }
+    return value;
+  }
+
+  private computeBaseScore(
+    signal: ActorSignal,
+    halfLife: number,
+    saturation: number,
+  ): number {
+    const sightingsScore = this.saturatingScore(signal.sightings ?? 0, saturation);
+    const recencyScore = 1 / (1 + Math.max(0, signal.recencyDays ?? 0) / halfLife);
+    const severityScore = this.clamp(signal.severity ?? 0.6);
+    const capabilityScore = this.clamp(signal.capability ?? severityScore);
+    const influenceScore = this.clamp(signal.influence ?? 0.5);
+    const exposureScore = this.clamp(signal.exposure ?? 0.5);
+    const confidenceScore = this.clamp(signal.confidence ?? 0.5);
+
+    return (
+      sightingsScore * 0.25 +
+      recencyScore * 0.2 +
+      severityScore * 0.2 +
+      capabilityScore * 0.15 +
+      influenceScore * 0.1 +
+      exposureScore * 0.05 +
+      confidenceScore * 0.05
+    );
+  }
+
+  private saturatingScore(value: number, saturation: number): number {
+    const safeValue = Math.max(0, value);
+    const safeSaturation = Math.max(1e-3, saturation);
+    return 1 - Math.exp(-safeValue / safeSaturation);
+  }
+
+  private clamp(value: number, min = 0, max = 1): number {
+    if (!Number.isFinite(value)) {
+      return min;
+    }
+    return Math.min(max, Math.max(min, value));
+  }
+}

--- a/server/src/services/mlAnalysisService.ts
+++ b/server/src/services/mlAnalysisService.ts
@@ -1,5 +1,11 @@
 import { persistenceService, GraphEntity, GraphRelationship } from './persistenceService';
 import { cacheService } from './cacheService';
+import {
+  ActorAwarenessOptions,
+  ActorAwarenessResult,
+  ActorSignal,
+  StochasticActorAwareness,
+} from './StochasticActorAwareness';
 
 interface MLPrediction {
   confidence: number;
@@ -39,8 +45,10 @@ interface GraphMetrics {
 export class MLAnalysisService {
   private modelVersion = '1.2.3';
   private lastTraining = new Date().toISOString();
+  private readonly actorAwareness: StochasticActorAwareness;
 
-  constructor() {
+  constructor(deps: { actorAwareness?: StochasticActorAwareness } = {}) {
+    this.actorAwareness = deps.actorAwareness ?? new StochasticActorAwareness();
     console.log('[ML] AI/ML Analysis Service initialized');
     console.log(`[ML] Model version: ${this.modelVersion}`);
   }
@@ -417,6 +425,38 @@ export class MLAnalysisService {
         'Behavioral Analyzer v2.5',
       ],
       cache_stats: cacheService.getStats(),
+    };
+  }
+
+  generateStochasticActorAwareness(
+    signals: ActorSignal[],
+    options: ActorAwarenessOptions = {},
+  ): {
+    actors: ActorAwarenessResult[];
+    summary: string;
+    sampleCount: number;
+    dominantActor: ActorAwarenessResult | null;
+  } {
+    if (!Array.isArray(signals) || signals.length === 0) {
+      return {
+        actors: [],
+        summary: 'No actor signals provided for awareness simulation.',
+        sampleCount: 0,
+        dominantActor: null,
+      };
+    }
+
+    const simulation = this.actorAwareness.runSimulation(signals, options);
+    const summary = this.actorAwareness.buildSummary(
+      simulation,
+      options.summaryLimit ?? 3,
+    );
+
+    return {
+      actors: simulation,
+      summary,
+      sampleCount: options.sampleCount ?? 500,
+      dominantActor: simulation.length > 0 ? simulation[0] : null,
     };
   }
 }

--- a/server/tests/services/StochasticActorAwareness.test.ts
+++ b/server/tests/services/StochasticActorAwareness.test.ts
@@ -1,0 +1,71 @@
+import {
+  ActorAwarenessResult,
+  ActorSignal,
+  StochasticActorAwareness,
+} from '../../src/services/StochasticActorAwareness';
+
+describe('StochasticActorAwareness', () => {
+  it('returns stable probabilities when noise is disabled', () => {
+    const deterministic = new StochasticActorAwareness(() => 0.5);
+    const signals: ActorSignal[] = [
+      { actor: 'APT29', sightings: 12, recencyDays: 2, confidence: 0.95, severity: 0.8 },
+      { actor: 'FIN7', sightings: 5, recencyDays: 6, confidence: 0.7, severity: 0.6 },
+      {
+        actor: 'Scattered Spider',
+        sightings: 1,
+        recencyDays: 20,
+        confidence: 0.5,
+        severity: 0.55,
+      },
+    ];
+
+    const results = deterministic.runSimulation(signals, {
+      sampleCount: 10,
+      noiseFloor: 0,
+      explorationWeight: 0,
+    });
+
+    expect(results.map((r) => r.actor)).toEqual([
+      'APT29',
+      'FIN7',
+      'Scattered Spider',
+    ]);
+    const totalProbability = results.reduce((sum, entry) => sum + entry.probability, 0);
+    expect(totalProbability).toBeCloseTo(1, 5);
+    expect(results[0].probability).toBe(1);
+    expect(results[0].baseWeight).toBeGreaterThan(results[1].baseWeight);
+    expect(results[0].dominanceCount).toBe(10);
+  });
+
+  it('summarizes top actors with awareness and probability signals', () => {
+    const awareness = new StochasticActorAwareness(() => 0.5);
+    const summary = awareness.buildSummary(
+      [
+        {
+          actor: 'APT29',
+          probability: 0.68,
+          meanScore: 0.57,
+          volatility: 0.08,
+          baseWeight: 0.51,
+          awarenessScore: 0.62,
+          confidence: 0.9,
+          dominanceCount: 68,
+        },
+        {
+          actor: 'FIN7',
+          probability: 0.22,
+          meanScore: 0.41,
+          volatility: 0.06,
+          baseWeight: 0.32,
+          awarenessScore: 0.37,
+          confidence: 0.7,
+          dominanceCount: 22,
+        },
+      ] satisfies ActorAwarenessResult[],
+    );
+
+    expect(summary).toContain('APT29');
+    expect(summary).toContain('FIN7');
+    expect(summary).toContain('awareness score');
+  });
+});

--- a/server/tests/services/mlAnalysisService.actorAwareness.test.ts
+++ b/server/tests/services/mlAnalysisService.actorAwareness.test.ts
@@ -1,0 +1,95 @@
+import {
+  ActorAwarenessOptions,
+  ActorAwarenessResult,
+  ActorSignal,
+  StochasticActorAwareness,
+} from '../../src/services/StochasticActorAwareness';
+import { MLAnalysisService } from '../../src/services/mlAnalysisService';
+
+class StubAwareness extends StochasticActorAwareness {
+  public receivedSignals: ActorSignal[] = [];
+  public receivedOptions: ActorAwarenessOptions | undefined;
+
+  constructor(
+    private readonly stubResults: ActorAwarenessResult[],
+    private readonly stubSummary: string,
+  ) {
+    super(() => 0.5);
+  }
+
+  override runSimulation(
+    signals: ActorSignal[],
+    options: ActorAwarenessOptions = {},
+  ): ActorAwarenessResult[] {
+    this.receivedSignals = signals;
+    this.receivedOptions = options;
+    return this.stubResults;
+  }
+
+  override buildSummary(
+    _results: ActorAwarenessResult[],
+    _limit = 3,
+  ): string {
+    return this.stubSummary;
+  }
+}
+
+describe('MLAnalysisService.generateStochasticActorAwareness', () => {
+  it('delegates to the stochastic awareness engine and returns a summary', () => {
+    const stubResults: ActorAwarenessResult[] = [
+      {
+        actor: 'APT29',
+        probability: 0.7,
+        meanScore: 0.6,
+        volatility: 0.1,
+        baseWeight: 0.55,
+        awarenessScore: 0.64,
+        confidence: 0.9,
+        dominanceCount: 70,
+      },
+      {
+        actor: 'FIN7',
+        probability: 0.2,
+        meanScore: 0.4,
+        volatility: 0.08,
+        baseWeight: 0.3,
+        awarenessScore: 0.32,
+        confidence: 0.7,
+        dominanceCount: 20,
+      },
+    ];
+    const stubAwareness = new StubAwareness(stubResults, 'Top actor APT29');
+    const service = new MLAnalysisService({ actorAwareness: stubAwareness });
+    const signals: ActorSignal[] = [
+      { actor: 'APT29', sightings: 12, recencyDays: 2, confidence: 0.95 },
+      { actor: 'FIN7', sightings: 4, recencyDays: 7, confidence: 0.7 },
+    ];
+
+    const response = service.generateStochasticActorAwareness(signals, {
+      sampleCount: 200,
+      summaryLimit: 2,
+    });
+
+    expect(stubAwareness.receivedSignals).toEqual(signals);
+    expect(stubAwareness.receivedOptions).toEqual({
+      sampleCount: 200,
+      summaryLimit: 2,
+    });
+    expect(response.actors).toEqual(stubResults);
+    expect(response.summary).toBe('Top actor APT29');
+    expect(response.sampleCount).toBe(200);
+    expect(response.dominantActor).toEqual(stubResults[0]);
+  });
+
+  it('returns an empty summary when no signals are supplied', () => {
+    const stubAwareness = new StubAwareness([], 'unused');
+    const service = new MLAnalysisService({ actorAwareness: stubAwareness });
+
+    const response = service.generateStochasticActorAwareness([]);
+
+    expect(response.actors).toEqual([]);
+    expect(response.summary).toBe('No actor signals provided for awareness simulation.');
+    expect(response.sampleCount).toBe(0);
+    expect(response.dominantActor).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a stochastic actor awareness service that Monte Carlo samples threat actor signals
- expose the simulation through mlAnalysisService for downstream consumers
- cover the new engine and integration behavior with focused unit tests

## Testing
- npm test -- StochasticActorAwareness *(fails: local jest binary missing because workspace dependencies cannot be installed)*
- pnpm install --filter ./server *(fails: workspace install aborts on invalid package name in apps/intelgraph-api)*

------
https://chatgpt.com/codex/tasks/task_e_68d73e4161a88333b4300618b1dc0fcc