### PR TITLE
feat: add CTPT service and SDK clients

### DIFF
--- a/sdk/python/maestro_sdk/__init__.py
+++ b/sdk/python/maestro_sdk/__init__.py
@@ -1,0 +1,15 @@
+from .ctpt import (
+  CTPTClient,
+  CallbackEventRequest as CTPTCallbackEventRequest,
+  DashboardResponse as CTPTDashboardResponse,
+  PlantTokenRequest as CTPTPlantTokenRequest,
+  PlantTokenResponse as CTPTPlantTokenResponse,
+)
+
+__all__ = [
+  'CTPTClient',
+  'CTPTCallbackEventRequest',
+  'CTPTDashboardResponse',
+  'CTPTPlantTokenRequest',
+  'CTPTPlantTokenResponse',
+]

--- a/sdk/python/maestro_sdk/ctpt.py
+++ b/sdk/python/maestro_sdk/ctpt.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Optional
+
+import httpx
+
+
+@dataclass
+class PlantTokenRequest:
+  type: str
+  planted_by: str
+  source_system: str
+  ttl_seconds: int
+  tags: Optional[list[str]] = None
+  metadata: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class PlantTokenResponse:
+  id: str
+  token_value: str
+  token_type: str
+  display_name: str
+  expires_at: str
+  leak_score: float
+
+
+@dataclass
+class CallbackEventRequest:
+  token_value: str
+  channel: str
+  source_address: Optional[str] = None
+  context: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class DashboardResponse:
+  totals: Dict[str, int]
+  tokens_by_type: Dict[str, int]
+  top_alerts: list[Dict[str, Any]]
+  recent_activity: list[Dict[str, Any]]
+
+
+class CTPTClient:
+  """Client for the Canary Token Planting & Traceback service."""
+
+  def __init__(
+    self,
+    base_url: str,
+    api_key: Optional[str] = None,
+    transport: Optional[httpx.BaseTransport] = None,
+    timeout: Optional[float] = 10.0,
+    client_factory: Callable[..., httpx.Client] = httpx.Client,
+  ) -> None:
+    self._base_url = base_url.rstrip('/')
+    self._api_key = api_key
+    self._client_factory = client_factory
+    self._client_kwargs: Dict[str, Any] = {
+      'base_url': self._base_url,
+      'timeout': timeout,
+    }
+    if transport is not None:
+      self._client_kwargs['transport'] = transport
+
+  def _headers(self) -> Dict[str, str]:
+    headers = {'content-type': 'application/json'}
+    if self._api_key:
+      headers['authorization'] = f'Bearer {self._api_key}'
+    return headers
+
+  def plant_token(self, request: PlantTokenRequest) -> PlantTokenResponse:
+    payload = {
+      'type': request.type,
+      'plantedBy': request.planted_by,
+      'sourceSystem': request.source_system,
+      'ttlSeconds': request.ttl_seconds,
+      'tags': request.tags,
+      'metadata': request.metadata,
+    }
+    with self._client_factory(**self._client_kwargs) as client:
+      response = client.post('/ctpt/tokens', json=payload, headers=self._headers())
+      response.raise_for_status()
+      data = response.json()
+      return PlantTokenResponse(
+        id=data['id'],
+        token_value=data['tokenValue'],
+        token_type=data['tokenType'],
+        display_name=data['displayName'],
+        expires_at=data['expiresAt'],
+        leak_score=float(data['leakScore']),
+      )
+
+  def record_callback(self, request: CallbackEventRequest) -> None:
+    payload = {
+      'tokenValue': request.token_value,
+      'channel': request.channel,
+      'sourceAddress': request.source_address,
+      'context': request.context,
+    }
+    with self._client_factory(**self._client_kwargs) as client:
+      response = client.post('/ctpt/callbacks', json=payload, headers=self._headers())
+      response.raise_for_status()
+
+  def get_dashboard(self) -> DashboardResponse:
+    with self._client_factory(**self._client_kwargs) as client:
+      response = client.get('/ctpt/dashboard', headers=self._headers())
+      response.raise_for_status()
+      data = response.json()
+      return DashboardResponse(
+        totals=data['totals'],
+        tokens_by_type=data['tokensByType'],
+        top_alerts=data['topAlerts'],
+        recent_activity=data['recentActivity'],
+      )
+
+
+__all__ = [
+  'CTPTClient',
+  'CallbackEventRequest',
+  'DashboardResponse',
+  'PlantTokenRequest',
+  'PlantTokenResponse',
+]

