### PR TITLE
feat: add redaction quality benchmark toolkit

### DIFF
--- a/tools/rqb/AGENTS.md
+++ b/tools/rqb/AGENTS.md
@@ -1,0 +1,5 @@
+# RQB Toolkit Guidelines
+
+- Python modules must use 4 spaces for indentation.
+- Prefer type hints for public interfaces.
+- Keep dataset fixtures small and deterministic.

--- a/tools/rqb/README.md
+++ b/tools/rqb/README.md
@@ -1,0 +1,36 @@
+# Redaction Quality Benchmark (RQB)
+
+RQB provides a deterministic harness for evaluating PII redaction detectors. It
+ships with a labeled ground-truth corpus that mixes natural language snippets
+and structured JSON logs. The toolkit produces precision/recall metrics, entity
+confusion matrices, latency profiles, and exportable JSON scorecards. A CI gate
+script compares scorecards to block regressions.
+
+## Quick start
+
+```bash
+python -m tools.rqb.cli --detector regex --scorecard /tmp/rqb-regex.json
+```
+
+Available detectors:
+
+- `regex`: production-ready deterministic baseline.
+- `ml-stub`: seeded ML-style detector that introduces controlled error for
+  regression testing.
+
+## CI gate
+
+Use the provided script to compare a candidate scorecard against a baseline
+(checking precision, recall, and F1 drops by default):
+
+```bash
+python -m tools.rqb.ci_gate tools/rqb/baselines/regex.json /tmp/rqb-regex.json --max-drop 0.02
+```
+
+## Extending
+
+1. Implement `Detector.detect` for your detector and expose it via
+   `tools.rqb.cli._DETECTOR_FACTORIES`.
+2. Run the harness to generate a baseline scorecard.
+3. Wire the CI gate into your pipeline to block regressions above the
+   configured threshold.

--- a/tools/rqb/__init__.py
+++ b/tools/rqb/__init__.py
@@ -1,0 +1,18 @@
+"""Redaction Quality Benchmark (RQB) toolkit."""
+
+from .data import DATASET, BenchmarkRecord, PIIEntity
+from .detectors import Detector, RegexDetector, MLStubDetector
+from .evaluation import BenchmarkHarness, BenchmarkResult
+from .scorecard import export_scorecard
+
+__all__ = [
+    "DATASET",
+    "BenchmarkRecord",
+    "PIIEntity",
+    "Detector",
+    "RegexDetector",
+    "MLStubDetector",
+    "BenchmarkHarness",
+    "BenchmarkResult",
+    "export_scorecard",
+]

--- a/tools/rqb/baselines/regex.json
+++ b/tools/rqb/baselines/regex.json
@@ -1,0 +1,85 @@
+{
+  "confusion_matrix": {
+    "ACCOUNT_ID": {
+      "fn": 0,
+      "fp": 0,
+      "tp": 1
+    },
+    "EMAIL": {
+      "fn": 0,
+      "fp": 0,
+      "tp": 2
+    },
+    "IBAN": {
+      "fn": 0,
+      "fp": 0,
+      "tp": 1
+    },
+    "IP_ADDRESS": {
+      "fn": 0,
+      "fp": 0,
+      "tp": 1
+    },
+    "PHONE": {
+      "fn": 0,
+      "fp": 0,
+      "tp": 2
+    },
+    "SSN": {
+      "fn": 0,
+      "fp": 0,
+      "tp": 1
+    }
+  },
+  "detector": "regex",
+  "latency": {
+    "mean_ms": 0.0274,
+    "median_ms": 0.0235,
+    "p95_ms": 0.0479
+  },
+  "per_entity": {
+    "ACCOUNT_ID": {
+      "f1": 1.0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "support": 1.0
+    },
+    "EMAIL": {
+      "f1": 1.0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "support": 2.0
+    },
+    "IBAN": {
+      "f1": 1.0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "support": 1.0
+    },
+    "IP_ADDRESS": {
+      "f1": 1.0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "support": 1.0
+    },
+    "PHONE": {
+      "f1": 1.0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "support": 2.0
+    },
+    "SSN": {
+      "f1": 1.0,
+      "precision": 1.0,
+      "recall": 1.0,
+      "support": 1.0
+    }
+  },
+  "records_evaluated": 5,
+  "summary": {
+    "f1": 1.0,
+    "precision": 1.0,
+    "recall": 1.0,
+    "support": 8.0
+  }
+}

