### PR TITLE
feat: add contextual access broker service

### DIFF
--- a/sdk/cab/README.md
+++ b/sdk/cab/README.md
@@ -1,0 +1,49 @@
+
+# CAB TypeScript SDK
+
+Lightweight TypeScript helper for interacting with the Contextual Access Broker (CAB) decision engine.
+
+## Usage
+
+```ts
+import { CABClient } from '@summit/cab-sdk';
+
+const client = new CABClient({ baseUrl: 'http://localhost:8085' });
+const decision = await client.evaluate({
+  action: 'workspace:update',
+  subject: { role: 'admin' },
+  resource: { classification: 'internal' },
+  signals: {
+    geo: 'US',
+    devicePosture: 'trusted',
+    anomalyScore: 0.18,
+  },
+});
+
+if (decision.decision === 'step-up') {
+  const completed = await client.completeStepUp(
+    {
+      action: 'workspace:update',
+      subject: { role: 'admin' },
+      resource: { classification: 'internal' },
+      signals: {
+        geo: 'US',
+        devicePosture: 'trusted',
+        anomalyScore: 0.51,
+      },
+    },
+    {
+      totp: { code: '654321' },
+      'hardware-key': { assertion: 'cab-hardware-assertion' },
+    }
+  );
+  console.log(completed.decision);
+}
+```
+
+The client also exposes helpers for working with saved simulator scenarios.
+```ts
+const scenario = await client.saveScenario('baseline admin', request);
+const replay = await client.replayScenario(scenario.id);
+console.log(replay.match); // true when the decision matches the saved outcome
+```