--- a/sdk/typescript/src/ctpt-client.ts
+++ b/sdk/typescript/src/ctpt-client.ts
@@ -1,0 +1,103 @@
+export interface CTPTClientOptions {
+  baseUrl: string;
+  apiKey?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface PlantTokenRequest {
+  type: 'email' | 'file-beacon' | 'unique-phrase';
+  plantedBy: string;
+  sourceSystem: string;
+  tags?: string[];
+  ttlSeconds: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PlantTokenResponse {
+  id: string;
+  tokenValue: string;
+  tokenType: PlantTokenRequest['type'];
+  displayName: string;
+  expiresAt: string;
+  leakScore: number;
+}
+
+export interface CallbackEventRequest {
+  tokenValue: string;
+  channel: 'http-callback' | 'inbox-hit' | 'keyword-scan';
+  sourceAddress?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface DashboardResponse {
+  totals: {
+    planted: number;
+    active: number;
+    expired: number;
+  };
+  tokensByType: Record<string, number>;
+  topAlerts: Array<{
+    tokenId: string;
+    displayName: string;
+    leakScore: number;
+    lastSeen: string | null;
+  }>;
+  recentActivity: Array<{
+    tokenId: string;
+    callbackId: string;
+    observedAt: string;
+    channel: CallbackEventRequest['channel'];
+    sourceAddress?: string;
+  }>;
+}
+
+export class CTPTClient {
+  private readonly baseUrl: string;
+  private readonly apiKey?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: CTPTClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, '');
+    this.apiKey = options.apiKey;
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
+    if (!this.fetchImpl) {
+      throw new Error('Fetch implementation is required');
+    }
+  }
+
+  async plantToken(request: PlantTokenRequest): Promise<PlantTokenResponse> {
+    const response = await this.request('/ctpt/tokens', 'POST', request);
+    return (await response.json()) as PlantTokenResponse;
+  }
+
+  async recordCallback(request: CallbackEventRequest): Promise<void> {
+    const response = await this.request('/ctpt/callbacks', 'POST', request);
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Failed to record callback (${response.status}): ${body}`);
+    }
+  }
+
+  async getDashboard(): Promise<DashboardResponse> {
+    const response = await this.request('/ctpt/dashboard', 'GET');
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Failed to fetch dashboard (${response.status}): ${body}`);
+    }
+    return (await response.json()) as DashboardResponse;
+  }
+
+  private request(path: string, method: 'GET' | 'POST', body?: unknown): Promise<Response> {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+    };
+    if (this.apiKey) {
+      headers['authorization'] = `Bearer ${this.apiKey}`;
+    }
+    return this.fetchImpl(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,2 +1,3 @@
 export * from './client';
+export * from './ctpt-client';
 export * from '../sdk/ts/src/generated';

--- a/services/ctpt/ctpt-service.test.ts
+++ b/services/ctpt/ctpt-service.test.ts
@@ -1,0 +1,116 @@
+import {
+  CanaryTokenPlantingTracebackService,
+  DefaultLeakScoringModel,
+} from './ctpt-service';
+import { InMemoryWebhookDispatcher } from './webhook-dispatcher';
+import { CallbackEvent, PlantHoneytokenInput } from './types';
+
+describe('CanaryTokenPlantingTracebackService', () => {
+  const baseInput: PlantHoneytokenInput = {
+    type: 'email',
+    plantedBy: 'alice',
+    sourceSystem: 'crm',
+    tags: ['pilot'],
+    ttlSeconds: 3600,
+  };
+
+  const createService = () => {
+    let currentTime = new Date('2025-01-01T00:00:00Z');
+    const dispatcher = new InMemoryWebhookDispatcher();
+    const events: any[] = [];
+    dispatcher.addListener((payload) => {
+      events.push(payload);
+    });
+    const service = new CanaryTokenPlantingTracebackService({
+      now: () => currentTime,
+      idFactory: (() => {
+        let counter = 0;
+        return () => `id-${++counter}`;
+      })(),
+      webhookDispatcher: dispatcher,
+      leakScoringModel: new DefaultLeakScoringModel(),
+    });
+    return { service, dispatcher, events, advance: (minutes: number) => {
+      currentTime = new Date(currentTime.getTime() + minutes * 60000);
+    } };
+  };
+
+  it('plants tokens with source attribution and TTL', () => {
+    const { service } = createService();
+    const token = service.plantToken(baseInput);
+    expect(token.sourceSystem).toBe('crm');
+    expect(token.expiresAt.getTime()).toBe(token.createdAt.getTime() + 3600 * 1000);
+    expect(token.tokenValue).toContain('alerts+id-1');
+  });
+
+  it('records callbacks and returns attribution results', () => {
+    const { service } = createService();
+    const token = service.plantToken(baseInput);
+    const event: CallbackEvent = {
+      tokenValue: token.tokenValue,
+      channel: 'http-callback',
+      sourceAddress: '198.51.100.5',
+      context: { userAgent: 'curl/8.0' },
+    };
+    const attribution = service.recordCallback(event);
+    expect(attribution).not.toBeNull();
+    expect(attribution?.token.id).toBe(token.id);
+    expect(attribution?.confidence).toBeGreaterThan(0.6);
+    expect(attribution?.token.leakScore).toBeGreaterThan(0);
+  });
+
+  it('suppresses callbacks once TTL has elapsed', () => {
+    const { service, advance } = createService();
+    const token = service.plantToken({ ...baseInput, ttlSeconds: 60 });
+    advance(120);
+    const event: CallbackEvent = {
+      tokenValue: token.tokenValue,
+      channel: 'keyword-scan',
+    };
+    const attribution = service.recordCallback(event);
+    expect(attribution).toBeNull();
+  });
+
+  it('builds dashboards with leak ordering and activity', () => {
+    const { service, advance } = createService();
+    const high = service.plantToken({ ...baseInput, tags: ['high-sensitivity'] });
+    const low = service.plantToken({ ...baseInput, type: 'unique-phrase', tags: [] });
+
+    service.recordCallback({ tokenValue: low.tokenValue, channel: 'keyword-scan' });
+    advance(1);
+    service.recordCallback({ tokenValue: high.tokenValue, channel: 'http-callback' });
+
+    const dashboard = service.getDashboard();
+    expect(dashboard.totals.planted).toBe(2);
+    expect(dashboard.tokensByType['email']).toBe(1);
+    expect(dashboard.tokensByType['unique-phrase']).toBe(1);
+    expect(dashboard.topAlerts[0].tokenId).toBe(high.id);
+    expect(dashboard.recentActivity[0].tokenId).toBe(high.id);
+  });
+
+  it('dispatches compact incident webhooks', () => {
+    const { service, events } = createService();
+    const token = service.plantToken({ ...baseInput, tags: ['high-sensitivity'] });
+    service.recordCallback({ tokenValue: token.tokenValue, channel: 'inbox-hit' });
+    expect(events).toHaveLength(1);
+    const payload = events[0];
+    expect(payload).toMatchObject({
+      tokenId: token.id,
+      tokenType: token.type,
+      tokenDisplayName: token.displayName,
+      channel: 'inbox-hit',
+    });
+    expect(Object.keys(payload)).toEqual([
+      'incidentId',
+      'tokenId',
+      'tokenType',
+      'tokenDisplayName',
+      'leakScore',
+      'sourceSystem',
+      'channel',
+      'observedAt',
+      'confidence',
+      'tags',
+    ]);
+  });
+});

--- a/services/ctpt/ctpt-service.ts
+++ b/services/ctpt/ctpt-service.ts
@@ -1,0 +1,224 @@
+import crypto from 'node:crypto';
+import {
+  AttributionResult,
+  CallbackEvent,
+  DashboardSummary,
+  Honeytoken,
+  HoneytokenType,
+  IncidentWebhookPayload,
+  LeakCallback,
+  LeakScoringModel,
+  PlantHoneytokenInput,
+  WebhookDispatcher,
+} from './types';
+import { DefaultLeakScoringModel } from './leak-scoring';
+
+interface ServiceOptions {
+  idFactory?: () => string;
+  now?: () => Date;
+  webhookDispatcher?: WebhookDispatcher;
+  leakScoringModel?: LeakScoringModel;
+  dashboardLimit?: number;
+}
+
+export class CanaryTokenPlantingTracebackService {
+  private readonly tokens = new Map<string, Honeytoken>();
+  private readonly tokensByValue = new Map<string, Honeytoken>();
+  private readonly idFactory: () => string;
+  private readonly now: () => Date;
+  private readonly webhookDispatcher?: WebhookDispatcher;
+  private readonly scoringModel: LeakScoringModel;
+  private readonly dashboardLimit: number;
+
+  constructor(options: ServiceOptions = {}) {
+    this.idFactory = options.idFactory ?? (() => crypto.randomUUID());
+    this.now = options.now ?? (() => new Date());
+    this.webhookDispatcher = options.webhookDispatcher;
+    this.scoringModel = options.leakScoringModel ?? new DefaultLeakScoringModel();
+    this.dashboardLimit = options.dashboardLimit ?? 10;
+  }
+
+  plantToken(input: PlantHoneytokenInput): Honeytoken {
+    this.removeExpiredTokens();
+    const id = this.idFactory();
+    const createdAt = this.now();
+    const expiresAt = new Date(createdAt.getTime() + input.ttlSeconds * 1000);
+    const tokenValue = this.generateTokenValue(input.type, id);
+    const displayName = this.createDisplayName(input.type, id);
+    const token: Honeytoken = {
+      id,
+      displayName,
+      type: input.type,
+      tokenValue,
+      plantedBy: input.plantedBy,
+      sourceSystem: input.sourceSystem,
+      tags: [...(input.tags ?? [])],
+      createdAt,
+      expiresAt,
+      leakScore: 0,
+      callbackHistory: [],
+      metadata: input.metadata,
+    };
+
+    this.tokens.set(id, token);
+    this.tokensByValue.set(tokenValue, token);
+    return token;
+  }
+
+  getTokenById(id: string): Honeytoken | undefined {
+    this.removeExpiredTokens();
+    return this.tokens.get(id);
+  }
+
+  recordCallback(event: CallbackEvent): AttributionResult | null {
+    this.removeExpiredTokens();
+    const token = this.tokensByValue.get(event.tokenValue);
+    if (!token) {
+      return null;
+    }
+
+    const callback = this.createCallback(event);
+    token.callbackHistory.push(callback);
+    token.leakScore = this.scoringModel.score(token, callback);
+
+    const payload: AttributionResult = {
+      token,
+      leakCallback: callback,
+      confidence: this.estimateConfidence(token, callback),
+    };
+
+    void this.dispatchWebhook(token, callback, payload.confidence);
+    return payload;
+  }
+
+  getDashboard(): DashboardSummary {
+    this.removeExpiredTokens();
+    const tokens = Array.from(this.tokens.values());
+    const totals = {
+      planted: tokens.length,
+      active: tokens.filter((token) => token.expiresAt.getTime() > this.now().getTime()).length,
+      expired: tokens.filter((token) => token.expiresAt.getTime() <= this.now().getTime()).length,
+    };
+    const tokensByType: DashboardSummary['tokensByType'] = {
+      email: 0,
+      'file-beacon': 0,
+      'unique-phrase': 0,
+    };
+    for (const token of tokens) {
+      tokensByType[token.type] = (tokensByType[token.type] ?? 0) + 1;
+    }
+    const topAlerts = tokens
+      .filter((token) => token.callbackHistory.length > 0)
+      .sort((a, b) => b.leakScore - a.leakScore)
+      .slice(0, this.dashboardLimit)
+      .map((token) => ({
+        tokenId: token.id,
+        displayName: token.displayName,
+        leakScore: token.leakScore,
+        lastSeen: token.callbackHistory[token.callbackHistory.length - 1]?.observedAt ?? null,
+      }));
+
+    const recentActivity = tokens
+      .flatMap((token) =>
+        token.callbackHistory.map((callback) => ({
+          tokenId: token.id,
+          callbackId: callback.id,
+          observedAt: callback.observedAt,
+          channel: callback.channel,
+          sourceAddress: callback.sourceAddress,
+        })),
+      )
+      .sort((a, b) => b.observedAt.getTime() - a.observedAt.getTime())
+      .slice(0, this.dashboardLimit);
+
+    return {
+      totals,
+      tokensByType,
+      topAlerts,
+      recentActivity,
+    };
+  }
+
+  registerWebhook(dispatcher: WebhookDispatcher): void {
+    (this as { webhookDispatcher?: WebhookDispatcher }).webhookDispatcher = dispatcher;
+  }
+
+  private createCallback(event: CallbackEvent): LeakCallback {
+    return {
+      id: this.idFactory(),
+      observedAt: this.now(),
+      channel: event.channel,
+      sourceAddress: event.sourceAddress,
+      context: event.context,
+    };
+  }
+
+  private createDisplayName(type: HoneytokenType, id: string): string {
+    const suffix = id.slice(0, 8);
+    switch (type) {
+      case 'email':
+        return `Inbox Canary ${suffix}`;
+      case 'file-beacon':
+        return `Document Canary ${suffix}`;
+      case 'unique-phrase':
+        return `Phrase Canary ${suffix}`;
+      default:
+        return `Canary ${suffix}`;
+    }
+  }
+
+  private generateTokenValue(type: HoneytokenType, id: string): string {
+    if (type === 'email') {
+      return `alerts+${id}@canary.intel`; // placeholder domain for instrumentation
+    }
+    if (type === 'file-beacon') {
+      return `<!-- ctpt:${id}:${crypto.randomBytes(6).toString('hex')} -->`;
+    }
+    return `ctpt-${id}-${crypto.randomBytes(4).toString('hex')}`;
+  }
+
+  private estimateConfidence(token: Honeytoken, callback: LeakCallback): number {
+    let confidence = 0.6;
+    if (token.tags.includes('high-sensitivity')) {
+      confidence += 0.1;
+    }
+    if (callback.channel === 'http-callback') {
+      confidence += 0.15;
+    }
+    if (callback.sourceAddress) {
+      confidence += 0.05;
+    }
+    return Math.min(0.95, Number(confidence.toFixed(2)));
+  }
+
+  private async dispatchWebhook(token: Honeytoken, callback: LeakCallback, confidence: number): Promise<void> {
+    if (!this.webhookDispatcher) {
+      return;
+    }
+    const payload: IncidentWebhookPayload = {
+      incidentId: this.idFactory(),
+      tokenId: token.id,
+      tokenType: token.type,
+      tokenDisplayName: token.displayName,
+      leakScore: token.leakScore,
+      sourceSystem: token.sourceSystem,
+      channel: callback.channel,
+      observedAt: callback.observedAt.toISOString(),
+      confidence,
+      tags: token.tags,
+    };
+    await this.webhookDispatcher.dispatch(payload);
+  }
+
+  private removeExpiredTokens(): void {
+    const now = this.now().getTime();
+    for (const token of this.tokens.values()) {
+      if (token.expiresAt.getTime() <= now) {
+        this.tokens.delete(token.id);
+        this.tokensByValue.delete(token.tokenValue);
+      }
+    }
+  }
+}
+
+export type CTPTService = CanaryTokenPlantingTracebackService;

--- a/services/ctpt/http-server.test.ts
+++ b/services/ctpt/http-server.test.ts
@@ -1,0 +1,55 @@
+import { createCTPTServer, CanaryTokenPlantingTracebackService } from './index';
+
+describe('CTPT HTTP server', () => {
+  it('exposes planting, callback, and dashboard endpoints', async () => {
+    let now = new Date('2025-01-01T00:00:00Z');
+    const service = new CanaryTokenPlantingTracebackService({
+      now: () => now,
+      idFactory: (() => {
+        let counter = 0;
+        return () => `server-id-${++counter}`;
+      })(),
+    });
+    const server = createCTPTServer(service);
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Server address was not assigned');
+    }
+    const baseUrl = `http://127.0.0.1:${address.port}`;
+
+    const plantResponse = await fetch(`${baseUrl}/ctpt/tokens`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        type: 'email',
+        plantedBy: 'api-test',
+        sourceSystem: 'erp',
+        ttlSeconds: 300,
+      }),
+    });
+    expect(plantResponse.status).toBe(201);
+    const planted = await plantResponse.json();
+
+    const callbackResponse = await fetch(`${baseUrl}/ctpt/callbacks`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        tokenValue: planted.tokenValue,
+        channel: 'http-callback',
+      }),
+    });
+    expect(callbackResponse.status).toBe(202);
+    const callback = await callbackResponse.json();
+    expect(callback.tokenId).toBe(planted.id);
+
+    now = new Date(now.getTime() + 60000);
+    const dashboardResponse = await fetch(`${baseUrl}/ctpt/dashboard`);
+    expect(dashboardResponse.status).toBe(200);
+    const dashboard = await dashboardResponse.json();
+    expect(dashboard.totals.planted).toBe(1);
+    expect(dashboard.topAlerts[0].tokenId).toBe(planted.id);
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+});

