### PR TITLE
feat: add verifiable consent receipt toolkit

### DIFF
--- a/packages/vcr-kit/README.md
+++ b/packages/vcr-kit/README.md
@@ -1,0 +1,137 @@
+# @summitsec/vcr-kit
+
+`@summitsec/vcr-kit` is a TypeScript toolkit and CLI for issuing, verifying, and revoking W3C Verifiable Credential (VC) consent receipts. It focuses on portable credentials for recording processing purpose, scope, retention, and tenant metadata and validates receipts completely offline.
+
+## Features
+
+- **Issuing** — create [ConsentReceiptCredential](https://w3id.org/consent) VC payloads with issuer/subject DIDs, purpose, scope, retention and lawful basis metadata.
+- **Offline verification** — deterministic JSON canonicalisation plus Ed25519 signature validation with support for `did:key` (auto-derived) and configurable `did:web` DID documents.
+- **Revocation** — append-only JSON revocation lists that are consulted during verification and via the CLI.
+- **CLI** — `vcr-kit` command for issuing, verifying, and revoking credentials without a network connection.
+- **Middleware** — `consentPresent()` Express middleware for JavaScript/TypeScript services and a matching ASGI middleware in `sdk/python/vcr_kit` for FastAPI/Starlette applications.
+- **Fixtures** — sample policies, DID documents, and revocation lists for rapid prototyping.
+
+## Installation
+
+```bash
+pnpm add @summitsec/vcr-kit
+# or
+npm install @summitsec/vcr-kit
+```
+
+The CLI is exposed as `vcr-kit` once the package is installed.
+
+## CLI usage
+
+Issue a consent receipt for a data processing purpose:
+
+```bash
+vcr-kit issue \
+  --issuer-did did:key:zExampleIssuer \
+  --issuer-key base58:3Fft... \
+  --subject did:key:zExampleSubject \
+  --tenant summit-retail \
+  --purpose marketing-updates:"Send product news" \
+  --scope email:send,personalize \
+  --retention-policy https://policies.summit.example/privacy#retention \
+  --retention-expires 2026-01-01T00:00:00Z \
+  --lawful-basis consent \
+  --output ./receipts/alice.json
+```
+
+Verify the receipt offline, providing a local DID document for `did:web` issuers and the revocation list JSON produced by `vcr-kit revoke`:
+
+```bash
+vcr-kit verify receipts/alice.json \
+  --revocations data/revocations.json \
+  --did-doc did:web:consent.summit.example=fixtures/did-web-summit.json
+```
+
+Revoke a credential immediately:
+
+```bash
+vcr-kit revoke urn:uuid:revoked-example --revocations data/revocations.json
+```
+
+## Library usage (TypeScript)
+
+```ts
+import {
+  InMemoryDidResolver,
+  issueConsentReceipt,
+  consentPresent,
+  FileRevocationRegistry,
+  verifyConsentReceipt,
+} from '@summitsec/vcr-kit';
+
+const resolver = new InMemoryDidResolver();
+const revocations = new FileRevocationRegistry('data/revocations.json');
+
+const credential = await issueConsentReceipt({
+  issuerDid: 'did:key:zExampleIssuer',
+  issuerPrivateKey: issuerKeyBytes,
+  subject: { id: 'did:key:zExampleSubject' },
+  claims: {
+    purpose: [{ purposeId: 'marketing-updates' }],
+    scope: [{ resource: 'email', actions: ['send'] }],
+    retention: {
+      policyUri: 'https://policies.summit.example/privacy#retention',
+      expiresAt: '2026-01-01T00:00:00Z',
+    },
+    tenant: 'summit-retail',
+  },
+});
+
+const result = await verifyConsentReceipt(credential, {
+  resolver,
+  revocationRegistry: revocations,
+});
+```
+
+Register the Express middleware to block missing or revoked receipts:
+
+```ts
+import express from 'express';
+import bodyParser from 'body-parser';
+import { consentPresent, InMemoryDidResolver } from '@summitsec/vcr-kit';
+
+const app = express();
+app.use(bodyParser.json());
+
+const resolver = new InMemoryDidResolver([didWebDoc]);
+
+app.use(
+  consentPresent({
+    resolver,
+    revocationRegistry: revocations,
+  }),
+);
+```
+
+## Python helper usage
+
+Install the optional Python module located at `sdk/python/vcr_kit` into your application environment and ensure [`PyNaCl`](https://pypi.org/project/PyNaCl/) is available:
+
+```python
+from vcr_kit import ConsentVerifier, InMemoryDidResolver, JsonRevocationRegistry, consent_present
+
+resolver = InMemoryDidResolver()
+revocations = JsonRevocationRegistry('data/revocations.json')
+verifier = ConsentVerifier(resolver, revocations=revocations)
+
+app.add_middleware(
+    consent_present(verifier),
+)
+```
+
+The middleware rejects HTTP requests that lack a valid, unexpired receipt or whose credential ID is present in the revocation list.
+
+## Fixtures
+
+- [`samples/marketing-policy.json`](samples/marketing-policy.json) – consent policy metadata for marketing communications.
+- [`fixtures/did-web-summit.json`](fixtures/did-web-summit.json) – offline DID document for a `did:web` issuer.
+- [`fixtures/revocations.json`](fixtures/revocations.json) – example revocation list structure.
+
+## Testing
+
+Install dependencies with `pnpm install --filter @summitsec/vcr-kit` and then run `pnpm build --filter @summitsec/vcr-kit` to transpile the TypeScript sources. The `test` script is wired for Node 20+ `node --test` suites emitted into `dist/`.

--- a/packages/vcr-kit/fixtures/did-web-summit.json
+++ b/packages/vcr-kit/fixtures/did-web-summit.json
@@ -1,0 +1,14 @@
+{
+  "id": "did:web:consent.summit.example",
+  "assertionMethod": [
+    "did:web:consent.summit.example#keys-1"
+  ],
+  "verificationMethod": [
+    {
+      "id": "did:web:consent.summit.example#keys-1",
+      "type": "Ed25519VerificationKey2020",
+      "controller": "did:web:consent.summit.example",
+      "publicKeyMultibase": "z6MkqM5hD5iJAfYj6nKQ6RZEqV7bR7HjXkqjzGqtEtFPoqrL"
+    }
+  ]
+}

--- a/packages/vcr-kit/fixtures/revocations.json
+++ b/packages/vcr-kit/fixtures/revocations.json
@@ -1,0 +1,5 @@
+{
+  "revoked": [
+    "urn:uuid:revoked-example"
+  ]
+}

--- a/packages/vcr-kit/package.json
+++ b/packages/vcr-kit/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@summitsec/vcr-kit",
+  "version": "0.1.0",
+  "description": "Verifiable Consent Receipt toolkit with issuer, verifier, CLI, and middleware",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "vcr-kit": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist",
+    "lint": "eslint src --ext .ts",
+    "test": "node --test dist/**/*.spec.js"
+  },
+  "keywords": [
+    "verifiable credentials",
+    "consent",
+    "privacy",
+    "did"
+  ],
+  "author": "Summit Engineering",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@noble/ed25519": "^3.0.0",
+    "bs58": "^6.0.0",
+    "canonicalize": "^2.0.0",
+    "commander": "^12.1.0",
+    "luxon": "^3.5.0"
+  },
+  "devDependencies": {
+    "@types/bs58": "^4.0.4",
+    "@types/node": "^20.12.7",
+    "typescript": "^5.9.2"
+  }
+}