--- a/tools/rqb/ci_gate.py
+++ b/tools/rqb/ci_gate.py
@@ -1,0 +1,57 @@
+"""CI regression gate for the Redaction Quality Benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Iterable
+
+MetricDict = Dict[str, float]
+
+
+def _load_scorecard(path: Path) -> Dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _assert_thresholds(
+    baseline: Dict[str, object],
+    candidate: Dict[str, object],
+    metrics: Iterable[str],
+    max_drop: float,
+) -> None:
+    baseline_summary: MetricDict = baseline["summary"]  # type: ignore[assignment]
+    candidate_summary: MetricDict = candidate["summary"]  # type: ignore[assignment]
+    for metric in metrics:
+        baseline_value = float(baseline_summary.get(metric, 0.0))
+        candidate_value = float(candidate_summary.get(metric, 0.0))
+        drop = baseline_value - candidate_value
+        if drop > max_drop + 1e-9:
+            raise SystemExit(
+                f"Metric '{metric}' regressed by {drop:.4f} (baseline={baseline_value:.4f}, "
+                f"candidate={candidate_value:.4f}, threshold={max_drop:.4f})"
+            )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="CI gate for RQB scorecards")
+    parser.add_argument("baseline", type=Path)
+    parser.add_argument("candidate", type=Path)
+    parser.add_argument("--max-drop", type=float, default=0.01, help="Allowed drop before failing")
+    parser.add_argument(
+        "--metrics",
+        nargs="+",
+        default=["precision", "recall", "f1"],
+        help="Metrics to compare",
+    )
+    args = parser.parse_args(argv)
+
+    baseline = _load_scorecard(args.baseline)
+    candidate = _load_scorecard(args.candidate)
+    _assert_thresholds(baseline, candidate, args.metrics, args.max_drop)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/rqb/cli.py
+++ b/tools/rqb/cli.py
@@ -1,0 +1,49 @@
+"""Command line entrypoints for the RQB toolkit."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Type
+
+from .detectors import Detector, MLStubDetector, RegexDetector
+from .evaluation import BenchmarkHarness
+from .scorecard import export_scorecard
+
+
+_DETECTOR_FACTORIES: Dict[str, Type[Detector]] = {
+    "regex": RegexDetector,
+    "ml-stub": MLStubDetector,
+}
+
+
+def build_detector(name: str) -> Detector:
+    try:
+        detector_cls = _DETECTOR_FACTORIES[name]
+    except KeyError as exc:  # pragma: no cover - argparse protects this, but keep explicit message.
+        raise ValueError(f"Unknown detector '{name}'") from exc
+    return detector_cls()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run the Redaction Quality Benchmark (RQB)")
+    parser.add_argument("--detector", choices=sorted(_DETECTOR_FACTORIES), default="regex")
+    parser.add_argument("--seed", type=int, default=1337, help="Seed for deterministic detectors")
+    parser.add_argument("--scorecard", type=Path, help="Optional path to write a JSON scorecard")
+    args = parser.parse_args(argv)
+
+    detector = build_detector(args.detector)
+    harness = BenchmarkHarness(seed=args.seed)
+    result = harness.run(detector)
+
+    payload = result.to_dict()
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if args.scorecard:
+        export_scorecard(result, args.scorecard)
+        print(f"Scorecard written to {args.scorecard}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/rqb/data.py
+++ b/tools/rqb/data.py
@@ -1,0 +1,94 @@
+"""Ground truth corpus for the Redaction Quality Benchmark (RQB)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True)
+class PIIEntity:
+    """Represents a single annotated PII entity."""
+
+    label: str
+    value: str
+    location: str
+
+
+@dataclass(frozen=True)
+class BenchmarkRecord:
+    """A single benchmark record with ground-truth annotations."""
+
+    record_id: str
+    source_type: str
+    content: str
+    entities: List[PIIEntity]
+
+
+DATASET: List[BenchmarkRecord] = [
+    BenchmarkRecord(
+        record_id="text-001",
+        source_type="text",
+        content=(
+            "Contact Jane Smith at jane.smith@example.com or (415) 555-1000 to "
+            "discuss invoice #A123."
+        ),
+        entities=[
+            PIIEntity(
+                label="EMAIL",
+                value="jane.smith@example.com",
+                location="offset:22-44",
+            ),
+            PIIEntity(
+                label="PHONE",
+                value="(415) 555-1000",
+                location="offset:48-62",
+            ),
+        ],
+    ),
+    BenchmarkRecord(
+        record_id="text-002",
+        source_type="text",
+        content="Server logs show login from 192.168.1.42 by user_id 883-23-9911.",
+        entities=[
+            PIIEntity(
+                label="IP_ADDRESS",
+                value="192.168.1.42",
+                location="offset:28-40",
+            ),
+            PIIEntity(
+                label="SSN",
+                value="883-23-9911",
+                location="offset:52-63",
+            ),
+        ],
+    ),
+    BenchmarkRecord(
+        record_id="json-001",
+        source_type="json",
+        content=(
+            '{"event":"signup","user":{"email":"api.user@company.test","phone":"+1-202-555-0199",'
+            '"metadata":{"session_id":"abc123","account":"ACC-443"}},"billing":{"card_last4":"4242",'
+            '"iban":"GB12BARC20201530093459"}}'
+        ),
+        entities=[
+            PIIEntity(label="EMAIL", value="api.user@company.test", location="user.email"),
+            PIIEntity(label="PHONE", value="+1-202-555-0199", location="user.phone"),
+            PIIEntity(label="ACCOUNT_ID", value="ACC-443", location="user.metadata.account"),
+            PIIEntity(label="IBAN", value="GB12BARC20201530093459", location="billing.iban"),
+        ],
+    ),
+    BenchmarkRecord(
+        record_id="json-002",
+        source_type="json",
+        content='{"event":"heartbeat","status":"healthy","attempt":3}',
+        entities=[],
+    ),
+    BenchmarkRecord(
+        record_id="text-003",
+        source_type="text",
+        content="System audit completed with anonymized data only.",
+        entities=[],
+    ),
+]
+"""Curated dataset with deterministic ground-truth labels."""

--- a/tools/rqb/detectors.py
+++ b/tools/rqb/detectors.py
@@ -1,0 +1,110 @@
+"""Detector implementations for the Redaction Quality Benchmark."""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+from dataclasses import dataclass
+from typing import Iterable, List, Optional
+
+from .data import BenchmarkRecord, PIIEntity
+
+
+@dataclass
+class Detector:
+    """Abstract detector interface."""
+
+    name: str
+
+    def detect(self, record: BenchmarkRecord, rng: Optional[random.Random] = None) -> List[PIIEntity]:
+        raise NotImplementedError
+
+
+_EMAIL_RE = re.compile(r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[A-Za-z]{2,}\b")
+_PHONE_RE = re.compile(
+    r"(?:\+?\d{1,3}[-\s]?)?(?:\(\d{3}\)\s*\d{3}-\d{4}|\d{3}[-\s]\d{3}[-\s]\d{4})"
+)
+_IP_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_SSN_RE = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+_ACCOUNT_RE = re.compile(r"ACC-\d{3}")
+_IBAN_RE = re.compile(r"[A-Z]{2}\d{2}[A-Z0-9]{1,30}")
+
+
+class RegexDetector(Detector):
+    """Regex-based detector that covers the benchmark entity types."""
+
+    def __init__(self) -> None:
+        super().__init__(name="regex")
+
+    def detect(self, record: BenchmarkRecord, rng: Optional[random.Random] = None) -> List[PIIEntity]:
+        if record.source_type == "text":
+            return list(self._detect_text(record))
+        if record.source_type == "json":
+            return list(self._detect_json(record))
+        raise ValueError(f"Unsupported record type: {record.source_type}")
+
+    def _detect_text(self, record: BenchmarkRecord) -> Iterable[PIIEntity]:
+        text = record.content
+        for match in _EMAIL_RE.finditer(text):
+            yield PIIEntity("EMAIL", match.group(0), f"offset:{match.start()}-{match.end()}")
+        for match in _PHONE_RE.finditer(text):
+            yield PIIEntity("PHONE", match.group(0), f"offset:{match.start()}-{match.end()}")
+        for match in _IP_RE.finditer(text):
+            yield PIIEntity("IP_ADDRESS", match.group(0), f"offset:{match.start()}-{match.end()}")
+        for match in _SSN_RE.finditer(text):
+            yield PIIEntity("SSN", match.group(0), f"offset:{match.start()}-{match.end()}")
+
+    def _detect_json(self, record: BenchmarkRecord) -> Iterable[PIIEntity]:
+        payload = json.loads(record.content)
+        for path, value in _walk_json(payload):
+            if not isinstance(value, str):
+                continue
+            if _EMAIL_RE.fullmatch(value):
+                yield PIIEntity("EMAIL", value, path)
+            elif _PHONE_RE.fullmatch(value):
+                yield PIIEntity("PHONE", value, path)
+            elif _ACCOUNT_RE.fullmatch(value):
+                yield PIIEntity("ACCOUNT_ID", value, path)
+            elif _IBAN_RE.fullmatch(value):
+                yield PIIEntity("IBAN", value, path)
+
+
+def _walk_json(payload: object, prefix: str = "") -> Iterable[tuple[str, object]]:
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            child_prefix = f"{prefix}.{key}" if prefix else key
+            yield from _walk_json(value, child_prefix)
+    elif isinstance(payload, list):
+        for idx, value in enumerate(payload):
+            child_prefix = f"{prefix}[{idx}]" if prefix else f"[{idx}]"
+            yield from _walk_json(value, child_prefix)
+    else:
+        yield prefix, payload
+
+
+class MLStubDetector(Detector):
+    """Deterministic ML-like detector for CI regression testing."""
+
+    def __init__(self, recall_bias: float = 0.9, precision_bias: float = 0.9) -> None:
+        super().__init__(name="ml-stub")
+        self._recall_bias = recall_bias
+        self._precision_bias = precision_bias
+        self._regex = RegexDetector()
+
+    def detect(self, record: BenchmarkRecord, rng: Optional[random.Random] = None) -> List[PIIEntity]:
+        rng = rng or random.Random(0)
+        baseline = self._regex.detect(record, rng=rng)
+        kept: List[PIIEntity] = []
+        for entity in baseline:
+            if rng.random() <= self._recall_bias:
+                kept.append(entity)
+        if rng.random() > self._precision_bias:
+            kept.append(
+                PIIEntity(
+                    label="EMAIL",
+                    value="noise@example.test",
+                    location=f"synthetic:{record.record_id}",
+                )
+            )
+        return kept

--- a/tools/rqb/evaluation.py
+++ b/tools/rqb/evaluation.py
@@ -1,0 +1,131 @@
+"""Evaluation harness for the Redaction Quality Benchmark."""
+
+from __future__ import annotations
+
+import hashlib
+import random
+import statistics
+import time
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, MutableMapping
+
+from .data import DATASET, BenchmarkRecord, PIIEntity
+from .detectors import Detector
+
+
+@dataclass
+class BenchmarkResult:
+    """Structured evaluation output."""
+
+    detector_name: str
+    summary: Dict[str, float]
+    per_entity: Dict[str, Dict[str, float]]
+    confusion_matrix: Dict[str, Dict[str, int]]
+    latency: Dict[str, float]
+    records_evaluated: int
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "detector": self.detector_name,
+            "summary": self.summary,
+            "per_entity": self.per_entity,
+            "confusion_matrix": self.confusion_matrix,
+            "latency": self.latency,
+            "records_evaluated": self.records_evaluated,
+        }
+
+
+class BenchmarkHarness:
+    """Runs detectors against the benchmark dataset and computes metrics."""
+
+    def __init__(self, dataset: Iterable[BenchmarkRecord] | None = None, seed: int = 1337) -> None:
+        self._dataset = list(dataset or DATASET)
+        self._seed = seed
+
+    def run(self, detector: Detector) -> BenchmarkResult:
+        overall_tp = 0
+        overall_fp = 0
+        overall_fn = 0
+        per_entity_counts: Dict[str, Dict[str, int]] = {}
+        latencies: List[float] = []
+        for record in self._dataset:
+            record_rng = random.Random(_seed_for(self._seed, record.record_id))
+            start = time.perf_counter()
+            predictions = detector.detect(record, rng=record_rng)
+            latencies.append(time.perf_counter() - start)
+            truth_index = _index_entities(record.entities)
+            pred_index = _index_entities(predictions)
+            labels = truth_index.keys() | pred_index.keys()
+            for label in labels:
+                truth_set = truth_index.get(label, set())
+                pred_set = pred_index.get(label, set())
+                tp = len(truth_set & pred_set)
+                fp = len(pred_set - truth_set)
+                fn = len(truth_set - pred_set)
+                counts = per_entity_counts.setdefault(label, {"tp": 0, "fp": 0, "fn": 0})
+                counts["tp"] += tp
+                counts["fp"] += fp
+                counts["fn"] += fn
+                overall_tp += tp
+                overall_fp += fp
+                overall_fn += fn
+
+        summary = _compute_metrics(overall_tp, overall_fp, overall_fn)
+        per_entity_metrics: Dict[str, Dict[str, float]] = {}
+        confusion_matrix: Dict[str, Dict[str, int]] = {}
+        for label, counts in sorted(per_entity_counts.items()):
+            per_entity_metrics[label] = _compute_metrics(counts["tp"], counts["fp"], counts["fn"])
+            per_entity_metrics[label]["support"] = float(counts["tp"] + counts["fn"])
+            confusion_matrix[label] = dict(counts)
+
+        latency_stats = _summarise_latency(latencies)
+        summary["support"] = float(sum(len(record.entities) for record in self._dataset))
+        return BenchmarkResult(
+            detector_name=detector.name,
+            summary=summary,
+            per_entity=per_entity_metrics,
+            confusion_matrix=confusion_matrix,
+            latency=latency_stats,
+            records_evaluated=len(self._dataset),
+        )
+
+
+def _seed_for(seed: int, record_id: str) -> int:
+    digest = hashlib.sha256(f"{seed}:{record_id}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big", signed=False)
+
+
+def _index_entities(entities: Iterable[PIIEntity]) -> Mapping[str, set[str]]:
+    index: MutableMapping[str, set[str]] = {}
+    for entity in entities:
+        index.setdefault(entity.label, set()).add(entity.location)
+    return index
+
+
+def _compute_metrics(tp: int, fp: int, fn: int) -> Dict[str, float]:
+    precision = tp / (tp + fp) if tp + fp else 1.0 if tp == 0 and fp == 0 else 0.0
+    recall = tp / (tp + fn) if tp + fn else 1.0
+    if precision + recall:
+        f1 = 2 * precision * recall / (precision + recall)
+    else:
+        f1 = 0.0
+    return {
+        "precision": round(precision, 4),
+        "recall": round(recall, 4),
+        "f1": round(f1, 4),
+    }
+
+
+def _summarise_latency(latencies: List[float]) -> Dict[str, float]:
+    if not latencies:
+        return {"mean_ms": 0.0, "median_ms": 0.0, "p95_ms": 0.0}
+    ordered = sorted(latencies)
+    mean_ms = statistics.mean(ordered) * 1000
+    median_ms = statistics.median(ordered) * 1000
+    p95_index = min(len(ordered) - 1, int(round(0.95 * (len(ordered) - 1))))
+    p95_ms = ordered[p95_index] * 1000
+    return {
+        "mean_ms": round(mean_ms, 4),
+        "median_ms": round(median_ms, 4),
+        "p95_ms": round(p95_ms, 4),
+    }

--- a/tools/rqb/scorecard.py
+++ b/tools/rqb/scorecard.py
@@ -1,0 +1,19 @@
+"""Scorecard export helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Union
+
+from .evaluation import BenchmarkResult
+
+
+def export_scorecard(result: BenchmarkResult, destination: Union[str, Path]) -> Path:
+    """Write the benchmark result to a JSON scorecard."""
+
+    path = Path(destination)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(result.to_dict(), handle, indent=2, sort_keys=True)
+    return path

--- a/tools/rqb/tests/test_harness.py
+++ b/tools/rqb/tests/test_harness.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.rqb import BenchmarkHarness, MLStubDetector, RegexDetector, export_scorecard
+from tools.rqb.ci_gate import _assert_thresholds
+
+BASELINE_PATH = Path(__file__).resolve().parents[1] / "baselines" / "regex.json"
+
+
+def test_regex_detector_matches_baseline(tmp_path: Path) -> None:
+    harness = BenchmarkHarness(seed=1337)
+    result = harness.run(RegexDetector())
+    export_scorecard(result, tmp_path / "regex.json")
+    baseline_payload = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    candidate_payload = json.loads((tmp_path / "regex.json").read_text(encoding="utf-8"))
+    assert candidate_payload["summary"] == pytest.approx(baseline_payload["summary"], rel=1e-4, abs=1e-4)
+    assert candidate_payload["confusion_matrix"] == baseline_payload["confusion_matrix"]
+
+
+def test_ml_stub_detector_is_deterministic() -> None:
+    harness = BenchmarkHarness(seed=42)
+    first = harness.run(MLStubDetector())
+    second = harness.run(MLStubDetector())
+    assert first.summary == second.summary
+    assert first.confusion_matrix == second.confusion_matrix
+
+
+def test_ci_gate_blocks_regressions() -> None:
+    baseline = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    candidate = json.loads(BASELINE_PATH.read_text(encoding="utf-8"))
+    candidate["summary"]["precision"] -= 0.02
+    with pytest.raises(SystemExit):
+        _assert_thresholds(baseline, candidate, ["precision"], max_drop=0.01)
+
+    # Within tolerance passes
+    candidate["summary"]["precision"] += 0.015
+    _assert_thresholds(baseline, candidate, ["precision"], max_drop=0.01)


### PR DESCRIPTION
## Summary
- add a tools/rqb package with a curated PII ground-truth corpus and benchmarking harness
- ship regex and seeded ML stub detectors plus CLI/scorecard utilities for deterministic evaluations
- provide a CI regression gate and pytest coverage to prevent metric drops beyond configured thresholds

## Testing
- pytest tools/rqb/tests

------
https://chatgpt.com/codex/tasks/task_e_68d73f82d3808333845a879b11bac4f5