--- a/sdk/cab/package.json
+++ b/sdk/cab/package.json
@@ -1,0 +1,18 @@
+
+{
+  "name": "@summit/cab-sdk",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for the Contextual Access Broker (CAB) risk decision engine",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint src --ext .ts",
+    "test": "node --test"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/sdk/cab/src/index.ts
+++ b/sdk/cab/src/index.ts
@@ -1,0 +1,154 @@
+
+export type RiskLevel = 'low' | 'medium' | 'high';
+
+export interface RiskResult {
+  name: string;
+  level: RiskLevel;
+  score: number;
+  reasons: string[];
+}
+
+export interface Signals {
+  geo: string;
+  devicePosture: string;
+  anomalyScore: number;
+  additional?: Record<string, unknown>;
+}
+
+export interface DecisionRequest {
+  action: string;
+  subject: Record<string, string>;
+  resource: Record<string, string>;
+  signals: Signals;
+  challengeResponses?: Record<string, Record<string, string>>;
+}
+
+export interface ChallengeInfo {
+  type: string;
+  prompt: string;
+}
+
+export interface DecisionResponse {
+  decision: 'allow' | 'deny' | 'step-up';
+  policyId?: string;
+  evaluationId: string;
+  riskLevel: RiskLevel;
+  riskBreakdown: RiskResult[];
+  reasons: string[];
+  requiredChallenges?: ChallengeInfo[];
+}
+
+export interface PolicyDescription {
+  id: string;
+  description: string;
+  actions: string[];
+  subject: Record<string, unknown>;
+  resource: Record<string, unknown>;
+  effect: string;
+  allowRisk: RiskLevel;
+  stepUpRisk: RiskLevel;
+  stepUpChallenges?: string[];
+}
+
+export interface ScenarioRecord {
+  id: string;
+  name: string;
+  request: DecisionRequest;
+  response: DecisionResponse;
+}
+
+export interface ReplayResponse {
+  match: boolean;
+  decision: DecisionResponse;
+}
+
+export interface CABClientOptions {
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  defaultHeaders?: HeadersInit;
+}
+
+export class CABClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly defaultHeaders: HeadersInit;
+
+  constructor(options: CABClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? 'http://localhost:8085';
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.defaultHeaders = options.defaultHeaders ?? { 'Content-Type': 'application/json' };
+  }
+
+  async evaluate(request: DecisionRequest): Promise<DecisionResponse> {
+    return this.post<DecisionResponse>('/evaluate', request);
+  }
+
+  async listPolicies(): Promise<PolicyDescription[]> {
+    return this.get<PolicyDescription[]>('/policies');
+  }
+
+  async listScenarios(): Promise<ScenarioRecord[]> {
+    return this.get<ScenarioRecord[]>('/scenarios');
+  }
+
+  async saveScenario(name: string, request: DecisionRequest): Promise<ScenarioRecord> {
+    return this.post<ScenarioRecord>('/scenarios', { name, request });
+  }
+
+  async replayScenario(id: string): Promise<ReplayResponse> {
+    return this.post<ReplayResponse>(`/scenarios/${id}/replay`);
+  }
+
+  async completeStepUp(
+    request: DecisionRequest,
+    challenges: Record<string, Record<string, string>>
+  ): Promise<DecisionResponse> {
+    return this.evaluate({ ...request, challengeResponses: challenges });
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    return this.request<T>(path, { method: 'GET' });
+  }
+
+  private async post<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>(path, {
+      method: 'POST',
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const url = this.normalize(path);
+    const response = await this.fetchImpl(url, {
+      headers: this.defaultHeaders,
+      ...init,
+    });
+    if (!response.ok) {
+      const message = await safeErrorMessage(response);
+      throw new Error(`CAB request failed (${response.status}): ${message}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  private normalize(path: string): string {
+    if (path.startsWith('http://') || path.startsWith('https://')) {
+      return path;
+    }
+    if (!path.startsWith('/')) {
+      path = `/${path}`;
+    }
+    return `${this.baseUrl}${path}`;
+  }
+}
+
+async function safeErrorMessage(response: Response): Promise<string> {
+  try {
+    const data = await response.json();
+    if (typeof data === 'object' && data && 'error' in data) {
+      return String((data as { error: unknown }).error);
+    }
+    return JSON.stringify(data);
+  } catch (error) {
+    return response.statusText || 'unknown error';
+  }
+}

--- a/sdk/cab/tsconfig.json
+++ b/sdk/cab/tsconfig.json
@@ -1,0 +1,17 @@
+
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": false,
+    "module": "ES2022",
+    "target": "ES2022",
+    "moduleResolution": "NodeNext",
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/services/cab/README.md
+++ b/services/cab/README.md
@@ -1,0 +1,57 @@
+
+# Contextual Access Broker (CAB)
+
+CAB is a risk-adaptive authorization decision engine that combines ABAC policies with contextual risk scoring.
+
+## Features
+
+- Deterministic decisions when evaluated with the same attributes and signals.
+- Pluggable risk scorers for geo, device posture, and anomaly telemetry.
+- Step-up challenges (TOTP and hardware key stubs) enforced when risk exceeds the baseline threshold.
+- Scenario simulator with replay support to guarantee policy stability over time.
+
+## Running the Decision Service
+
+```bash
+cd services/cab
+go run ./cmd/cab-server
+```
+
+The server listens on `:8085` by default. Override with `CAB_PORT`.
+
+### Example Request
+
+```bash
+curl -s http://localhost:8085/evaluate       -H 'content-type: application/json'       -d '{
+    "action": "workspace:update",
+    "subject": {"role": "admin"},
+    "resource": {"classification": "internal"},
+    "signals": {"geo": "US", "devicePosture": "trusted", "anomalyScore": 0.2}
+  }'
+```
+
+A `step-up` decision includes the challenges that must be satisfied. Provide challenge responses on subsequent requests:
+
+```bash
+curl -s http://localhost:8085/evaluate       -H 'content-type: application/json'       -d '{
+    "action": "workspace:update",
+    "subject": {"role": "admin"},
+    "resource": {"classification": "internal"},
+    "signals": {"geo": "US", "devicePosture": "trusted", "anomalyScore": 0.55},
+    "challengeResponses": {
+      "totp": {"code": "654321"},
+      "hardware-key": {"assertion": "cab-hardware-assertion"}
+    }
+  }'
+```
+
+## Simulator UI
+
+Open `ui/cab-simulator.html` in a browser and point it at the running service to experiment with policies and saved scenarios.
+
+## Tests
+
+```bash
+cd services/cab
+go test ./...
+```

--- a/services/cab/cmd/cab-server/main.go
+++ b/services/cab/cmd/cab-server/main.go
@@ -1,0 +1,256 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/summit/cab/internal/challenge"
+	"github.com/summit/cab/internal/engine"
+	"github.com/summit/cab/internal/risk"
+)
+
+func main() {
+	srv, err := newServer()
+	if err != nil {
+		log.Fatalf("failed to start cab server: %v", err)
+	}
+	port := os.Getenv("CAB_PORT")
+	if port == "" {
+		port = "8085"
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+	mux.HandleFunc("/policies", srv.handlePolicies)
+	mux.HandleFunc("/evaluate", srv.handleEvaluate)
+	mux.HandleFunc("/scenarios", srv.handleScenarios)
+	mux.HandleFunc("/scenarios/", srv.handleScenarioByID)
+	log.Printf("CAB listening on :%s", port)
+	log.Fatal(http.ListenAndServe(":"+port, withJSON(mux)))
+}
+
+type server struct {
+	engine    *engine.Engine
+	policies  []engine.Policy
+	scenarios *scenarioStore
+}
+
+func newServer() (*server, error) {
+	policies := defaultPolicies()
+	scorers := []risk.Scorer{
+		risk.GeoScorer{Allowed: []string{"us", "ca", "uk"}, Elevated: []string{"de", "fr"}, UnknownIsRisk: true},
+		risk.DevicePostureScorer{TrustedPostures: []string{"trusted", "managed"}},
+		risk.AnomalyScorer{Name: "anomaly", StepUpFloor: 0.35, DenyFloor: 0.75},
+	}
+	registry := challenge.NewRegistry(
+		challenge.NewTOTPChallenge("654321"),
+		challenge.NewHardwareKeyChallenge("cab-hardware-assertion"),
+	)
+	eng, err := engine.New(policies, scorers, registry)
+	if err != nil {
+		return nil, err
+	}
+	return &server{engine: eng, policies: policies, scenarios: newScenarioStore()}, nil
+}
+
+func (s *server) handlePolicies(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	writeJSON(w, s.policies)
+}
+
+func (s *server) handleEvaluate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeErr(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req engine.Request
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid request payload")
+		return
+	}
+	resp, err := s.engine.Evaluate(req)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, resp)
+}
+
+func (s *server) handleScenarios(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		writeJSON(w, s.scenarios.List())
+	case http.MethodPost:
+		var body struct {
+			Name    string         `json:"name"`
+			Request engine.Request `json:"request"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			writeErr(w, http.StatusBadRequest, "invalid request payload")
+			return
+		}
+		decision, err := s.engine.Evaluate(body.Request)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		scenario := Scenario{ID: uuid.NewString(), Name: body.Name, Request: body.Request, Response: decision}
+		s.scenarios.Save(scenario)
+		writeJSON(w, scenario)
+	default:
+		writeErr(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func (s *server) handleScenarioByID(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/scenarios/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		writeErr(w, http.StatusNotFound, "scenario id missing")
+		return
+	}
+	id := parts[0]
+	scenario, ok := s.scenarios.Get(id)
+	if !ok {
+		writeErr(w, http.StatusNotFound, "scenario not found")
+		return
+	}
+	if len(parts) == 1 {
+		if r.Method != http.MethodGet {
+			writeErr(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		writeJSON(w, scenario)
+		return
+	}
+	if parts[1] == "replay" {
+		if r.Method != http.MethodPost {
+			writeErr(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		decision, err := s.engine.Evaluate(scenario.Request)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		match := compareDecisions(decision, scenario.Response)
+		writeJSON(w, map[string]any{"match": match, "decision": decision})
+		return
+	}
+	writeErr(w, http.StatusNotFound, "unsupported scenario path")
+}
+
+func compareDecisions(a, b engine.Response) bool {
+	if a.Decision != b.Decision || a.RiskLevel != b.RiskLevel || len(a.RequiredChallenges) != len(b.RequiredChallenges) {
+		return false
+	}
+	return true
+}
+
+type scenarioStore struct {
+	mu        sync.RWMutex
+	scenarios map[string]Scenario
+}
+
+type Scenario struct {
+	ID       string          `json:"id"`
+	Name     string          `json:"name"`
+	Request  engine.Request  `json:"request"`
+	Response engine.Response `json:"response"`
+}
+
+func newScenarioStore() *scenarioStore {
+	return &scenarioStore{scenarios: make(map[string]Scenario)}
+}
+
+func (s *scenarioStore) Save(sc Scenario) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.scenarios[sc.ID] = sc
+}
+
+func (s *scenarioStore) Get(id string) (Scenario, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	sc, ok := s.scenarios[id]
+	return sc, ok
+}
+
+func (s *scenarioStore) List() []Scenario {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]Scenario, 0, len(s.scenarios))
+	for _, sc := range s.scenarios {
+		out = append(out, sc)
+	}
+	return out
+}
+
+func writeJSON(w http.ResponseWriter, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		log.Printf("failed to encode response: %v", err)
+	}
+}
+
+func writeErr(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}
+
+func withJSON(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func defaultPolicies() []engine.Policy {
+	return []engine.Policy{
+		{
+			ID:          "workspace-admin",
+			Description: "Privileged workspace administration operations",
+			Actions:     []string{"workspace:update", "workspace:delete"},
+			Subject: map[string]engine.AttributeCondition{
+				"role": {Equals: "admin"},
+			},
+			Resource: map[string]engine.AttributeCondition{
+				"classification": {In: []string{"internal", "confidential"}},
+			},
+			Effect:           engine.DecisionAllow,
+			AllowRisk:        risk.LevelLow,
+			StepUpRisk:       risk.LevelMedium,
+			StepUpChallenges: []string{"totp", "hardware-key"},
+		},
+		{
+			ID:          "workspace-viewer",
+			Description: "Read access for trusted analysts",
+			Actions:     []string{"workspace:view"},
+			Subject: map[string]engine.AttributeCondition{
+				"role": {In: []string{"analyst", "admin"}},
+			},
+			Resource: map[string]engine.AttributeCondition{
+				"classification": {NotIn: []string{"restricted"}},
+			},
+			Effect:     engine.DecisionAllow,
+			AllowRisk:  risk.LevelMedium,
+			StepUpRisk: risk.LevelMedium,
+		},
+	}
+}

--- a/services/cab/go.mod
+++ b/services/cab/go.mod
@@ -1,0 +1,5 @@
+module github.com/summit/cab
+
+go 1.22
+
+require github.com/google/uuid v1.6.0

--- a/services/cab/go.sum
+++ b/services/cab/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/services/cab/internal/challenge/challenge.go
+++ b/services/cab/internal/challenge/challenge.go
@@ -1,0 +1,54 @@
+package challenge
+
+import "fmt"
+
+// VerificationInput represents user supplied data used to satisfy a challenge.
+type VerificationInput map[string]string
+
+// Challenge describes an additional verification step required to elevate trust.
+type Challenge interface {
+	Type() string
+	Prompt() string
+	Verify(input VerificationInput) error
+}
+
+// Info describes a challenge presented back to clients.
+type Info struct {
+	Type   string `json:"type"`
+	Prompt string `json:"prompt"`
+}
+
+// Registry stores challenge implementations keyed by their type.
+type Registry struct {
+	entries map[string]Challenge
+}
+
+// NewRegistry constructs a registry from the provided challenges.
+func NewRegistry(challenges ...Challenge) *Registry {
+	r := &Registry{entries: make(map[string]Challenge, len(challenges))}
+	for _, ch := range challenges {
+		r.entries[ch.Type()] = ch
+	}
+	return r
+}
+
+// Get returns the challenge for the requested type.
+func (r *Registry) Get(t string) (Challenge, error) {
+	if r == nil {
+		return nil, fmt.Errorf("challenge registry uninitialized")
+	}
+	ch, ok := r.entries[t]
+	if !ok {
+		return nil, fmt.Errorf("challenge %s not registered", t)
+	}
+	return ch, nil
+}
+
+// Types returns the registered challenge types.
+func (r *Registry) Types() []string {
+	keys := make([]string, 0, len(r.entries))
+	for k := range r.entries {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/services/cab/internal/challenge/hardware.go
+++ b/services/cab/internal/challenge/hardware.go
@@ -1,0 +1,30 @@
+package challenge
+
+import "fmt"
+
+// HardwareKeyChallenge is a stubbed WebAuthn-like challenge.
+type HardwareKeyChallenge struct {
+	ExpectedAssertion string
+	prompt            string
+}
+
+func NewHardwareKeyChallenge(expected string) *HardwareKeyChallenge {
+	return &HardwareKeyChallenge{
+		ExpectedAssertion: expected,
+		prompt:            "Touch your registered security key to continue.",
+	}
+}
+
+func (h *HardwareKeyChallenge) Type() string { return "hardware-key" }
+
+func (h *HardwareKeyChallenge) Prompt() string { return h.prompt }
+
+func (h *HardwareKeyChallenge) Verify(input VerificationInput) error {
+	if input == nil {
+		return fmt.Errorf("missing hardware assertion")
+	}
+	if assertion := input["assertion"]; assertion == h.ExpectedAssertion {
+		return nil
+	}
+	return fmt.Errorf("hardware assertion mismatch")
+}

--- a/services/cab/internal/challenge/totp.go
+++ b/services/cab/internal/challenge/totp.go
@@ -1,0 +1,27 @@
+package challenge
+
+import "fmt"
+
+// TOTPChallenge is a deterministic stub that validates a provided one-time code.
+type TOTPChallenge struct {
+	ExpectedCode string
+	prompt       string
+}
+
+func NewTOTPChallenge(expected string) *TOTPChallenge {
+	return &TOTPChallenge{ExpectedCode: expected, prompt: "Enter the code from your authenticator app."}
+}
+
+func (t *TOTPChallenge) Type() string { return "totp" }
+
+func (t *TOTPChallenge) Prompt() string { return t.prompt }
+
+func (t *TOTPChallenge) Verify(input VerificationInput) error {
+	if input == nil {
+		return fmt.Errorf("missing totp input")
+	}
+	if code := input["code"]; code == t.ExpectedCode {
+		return nil
+	}
+	return fmt.Errorf("invalid totp code")
+}

--- a/services/cab/internal/engine/engine.go
+++ b/services/cab/internal/engine/engine.go
@@ -1,0 +1,121 @@
+package engine
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/google/uuid"
+
+	"github.com/summit/cab/internal/challenge"
+	"github.com/summit/cab/internal/risk"
+)
+
+type Decision string
+
+const (
+	DecisionAllow  Decision = "allow"
+	DecisionDeny   Decision = "deny"
+	DecisionStepUp Decision = "step-up"
+)
+
+// Request captures the data provided by a relying party when requesting a decision.
+type Request struct {
+	Action             string                                 `json:"action"`
+	Subject            map[string]string                      `json:"subject"`
+	Resource           map[string]string                      `json:"resource"`
+	Signals            risk.Signals                           `json:"signals"`
+	ChallengeResponses map[string]challenge.VerificationInput `json:"challengeResponses"`
+}
+
+// Response captures the result of evaluating a request.
+type Response struct {
+	Decision           Decision         `json:"decision"`
+	PolicyID           string           `json:"policyId,omitempty"`
+	EvaluationID       string           `json:"evaluationId"`
+	RiskLevel          risk.Level       `json:"riskLevel"`
+	RiskBreakdown      []risk.Result    `json:"riskBreakdown"`
+	Reasons            []string         `json:"reasons"`
+	RequiredChallenges []challenge.Info `json:"requiredChallenges,omitempty"`
+}
+
+// Engine evaluates requests against ABAC policies and risk scorers.
+type Engine struct {
+	policies   []Policy
+	scorers    []risk.Scorer
+	challenges *challenge.Registry
+}
+
+func New(policies []Policy, scorers []risk.Scorer, registry *challenge.Registry) (*Engine, error) {
+	if len(policies) == 0 {
+		return nil, fmt.Errorf("at least one policy must be supplied")
+	}
+	return &Engine{policies: policies, scorers: scorers, challenges: registry}, nil
+}
+
+func (e *Engine) Evaluate(req Request) (Response, error) {
+	evaluationID := uuid.NewString()
+	res := Response{EvaluationID: evaluationID}
+
+	matched := false
+	var policy Policy
+	for _, p := range e.policies {
+		if p.matches(req) {
+			policy = p
+			matched = true
+			break
+		}
+	}
+
+	if !matched {
+		res.Decision = DecisionDeny
+		res.Reasons = append(res.Reasons, "no matching policy")
+		return res, nil
+	}
+
+	res.PolicyID = policy.ID
+	res.Reasons = append(res.Reasons, fmt.Sprintf("policy %s matched", policy.ID))
+
+	riskInput := risk.Input{Signals: req.Signals, Subject: req.Subject, Resource: req.Resource, Action: req.Action}
+	breakdown := make([]risk.Result, 0, len(e.scorers))
+	for _, scorer := range e.scorers {
+		breakdown = append(breakdown, scorer.Score(riskInput))
+	}
+	sort.SliceStable(breakdown, func(i, j int) bool {
+		return breakdown[i].Name < breakdown[j].Name
+	})
+	res.RiskBreakdown = breakdown
+	res.RiskLevel = risk.CombineLevels(breakdown)
+
+	switch {
+	case res.RiskLevel <= policy.AllowRisk:
+		res.Decision = policy.Effect
+		res.Reasons = append(res.Reasons, "risk within allow threshold")
+		return res, nil
+	case res.RiskLevel <= policy.StepUpRisk && len(policy.StepUpChallenges) > 0:
+		challengesSatisfied := true
+		missing := make([]challenge.Info, 0, len(policy.StepUpChallenges))
+		for _, chType := range policy.StepUpChallenges {
+			ch, err := e.challenges.Get(chType)
+			if err != nil {
+				return res, fmt.Errorf("challenge %s not available: %w", chType, err)
+			}
+			if err := ch.Verify(req.ChallengeResponses[chType]); err != nil {
+				challengesSatisfied = false
+				missing = append(missing, challenge.Info{Type: chType, Prompt: ch.Prompt()})
+			}
+		}
+		if challengesSatisfied {
+			res.Decision = policy.Effect
+			res.Reasons = append(res.Reasons, "step-up completed")
+			return res, nil
+		}
+		res.Decision = DecisionStepUp
+		res.RequiredChallenges = missing
+		res.Reasons = append(res.Reasons, "step-up required")
+		return res, nil
+	default:
+		res.Decision = DecisionDeny
+		res.Reasons = append(res.Reasons, "risk exceeds deny threshold")
+		return res, nil
+	}
+}

--- a/services/cab/internal/engine/engine_test.go
+++ b/services/cab/internal/engine/engine_test.go
@@ -1,0 +1,110 @@
+package engine_test
+
+import (
+	"testing"
+
+	"github.com/summit/cab/internal/challenge"
+	"github.com/summit/cab/internal/engine"
+	"github.com/summit/cab/internal/risk"
+)
+
+func newTestEngine(t *testing.T) *engine.Engine {
+	t.Helper()
+	policies := []engine.Policy{
+		{
+			ID:               "test-policy",
+			Actions:          []string{"workspace:update"},
+			Subject:          map[string]engine.AttributeCondition{"role": {Equals: "admin"}},
+			Resource:         map[string]engine.AttributeCondition{"classification": {Equals: "internal"}},
+			Effect:           engine.DecisionAllow,
+			AllowRisk:        risk.LevelLow,
+			StepUpRisk:       risk.LevelMedium,
+			StepUpChallenges: []string{"totp", "hardware-key"},
+		},
+	}
+	scorers := []risk.Scorer{
+		risk.GeoScorer{Allowed: []string{"us"}, UnknownIsRisk: true},
+		risk.DevicePostureScorer{TrustedPostures: []string{"trusted"}},
+		risk.AnomalyScorer{Name: "anomaly", StepUpFloor: 0.4, DenyFloor: 0.8},
+	}
+	registry := challenge.NewRegistry(
+		challenge.NewTOTPChallenge("654321"),
+		challenge.NewHardwareKeyChallenge("cab-hardware-assertion"),
+	)
+	eng, err := engine.New(policies, scorers, registry)
+	if err != nil {
+		t.Fatalf("failed to create engine: %v", err)
+	}
+	return eng
+}
+
+func baseRequest() engine.Request {
+	return engine.Request{
+		Action:   "workspace:update",
+		Subject:  map[string]string{"role": "admin"},
+		Resource: map[string]string{"classification": "internal"},
+		Signals: risk.Signals{
+			Geo:           "US",
+			DevicePosture: "trusted",
+			AnomalyScore:  0.2,
+		},
+	}
+}
+
+func TestDeterministicDecision(t *testing.T) {
+	eng := newTestEngine(t)
+	req := baseRequest()
+	first, err := eng.Evaluate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	second, err := eng.Evaluate(req)
+	if err != nil {
+		t.Fatalf("unexpected error on second evaluation: %v", err)
+	}
+	if first.Decision != second.Decision || first.RiskLevel != second.RiskLevel {
+		t.Fatalf("expected deterministic results, got %v and %v", first, second)
+	}
+}
+
+func TestStepUpRequiredAndSatisfied(t *testing.T) {
+	eng := newTestEngine(t)
+	req := baseRequest()
+	req.Signals.AnomalyScore = 0.5 // triggers step-up window
+	resp, err := eng.Evaluate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Decision != engine.DecisionStepUp {
+		t.Fatalf("expected step-up decision, got %s", resp.Decision)
+	}
+	if len(resp.RequiredChallenges) != 2 {
+		t.Fatalf("expected both challenges, got %d", len(resp.RequiredChallenges))
+	}
+
+	req.ChallengeResponses = map[string]challenge.VerificationInput{
+		"totp":         {"code": "654321"},
+		"hardware-key": {"assertion": "cab-hardware-assertion"},
+	}
+	resp, err = eng.Evaluate(req)
+	if err != nil {
+		t.Fatalf("unexpected error when verifying: %v", err)
+	}
+	if resp.Decision != engine.DecisionAllow {
+		t.Fatalf("expected allow after step-up, got %s", resp.Decision)
+	}
+}
+
+func TestHighRiskDenied(t *testing.T) {
+	eng := newTestEngine(t)
+	req := baseRequest()
+	req.Signals.AnomalyScore = 0.95
+	req.Signals.DevicePosture = "compromised"
+	resp, err := eng.Evaluate(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Decision != engine.DecisionDeny {
+		t.Fatalf("expected deny, got %s", resp.Decision)
+	}
+}

--- a/services/cab/internal/engine/policy.go
+++ b/services/cab/internal/engine/policy.go
@@ -1,0 +1,94 @@
+package engine
+
+import (
+	"strings"
+
+	"github.com/summit/cab/internal/risk"
+)
+
+// AttributeCondition expresses a simple ABAC condition on an attribute value.
+type AttributeCondition struct {
+	Equals string   `json:"equals,omitempty"`
+	In     []string `json:"in,omitempty"`
+	NotIn  []string `json:"notIn,omitempty"`
+	Exists *bool    `json:"exists,omitempty"`
+}
+
+func (c AttributeCondition) evaluate(val string, ok bool) bool {
+	if c.Exists != nil {
+		if *c.Exists != ok {
+			return false
+		}
+	}
+	if !ok {
+		return c.Equals == "" && len(c.In) == 0 && len(c.NotIn) == 0
+	}
+	if c.Equals != "" && !strings.EqualFold(c.Equals, val) {
+		return false
+	}
+	if len(c.In) > 0 {
+		matched := false
+		for _, candidate := range c.In {
+			if strings.EqualFold(candidate, val) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	if len(c.NotIn) > 0 {
+		for _, candidate := range c.NotIn {
+			if strings.EqualFold(candidate, val) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// Policy describes an ABAC rule used by the engine.
+type Policy struct {
+	ID               string
+	Description      string
+	Actions          []string
+	Subject          map[string]AttributeCondition
+	Resource         map[string]AttributeCondition
+	Effect           Decision
+	AllowRisk        risk.Level
+	StepUpRisk       risk.Level
+	StepUpChallenges []string
+}
+
+func (p Policy) matches(req Request) bool {
+	if len(p.Actions) > 0 {
+		matched := false
+		for _, action := range p.Actions {
+			if strings.EqualFold(action, req.Action) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	if !matchAttributes(p.Subject, req.Subject) {
+		return false
+	}
+	if !matchAttributes(p.Resource, req.Resource) {
+		return false
+	}
+	return true
+}
+
+func matchAttributes(conditions map[string]AttributeCondition, values map[string]string) bool {
+	for key, cond := range conditions {
+		val, ok := values[key]
+		if !cond.evaluate(val, ok) {
+			return false
+		}
+	}
+	return true
+}

--- a/services/cab/internal/risk/anomaly.go
+++ b/services/cab/internal/risk/anomaly.go
@@ -1,0 +1,28 @@
+package risk
+
+// AnomalyScorer thresholds anomaly scores into discrete risk levels.
+type AnomalyScorer struct {
+	Name        string
+	StepUpFloor float64
+	DenyFloor   float64
+}
+
+func (a AnomalyScorer) Score(in Input) Result {
+	result := Result{Name: chooseName(a.Name, "anomaly")}
+	score := in.Signals.AnomalyScore
+	switch {
+	case score < a.StepUpFloor:
+		result.Level = LevelLow
+		result.Score = score
+		result.Reasons = []string{"anomaly score within baseline"}
+	case score < a.DenyFloor:
+		result.Level = LevelMedium
+		result.Score = score
+		result.Reasons = []string{"anomaly score suggests friction"}
+	default:
+		result.Level = LevelHigh
+		result.Score = score
+		result.Reasons = []string{"anomaly score exceeds deny floor"}
+	}
+	return result
+}

--- a/services/cab/internal/risk/device.go
+++ b/services/cab/internal/risk/device.go
@@ -1,0 +1,34 @@
+package risk
+
+import "strings"
+
+// DevicePostureScorer raises risk when the reported device posture is not trusted.
+type DevicePostureScorer struct {
+	Name            string
+	TrustedPostures []string
+}
+
+func (d DevicePostureScorer) Score(in Input) Result {
+	result := Result{Name: chooseName(d.Name, "device_posture")}
+	posture := strings.ToLower(strings.TrimSpace(in.Signals.DevicePosture))
+	if posture == "" {
+		result.Level = LevelMedium
+		result.Score = 0.65
+		result.Reasons = []string{"device posture unavailable"}
+		return result
+	}
+
+	for _, trusted := range d.TrustedPostures {
+		if posture == strings.ToLower(strings.TrimSpace(trusted)) {
+			result.Level = LevelLow
+			result.Score = 0.2
+			result.Reasons = []string{"device posture trusted"}
+			return result
+		}
+	}
+
+	result.Level = LevelHigh
+	result.Score = 0.92
+	result.Reasons = []string{"untrusted device posture"}
+	return result
+}

--- a/services/cab/internal/risk/geo.go
+++ b/services/cab/internal/risk/geo.go
@@ -1,0 +1,52 @@
+package risk
+
+import "strings"
+
+// GeoScorer flags access from locations outside the allowed list as elevated risk.
+type GeoScorer struct {
+	Name          string
+	Allowed       []string
+	Elevated      []string
+	UnknownIsRisk bool
+}
+
+func (g GeoScorer) Score(in Input) Result {
+	result := Result{Name: chooseName(g.Name, "geo")}
+	region := strings.ToLower(strings.TrimSpace(in.Signals.Geo))
+	if region == "" {
+		result.Level = LevelMedium
+		result.Score = 0.6
+		result.Reasons = []string{"missing geo signal"}
+		return result
+	}
+
+	for _, allowed := range g.Allowed {
+		if region == strings.ToLower(strings.TrimSpace(allowed)) {
+			result.Level = LevelLow
+			result.Score = 0.1
+			result.Reasons = []string{"geo within allowlist"}
+			return result
+		}
+	}
+
+	for _, elevated := range g.Elevated {
+		if region == strings.ToLower(strings.TrimSpace(elevated)) {
+			result.Level = LevelMedium
+			result.Score = 0.7
+			result.Reasons = []string{"geo requires step-up"}
+			return result
+		}
+	}
+
+	if g.UnknownIsRisk {
+		result.Level = LevelHigh
+		result.Score = 0.95
+		result.Reasons = []string{"geo outside trust boundary"}
+		return result
+	}
+
+	result.Level = LevelMedium
+	result.Score = 0.75
+	result.Reasons = []string{"geo not explicitly allowed"}
+	return result
+}

--- a/services/cab/internal/risk/helpers.go
+++ b/services/cab/internal/risk/helpers.go
@@ -1,0 +1,8 @@
+package risk
+
+func chooseName(provided, fallback string) string {
+	if provided != "" {
+		return provided
+	}
+	return fallback
+}

--- a/services/cab/internal/risk/risk.go
+++ b/services/cab/internal/risk/risk.go
@@ -1,0 +1,65 @@
+package risk
+
+import "fmt"
+
+// Level represents the aggregated risk level determined by the engine.
+type Level int
+
+const (
+	LevelLow Level = iota
+	LevelMedium
+	LevelHigh
+)
+
+func (l Level) String() string {
+	switch l {
+	case LevelLow:
+		return "low"
+	case LevelMedium:
+		return "medium"
+	case LevelHigh:
+		return "high"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(l))
+	}
+}
+
+// Signals captures the core telemetry that feeds risk scorers.
+type Signals struct {
+	Geo           string         `json:"geo"`
+	DevicePosture string         `json:"devicePosture"`
+	AnomalyScore  float64        `json:"anomalyScore"`
+	Additional    map[string]any `json:"additional,omitempty"`
+}
+
+// Input represents the data provided to risk scorers.
+type Input struct {
+	Signals  Signals
+	Subject  map[string]string
+	Resource map[string]string
+	Action   string
+}
+
+// Result captures the outcome of a risk scorer evaluation.
+type Result struct {
+	Name    string
+	Level   Level
+	Score   float64
+	Reasons []string
+}
+
+// Scorer evaluates a set of signals and produces a risk result.
+type Scorer interface {
+	Score(in Input) Result
+}
+
+// CombineLevels returns the highest severity level from a set of results.
+func CombineLevels(results []Result) Level {
+	highest := LevelLow
+	for _, res := range results {
+		if res.Level > highest {
+			highest = res.Level
+		}
+	}
+	return highest
+}

--- a/ui/cab-simulator.html
+++ b/ui/cab-simulator.html
@@ -1,0 +1,469 @@
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>CAB Simulator</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" />
+    <style>
+      body {
+        background: #0f172a;
+        color: #e2e8f0;
+      }
+      main {
+        max-width: 1100px;
+        margin: 2rem auto;
+      }
+      .card {
+        background: rgba(15, 23, 42, 0.85);
+        border-radius: 12px;
+        padding: 1.5rem;
+        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.4);
+      }
+      .grid {
+        display: grid;
+        gap: 1rem;
+      }
+      .grid.two {
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+      textarea {
+        min-height: 120px;
+      }
+      .decision-allow {
+        color: #4ade80;
+      }
+      .decision-step-up {
+        color: #fbbf24;
+      }
+      .decision-deny {
+        color: #f87171;
+      }
+      .scenario-list li {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        background: rgba(30, 41, 59, 0.8);
+        padding: 0.75rem 1rem;
+        border-radius: 10px;
+        margin-bottom: 0.5rem;
+      }
+    </style>
+  </head>
+  <body>
+    <main id="app"></main>
+    <script type="text/babel">
+      const { useState, useEffect } = React;
+
+      const defaultRequest = {
+        action: 'workspace:update',
+        subject: { role: 'admin' },
+        resource: { classification: 'internal' },
+        signals: {
+          geo: 'US',
+          devicePosture: 'trusted',
+          anomalyScore: 0.2,
+        },
+      };
+
+      const API = {
+        async request(baseUrl, path, options = {}) {
+          const url = `${baseUrl}${path}`;
+          const response = await fetch(url, {
+            headers: { 'Content-Type': 'application/json' },
+            ...options,
+          });
+          const text = await response.text();
+          const json = text ? JSON.parse(text) : {};
+          if (!response.ok) {
+            throw new Error(json.error || response.statusText);
+          }
+          return json;
+        },
+        evaluate(baseUrl, payload) {
+          return API.request(baseUrl, '/evaluate', {
+            method: 'POST',
+            body: JSON.stringify(payload),
+          });
+        },
+        saveScenario(baseUrl, name, request) {
+          return API.request(baseUrl, '/scenarios', {
+            method: 'POST',
+            body: JSON.stringify({ name, request }),
+          });
+        },
+        listScenarios(baseUrl) {
+          return API.request(baseUrl, '/scenarios', {
+            method: 'GET',
+          });
+        },
+        replayScenario(baseUrl, id) {
+          return API.request(baseUrl, `/scenarios/${id}/replay`, {
+            method: 'POST',
+          });
+        },
+      };
+
+      const ScenarioStorage = {
+        key: 'cab-scenarios',
+        load() {
+          try {
+            const raw = window.localStorage.getItem(ScenarioStorage.key);
+            return raw ? JSON.parse(raw) : [];
+          } catch (error) {
+            console.warn('Failed to load scenarios', error);
+            return [];
+          }
+        },
+        save(scenarios) {
+          window.localStorage.setItem(ScenarioStorage.key, JSON.stringify(scenarios));
+        },
+      };
+
+      function DecisionBadge({ decision }) {
+        const className = {
+          allow: 'decision-allow',
+          'step-up': 'decision-step-up',
+          deny: 'decision-deny',
+        }[decision] || '';
+        return <strong className={className}>{decision.toUpperCase()}</strong>;
+      }
+
+      function RequestEditor({ request, onChange }) {
+        const updateField = (section, key, value) => {
+          const next = { ...request, [section]: { ...request[section], [key]: value } };
+          if (section === 'signals' && key === 'anomalyScore') {
+            next.signals.anomalyScore = parseFloat(value) || 0;
+          }
+          onChange(next);
+        };
+
+        return (
+          <div className="grid two">
+            <div className="card">
+              <h3>Subject</h3>
+              <label>
+                Role
+                <input
+                  value={request.subject.role || ''}
+                  onChange={(e) => updateField('subject', 'role', e.target.value)}
+                />
+              </label>
+            </div>
+            <div className="card">
+              <h3>Resource</h3>
+              <label>
+                Classification
+                <input
+                  value={request.resource.classification || ''}
+                  onChange={(e) => updateField('resource', 'classification', e.target.value)}
+                />
+              </label>
+            </div>
+            <div className="card">
+              <h3>Action</h3>
+              <label>
+                Action
+                <input value={request.action} onChange={(e) => onChange({ ...request, action: e.target.value })} />
+              </label>
+            </div>
+            <div className="card">
+              <h3>Signals</h3>
+              <label>
+                Geo
+                <input
+                  value={request.signals.geo}
+                  onChange={(e) => updateField('signals', 'geo', e.target.value)}
+                />
+              </label>
+              <label>
+                Device Posture
+                <input
+                  value={request.signals.devicePosture}
+                  onChange={(e) => updateField('signals', 'devicePosture', e.target.value)}
+                />
+              </label>
+              <label>
+                Anomaly Score
+                <input
+                  type="number"
+                  step="0.01"
+                  value={request.signals.anomalyScore}
+                  onChange={(e) => updateField('signals', 'anomalyScore', e.target.value)}
+                />
+              </label>
+            </div>
+          </div>
+        );
+      }
+
+      function StepUpInputs({ responses, onChange }) {
+        const update = (key, value) => {
+          onChange({ ...responses, [key]: value });
+        };
+        return (
+          <div className="card">
+            <h3>Step-Up Challenges</h3>
+            <label>
+              TOTP Code
+              <input value={responses.totp || ''} onChange={(e) => update('totp', e.target.value)} />
+            </label>
+            <label>
+              Hardware Assertion
+              <input value={responses.hardware || ''} onChange={(e) => update('hardware', e.target.value)} />
+            </label>
+            <small>Use code <code>654321</code> and assertion <code>cab-hardware-assertion</code> to satisfy defaults.</small>
+          </div>
+        );
+      }
+
+      function RiskBreakdown({ breakdown }) {
+        return (
+          <div className="card">
+            <h3>Risk Breakdown</h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Source</th>
+                  <th>Level</th>
+                  <th>Score</th>
+                  <th>Reasons</th>
+                </tr>
+              </thead>
+              <tbody>
+                {breakdown.map((entry) => (
+                  <tr key={entry.name}>
+                    <td>{entry.name}</td>
+                    <td>{entry.level}</td>
+                    <td>{entry.score.toFixed(2)}</td>
+                    <td>{entry.reasons.join(', ')}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        );
+      }
+
+      function ScenarioList({ scenarios, onReplay, onSelect }) {
+        return (
+          <div className="card">
+            <h3>Saved Scenarios</h3>
+            {scenarios.length === 0 ? (
+              <p>No scenarios saved yet.</p>
+            ) : (
+              <ul className="scenario-list">
+                {scenarios.map((scenario) => (
+                  <li key={scenario.id}>
+                    <div>
+                      <strong>{scenario.name}</strong>
+                      <br />
+                      <small>{scenario.response.decision.toUpperCase()}</small>
+                    </div>
+                    <div>
+                      <button onClick={() => onSelect(scenario)}>Load</button>
+                      <button onClick={() => onReplay(scenario)}>Replay</button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        );
+      }
+
+      function App() {
+        const [baseUrl, setBaseUrl] = useState('http://localhost:8085');
+        const [request, setRequest] = useState(defaultRequest);
+        const [responses, setResponses] = useState({ totp: '', hardware: '' });
+        const [decision, setDecision] = useState(null);
+        const [loading, setLoading] = useState(false);
+        const [error, setError] = useState('');
+        const [scenarios, setScenarios] = useState(() => ScenarioStorage.load());
+        const [serverScenarios, setServerScenarios] = useState([]);
+        const [replayStatus, setReplayStatus] = useState('');
+
+        useEffect(() => {
+          ScenarioStorage.save(scenarios);
+        }, [scenarios]);
+
+        const evaluate = async (overrideResponses) => {
+          setLoading(true);
+          setError('');
+          setReplayStatus('');
+          try {
+            const challengeResponses = buildChallenges(overrideResponses ?? responses);
+            const payload = {
+              ...request,
+              ...(challengeResponses ? { challengeResponses } : {}),
+            };
+            const result = await API.evaluate(baseUrl, payload);
+            setDecision(result);
+            return result;
+          } catch (err) {
+            setError(err.message || String(err));
+          } finally {
+            setLoading(false);
+          }
+        };
+
+        const saveScenario = async () => {
+          if (!decision) return;
+          const name = window.prompt('Scenario name');
+          if (!name) return;
+          try {
+            const remote = await API.saveScenario(baseUrl, name, request);
+            const local = { id: remote.id, name, request, response: decision };
+            setScenarios((prev) => [...prev, local]);
+            await refreshServerScenarios();
+          } catch (err) {
+            setError(err.message || String(err));
+          }
+        };
+
+        const refreshServerScenarios = async () => {
+          try {
+            const remote = await API.listScenarios(baseUrl);
+            setServerScenarios(remote);
+          } catch (err) {
+            console.warn('Unable to list scenarios', err);
+          }
+        };
+
+        useEffect(() => {
+          refreshServerScenarios();
+        }, []);
+
+        const handleReplay = async (scenario) => {
+          try {
+            const result = await API.replayScenario(baseUrl, scenario.id);
+            setReplayStatus(result.match ? 'Scenario decision reproduced.' : 'Decision drift detected.');
+            setDecision(result.decision);
+          } catch (err) {
+            setError(err.message || String(err));
+          }
+        };
+
+        const loadScenario = (scenario) => {
+          setRequest(scenario.request);
+          setDecision(scenario.response);
+        };
+
+        const challengeSummaries = decision?.requiredChallenges?.map((c) => `${c.type}: ${c.prompt}`);
+
+        return (
+          <main>
+            <header>
+              <h1>Contextual Access Broker Simulator</h1>
+              <p>
+                Exercise CAB policies with adjustable signals. Decisions are deterministic for a given input, and saved
+                scenarios can be replayed to confirm stability.
+              </p>
+            </header>
+
+            <article className="card">
+              <label>
+                CAB Base URL
+                <input value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} />
+              </label>
+              <button disabled={loading} onClick={() => evaluate()}>
+                {loading ? 'Evaluating…' : 'Evaluate request'}
+              </button>
+              {decision?.decision === 'step-up' && (
+                <button
+                  style={{ marginLeft: '0.5rem' }}
+                  onClick={() =>
+                    evaluate({
+                      totp: responses.totp,
+                      hardware: responses.hardware,
+                    })
+                  }
+                >
+                  Re-run with challenges
+                </button>
+              )}
+              <button style={{ marginLeft: '0.5rem' }} disabled={!decision} onClick={saveScenario}>
+                Save scenario
+              </button>
+              <button style={{ marginLeft: '0.5rem' }} onClick={refreshServerScenarios}>
+                Refresh server scenarios
+              </button>
+              {error && <p style={{ color: '#f87171' }}>{error}</p>}
+              {replayStatus && <p style={{ color: '#38bdf8' }}>{replayStatus}</p>}
+            </article>
+
+            <section>
+              <RequestEditor request={request} onChange={setRequest} />
+              <StepUpInputs responses={responses} onChange={setResponses} />
+            </section>
+
+            {decision && (
+              <section className="card">
+                <h2>
+                  Decision: <DecisionBadge decision={decision.decision} />
+                </h2>
+                <p>
+                  Risk level: <strong>{decision.riskLevel.toUpperCase()}</strong>
+                </p>
+                <p>{decision.reasons.join(', ')}</p>
+                {challengeSummaries && challengeSummaries.length > 0 && (
+                  <ul>
+                    {challengeSummaries.map((summary) => (
+                      <li key={summary}>{summary}</li>
+                    ))}
+                  </ul>
+                )}
+                {decision.riskBreakdown && decision.riskBreakdown.length > 0 && (
+                  <RiskBreakdown breakdown={decision.riskBreakdown} />
+                )}
+              </section>
+            )}
+
+            <section className="grid two">
+              <ScenarioList scenarios={scenarios} onReplay={handleReplay} onSelect={loadScenario} />
+              <div className="card">
+                <h3>Server Scenarios</h3>
+                {serverScenarios.length === 0 ? (
+                  <p>No server-side scenarios stored yet.</p>
+                ) : (
+                  <ul className="scenario-list">
+                    {serverScenarios.map((scenario) => (
+                      <li key={scenario.id}>
+                        <div>
+                          <strong>{scenario.name}</strong>
+                          <br />
+                          <small>{scenario.response.decision.toUpperCase()}</small>
+                        </div>
+                        <div>
+                          <button onClick={() => loadScenario(scenario)}>Load</button>
+                          <button onClick={() => handleReplay(scenario)}>Replay</button>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </section>
+          </main>
+        );
+      }
+
+      function buildChallenges(responses) {
+        const entries = {};
+        if (responses.totp) {
+          entries['totp'] = { code: responses.totp };
+        }
+        if (responses.hardware) {
+          entries['hardware-key'] = { assertion: responses.hardware };
+        }
+        return Object.keys(entries).length > 0 ? entries : null;
+      }
+
+      ReactDOM.createRoot(document.getElementById('app')).render(<App />);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement a Go-based Contextual Access Broker with ABAC policies, pluggable risk scorers, enforced step-up challenges, and scenario replay APIs
- add a TypeScript SDK that wraps the CAB service endpoints for evaluation, scenario storage, and replay flows
- deliver a standalone simulator UI for exercising CAB requests, validating step-up responses, and managing saved scenarios

## Testing
- `(cd services/cab && go test ./...)`

------
https://chatgpt.com/codex/tasks/task_e_68d73f7db9cc8333a6d8d338b12b9df6