--- a/packages/vcr-kit/samples/marketing-policy.json
+++ b/packages/vcr-kit/samples/marketing-policy.json
@@ -1,0 +1,22 @@
+{
+  "id": "policy:marketing-updates",
+  "tenant": "summit-retail",
+  "purpose": [
+    {
+      "purposeId": "marketing-updates",
+      "description": "Send product news and quarterly product digests"
+    }
+  ],
+  "scope": [
+    {
+      "resource": "email",
+      "actions": ["send", "personalize"]
+    }
+  ],
+  "retention": {
+    "policyUri": "https://policies.summit.example/privacy#retention",
+    "expiresAt": "2026-01-01T00:00:00Z"
+  },
+  "lawfulBasis": "consent",
+  "policyUri": "https://policies.summit.example/privacy"
+}

--- a/packages/vcr-kit/src/cli.ts
+++ b/packages/vcr-kit/src/cli.ts
@@ -1,0 +1,220 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve as resolvePath } from 'node:path';
+import { Command } from 'commander';
+import bs58 from 'bs58';
+import { getPublicKey } from '@noble/ed25519';
+import { issueConsentReceipt } from './issuer.js';
+import { verifyConsentReceipt } from './verifier.js';
+import { InMemoryDidResolver } from './dids.js';
+import { FileRevocationRegistry, InMemoryRevocationRegistry } from './revocation.js';
+import {
+  ConsentReceiptClaims,
+  ConsentPurpose,
+  ConsentScope,
+  ConsentSubject,
+  DidDocument,
+  VerifiableConsentReceipt,
+} from './types.js';
+
+const program = new Command();
+program
+  .name('vcr-kit')
+  .description('Verifiable consent receipt issuing and verification toolkit')
+  .version('0.1.0');
+
+program
+  .command('issue')
+  .description('Issue a verifiable consent receipt credential')
+  .requiredOption('--issuer-did <did>', 'Issuer DID (did:key or did:web)')
+  .requiredOption('--issuer-key <secret>', 'Issuer private key (hex or base58)')
+  .requiredOption('--subject <did>', 'Subject DID')
+  .requiredOption('--tenant <tenant>', 'Tenant identifier')
+  .requiredOption('--retention-policy <uri>', 'Retention policy URI')
+  .requiredOption('--retention-expires <iso>', 'Retention expiry ISO-8601 timestamp')
+  .option(
+    '--purpose <id[:description]>',
+    'Purpose identifier optionally with description',
+    collectValues,
+    [],
+  )
+  .option(
+    '--scope <resource:action1,action2>',
+    'Scope resource and actions',
+    collectValues,
+    [],
+  )
+  .option('--lawful-basis <basis>', 'Lawful basis for processing')
+  .option('--policy-uri <uri>', 'Additional policy URI')
+  .option('--expires <iso>', 'Credential expiry ISO timestamp')
+  .option('--output <file>', 'Write credential to file (defaults to stdout)')
+  .option('--revocation-list <uri>', 'Revocation list credential URI')
+  .action(async (opts) => {
+    const rawKey = parsePrivateKey(opts.issuerKey);
+    const privateKey = normalizeEd25519Secret(rawKey);
+    validateKeyMatchesDid(opts.issuerDid, privateKey);
+
+    const purposes: ConsentPurpose[] = (opts.purpose ?? []).map(parsePurpose);
+    const scopes: ConsentScope[] = (opts.scope ?? []).map(parseScope);
+    if (scopes.length === 0) {
+      throw new Error('At least one scope is required');
+    }
+    const claims: ConsentReceiptClaims = {
+      purpose: purposes,
+      scope: scopes,
+      retention: {
+        policyUri: opts.retentionPolicy,
+        expiresAt: opts.retentionExpires,
+      },
+      tenant: opts.tenant,
+      lawfulBasis: opts.lawfulBasis,
+      policyUri: opts.policyUri,
+    };
+
+    const subject: ConsentSubject = { id: opts.subject };
+    const credential = await issueConsentReceipt({
+      issuerDid: opts.issuerDid,
+      issuerPrivateKey: privateKey,
+      subject,
+      claims,
+      expirationDate: opts.expires,
+      revocationListCredential: opts.revocationList,
+    });
+
+    const serialized = JSON.stringify(credential, null, 2);
+    if (opts.output) {
+      mkdirSync(dirname(opts.output), { recursive: true });
+      writeFileSync(opts.output, serialized, 'utf8');
+    } else {
+      process.stdout.write(`${serialized}\n`);
+    }
+  });
+
+program
+  .command('verify')
+  .description('Verify a consent receipt credential offline')
+  .argument('<credential>', 'Path to credential JSON file or - for stdin')
+  .option('--revocations <file>', 'Path to revocation registry JSON file')
+  .option(
+    '--did-doc <did=path>',
+    'Preload DID document for did:web issuers',
+    collectValues,
+    [],
+  )
+  .option('--at <iso>', 'Verification time ISO timestamp')
+  .action(async (credentialPath, opts) => {
+    const credential = loadCredential(credentialPath);
+    const resolver = new InMemoryDidResolver(loadDidDocs(opts.didDoc ?? []));
+    const registry = opts.revocations
+      ? new FileRevocationRegistry(resolvePath(opts.revocations))
+      : new InMemoryRevocationRegistry();
+    const result = await verifyConsentReceipt(credential, {
+      resolver,
+      revocationRegistry: registry,
+      atTime: opts.at,
+    });
+    if (!result.verified) {
+      process.stderr.write(`❌ ${result.reason ?? 'Verification failed'}\n`);
+      process.exitCode = 1;
+      return;
+    }
+    process.stdout.write('✅ Receipt verified\n');
+  });
+
+program
+  .command('revoke')
+  .description('Add a credential ID to a revocation list file')
+  .argument('<credentialId>', 'Credential identifier to revoke')
+  .requiredOption('--revocations <file>', 'Path to revocation registry JSON file')
+  .action(async (credentialId, opts) => {
+    const registry = new FileRevocationRegistry(resolvePath(opts.revocations));
+    await registry.revoke(credentialId);
+    process.stdout.write(`Revoked ${credentialId}\n`);
+  });
+
+program.parseAsync(process.argv).catch((error) => {
+  process.stderr.write(`Error: ${error.message}\n`);
+  process.exit(1);
+});
+
+function collectValues(value: string, previous: string[] = []): string[] {
+  return [...previous, value];
+}
+
+function parsePurpose(value: string): ConsentPurpose {
+  const [purposeIdRaw, description] = value.split(':', 2);
+  const purposeId = purposeIdRaw.trim();
+  if (!purposeId) {
+    throw new Error('Purpose identifier cannot be empty');
+  }
+  return { purposeId, description: description?.trim() || undefined };
+}
+
+function parseScope(value: string): ConsentScope {
+  const [resourceRaw, actionPart] = value.split(':', 2);
+  const resource = resourceRaw?.trim();
+  const actions = actionPart
+    ? actionPart
+        .split(',')
+        .map((a) => a.trim())
+        .filter(Boolean)
+    : [];
+  if (!resource || actions.length === 0) {
+    throw new Error('Scope must be formatted as resource:action1,action2');
+  }
+  return { resource, actions };
+}
+
+function parsePrivateKey(value: string): Uint8Array {
+  const normalized = value.trim();
+  if (normalized.startsWith('base58:')) {
+    return bs58.decode(normalized.slice('base58:'.length));
+  }
+  if (/^[0-9a-fA-F]+$/.test(normalized)) {
+    return new Uint8Array(Buffer.from(normalized, 'hex'));
+  }
+  return bs58.decode(normalized);
+}
+
+function normalizeEd25519Secret(secret: Uint8Array): Uint8Array {
+  if (secret.length === 32) {
+    return secret;
+  }
+  if (secret.length === 64) {
+    return secret.slice(0, 32);
+  }
+  throw new Error(`Unsupported Ed25519 secret key length: ${secret.length}`);
+}
+
+function validateKeyMatchesDid(did: string, secretKey: Uint8Array): void {
+  if (!did.startsWith('did:key:')) {
+    return;
+  }
+  const publicKey = getPublicKey(secretKey);
+  const multicodec = Buffer.concat([
+    Buffer.from([0xed, 0x01]),
+    Buffer.from(publicKey),
+  ]);
+  const expectedDid = `did:key:z${bs58.encode(multicodec)}`;
+  if (expectedDid !== did) {
+    throw new Error('Issuer private key does not match issuer did:key');
+  }
+}
+
+function loadCredential(path: string): VerifiableConsentReceipt {
+  const contents =
+    path === '-' ? readFileSync(0, 'utf8') : readFileSync(resolvePath(path), 'utf8');
+  return JSON.parse(contents) as VerifiableConsentReceipt;
+}
+
+function loadDidDocs(entries: string[]): DidDocument[] {
+  return entries.map((entry) => {
+    const [did, path] = entry.split('=');
+    if (!did || !path) {
+      throw new Error(`Invalid DID document mapping: ${entry}`);
+    }
+    const doc = JSON.parse(readFileSync(resolvePath(path), 'utf8')) as DidDocument;
+    return doc;
+  });
+}

