### PR TITLE
feat: add prompt policy composer framework

### DIFF
--- a/src/ppc/adapters.ts
+++ b/src/ppc/adapters.ts
@@ -1,0 +1,247 @@
+import {
+  GuardTrace,
+  Policy,
+  PolicyExecution,
+} from './types';
+
+export interface LLMRequest {
+  prompt: string;
+  tools?: string[];
+  metadata?: Record<string, unknown>;
+  response?: string;
+}
+
+export interface GuardedLLMResult {
+  blocked: boolean;
+  blockedBy?: string;
+  prompt: string;
+  response?: string;
+  tools: string[];
+  metadata: Record<string, unknown>;
+  trace: GuardTrace[];
+  stage: 'prompt' | 'response' | 'complete';
+}
+
+export interface OpenAIStubCompletion {
+  output?: string;
+  content?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface OpenAIStub {
+  complete(request: { prompt: string; tools?: string[] }): Promise<
+    OpenAIStubCompletion | string
+  >;
+}
+
+export interface AnthropicStubCompletion {
+  text?: string;
+  content?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AnthropicStub {
+  respond(request: { prompt: string; tools?: string[] }): Promise<
+    AnthropicStubCompletion | string
+  >;
+}
+
+const normalizeOutput = (
+  completion: string | OpenAIStubCompletion | AnthropicStubCompletion
+): { output: string; metadata: Record<string, unknown> } => {
+  if (typeof completion === 'string') {
+    return { output: completion, metadata: {} };
+  }
+
+  const output =
+    completion.output ?? completion.content ?? completion.text ?? '';
+
+  return {
+    output,
+    metadata: { ...(completion.metadata ?? {}) },
+  };
+};
+
+const mergeTraces = (first: GuardTrace[], second: GuardTrace[]): GuardTrace[] => {
+  const offset = first.length;
+  return [
+    ...first,
+    ...second.map((trace) => ({
+      ...trace,
+      order: trace.order + offset,
+    })),
+  ];
+};
+
+const runPromptStage = async (
+  policy: Policy,
+  provider: string,
+  request: LLMRequest
+): Promise<PolicyExecution> =>
+  policy.execute({
+    prompt: request.prompt,
+    tools: request.tools,
+    metadata: { provider, ...(request.metadata ?? {}) },
+  });
+
+const runResponseStage = async (
+  policy: Policy,
+  provider: string,
+  promptResult: PolicyExecution,
+  responseText: string
+): Promise<PolicyExecution> =>
+  policy.execute({
+    prompt: promptResult.prompt,
+    response: responseText,
+    tools: promptResult.tools,
+    metadata: { ...promptResult.metadata, provider },
+  });
+
+const dryRun = async (
+  policy: Policy,
+  provider: string,
+  request: LLMRequest
+): Promise<GuardedLLMResult> => {
+  const evaluation = await policy.dryRun({
+    prompt: request.prompt,
+    response: request.response,
+    tools: request.tools,
+    metadata: { provider, ...(request.metadata ?? {}) },
+  });
+
+  return {
+    blocked: !evaluation.allowed,
+    blockedBy: evaluation.blockedBy,
+    prompt: evaluation.prompt,
+    response: evaluation.response,
+    tools: evaluation.tools,
+    metadata: evaluation.metadata,
+    trace: evaluation.trace,
+    stage: request.response ? 'response' : 'prompt',
+  };
+};
+
+export const createOpenAIAdapter = (
+  policy: Policy,
+  client: OpenAIStub
+) => ({
+  async complete(request: LLMRequest): Promise<GuardedLLMResult> {
+    const promptStage = await runPromptStage(policy, 'openai', request);
+    if (!promptStage.allowed) {
+      return {
+        blocked: true,
+        blockedBy: promptStage.blockedBy,
+        prompt: promptStage.prompt,
+        response: promptStage.response,
+        tools: promptStage.tools,
+        metadata: promptStage.metadata,
+        trace: promptStage.trace,
+        stage: 'prompt',
+      };
+    }
+
+    const completion = await client.complete({
+      prompt: promptStage.prompt,
+      tools: promptStage.tools,
+    });
+
+    const normalized = normalizeOutput(completion);
+
+    const responseStage = await runResponseStage(
+      policy,
+      'openai',
+      promptStage,
+      normalized.output
+    );
+
+    const trace = mergeTraces(promptStage.trace, responseStage.trace);
+
+    if (!responseStage.allowed) {
+      return {
+        blocked: true,
+        blockedBy: responseStage.blockedBy,
+        prompt: promptStage.prompt,
+        response: responseStage.response ?? normalized.output,
+        tools: responseStage.tools,
+        metadata: { ...promptStage.metadata, ...normalized.metadata },
+        trace,
+        stage: 'response',
+      };
+    }
+
+    return {
+      blocked: false,
+      prompt: responseStage.prompt,
+      response: responseStage.response ?? normalized.output,
+      tools: responseStage.tools,
+      metadata: { ...promptStage.metadata, ...normalized.metadata },
+      trace,
+      stage: 'complete',
+    };
+  },
+  dryRun(request: LLMRequest): Promise<GuardedLLMResult> {
+    return dryRun(policy, 'openai', request);
+  },
+});
+
+export const createAnthropicAdapter = (
+  policy: Policy,
+  client: AnthropicStub
+) => ({
+  async complete(request: LLMRequest): Promise<GuardedLLMResult> {
+    const promptStage = await runPromptStage(policy, 'anthropic', request);
+    if (!promptStage.allowed) {
+      return {
+        blocked: true,
+        blockedBy: promptStage.blockedBy,
+        prompt: promptStage.prompt,
+        response: promptStage.response,
+        tools: promptStage.tools,
+        metadata: promptStage.metadata,
+        trace: promptStage.trace,
+        stage: 'prompt',
+      };
+    }
+
+    const completion = await client.respond({
+      prompt: promptStage.prompt,
+      tools: promptStage.tools,
+    });
+
+    const normalized = normalizeOutput(completion);
+
+    const responseStage = await runResponseStage(
+      policy,
+      'anthropic',
+      promptStage,
+      normalized.output
+    );
+    const trace = mergeTraces(promptStage.trace, responseStage.trace);
+
+    if (!responseStage.allowed) {
+      return {
+        blocked: true,
+        blockedBy: responseStage.blockedBy,
+        prompt: promptStage.prompt,
+        response: responseStage.response ?? normalized.output,
+        tools: responseStage.tools,
+        metadata: { ...promptStage.metadata, ...normalized.metadata },
+        trace,
+        stage: 'response',
+      };
+    }
+
+    return {
+      blocked: false,
+      prompt: responseStage.prompt,
+      response: responseStage.response ?? normalized.output,
+      tools: responseStage.tools,
+      metadata: { ...promptStage.metadata, ...normalized.metadata },
+      trace,
+      stage: 'complete',
+    };
+  },
+  dryRun(request: LLMRequest): Promise<GuardedLLMResult> {
+    return dryRun(policy, 'anthropic', request);
+  },
+});

--- a/src/ppc/dsl.ts
+++ b/src/ppc/dsl.ts
@@ -1,0 +1,169 @@
+import { instantiatePolicy } from './policy';
+import {
+  ClassifierFn,
+  ClassifierGuardOptions,
+  GuardDefinition,
+  Policy,
+  RedactorGuardOptions,
+  RedactorRule,
+  RegexGuardOptions,
+  ToolScopeGuardOptions,
+} from './types';
+
+type RegexGuardConfig = Omit<RegexGuardOptions, 'name' | 'pattern' | 'target'>;
+type ClassifierGuardConfig = Omit<
+  ClassifierGuardOptions,
+  'name' | 'classifier' | 'target'
+>;
+type RedactorGuardConfig = Omit<
+  RedactorGuardOptions,
+  'name' | 'rules' | 'target'
+>;
+type ToolScopeGuardConfig = Omit<ToolScopeGuardOptions, 'name' | 'allowedTools'>;
+
+interface PromptDSL {
+  regex(name: string, pattern: RegExp, options?: RegexGuardConfig): void;
+  classifier(
+    name: string,
+    classifier: ClassifierFn,
+    options: ClassifierGuardConfig
+  ): void;
+  redactor(
+    name: string,
+    rules: RedactorRule[],
+    options?: RedactorGuardConfig
+  ): void;
+}
+
+interface ResponseDSL {
+  regex(name: string, pattern: RegExp, options?: RegexGuardConfig): void;
+  classifier(
+    name: string,
+    classifier: ClassifierFn,
+    options: ClassifierGuardConfig
+  ): void;
+  redactor(
+    name: string,
+    rules: RedactorRule[],
+    options?: RedactorGuardConfig
+  ): void;
+}
+
+interface ToolsDSL {
+  limit(name: string, allowedTools: string[], options?: ToolScopeGuardConfig): void;
+}
+
+export interface DSL {
+  prompt: PromptDSL;
+  response: ResponseDSL;
+  tools: ToolsDSL;
+  use(definition: GuardDefinition): void;
+}
+
+const createDSL = (definitions: GuardDefinition[]): DSL => {
+  const push = (definition: GuardDefinition) => {
+    definitions.push(definition);
+  };
+
+  const prompt: PromptDSL = {
+    regex(name, pattern, options) {
+      push({
+        kind: 'regex',
+        options: {
+          name,
+          pattern,
+          target: 'prompt',
+          ...options,
+        },
+      });
+    },
+    classifier(name, classifier, options) {
+      push({
+        kind: 'classifier',
+        options: {
+          name,
+          classifier,
+          target: 'prompt',
+          ...options,
+        },
+      });
+    },
+    redactor(name, rules, options) {
+      push({
+        kind: 'redactor',
+        options: {
+          name,
+          rules,
+          target: 'prompt',
+          ...options,
+        },
+      });
+    },
+  };
+
+  const response: ResponseDSL = {
+    regex(name, pattern, options) {
+      push({
+        kind: 'regex',
+        options: {
+          name,
+          pattern,
+          target: 'response',
+          ...options,
+        },
+      });
+    },
+    classifier(name, classifier, options) {
+      push({
+        kind: 'classifier',
+        options: {
+          name,
+          classifier,
+          target: 'response',
+          ...options,
+        },
+      });
+    },
+    redactor(name, rules, options) {
+      push({
+        kind: 'redactor',
+        options: {
+          name,
+          rules,
+          target: 'response',
+          ...options,
+        },
+      });
+    },
+  };
+
+  const tools: ToolsDSL = {
+    limit(name, allowedTools, options) {
+      push({
+        kind: 'tool-scope',
+        options: {
+          name,
+          allowedTools,
+          ...options,
+        },
+      });
+    },
+  };
+
+  return {
+    prompt,
+    response,
+    tools,
+    use: push,
+  };
+};
+
+export const policy = (
+  name: string,
+  compose: (dsl: DSL) => void
+): Policy => {
+  const definitions: GuardDefinition[] = [];
+  const dsl = createDSL(definitions);
+  compose(dsl);
+  return instantiatePolicy(name, definitions);
+};

--- a/src/ppc/guards.ts
+++ b/src/ppc/guards.ts
@@ -1,0 +1,256 @@
+import {
+  ClassifierGuardOptions,
+  ClassifierResult,
+  Guard,
+  GuardDefinition,
+  GuardEvaluation,
+  GuardKind,
+  GuardRuntimeState,
+  RedactorGuardOptions,
+  RegexGuardOptions,
+  ToolScopeGuardOptions,
+} from './types';
+
+const clonePattern = (pattern: RegExp): RegExp =>
+  new RegExp(pattern.source, pattern.flags);
+
+const resolveTargetValue = (
+  state: GuardRuntimeState,
+  target: 'prompt' | 'response'
+): string | undefined => {
+  if (target === 'prompt') {
+    return state.prompt;
+  }
+
+  return state.response;
+};
+
+class RegexGuard implements Guard {
+  public readonly kind: GuardKind = 'regex';
+
+  public constructor(private readonly options: RegexGuardOptions) {}
+
+  public get name(): string {
+    return this.options.name;
+  }
+
+  public evaluate(state: GuardRuntimeState): GuardEvaluation {
+    const source = resolveTargetValue(state, this.options.target);
+    if (typeof source !== 'string') {
+      return {
+        triggered: false,
+        effect: 'allow',
+      };
+    }
+
+    const pattern = clonePattern(this.options.pattern);
+    const match = pattern.test(source);
+
+    if (!match) {
+      return {
+        triggered: false,
+        effect: 'allow',
+      };
+    }
+
+    const effect = this.options.effect ?? 'block';
+    const description =
+      this.options.description ??
+      `Matched pattern ${pattern.toString()} on ${this.options.target}`;
+
+    if (effect === 'redact') {
+      const replacement = this.options.redaction ?? '[REDACTED]';
+      const updated = source.replace(pattern, replacement);
+      return {
+        triggered: true,
+        effect: 'redact',
+        description,
+        modifications:
+          this.options.target === 'prompt'
+            ? { prompt: updated }
+            : { response: updated },
+      };
+    }
+
+    return {
+      triggered: true,
+      effect,
+      description,
+    };
+  }
+}
+
+class ClassifierGuard implements Guard {
+  public readonly kind: GuardKind = 'classifier';
+
+  public constructor(private readonly options: ClassifierGuardOptions) {}
+
+  public get name(): string {
+    return this.options.name;
+  }
+
+  public async evaluate(
+    state: GuardRuntimeState
+  ): Promise<GuardEvaluation> {
+    const target = resolveTargetValue(state, this.options.target);
+    if (typeof target !== 'string') {
+      return {
+        triggered: false,
+        effect: 'allow',
+      };
+    }
+
+    const result: ClassifierResult = await this.options.classifier(
+      target,
+      state
+    );
+    const triggered = result.score >= this.options.threshold;
+
+    if (!triggered) {
+      return {
+        triggered: false,
+        effect: 'allow',
+        score: result.score,
+        label: result.label,
+      };
+    }
+
+    const effect = this.options.effect ?? 'block';
+    const description =
+      this.options.description ??
+      (result.explanation ??
+        `Classifier score ${result.score.toFixed(2)} exceeded threshold ${this.options.threshold.toFixed(2)}`);
+
+    return {
+      triggered: true,
+      effect,
+      description,
+      score: result.score,
+      label: result.label,
+    };
+  }
+}
+
+class ToolScopeGuard implements Guard {
+  public readonly kind: GuardKind = 'tool-scope';
+
+  public constructor(private readonly options: ToolScopeGuardOptions) {}
+
+  public get name(): string {
+    return this.options.name;
+  }
+
+  public evaluate(state: GuardRuntimeState): GuardEvaluation {
+    const requested = state.tools ?? [];
+    const allowed = new Set(this.options.allowedTools);
+    const unauthorized = requested.filter((tool) => !allowed.has(tool));
+
+    if (unauthorized.length === 0) {
+      return {
+        triggered: false,
+        effect: 'allow',
+      };
+    }
+
+    const mode = this.options.mode ?? 'filter';
+    const description =
+      this.options.description ??
+      `Disallowed tools requested: ${unauthorized.join(', ') || 'unknown'}`;
+
+    if (mode === 'block') {
+      return {
+        triggered: true,
+        effect: 'block',
+        description,
+      };
+    }
+
+    const filteredTools = requested.filter((tool) => allowed.has(tool));
+
+    return {
+      triggered: true,
+      effect: 'limit-tools',
+      description,
+      modifications: {
+        tools: filteredTools,
+      },
+    };
+  }
+}
+
+class RedactorGuard implements Guard {
+  public readonly kind: GuardKind = 'redactor';
+
+  public constructor(private readonly options: RedactorGuardOptions) {}
+
+  public get name(): string {
+    return this.options.name;
+  }
+
+  public evaluate(state: GuardRuntimeState): GuardEvaluation {
+    const source = resolveTargetValue(state, this.options.target);
+    if (typeof source !== 'string') {
+      return {
+        triggered: false,
+        effect: 'allow',
+      };
+    }
+
+    let updated = source;
+    let modified = false;
+    const details: string[] = [];
+
+    for (const rule of this.options.rules) {
+      const pattern = clonePattern(rule.pattern);
+      if (!pattern.test(updated)) {
+        continue;
+      }
+
+      modified = true;
+      updated = updated.replace(pattern, rule.replacement);
+      if (rule.description) {
+        details.push(rule.description);
+      }
+    }
+
+    if (!modified) {
+      return {
+        triggered: false,
+        effect: 'allow',
+      };
+    }
+
+    const description =
+      this.options.description ??
+      (details.length > 0
+        ? `Applied redaction rules: ${details.join(', ')}`
+        : 'Applied redaction rules');
+
+    return {
+      triggered: true,
+      effect: 'redact',
+      description,
+      modifications:
+        this.options.target === 'prompt'
+          ? { prompt: updated }
+          : { response: updated },
+    };
+  }
+}
+
+export const buildGuard = (definition: GuardDefinition): Guard => {
+  switch (definition.kind) {
+    case 'regex':
+      return new RegexGuard(definition.options as RegexGuardOptions);
+    case 'classifier':
+      return new ClassifierGuard(definition.options as ClassifierGuardOptions);
+    case 'tool-scope':
+      return new ToolScopeGuard(definition.options as ToolScopeGuardOptions);
+    case 'redactor':
+      return new RedactorGuard(definition.options as RedactorGuardOptions);
+    default: {
+      const exhaustiveCheck: never = definition;
+      throw new Error(`Unsupported guard kind: ${JSON.stringify(exhaustiveCheck)}`);
+    }
+  }
+};

--- a/src/ppc/index.ts
+++ b/src/ppc/index.ts
@@ -1,0 +1,14 @@
+import { policy as composePolicy } from './dsl';
+import { createAnthropicAdapter, createOpenAIAdapter } from './adapters';
+
+export * from './types';
+export { policy } from './dsl';
+export { createOpenAIAdapter, createAnthropicAdapter } from './adapters';
+
+export const ppc = {
+  policy: composePolicy,
+  adapters: {
+    openai: createOpenAIAdapter,
+    anthropic: createAnthropicAdapter,
+  },
+};

--- a/src/ppc/policy.ts
+++ b/src/ppc/policy.ts
@@ -1,0 +1,120 @@
+import { buildGuard } from './guards';
+import {
+  Guard,
+  GuardDefinition,
+  GuardRuntimeState,
+  GuardTrace,
+  Policy,
+  PolicyExecution,
+  PolicyExecutionOptions,
+  PPCContext,
+} from './types';
+
+const cloneState = (state: GuardRuntimeState): GuardRuntimeState => ({
+  prompt: state.prompt,
+  response: state.response,
+  tools: [...state.tools],
+  metadata: { ...state.metadata },
+});
+
+const applyModifications = (
+  state: GuardRuntimeState,
+  modifications?: Partial<GuardRuntimeState>
+): void => {
+  if (!modifications) {
+    return;
+  }
+
+  if (typeof modifications.prompt === 'string') {
+    state.prompt = modifications.prompt;
+  }
+
+  if (typeof modifications.response === 'string') {
+    state.response = modifications.response;
+  }
+
+  if (Array.isArray(modifications.tools)) {
+    state.tools = [...modifications.tools];
+  }
+
+  if (modifications.metadata && typeof modifications.metadata === 'object') {
+    state.metadata = {
+      ...state.metadata,
+      ...modifications.metadata,
+    };
+  }
+};
+
+class GuardPipeline implements Policy {
+  public constructor(
+    public readonly name: string,
+    private readonly guards: Guard[]
+  ) {}
+
+  public async execute(
+    context: PPCContext,
+    options: PolicyExecutionOptions = {}
+  ): Promise<PolicyExecution> {
+    const state: GuardRuntimeState = {
+      prompt: context.prompt,
+      response: context.response,
+      tools: [...(context.tools ?? [])],
+      metadata: { ...(context.metadata ?? {}) },
+    };
+
+    const trace: GuardTrace[] = [];
+    let allowed = true;
+    let blockedBy: string | undefined;
+
+    for (let index = 0; index < this.guards.length; index += 1) {
+      const guard = this.guards[index];
+      const evaluation = await guard.evaluate(cloneState(state));
+      trace.push({
+        name: guard.name,
+        kind: guard.kind,
+        order: index,
+        triggered: evaluation.triggered,
+        effect: evaluation.effect,
+        description: evaluation.description,
+        modifications: evaluation.modifications,
+        score: evaluation.score,
+        label: evaluation.label,
+      });
+
+      if (!options.dryRun) {
+        applyModifications(state, evaluation.modifications);
+      }
+
+      if (evaluation.triggered && evaluation.effect === 'block') {
+        allowed = false;
+        blockedBy = guard.name;
+        if (!options.dryRun) {
+          break;
+        }
+      }
+    }
+
+    return {
+      name: this.name,
+      allowed,
+      prompt: state.prompt,
+      response: state.response,
+      tools: state.tools,
+      metadata: state.metadata,
+      trace,
+      blockedBy,
+    };
+  }
+
+  public dryRun(context: PPCContext): Promise<PolicyExecution> {
+    return this.execute(context, { dryRun: true });
+  }
+}
+
+export const instantiatePolicy = (
+  name: string,
+  definitions: GuardDefinition[]
+): Policy => {
+  const guards = definitions.map((definition) => buildGuard(definition));
+  return new GuardPipeline(name, guards);
+};

--- a/src/ppc/types.ts
+++ b/src/ppc/types.ts
@@ -1,0 +1,120 @@
+export type GuardKind = 'regex' | 'classifier' | 'tool-scope' | 'redactor';
+
+export type GuardEffect = 'allow' | 'block' | 'redact' | 'limit-tools';
+
+export interface PPCContext {
+  prompt: string;
+  response?: string;
+  tools?: string[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface GuardRuntimeState {
+  prompt: string;
+  response?: string;
+  tools: string[];
+  metadata: Record<string, unknown>;
+}
+
+export interface GuardEvaluation {
+  triggered: boolean;
+  effect: GuardEffect;
+  description?: string;
+  modifications?: Partial<GuardRuntimeState>;
+  score?: number;
+  label?: string;
+}
+
+export interface GuardTrace extends GuardEvaluation {
+  name: string;
+  kind: GuardKind;
+  order: number;
+}
+
+export interface Guard {
+  readonly name: string;
+  readonly kind: GuardKind;
+  evaluate(state: GuardRuntimeState): Promise<GuardEvaluation> | GuardEvaluation;
+}
+
+export interface PolicyExecution {
+  name: string;
+  allowed: boolean;
+  prompt: string;
+  response?: string;
+  tools: string[];
+  metadata: Record<string, unknown>;
+  trace: GuardTrace[];
+  blockedBy?: string;
+}
+
+export interface PolicyExecutionOptions {
+  dryRun?: boolean;
+}
+
+export interface Policy {
+  readonly name: string;
+  execute(
+    context: PPCContext,
+    options?: PolicyExecutionOptions
+  ): Promise<PolicyExecution>;
+  dryRun(context: PPCContext): Promise<PolicyExecution>;
+}
+
+export interface ClassifierResult {
+  score: number;
+  label?: string;
+  explanation?: string;
+}
+
+export type ClassifierFn = (
+  input: string,
+  state: GuardRuntimeState
+) => Promise<ClassifierResult> | ClassifierResult;
+
+export interface RegexGuardOptions {
+  name: string;
+  pattern: RegExp;
+  description?: string;
+  effect?: Extract<GuardEffect, 'block' | 'redact'>;
+  redaction?: string;
+  target: 'prompt' | 'response';
+}
+
+export interface ClassifierGuardOptions {
+  name: string;
+  classifier: ClassifierFn;
+  threshold: number;
+  description?: string;
+  target: 'prompt' | 'response';
+  effect?: Extract<GuardEffect, 'block' | 'allow'>;
+}
+
+export interface ToolScopeGuardOptions {
+  name: string;
+  allowedTools: string[];
+  description?: string;
+  mode?: 'filter' | 'block';
+}
+
+export interface RedactorRule {
+  pattern: RegExp;
+  replacement: string;
+  description?: string;
+}
+
+export interface RedactorGuardOptions {
+  name: string;
+  target: 'prompt' | 'response';
+  rules: RedactorRule[];
+  description?: string;
+}
+
+export interface GuardDefinition {
+  kind: GuardKind;
+  options:
+    | RegexGuardOptions
+    | ClassifierGuardOptions
+    | ToolScopeGuardOptions
+    | RedactorGuardOptions;
+}

--- a/test/ppc/golden-prompts.ts
+++ b/test/ppc/golden-prompts.ts
@@ -1,0 +1,78 @@
+export interface GoldenCase {
+  name: string;
+  request: {
+    prompt: string;
+    tools?: string[];
+    metadata?: Record<string, unknown>;
+  };
+  modelResponse?: string;
+  expected: {
+    stage: 'prompt' | 'response' | 'complete';
+    blocked: boolean;
+    blockedBy?: string;
+    prompt?: string;
+    response?: string;
+    tools?: string[];
+  };
+}
+
+export const goldenPrompts: GoldenCase[] = [
+  {
+    name: 'blocks ssn disclosure',
+    request: {
+      prompt: 'My SSN is 123-45-6789, please remember it.',
+      tools: ['search'],
+    },
+    expected: {
+      stage: 'prompt',
+      blocked: true,
+      blockedBy: 'block-ssn',
+    },
+  },
+  {
+    name: 'redacts email and filters tools',
+    request: {
+      prompt: 'Contact me at admin@example.com tomorrow.',
+      tools: ['search', 'code', 'math'],
+    },
+    modelResponse: 'Sure, I will reach out tomorrow.',
+    expected: {
+      stage: 'complete',
+      blocked: false,
+      prompt: 'Contact me at [email redacted] tomorrow.',
+      response: 'Sure, I will reach out tomorrow.',
+      tools: ['search', 'math'],
+    },
+  },
+  {
+    name: 'blocks toxic response content',
+    request: {
+      prompt: 'Please give me suggestions for my weekend.',
+      tools: ['math'],
+    },
+    modelResponse: 'You should harm others to have fun.',
+    expected: {
+      stage: 'response',
+      blocked: true,
+      blockedBy: 'toxicity',
+      prompt: 'Please give me suggestions for my weekend.',
+      response: 'You should harm others to have fun.',
+      tools: ['math'],
+    },
+  },
+  {
+    name: 'redacts top secret response disclosure',
+    request: {
+      prompt: 'Report the mission status.',
+      tools: ['search'],
+    },
+    modelResponse: 'The mission is TOP SECRET and on schedule.',
+    expected: {
+      stage: 'complete',
+      blocked: false,
+      prompt: 'Report the mission status.',
+      response: 'The mission is [classified] and on schedule.',
+      tools: ['search'],
+    },
+  },
+];

--- a/test/ppc/ppc.spec.ts
+++ b/test/ppc/ppc.spec.ts
@@ -1,0 +1,142 @@
+import { createOpenAIAdapter, ppc, ClassifierFn } from '../../src/ppc';
+import { goldenPrompts } from './golden-prompts';
+
+describe('Prompt Policy Composer (ppc)', () => {
+  const toxicityClassifier: ClassifierFn = async (input) => {
+    const harmful = /harm|attack|kill/i.test(input);
+    return {
+      score: harmful ? 0.92 : 0.08,
+      label: harmful ? 'harmful' : 'benign',
+      explanation: harmful
+        ? 'Detected harmful intent keyword in model response.'
+        : 'No harmful intent detected.',
+    };
+  };
+
+  const policy = ppc.policy('ppc-conformance', ({ prompt, response, tools }) => {
+    prompt.regex('block-ssn', /\b\d{3}-\d{2}-\d{4}\b/, {
+      description: 'Blocks US Social Security numbers in prompts.',
+    });
+
+    prompt.redactor(
+      'mask-email',
+      [
+        {
+          pattern: /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi,
+          replacement: '[email redacted]',
+          description: 'Redacts email addresses from prompts.',
+        },
+      ],
+      { description: 'Prompt email redaction' }
+    );
+
+    tools.limit('restrict-tools', ['search', 'math'], {
+      description: 'Filters tools outside the approved list.',
+      mode: 'filter',
+    });
+
+    response.classifier('toxicity', toxicityClassifier, {
+      threshold: 0.6,
+      description: 'Blocks responses flagged as harmful by classifier.',
+    });
+
+    response.redactor(
+      'mask-secrets',
+      [
+        {
+          pattern: /top secret/gi,
+          replacement: '[classified]',
+          description: 'Masks disclosure of top secret phrases.',
+        },
+      ],
+      { description: 'Response secret redaction' }
+    );
+  });
+
+  it('maintains deterministic guard execution order', async () => {
+    const result = await policy.dryRun({
+      prompt: 'Provide general advice only.',
+      tools: ['code', 'math'],
+    });
+
+    const guardExecutionOrder = result.trace.map((entry) => entry.name);
+    expect(guardExecutionOrder).toEqual([
+      'block-ssn',
+      'mask-email',
+      'restrict-tools',
+      'toxicity',
+      'mask-secrets',
+    ]);
+  });
+
+  it('applies redaction and tool filtering during enforcement', async () => {
+    const result = await policy.execute({
+      prompt: 'Reach me at admin@example.com later.',
+      tools: ['search', 'code', 'math'],
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.prompt).toBe('Reach me at [email redacted] later.');
+    expect(result.tools).toEqual(['search', 'math']);
+
+    const redactionTrace = result.trace.find((entry) => entry.name === 'mask-email');
+    expect(redactionTrace?.triggered).toBe(true);
+    expect(redactionTrace?.effect).toBe('redact');
+
+    const toolTrace = result.trace.find((entry) => entry.name === 'restrict-tools');
+    expect(toolTrace?.triggered).toBe(true);
+    expect(toolTrace?.effect).toBe('limit-tools');
+  });
+
+  it('blocks harmful responses using classifier guard', async () => {
+    const adapter = createOpenAIAdapter(policy, {
+      async complete() {
+        return 'I recommend you harm people.';
+      },
+    });
+
+    const result = await adapter.complete({
+      prompt: 'Suggest fun activities.',
+      tools: ['search'],
+    });
+
+    expect(result.blocked).toBe(true);
+    expect(result.stage).toBe('response');
+    expect(result.blockedBy).toBe('toxicity');
+    const toxicityTrace = result.trace.find((entry) => entry.name === 'toxicity');
+    expect(toxicityTrace?.triggered).toBe(true);
+  });
+
+  describe('golden prompt conformance suite', () => {
+    for (const golden of goldenPrompts) {
+      it(`matches expectations for ${golden.name}`, async () => {
+        const adapter = createOpenAIAdapter(policy, {
+          async complete() {
+            return golden.modelResponse ?? `Echo: ${golden.request.prompt}`;
+          },
+        });
+
+        const result = await adapter.complete(golden.request);
+
+        expect(result.stage).toBe(golden.expected.stage);
+        expect(result.blocked).toBe(golden.expected.blocked);
+
+        if (golden.expected.blockedBy) {
+          expect(result.blockedBy).toBe(golden.expected.blockedBy);
+        }
+
+        if (golden.expected.prompt) {
+          expect(result.prompt).toBe(golden.expected.prompt);
+        }
+
+        if (golden.expected.response) {
+          expect(result.response).toBe(golden.expected.response);
+        }
+
+        if (golden.expected.tools) {
+          expect(result.tools).toEqual(golden.expected.tools);
+        }
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Prompt Policy Composer DSL and guard pipeline for composing regex, classifier, tool-scope, and redactor protections
- provide OpenAI and Anthropic adapters with deterministic tracing and dry-run support
- introduce conformance suite with golden prompts covering guard ordering, redaction, and classifier behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d73d56b4448333a0a24c34c0e2f620