--- a/services/ctpt/http-server.ts
+++ b/services/ctpt/http-server.ts
@@ -1,0 +1,113 @@
+import http, { IncomingMessage, ServerResponse } from 'node:http';
+import { CanaryTokenPlantingTracebackService } from './ctpt-service';
+import { CallbackEvent, PlantHoneytokenInput } from './types';
+
+function parseBody<T>(req: IncomingMessage): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req
+      .on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+      .on('end', () => {
+        try {
+          const body = Buffer.concat(chunks).toString('utf-8');
+          resolve(body ? (JSON.parse(body) as T) : ({} as T));
+        } catch (error) {
+          reject(error);
+        }
+      })
+      .on('error', (error) => reject(error));
+  });
+}
+
+function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+  const body = JSON.stringify(payload);
+  res.writeHead(status, {
+    'content-type': 'application/json',
+    'content-length': Buffer.byteLength(body),
+  });
+  res.end(body);
+}
+
+export function createCTPTHttpHandler(service: CanaryTokenPlantingTracebackService): http.RequestListener {
+  return async (req, res) => {
+    if (!req.url) {
+      res.writeHead(404).end();
+      return;
+    }
+    const { url, method = 'GET' } = req;
+    if (url === '/ctpt/tokens' && method === 'POST') {
+      try {
+        const body = await parseBody<PlantHoneytokenInput>(req);
+        if (!body.type || !body.plantedBy || !body.sourceSystem || !body.ttlSeconds) {
+          sendJson(res, 400, { message: 'Missing required fields' });
+          return;
+        }
+        const token = service.plantToken({
+          type: body.type,
+          plantedBy: body.plantedBy,
+          sourceSystem: body.sourceSystem,
+          tags: body.tags,
+          ttlSeconds: body.ttlSeconds,
+          metadata: body.metadata,
+        });
+        sendJson(res, 201, {
+          id: token.id,
+          tokenValue: token.tokenValue,
+          tokenType: token.type,
+          displayName: token.displayName,
+          expiresAt: token.expiresAt.toISOString(),
+          leakScore: token.leakScore,
+        });
+      } catch (error) {
+        sendJson(res, 400, { message: (error as Error).message });
+      }
+      return;
+    }
+
+    if (url === '/ctpt/callbacks' && method === 'POST') {
+      try {
+        const body = await parseBody<CallbackEvent>(req);
+        if (!body.tokenValue || !body.channel) {
+          sendJson(res, 400, { message: 'Missing required fields' });
+          return;
+        }
+        const attribution = service.recordCallback(body);
+        if (!attribution) {
+          sendJson(res, 404, { message: 'Token not found or expired' });
+          return;
+        }
+        sendJson(res, 202, {
+          tokenId: attribution.token.id,
+          leakScore: attribution.token.leakScore,
+          confidence: attribution.confidence,
+        });
+      } catch (error) {
+        sendJson(res, 400, { message: (error as Error).message });
+      }
+      return;
+    }
+
+    if (url === '/ctpt/dashboard' && method === 'GET') {
+      const dashboard = service.getDashboard();
+      sendJson(res, 200, {
+        totals: dashboard.totals,
+        tokensByType: dashboard.tokensByType,
+        topAlerts: dashboard.topAlerts.map((alert) => ({
+          ...alert,
+          lastSeen: alert.lastSeen ? alert.lastSeen.toISOString() : null,
+        })),
+        recentActivity: dashboard.recentActivity.map((activity) => ({
+          ...activity,
+          observedAt: activity.observedAt.toISOString(),
+        })),
+      });
+      return;
+    }
+
+    res.writeHead(404).end();
+  };
+}
+
+export function createCTPTServer(service: CanaryTokenPlantingTracebackService): http.Server {
+  return http.createServer(createCTPTHttpHandler(service));
+}