--- a/packages/vcr-kit/src/crypto.ts
+++ b/packages/vcr-kit/src/crypto.ts
@@ -1,0 +1,22 @@
+import { sign } from '@noble/ed25519';
+
+export function base64UrlEncode(data: Uint8Array): string {
+  return Buffer.from(data)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+export function base64UrlDecode(value: string): Uint8Array {
+  const padded = value.padEnd(value.length + ((4 - (value.length % 4)) % 4), '=');
+  const normalized = padded.replace(/-/g, '+').replace(/_/g, '/');
+  return new Uint8Array(Buffer.from(normalized, 'base64'));
+}
+
+export async function signEd25519(
+  message: Uint8Array,
+  secretKey: Uint8Array,
+): Promise<Uint8Array> {
+  return sign(message, secretKey);
+}

--- a/packages/vcr-kit/src/dids.ts
+++ b/packages/vcr-kit/src/dids.ts
@@ -1,0 +1,74 @@
+import bs58 from 'bs58';
+import { verify } from '@noble/ed25519';
+import { DidDocument, DidResolver } from './types.js';
+
+// Multicodec prefix for Ed25519 public key
+const ED25519_PREFIX = new Uint8Array([0xed, 0x01]);
+
+export class InMemoryDidResolver implements DidResolver {
+  private readonly docs = new Map<string, DidDocument>();
+
+  constructor(initialDocs: DidDocument[] = []) {
+    initialDocs.forEach((doc) => this.docs.set(doc.id, doc));
+  }
+
+  register(doc: DidDocument): void {
+    this.docs.set(doc.id, doc);
+  }
+
+  async resolve(did: string): Promise<DidDocument> {
+    if (did.startsWith('did:key:')) {
+      return deriveDidKeyDocument(did);
+    }
+
+    const doc = this.docs.get(did);
+    if (!doc) {
+      throw new Error(`DID document not found for ${did}`);
+    }
+
+    return doc;
+  }
+}
+
+export function deriveDidKeyDocument(did: string): DidDocument {
+  const fragment = `${did}#keys-1`;
+  const publicKeyMultibase = did.replace('did:key:', '');
+  return {
+    id: did,
+    assertionMethod: [fragment],
+    verificationMethod: [
+      {
+        id: fragment,
+        type: 'Ed25519VerificationKey2020',
+        controller: did,
+        publicKeyMultibase,
+      },
+    ],
+  };
+}
+
+export function publicKeyFromMultibase(multibaseKey: string): Uint8Array {
+  if (!multibaseKey.startsWith('z')) {
+    throw new Error('Only base58-btc multibase keys are supported');
+  }
+  const decoded = bs58.decode(multibaseKey.slice(1));
+  if (decoded.length !== 34) {
+    throw new Error('Unsupported key length for did:key');
+  }
+  const keyBytes = decoded.slice(2);
+  if (
+    decoded[0] !== ED25519_PREFIX[0] ||
+    decoded[1] !== ED25519_PREFIX[1]
+  ) {
+    throw new Error('Unsupported multicodec prefix for did:key');
+  }
+  return keyBytes;
+}
+
+export async function verifyEd25519Signature(
+  publicKey: Uint8Array,
+  data: Uint8Array,
+  signature: Uint8Array,
+): Promise<boolean> {
+  return verify(signature, data, publicKey);
+}

--- a/packages/vcr-kit/src/index.ts
+++ b/packages/vcr-kit/src/index.ts
@@ -1,0 +1,6 @@
+export * from './types.js';
+export * from './issuer.js';
+export * from './verifier.js';
+export * from './dids.js';
+export * from './revocation.js';
+export * from './middleware.js';

--- a/packages/vcr-kit/src/issuer.ts
+++ b/packages/vcr-kit/src/issuer.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from 'node:crypto';
+import canonicalize from 'canonicalize';
+import { DateTime } from 'luxon';
+import { base64UrlEncode, signEd25519 } from './crypto.js';
+import { VerifiableConsentReceipt, IssueOptions, Proof } from './types.js';
+
+export async function issueConsentReceipt(options: IssueOptions): Promise<VerifiableConsentReceipt> {
+  const issuanceDate = DateTime.utc().toISO();
+  const credentialId = options.credentialId ?? `urn:uuid:${randomUUID()}`;
+  const expirationDate = options.expirationDate
+    ? normalizeExpiration(options.expirationDate)
+    : undefined;
+
+  const credential: VerifiableConsentReceipt = {
+    '@context': [
+      'https://www.w3.org/2018/credentials/v1',
+      'https://w3id.org/consent/v1',
+    ],
+    id: credentialId,
+    type: ['VerifiableCredential', 'ConsentReceiptCredential'],
+    issuer: options.issuerDid,
+    issuanceDate,
+    expirationDate,
+    credentialSubject: {
+      ...options.subject,
+      consent: options.claims,
+    },
+  };
+
+  const serialized = canonicalize({ ...credential });
+  if (!serialized) {
+    throw new Error('Failed to canonicalize credential');
+  }
+  const signature = await signEd25519(Buffer.from(serialized), options.issuerPrivateKey);
+
+  const proof: Proof = {
+    type: 'Ed25519Signature2020',
+    created: issuanceDate,
+    verificationMethod: `${options.issuerDid}#keys-1`,
+    proofPurpose: 'assertionMethod',
+    proofValue: base64UrlEncode(signature),
+    revocationListCredential: options.revocationListCredential,
+  };
+
+  credential.proof = proof;
+  return credential;
+}
+
+function normalizeExpiration(value: IssueOptions['expirationDate']): string {
+  if (!value) {
+    throw new Error('Expiration value missing');
+  }
+  if (typeof value === 'string') {
+    return DateTime.fromISO(value, { zone: 'utc' }).toISO();
+  }
+  if (value instanceof Date) {
+    return DateTime.fromJSDate(value).toUTC().toISO();
+  }
+  return value.toUTC().toISO();
+}

--- a/packages/vcr-kit/src/middleware.ts
+++ b/packages/vcr-kit/src/middleware.ts
@@ -1,0 +1,61 @@
+import type { Request, Response, NextFunction, RequestHandler } from 'express';
+import { verifyConsentReceipt } from './verifier.js';
+import { VerifiableConsentReceipt, VerifyOptions } from './types.js';
+
+export interface ConsentPresentOptions extends VerifyOptions {
+  header?: string;
+  extract?(req: Request): VerifiableConsentReceipt | undefined;
+}
+
+export function consentPresent(options: ConsentPresentOptions): RequestHandler {
+  const header = options.header ?? 'x-consent-receipt';
+
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const receipt = options.extract?.(req) ?? readReceiptFromRequest(req, header);
+      if (!receipt) {
+        res.status(403).json({ error: 'Consent receipt required' });
+        return;
+      }
+      const result = await verifyConsentReceipt(receipt, options);
+      if (!result.verified) {
+        res.status(403).json({ error: result.reason ?? 'Consent receipt invalid' });
+        return;
+      }
+      (req as Request & { consentReceipt?: VerifiableConsentReceipt }).consentReceipt = receipt;
+      next();
+    } catch (error: unknown) {
+      next(error);
+    }
+  };
+}
+
+function readReceiptFromRequest(
+  req: Request,
+  headerName: string,
+): VerifiableConsentReceipt | undefined {
+  const headerValue = req.headers[headerName.toLowerCase()];
+  if (typeof headerValue === 'string') {
+    return parseReceipt(headerValue);
+  }
+  if (Array.isArray(headerValue) && headerValue.length > 0) {
+    return parseReceipt(headerValue[0]);
+  }
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const receipt = body.consentReceipt || body.consent_receipt;
+  if (typeof receipt === 'string') {
+    return parseReceipt(receipt);
+  }
+  if (typeof receipt === 'object' && receipt) {
+    return receipt as VerifiableConsentReceipt;
+  }
+  return undefined;
+}
+
+function parseReceipt(value: string): VerifiableConsentReceipt | undefined {
+  try {
+    return JSON.parse(value) as VerifiableConsentReceipt;
+  } catch (error) {
+    return undefined;
+  }
+}

--- a/packages/vcr-kit/src/revocation.ts
+++ b/packages/vcr-kit/src/revocation.ts
@@ -1,0 +1,69 @@
+import { promises as fs } from 'node:fs';
+import { dirname } from 'node:path';
+import { mkdir } from 'node:fs/promises';
+import { MutableRevocationRegistry } from './types.js';
+
+export class InMemoryRevocationRegistry implements MutableRevocationRegistry {
+  protected revoked = new Set<string>();
+
+  constructor(initial: Iterable<string> = []) {
+    for (const id of initial) {
+      this.revoked.add(id);
+    }
+  }
+
+  async isRevoked(credentialId: string): Promise<boolean> {
+    return this.revoked.has(credentialId);
+  }
+
+  async revoke(credentialId: string): Promise<void> {
+    this.revoked.add(credentialId);
+  }
+
+  async list(): Promise<string[]> {
+    return Array.from(this.revoked);
+  }
+}
+
+export class FileRevocationRegistry extends InMemoryRevocationRegistry {
+  constructor(private readonly filePath: string) {
+    super();
+  }
+
+  override async isRevoked(credentialId: string): Promise<boolean> {
+    await this.load();
+    return super.isRevoked(credentialId);
+  }
+
+  override async revoke(credentialId: string): Promise<void> {
+    await this.load();
+    await super.revoke(credentialId);
+    await this.persist();
+  }
+
+  override async list(): Promise<string[]> {
+    await this.load();
+    return super.list();
+  }
+
+  private async load(): Promise<void> {
+    try {
+      const contents = await fs.readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(contents);
+      if (Array.isArray(parsed.revoked)) {
+        this.revoked = new Set(parsed.revoked);
+      }
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        return;
+      }
+      throw error;
+    }
+  }
+
+  private async persist(): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const data = JSON.stringify({ revoked: await super.list() }, null, 2);
+    await fs.writeFile(this.filePath, data, 'utf8');
+  }
+}