--- a/services/ctpt/index.ts
+++ b/services/ctpt/index.ts
@@ -1,0 +1,5 @@
+export * from './types';
+export * from './leak-scoring';
+export * from './webhook-dispatcher';
+export * from './ctpt-service';
+export * from './http-server';

--- a/services/ctpt/leak-scoring.ts
+++ b/services/ctpt/leak-scoring.ts
@@ -1,0 +1,48 @@
+import { Honeytoken, LeakCallback, LeakScoringModel } from './types';
+
+const TYPE_WEIGHTS: Record<Honeytoken['type'], number> = {
+  email: 0.8,
+  'file-beacon': 0.6,
+  'unique-phrase': 0.5,
+};
+
+export class DefaultLeakScoringModel implements LeakScoringModel {
+  score(token: Honeytoken, callback: LeakCallback): number {
+    const base = TYPE_WEIGHTS[token.type] ?? 0.4;
+    const recencyBoost = this.computeRecencyBoost(token, callback);
+    const repetitionBoost = Math.min(token.callbackHistory.length * 0.05, 0.2);
+    const ttlPenalty = this.computeTtlPenalty(token);
+    const rawScore = base + recencyBoost + repetitionBoost - ttlPenalty;
+    return Math.max(0, Math.min(1, Number(rawScore.toFixed(3))));
+  }
+
+  private computeRecencyBoost(token: Honeytoken, callback: LeakCallback): number {
+    if (!token.callbackHistory.length) {
+      return 0.1;
+    }
+    const last = token.callbackHistory[token.callbackHistory.length - 1];
+    const minutes = (callback.observedAt.getTime() - last.observedAt.getTime()) / 60000;
+    if (minutes <= 5) {
+      return 0.15;
+    }
+    if (minutes <= 60) {
+      return 0.1;
+    }
+    return 0.05;
+  }
+
+  private computeTtlPenalty(token: Honeytoken): number {
+    const millisRemaining = token.expiresAt.getTime() - Date.now();
+    if (millisRemaining <= 0) {
+      return 0.3;
+    }
+    const hoursRemaining = millisRemaining / 3600000;
+    if (hoursRemaining < 1) {
+      return 0.2;
+    }
+    if (hoursRemaining < 6) {
+      return 0.1;
+    }
+    return 0;
+  }
+}