--- a/packages/vcr-kit/src/types.ts
+++ b/packages/vcr-kit/src/types.ts
@@ -1,0 +1,94 @@
+import type { DateTime } from 'luxon';
+
+export interface ConsentPurpose {
+  purposeId: string;
+  description?: string;
+}
+
+export interface ConsentScope {
+  resource: string;
+  actions: string[];
+}
+
+export interface RetentionPolicy {
+  policyUri: string;
+  expiresAt: string; // ISO timestamp
+}
+
+export interface ConsentReceiptClaims {
+  purpose: ConsentPurpose[];
+  scope: ConsentScope[];
+  retention: RetentionPolicy;
+  tenant: string;
+  lawfulBasis?: string;
+  policyUri?: string;
+}
+
+export interface ConsentSubject {
+  id: string;
+  email?: string;
+  givenName?: string;
+  familyName?: string;
+}
+
+export interface VerifiableConsentReceipt {
+  '@context': string[];
+  id: string;
+  type: ['VerifiableCredential', 'ConsentReceiptCredential'];
+  issuer: string;
+  issuanceDate: string;
+  expirationDate?: string;
+  credentialSubject: ConsentSubject & {
+    consent: ConsentReceiptClaims;
+  };
+  proof?: Proof;
+}
+
+export interface Proof {
+  type: 'Ed25519Signature2020';
+  created: string;
+  verificationMethod: string;
+  proofPurpose: 'assertionMethod';
+  proofValue: string; // base64url signature
+  revocationListCredential?: string;
+}
+
+export interface IssueOptions {
+  issuerDid: string;
+  issuerPrivateKey: Uint8Array;
+  subject: ConsentSubject;
+  claims: ConsentReceiptClaims;
+  credentialId?: string;
+  expirationDate?: string | Date | DateTime;
+  revocationListCredential?: string;
+}
+
+export interface VerifyOptions {
+  resolver: DidResolver;
+  revocationRegistry?: RevocationRegistry;
+  atTime?: Date | DateTime | string;
+}
+
+export interface DidDocument {
+  id: string;
+  assertionMethod: string[];
+  verificationMethod: Array<{
+    id: string;
+    type: 'Ed25519VerificationKey2020';
+    controller: string;
+    publicKeyMultibase: string;
+  }>;
+}
+
+export interface DidResolver {
+  resolve(did: string): Promise<DidDocument>;
+}
+
+export interface RevocationRegistry {
+  isRevoked(credentialId: string): Promise<boolean>;
+}
+
+export interface MutableRevocationRegistry extends RevocationRegistry {
+  revoke(credentialId: string): Promise<void>;
+  list(): Promise<string[]>;
+}

--- a/packages/vcr-kit/src/verifier.ts
+++ b/packages/vcr-kit/src/verifier.ts
@@ -1,0 +1,87 @@
+import canonicalize from 'canonicalize';
+import { DateTime } from 'luxon';
+import { base64UrlDecode } from './crypto.js';
+import { publicKeyFromMultibase, verifyEd25519Signature } from './dids.js';
+import { VerifiableConsentReceipt, VerifyOptions, DidDocument } from './types.js';
+
+export interface VerificationResult {
+  verified: boolean;
+  reason?: string;
+}
+
+export async function verifyConsentReceipt(
+  credential: VerifiableConsentReceipt,
+  options: VerifyOptions,
+): Promise<VerificationResult> {
+  if (!credential.proof) {
+    return { verified: false, reason: 'Missing proof' };
+  }
+  const { proof } = credential;
+  const unsigned = { ...credential };
+  delete (unsigned as Partial<VerifiableConsentReceipt>).proof;
+
+  const serialized = canonicalize(unsigned);
+  if (!serialized) {
+    return { verified: false, reason: 'Unable to canonicalize credential' };
+  }
+
+  let doc: DidDocument;
+  try {
+    doc = await options.resolver.resolve(credential.issuer);
+  } catch (error: unknown) {
+    return { verified: false, reason: (error as Error).message };
+  }
+
+  const verificationMethod = doc.verificationMethod.find(
+    (vm) => vm.id === proof.verificationMethod,
+  );
+  if (!verificationMethod) {
+    return { verified: false, reason: 'Verification method not found in DID document' };
+  }
+
+  const publicKey = publicKeyFromMultibase(verificationMethod.publicKeyMultibase);
+  const signature = base64UrlDecode(proof.proofValue);
+  const message = Buffer.from(serialized);
+
+  const valid = await verifyEd25519Signature(publicKey, message, signature);
+  if (!valid) {
+    return { verified: false, reason: 'Signature verification failed' };
+  }
+
+  const now = resolveVerificationTime(options.atTime);
+
+  const expiry = credential.expirationDate
+    ? DateTime.fromISO(credential.expirationDate, { zone: 'utc' })
+    : undefined;
+  if (expiry && now > expiry) {
+    return { verified: false, reason: 'Credential expired' };
+  }
+
+  if (options.revocationRegistry) {
+    const revoked = await options.revocationRegistry.isRevoked(credential.id);
+    if (revoked) {
+      return { verified: false, reason: 'Credential revoked' };
+    }
+  }
+
+  return { verified: true };
+}
+
+export function assertVerified(result: VerificationResult): void {
+  if (!result.verified) {
+    throw new Error(result.reason ?? 'Verification failed');
+  }
+}
+
+function resolveVerificationTime(atTime: VerifyOptions['atTime']): DateTime {
+  if (!atTime) {
+    return DateTime.utc();
+  }
+  if (atTime instanceof Date) {
+    return DateTime.fromJSDate(atTime).toUTC();
+  }
+  if (typeof atTime === 'string') {
+    return DateTime.fromISO(atTime, { zone: 'utc' });
+  }
+  return atTime.toUTC();
+}

--- a/packages/vcr-kit/tsconfig.json
+++ b/packages/vcr-kit/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/sdk/python/vcr_kit/__init__.py
+++ b/sdk/python/vcr_kit/__init__.py
@@ -1,0 +1,16 @@
+"""Python helpers for the Summit verifiable consent receipt kit."""
+
+from .dids import InMemoryDidResolver, derive_did_key_document
+from .middleware import ConsentPresentMiddleware, consent_present
+from .revocation import JsonRevocationRegistry
+from .verifier import ConsentVerifier, VerificationResult
+
+__all__ = [
+    "ConsentPresentMiddleware",
+    "ConsentVerifier",
+    "InMemoryDidResolver",
+    "JsonRevocationRegistry",
+    "VerificationResult",
+    "consent_present",
+    "derive_did_key_document",
+]