--- a/services/ctpt/types.ts
+++ b/services/ctpt/types.ts
@@ -1,0 +1,89 @@
+export type HoneytokenType = 'email' | 'file-beacon' | 'unique-phrase';
+
+export interface Honeytoken {
+  id: string;
+  displayName: string;
+  type: HoneytokenType;
+  tokenValue: string;
+  plantedBy: string;
+  sourceSystem: string;
+  tags: string[];
+  createdAt: Date;
+  expiresAt: Date;
+  leakScore: number;
+  callbackHistory: LeakCallback[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface LeakCallback {
+  id: string;
+  observedAt: Date;
+  channel: 'http-callback' | 'inbox-hit' | 'keyword-scan';
+  sourceAddress?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface PlantHoneytokenInput {
+  type: HoneytokenType;
+  plantedBy: string;
+  sourceSystem: string;
+  tags?: string[];
+  ttlSeconds: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CallbackEvent {
+  tokenValue: string;
+  channel: LeakCallback['channel'];
+  sourceAddress?: string;
+  context?: Record<string, unknown>;
+}
+
+export interface AttributionResult {
+  token: Honeytoken;
+  leakCallback: LeakCallback;
+  confidence: number;
+}
+
+export interface DashboardSummary {
+  totals: {
+    planted: number;
+    active: number;
+    expired: number;
+  };
+  tokensByType: Record<HoneytokenType, number>;
+  topAlerts: Array<{
+    tokenId: string;
+    displayName: string;
+    leakScore: number;
+    lastSeen: Date | null;
+  }>;
+  recentActivity: Array<{
+    tokenId: string;
+    callbackId: string;
+    observedAt: Date;
+    channel: LeakCallback['channel'];
+    sourceAddress?: string;
+  }>;
+}
+
+export interface IncidentWebhookPayload {
+  incidentId: string;
+  tokenId: string;
+  tokenType: HoneytokenType;
+  tokenDisplayName: string;
+  leakScore: number;
+  sourceSystem: string;
+  channel: LeakCallback['channel'];
+  observedAt: string;
+  confidence: number;
+  tags: string[];
+}
+
+export interface WebhookDispatcher {
+  dispatch(payload: IncidentWebhookPayload): Promise<void>;
+}
+
+export interface LeakScoringModel {
+  score(token: Honeytoken, callback: LeakCallback): number;
+}

--- a/services/ctpt/webhook-dispatcher.ts
+++ b/services/ctpt/webhook-dispatcher.ts
@@ -1,0 +1,45 @@
+import { IncidentWebhookPayload, WebhookDispatcher } from './types';
+
+type FetchFn = typeof fetch;
+
+export class HttpWebhookDispatcher implements WebhookDispatcher {
+  private readonly fetchImpl: FetchFn;
+
+  constructor(private readonly endpoint: string, fetchImpl?: FetchFn) {
+    this.fetchImpl = fetchImpl ?? globalThis.fetch;
+    if (!this.fetchImpl) {
+      throw new Error('Fetch API is not available in this runtime');
+    }
+  }
+
+  async dispatch(payload: IncidentWebhookPayload): Promise<void> {
+    const response = await this.fetchImpl(this.endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`Failed to dispatch webhook (${response.status}): ${body}`);
+    }
+  }
+}
+
+type Listener = (payload: IncidentWebhookPayload) => void | Promise<void>;
+
+export class InMemoryWebhookDispatcher implements WebhookDispatcher {
+  private readonly listeners: Listener[] = [];
+
+  addListener(listener: Listener): void {
+    this.listeners.push(listener);
+  }
+
+  async dispatch(payload: IncidentWebhookPayload): Promise<void> {
+    for (const listener of this.listeners) {
+      await listener(payload);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement the Canary Token Planting & Traceback domain service with leak scoring, dashboards, TTL enforcement, and webhook dispatching
- provide an HTTP surface and regression tests to validate token planting, callback ingestion, and dashboard reporting
- add TypeScript and Python SDK clients that cover token creation, callback reporting, and dashboard retrieval APIs

## Testing
- `npx --yes jest --config jest.config.cjs services/ctpt --runInBand` *(fails: existing jest.config.cjs in repo has malformed configuration and cannot be parsed)*

------
https://chatgpt.com/codex/tasks/task_e_68d73fab9a948333b0f2cb3f82f1d69b