--- a/sdk/python/vcr_kit/base58.py
+++ b/sdk/python/vcr_kit/base58.py
@@ -1,0 +1,28 @@
+"""Minimal Base58 codec compatible with Bitcoin alphabet."""
+
+ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+ALPHABET_INDEX = {ch: idx for idx, ch in enumerate(ALPHABET)}
+
+
+def b58decode(value: str) -> bytes:
+    value = value.strip()
+    if not value:
+        return b""
+    num = 0
+    for char in value:
+        if char not in ALPHABET_INDEX:
+            raise ValueError(f"Invalid base58 character: {char}")
+        num = num * 58 + ALPHABET_INDEX[char]
+    # Convert to bytes
+    result = bytearray()
+    while num > 0:
+        num, rem = divmod(num, 256)
+        result.append(rem)
+    # Handle leading zeros
+    pad = 0
+    for char in value:
+        if char == "1":
+            pad += 1
+        else:
+            break
+    return b"\x00" * pad + bytes(reversed(result))

--- a/sdk/python/vcr_kit/dids.py
+++ b/sdk/python/vcr_kit/dids.py
@@ -1,0 +1,74 @@
+"""DID resolution helpers for offline verification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List
+
+from .base58 import b58decode
+
+ED25519_PREFIX = b"\xed\x01"
+
+
+@dataclass
+class VerificationMethod:
+    id: str
+    type: str
+    controller: str
+    publicKeyMultibase: str
+
+
+@dataclass
+class DidDocument:
+    id: str
+    assertionMethod: List[str]
+    verificationMethod: List[VerificationMethod] = field(default_factory=list)
+
+
+class InMemoryDidResolver:
+    """Resolver that holds DID documents in memory."""
+
+    def __init__(self, docs: Iterable[DidDocument] | None = None) -> None:
+        self._docs: Dict[str, DidDocument] = {}
+        if docs:
+            for doc in docs:
+                self.register(doc)
+
+    def register(self, doc: DidDocument) -> None:
+        self._docs[doc.id] = doc
+
+    async def resolve(self, did: str) -> DidDocument:
+        if did.startswith("did:key:"):
+            return derive_did_key_document(did)
+        try:
+            return self._docs[did]
+        except KeyError as exc:
+            raise KeyError(f"DID document not found for {did}") from exc
+
+
+def derive_did_key_document(did: str) -> DidDocument:
+    fragment = f"{did}#keys-1"
+    return DidDocument(
+        id=did,
+        assertionMethod=[fragment],
+        verificationMethod=[
+            VerificationMethod(
+                id=fragment,
+                type="Ed25519VerificationKey2020",
+                controller=did,
+                publicKeyMultibase=did.replace("did:key:", ""),
+            )
+        ],
+    )
+
+
+def public_key_from_multibase(multibase: str) -> bytes:
+    if not multibase.startswith("z"):
+        raise ValueError("Only base58-btc multibase keys are supported")
+    decoded = b58decode(multibase[1:])
+    if not decoded.startswith(ED25519_PREFIX):
+        raise ValueError("Unsupported multicodec prefix for did:key")
+    key = decoded[len(ED25519_PREFIX) :]
+    if len(key) != 32:
+        raise ValueError("Expected 32-byte Ed25519 public key")
+    return key

--- a/sdk/python/vcr_kit/middleware.py
+++ b/sdk/python/vcr_kit/middleware.py
@@ -1,0 +1,91 @@
+"""ASGI middleware enforcing consent receipt presence."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Awaitable, Callable, Dict
+
+from .verifier import ConsentVerifier
+
+ASGISend = Callable[[Dict[str, Any]], Awaitable[None]]
+ASGIReceive = Callable[[], Awaitable[Dict[str, Any]]]
+ASGIApp = Callable[[Dict[str, Any], ASGIReceive, ASGISend], Awaitable[None]]
+
+
+class ConsentPresentMiddleware:
+    """ASGI middleware that rejects requests without a valid consent receipt."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        verifier: ConsentVerifier,
+        *,
+        header: str = "x-consent-receipt",
+    ) -> None:
+        self.app = app
+        self.verifier = verifier
+        self.header = header.lower()
+
+    async def __call__(self, scope: Dict[str, Any], receive: ASGIReceive, send: ASGISend) -> None:
+        if scope.get("type") != "http":
+            await self.app(scope, receive, send)
+            return
+
+        header_value = _extract_header(scope, self.header)
+        if not header_value:
+            await _forbidden(send, "Consent receipt required")
+            return
+
+        try:
+            receipt = json.loads(header_value)
+        except json.JSONDecodeError:
+            await _forbidden(send, "Consent receipt header must be JSON")
+            return
+
+        result = await self.verifier.verify(receipt)
+        if not result.verified:
+            await _forbidden(send, result.reason or "Consent receipt invalid")
+            return
+
+        scope.setdefault("state", {})["consent_receipt"] = receipt
+        await self.app(scope, receive, send)
+
+
+def consent_present(
+    verifier: ConsentVerifier,
+    *,
+    header: str = "x-consent-receipt",
+) -> Callable[[ASGIApp], ASGIApp]:
+    """Wrap an ASGI app to enforce consent receipts."""
+
+    def wrapper(app: ASGIApp) -> ASGIApp:
+        return ConsentPresentMiddleware(app, verifier, header=header)
+
+    return wrapper
+
+
+def _extract_header(scope: Dict[str, Any], header: str) -> str | None:
+    headers = scope.get("headers") or []
+    for key, value in headers:
+        if isinstance(key, bytes) and key.decode("latin-1").lower() == header:
+            return value.decode("latin-1") if isinstance(value, bytes) else value
+    return None
+
+
+def _forbidden(send: ASGISend, message: str) -> Awaitable[None]:
+    body = json.dumps({"error": message}).encode("utf-8")
+
+    async def responder() -> None:
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 403,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+
+    return responder()

--- a/sdk/python/vcr_kit/revocation.py
+++ b/sdk/python/vcr_kit/revocation.py
@@ -1,0 +1,38 @@
+"""Revocation registry helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Set
+
+
+class JsonRevocationRegistry:
+    """Revocation registry persisted as a JSON file."""
+
+    def __init__(self, path: str | Path, initial: Iterable[str] | None = None) -> None:
+        self.path = Path(path)
+        self._revoked: Set[str] = set(initial or [])
+        if self.path.exists():
+            self._load()
+
+    def _load(self) -> None:
+        data = json.loads(self.path.read_text("utf-8"))
+        revoked = data.get("revoked", [])
+        if isinstance(revoked, list):
+            self._revoked = set(map(str, revoked))
+
+    def _persist(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"revoked": sorted(self._revoked)}
+        self.path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    async def is_revoked(self, credential_id: str) -> bool:
+        return credential_id in self._revoked
+
+    async def revoke(self, credential_id: str) -> None:
+        self._revoked.add(credential_id)
+        self._persist()
+
+    async def list(self) -> list[str]:
+        return sorted(self._revoked)

--- a/sdk/python/vcr_kit/verifier.py
+++ b/sdk/python/vcr_kit/verifier.py
@@ -1,0 +1,101 @@
+"""Offline verification helpers for consent receipts."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - optional dependency
+    from nacl.signing import VerifyKey
+except ImportError:  # pragma: no cover
+    VerifyKey = None  # type: ignore
+
+from .dids import InMemoryDidResolver, public_key_from_multibase
+from .revocation import JsonRevocationRegistry
+
+
+@dataclass
+class VerificationResult:
+    verified: bool
+    reason: Optional[str] = None
+
+
+class ConsentVerifier:
+    """Verify consent receipts offline."""
+
+    def __init__(
+        self,
+        resolver: InMemoryDidResolver,
+        revocations: JsonRevocationRegistry | None = None,
+    ) -> None:
+        self.resolver = resolver
+        self.revocations = revocations
+
+    async def verify(
+        self,
+        credential: Dict[str, Any],
+        *,
+        at_time: datetime | None = None,
+    ) -> VerificationResult:
+        proof = credential.get("proof")
+        if not proof:
+            return VerificationResult(False, "Missing proof")
+
+        unsigned = dict(credential)
+        unsigned.pop("proof", None)
+        payload = _canonicalize(unsigned)
+
+        if VerifyKey is None:
+            return VerificationResult(False, "PyNaCl is required for signature verification")
+
+        try:
+            doc = await self.resolver.resolve(str(credential["issuer"]))
+        except Exception as exc:  # pragma: no cover - passthrough
+            return VerificationResult(False, str(exc))
+
+        verification_method_id = proof.get("verificationMethod")
+        method = next(
+            (vm for vm in doc.verificationMethod if vm.id == verification_method_id),
+            None,
+        )
+        if not method:
+            return VerificationResult(False, "Verification method missing from DID document")
+
+        public_key = public_key_from_multibase(method.publicKeyMultibase)
+        signature = _b64url_decode(proof.get("proofValue", ""))
+
+        try:
+            VerifyKey(public_key).verify(payload, signature)
+        except Exception:  # pragma: no cover - signature failure
+            return VerificationResult(False, "Signature verification failed")
+
+        now = at_time or datetime.now(timezone.utc)
+        expiry = credential.get("expirationDate")
+        if expiry:
+            exp_raw = str(expiry)
+            if exp_raw.endswith("Z"):
+                exp_raw = exp_raw[:-1] + "+00:00"
+            exp_time = datetime.fromisoformat(exp_raw)
+            if exp_time.tzinfo is None:
+                exp_time = exp_time.replace(tzinfo=timezone.utc)
+            if now > exp_time:
+                return VerificationResult(False, "Credential expired")
+
+        if self.revocations:
+            revoked = await self.revocations.is_revoked(str(credential["id"]))
+            if revoked:
+                return VerificationResult(False, "Credential revoked")
+
+        return VerificationResult(True)
+
+
+def _canonicalize(value: Dict[str, Any]) -> bytes:
+    return json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
+
+
+def _b64url_decode(value: str) -> bytes:
+    padded = value + "=" * ((4 - len(value) % 4) % 4)
+    return base64.urlsafe_b64decode(padded.encode("ascii"))


### PR DESCRIPTION
## Summary
- add a TypeScript vcr-kit workspace with issuance, verification, DID resolution, revocation, and Express middleware exports
- provide a vcr-kit CLI for issuing, verifying, and revoking consent receipt credentials plus sample fixtures and policy assets
- ship a Python helper module with offline verifier, DID resolver, revocation store, and ASGI middleware for consent enforcement

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d73e8591948333b3992741d68441e4