### PR TITLE
Expand intention imputation implementation blueprint

### DIFF
--- a/ga-graphai/docs/intention_imputation_digital_twin.md
+++ b/ga-graphai/docs/intention_imputation_digital_twin.md
@@ -1,0 +1,375 @@
+# Intention Imputation Digital Twin Tool
+
+## Summary
+
+This document formalizes a production-grade capability that infers multi-step actor intentions by orchestrating digital twins, provenance capture, and N-step plan synthesis inside the GraphAI ecosystem. The tool empowers operators to forecast, explain, and audit probable action trajectories before they manifest in live systems, while enforcing the governance, reliability, and security expectations of enterprise deployments.
+
+## Objectives
+
+- **Impute Intentions**: Estimate the likely goals and sub-goals behind observed telemetry or prompts by running hypothetical trajectories across digital twins enriched with historical priors.
+- **N-Step Forecasting**: Produce branching plans up to N steps ahead, highlighting decision points, confidence scores, required resources, and mitigation leverage points.
+- **Provenance Traceability**: Generate an auditable provenance ledger for each simulated run so downstream reviewers can validate assumptions, datasets, and model versions used.
+- **Operator Tooling**: Deliver analyst-facing overlays and APIs that surface intention hypotheses, supporting evidence, recommended mitigations, and explainability artifacts.
+- **Operational Resilience**: Ensure the service meets explicit SLAs/SLOs, supports disaster recovery, and exposes observability hooks for continuous monitoring.
+
+## Core Components
+
+1. **Observation Collector**
+   - Ingests structured telemetry (GraphAI overlays, edge events) and unstructured cues (LLM transcripts, incident tickets, analyst annotations).
+   - Normalizes artifacts into the common `Observation` schema with timestamps, actor identifiers, provenance references, and sensitivity tags.
+   - Applies pre-ingestion policy filters (PII scrubbing, mission-scoped routing) before forwarding to downstream services.
+
+2. **Goal Hypothesizer**
+   - Uses Bayesian goal recognition combined with retrieval-augmented generation over past missions and counterfactual datasets.
+   - Outputs weighted candidate intentions with supporting precedent cases from the Provenance Ledger.
+   - Supports configurable priors (mission templates, actor ontologies) and allows analyst overrides with tracked justification.
+
+3. **Digital Twin Orchestrator**
+   - Spins up domain-specific twins (e.g., supply-chain, comms, policy workflows) using the workcell runtime and deterministic seed management for replay.
+   - Applies candidate goals and constraints to produce branching execution trees up to depth N with adaptive heuristics per domain.
+   - Captures state deltas, risk scores, resource consumption, and confidence deltas for each branch while enforcing safety rails.
+
+4. **Provenance Ledger Writer**
+   - Records every simulation run, including model versions, prompt templates, datasets, and parameter hashes within Merkle-linked attestations.
+   - Links ledger entries back to Observation IDs, twin state snapshots, and analyst decisions for full auditability.
+   - Emits signed SBOM artifacts for downstream compliance tooling.
+
+5. **Analyst Overlay & API**
+   - Visualizes intention trajectories on the Investigations overlay with filters for confidence, risk, time horizon, and governance status.
+   - Provides GraphQL and event-stream endpoints for programmatic consumption by policy automation or alerting pipelines.
+   - Surfaces explainability snippets (key features, turning points, alternative hypotheses) and integrates human-in-the-loop feedback capture.
+
+## Implementation Blueprint
+
+### Service Backlog
+
+| Sprint | Deliverable | Owner Squad | Exit Criteria |
+|--------|-------------|-------------|---------------|
+| 0 | Foundational schemas (`Observation`, `IntentHypothesis`, `TwinScenarioRun`) and shared TypeScript types | Common Types | Schema definitions merged, JSON Schema + Zod validators published, API mocks available |
+| 1 | Observation Collector service (ingestion adapters, normalization pipeline) | Signals | Kafka topics live, 2 ingestion adapters operational, unit + contract tests ≥85% |
+| 1 | Goal Hypothesizer microservice with Bayesian/RAG hybrid engine | Intelligence | Hypothesis P95 latency ≤ 6s, supports 3 mission ontologies, baseline accuracy report produced |
+| 2 | Digital Twin Orchestrator workcell extension | Twin Ops | Deterministic replay verified across 5 seeds, autoscaling tuned, telemetry exported |
+| 2 | Provenance Ledger pipeline (writer + Merkle signer + retention jobs) | ProvLedger | Ledger entries queryable via API, SBOM signing automated, retention jobs dry-run completed |
+| 3 | Analyst overlay UI surfaces branch visualizations & mitigation workflow | Investigations | UX review signed off, SOC webhook integration validated, accessibility audit passed |
+| 3 | Policy automation hooks + REST webhooks | Policy | Policy engine consumes advisories end-to-end, audit trail stored in compliance vault |
+
+### Delivery Milestones
+
+1. **Readiness Gate A (end Sprint 1)**
+   - Observation Collector and Goal Hypothesizer running in staging with synthetic data replay.
+   - Schema registry entries approved and versioned; SDK clients consuming mocks.
+   - Initial SLO dashboards deployed in Grafana with burn-rate alerts configured.
+
+2. **Readiness Gate B (end Sprint 2)**
+   - Digital Twin Orchestrator executing N=5 plans with branch pruning metrics published.
+   - Provenance Ledger writer emitting signed bundles; SOC compliance attestation drafted.
+   - End-to-end pipeline validated via canary mission replay with analyst sign-off.
+
+3. **Production Launch (end Sprint 3)**
+   - Analyst overlay and automation hooks in production behind feature flags.
+   - On-call rotation trained; runbooks rehearsed; chaos drill executed.
+   - Executive go/no-go review completed with risk acceptance memo.
+
+### Build Tasks by Component
+
+- **Observation Collector**
+  - Implement Kafka consumer group with exactly-once semantics using idempotent producers for downstream topics.
+  - Build normalization pipeline leveraging `@graphai/common-types` validators and redactors for sensitive fields.
+  - Configure mission-scoped rate limiting and dead-letter queue forwarding to compliance storage.
+
+- **Goal Hypothesizer**
+  - Stand up inference service with Triton-managed LLM endpoints and RAG retrieval over mission vector store.
+  - Train Bayesian updater using historical mission logs; expose calibration job to tune priors weekly.
+  - Integrate guardrail policies (toxicity, disallowed actions) via middleware; log overrides to ledger.
+
+- **Digital Twin Orchestrator**
+  - Extend workcell runtime to support branching tree datastructure with incremental snapshotting.
+  - Implement heuristics module interface (`ScoreContext -> BranchDecision[]`) for plug-in strategies.
+  - Add compute budget enforcer reading from mission policy service; throttle or abort branches when thresholds exceed budget.
+
+- **Provenance Ledger Writer**
+  - Serialize run artifacts into content-addressable storage (CAS) with SHA-512 hashing.
+  - Emit Merkle root signatures using HSM-backed keys; store attestations in prov-ledger service.
+  - Build retention sweeper with policy-driven TTL (default 365 days, overridable per mission).
+
+- **Analyst Overlay & API**
+  - Extend GraphQL schema with `IntentionAdvisory`, `TwinBranch`, `ProvenanceBundle` types and resolvers backed by aggregated views.
+  - Build timeline visualization using D3-based branch tree plus heatmaps for risk and confidence.
+  - Implement action workflow to approve or reject mitigation hooks with audit logging to ledger.
+
+- **Automation Hooks**
+  - Publish signed webhook payloads conforming to policy automation schema; include `x-ledger-hash` header for verification.
+  - Integrate with orchestration playbooks to auto-create tickets and policy updates upon advisory approval.
+  - Provide Terraform module to register webhooks with mission-specific secrets rotated via Vault.
+
+## Reference Architecture
+
+1. **Ingestion Tier** → **Observation Collector** (Kafka consumers, webhook adapters).
+2. **Hypothesis Tier** → **Goal Hypothesizer** (LLM/RAG services, Bayesian scorer, policy guardrails).
+3. **Simulation Tier** → **Digital Twin Orchestrator** (workcell runtime, scenario registry, compute autoscaling).
+4. **Ledger Tier** → **Provenance Ledger Writer** (prov-ledger package, artifact signer, retention manager).
+5. **Delivery Tier** → **Analyst Overlay & API** (GraphQL gateway, event streams, UI overlays, automation webhooks).
+
+A Zero-Trust mesh connects the tiers. Each boundary enforces mutual TLS, per-mission authorization, and event-level provenance tagging. High-level data flow:
+
+| Step | Producer | Consumer | Artifact | Notes |
+|------|----------|----------|----------|-------|
+| 1 | Observation Collector | Goal Hypothesizer | `Observation` | JSON schema, includes source, sensitivity, policy tags |
+| 2 | Goal Hypothesizer | Twin Orchestrator | `IntentHypothesisBatch` | Ranked list with priors, time horizon, guardrail metadata |
+| 3 | Twin Orchestrator | Provenance Ledger Writer | `TwinScenarioRun` | Branch tree, metrics, per-branch evidence references |
+| 4 | Ledger Writer | Analyst Overlay | `ProvenanceBundle` | Ledger entry IDs, SBOM signature, compliance classification |
+| 5 | Overlay | External Consumers | `IntentionAdvisory` | GraphQL types, includes recommended mitigations and audit link |
+
+### Deployment Topology
+
+- **Control Plane**: Kubernetes namespaces per environment (`intention-dev`, `intention-staging`, `intention-prod`) with Argo CD managing desired state.
+- **Data Plane**: Dedicated Kafka cluster for intention topics with Schema Registry enforcing compatibility; Neo4j mission graph leveraged for actor ontology lookups; MinIO/S3 bucket for twin state snapshots.
+- **Security Plane**: SPIFFE identities issued per workload, enforced via Istio mTLS. Vault provides short-lived tokens for ledger signing and retrieval of mission-specific credentials.
+- **Scaling Model**: HPA policies keyed on queue depth (`intention.hypotheses.pending`) and CPU for orchestrator pods; KEDA triggers for burst scaling based on Kafka lag.
+- **Resilience Features**: Multi-AZ deployments, PodDisruptionBudgets to avoid quorum loss, chaos experiments scheduled monthly via Chaos Mesh.
+
+## Data Contracts & Schemas
+
+### Observation
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `observationId` | UUID | Unique identifier for correlation and replay |
+| `timestamp` | ISO 8601 | Event time in UTC |
+| `actorRef` | String | Actor or entity identifier in GraphAI ontology |
+| `signals` | Array<Object> | Structured or unstructured features, each with provenance reference |
+| `sensitivity` | Enum | `PUBLIC`, `CONFIDENTIAL`, `RESTRICTED`, `SECRET` |
+| `sourceProvenance` | Object | Hashes, ingestion adapter metadata, signature |
+
+### IntentHypothesis
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hypothesisId` | UUID | Primary key linked to ledger |
+| `goal` | OntologyRef | Canonical goal identifier |
+| `confidence` | Float | Posterior probability (0-1) |
+| `supportingEvidence` | Array<ObservationRef> | Observations and precedent cases |
+| `counterfactualScore` | Float | Divergence between actual and best-fit simulated path |
+| `governanceState` | Enum | `DRAFT`, `REVIEW`, `APPROVED`, `REJECTED` |
+
+### TwinScenarioRun
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `scenarioId` | UUID | Run identifier |
+| `seed` | Integer | Deterministic seed for repeatability |
+| `branchTree` | JSON | Nested structure capturing decisions, transitions, and metrics |
+| `resourceLedger` | Object | Compute, storage, API credits consumed |
+| `riskScores` | Map<String, Float> | Impact, likelihood, collateral metrics |
+| `mitigationHooks` | Array<PolicyRef> | Automation triggers mapped to policy engine |
+
+### IntentionAdvisory (GraphQL)
+
+```
+type IntentionAdvisory {
+  advisoryId: ID!
+  missionId: ID!
+  actorRef: String!
+  generatedAt: DateTime!
+  topHypothesis: IntentHypothesis!
+  branches: [TwinBranch!]!
+  recommendedMitigations: [MitigationHook!]!
+  provenanceBundle: ProvenanceBundle!
+  confidenceSummary: ConfidenceSummary!
+}
+
+type TwinBranch {
+  branchId: ID!
+  depth: Int!
+  pathScore: Float!
+  stateDelta: JSON!
+  riskSummary: RiskSummary!
+  nextEvents: [ProjectedEvent!]!
+}
+
+type MitigationHook {
+  hookId: ID!
+  policyRef: String!
+  actionType: String!
+  approvalStatus: GovernanceState!
+  rollbackPlan: String
+}
+```
+
+### Kafka Topic Schemas
+
+- `intention.observations`: Avro schema referencing `Observation` contract; key = `observationId`, value includes mission context and redaction metadata.
+- `intention.hypotheses`: Avro schema referencing `IntentHypothesisBatch`; includes array of hypotheses, model metadata, and guardrail outcomes.
+- `intention.twin-runs`: JSON schema storing `TwinScenarioRun` plus compressed branch trees (snappy compression) and pointer to CAS blob for large payloads.
+- `intention.advisories`: Protobuf schema for downstream automation with deterministic field ordering to support signature verification.
+
+## Algorithms & Heuristics
+
+- **Bayesian Goal Recognition**: Updates priors using streaming telemetry, conditioned on actor ontologies and mission phases.
+- **RAG Support**: Pulls similar historical missions to inform hypothesis ranking. Configurable retrieval depth with semantic caching.
+- **Adaptive Branching**: Hybrid pruning strategy combining entropy reduction, mitigation cost thresholds, and operator-defined guardrails.
+- **Counterfactual Evaluation**: Measures the divergence between simulated branches and observed trajectory to score plausibility.
+- **Risk Weighting**: Multi-objective optimization balancing impact, probability, and mitigation feasibility.
+
+### Heuristic Extension Points
+
+- `GoalSelector`: Prioritizes hypotheses for simulation based on mission urgency, expected value, and novelty scores.
+- `BranchExpander`: Adds candidate decisions per depth using domain knowledge (supply chain, policy, comms) with plug-in registry.
+- `ConfidenceCalibrator`: Applies Platt scaling or isotonic regression using historical outcomes to stabilize advisory confidence.
+- `MitigationRecommender`: Scores mitigation hooks by combining risk reduction, implementation cost, and policy alignment metrics.
+- `PostSimulationAuditor`: Evaluates ledger completeness, ensures seeds recorded, triggers retry on signature failure.
+
+## Simulation Governance & Safety
+
+- **Deterministic Replay**: Each run stores seeds, configuration snapshots, and dependency hashes for deterministic replay.
+- **Safety Filters**: Pre-simulation guardrails reject scenarios breaching policy constraints (e.g., forbidden tactics, PII leaks).
+- **Human-in-the-Loop**: Analysts can pause, annotate, or terminate branches; actions are ledgered with justification.
+- **Red-Team Sandboxes**: Adversarial simulation spaces allow testing high-risk hypotheses without touching production data.
+- **Access Control**: Attribute-based policies enforce mission, clearance, and role constraints on scenario initiation and data access.
+- **Model Risk Management**: Maintain inventory of models used (LLM, Bayesian modules, heuristics) with periodic validation, drift detection, and approval workflow per risk committee guidelines.
+- **Bias & Ethics Reviews**: Quarterly audits with ethics board to evaluate unintended bias in goal inference and mitigation recommendations; document corrective actions.
+
+## Reliability, Performance & Scaling
+
+- **SLOs**: 99.5% availability, <2 minute P95 time-to-first-advisory, <30 second replay initialization.
+- **Autoscaling**: Horizontal scaling of twin orchestrator pods based on queued hypotheses and compute budget.
+- **Caching**: Memoize common scenario templates and retrieved precedent cases to reduce inference latency.
+- **Backpressure**: Queue depth thresholds trigger adaptive pruning and analyst notifications when compute budgets are exceeded.
+- **Disaster Recovery**: Cross-region replication of provenance ledger, warm standby for orchestrator clusters, quarterly failover drills.
+- **Capacity Forecasting**: Predictive autoscaling via time-series forecasting on mission load and compute utilization; integrates with cost dashboards for budget adherence.
+- **Performance Budgets**: Document explicit CPU/memory/network budgets per component; enforce with Kubernetes LimitRanges and ResourceQuotas.
+
+## API & Integration Surface
+
+- **GraphQL**: `query intentionAdvisories(missionId, actorRef)` returns hypotheses, branches, mitigation hooks, and ledger URIs.
+- **Event Streams**: Kafka topics (`intention.hypotheses`, `intention.mitigations`) for asynchronous consumers with schema registry enforcement.
+- **REST Hooks**: Signed webhook callbacks for policy engine and SOC platforms; include HMAC signatures and rate-limited retries.
+- **SDK Extensions**: Worker and gateway packages gain helper clients with retry, pagination, and structured logging support.
+- **UI Overlays**: Investigations UI overlays render branch timelines, heatmaps, and provenance breadcrumbs with export-to-PDF capability.
+- **CLI Utilities**: Provide `graphai intention` CLI plugin enabling analysts to query advisories, replay scenarios, and download provenance bundles from terminal.
+- **Terraform Modules**: Ship infrastructure modules for provisioning Kafka topics, secrets, and observability dashboards tailored for intention tooling.
+
+## Observability & Telemetry
+
+- **Metrics**: Emit Prometheus counters/gauges for hypothesis volume, branch depth distribution, mitigation acceptance, replay success rate.
+- **Tracing**: OpenTelemetry spans for ingestion → hypothesis → simulation → ledger; propagate correlation IDs.
+- **Logging**: Structured JSON logs with redaction of sensitive payload fields, correlated to ledger entry IDs.
+- **Health Checks**: Liveness and readiness endpoints verifying upstream dependencies (RAG store, ledger signer, workcell runtime).
+- **Alerting**: SLO burn-rate alerts, anomaly detection on hypothesis distributions, and ledger write failure alarms.
+- **Dashboards**: Grafana boards for pipeline throughput, hypothesis accuracy, branch depth histograms, mitigation acceptance rate, and ledger replication lag.
+- **Synthetic Monitoring**: Nightly synthetic missions executed via staging pipelines with assertions on advisory correctness and latency SLAs.
+
+## Validation & QA Strategy
+
+- **Unit Tests**: Coverage of schema validators, Bayesian updater, branch pruning logic, and ledger signature routines.
+- **Integration Tests**: Simulated pipelines verifying ingestion to advisory delivery with mocked external systems.
+- **Scenario Benchmarks**: Load tests on representative missions to validate autoscaling and latency SLOs.
+- **Red-Team Calibration**: Quarterly exercises to measure precision/recall of intention forecasts versus adversarial behavior.
+- **Change Control**: Provenance-aware configuration promotion requiring dual-approval and automated diff summaries.
+- **Data Quality Gates**: Great Expectations suites verifying observation completeness, hypothesis confidence ranges, and ledger integrity before promotion.
+- **Fairness Benchmarks**: Evaluate hypotheses across actor demographics to ensure consistent precision/recall; track metrics in compliance dashboard.
+
+## Operational Lifecycle
+
+- **Environment Promotion**: Dev → Staging → Prod with gated promotions requiring ledger integrity checks and UI approval.
+- **Runbooks**: Incident response playbooks for hypothesis backlog spikes, ledger divergence, and twin orchestration failures.
+- **On-Call Rotation**: Shared between analytics and platform squads; pager thresholds tied to SLOs and ledger integrity metrics.
+- **Capacity Planning**: Quarterly review of mission pipeline growth, digital twin coverage gaps, and compute budget adjustments.
+- **Training & Adoption**: Analyst workshops, knowledge base articles, and simulations library tours to socialize new capabilities.
+- **Release Cadence**: Bi-weekly release trains with freeze period prior to critical missions; utilize feature flags for incremental rollout.
+- **Cost Management**: Monitor compute/storage spend with budget thresholds; integrate with FinOps reporting for chargeback to mission owners.
+
+## Roadmap
+
+1. **MVP (Sprint 1)**
+   - Stand up Observation Collector and Goal Hypothesizer using existing telemetry pipelines.
+   - Prototype a single digital twin scenario (e.g., insider data exfiltration) with N=3.
+   - Implement provenance logging via prov-ledger with manual review workflow.
+   - Define initial SLOs, health checks, and on-call runbooks.
+
+2. **Expansion (Sprint 2-3)**
+   - Add adaptive branching heuristics and multi-domain twin coverage (supply chain, policy workflow, comms influence).
+   - Integrate overlays investigator view with interactive branch exploration and mitigation approval workflow.
+   - Automate SBOM/provenance signing pipeline via ComposerVNext hooks; enforce signed artifact promotion gates.
+   - Ship SDK clients and schema registry definitions for downstream consumers.
+
+3. **Hardening (Sprint 4+)**
+   - Stress-test twin orchestrations under adversarial inputs and budget exhaustion scenarios.
+   - Enforce retention policies, encryption-at-rest, and access controls on provenance artifacts.
+   - Measure precision/recall of intention forecasts against red-team exercises and calibrate risk scoring thresholds.
+   - Establish disaster recovery playbooks, cross-region replication, and quarterly chaos drills.
+
+## Implementation Playbooks
+
+### Environment Setup
+
+1. Provision Kubernetes namespaces using Argo CD Application manifests; apply pod security standards (`restricted` profile).
+2. Deploy Kafka cluster with Schema Registry and configure ACLs for intention services; bootstrap topics and quotas.
+3. Configure Vault secrets engines for ledger signing keys, webhook secrets, and database credentials.
+4. Register services with service mesh (Istio) and enable mutual TLS plus authorization policies scoped to mission labels.
+5. Seed Neo4j mission ontology and vector store (Qdrant) with historical missions for RAG initialization.
+
+### CI/CD Integration
+
+- Implement GitHub Actions workflow `intention-toolkit.yml` executing lint/tests, contract validation, and container image builds.
+- Integrate with Trunk-based development using short-lived feature branches; require successful synthetic mission replay before merge.
+- Publish container images to GHCR with cosign signatures; enforce image policy admission via Kyverno.
+- Run nightly `dbt` jobs updating analytical marts feeding risk dashboards.
+- Configure deployment promotions through Argo Rollouts with automated analysis (Kayenta) gating full rollout.
+
+### Incident Response
+
+| Scenario | Primary Signals | Response Actions |
+|----------|-----------------|------------------|
+| Hypothesis backlog spike | Kafka lag, queue depth alerts | Invoke backlog playbook: increase orchestrator replicas, adjust pruning threshold, notify mission commanders |
+| Ledger signing failure | Alert from ProvLedger signer, failed SBOM attestation | Fail closed; pause advisory publication, rotate HSM keys, rerun signing job with audit trail |
+| Twin drift detected | Drift metrics exceeding thresholds, fairness dashboard alert | Trigger calibration workflow: retrain models, update twin parameters, document review |
+| Automation webhook failure | HTTP 5xx from policy engine, retry exhaustion | Switch to manual mitigation approval, open incident ticket, run webhook replay tool |
+
+### Adoption & Change Management
+
+- Conduct executive demos focusing on mission impact, quantified via reduced time-to-mitigation and increased forecast accuracy.
+- Provide certification pathway for analysts (Foundations → Advanced Twin Operations) with LMS integration.
+- Maintain FAQ, troubleshooting guides, and office hours schedule; capture feedback in product backlog.
+- Align OKRs with mission leadership: target ≥30% reduction in surprise escalations, ≥20% faster mitigation approval.
+
+## Compliance & Risk Controls
+
+- **Regulatory Alignment**: Map provenance requirements to SOC2, ISO 27001, and DoD IL5 controls; document control ownership and evidence collection cadence.
+- **Data Residency**: Configure storage policies ensuring mission data remains within approved regions; leverage bucket-level replication filters.
+- **Audit Tooling**: Provide auditors with read-only dashboards exposing ledger entries, advisory history, and override logs; include export function for CSV evidence.
+- **Access Reviews**: Quarterly IAM review using automated scripts verifying least privilege; store attestations in governance system.
+- **Third-Party Dependencies**: Maintain SBOM for all components, monitor for CVEs via Dependabot and OSV; enforce remediation SLAs based on severity.
+
+## KPIs & Success Metrics
+
+- **Forecast Accuracy**: Measure precision/recall of top-3 hypotheses versus realized outcomes per mission.
+- **Time-to-Mitigation**: Track elapsed time from observation ingestion to mitigation approval; set targets per mission tier.
+- **Analyst Adoption**: Monitor daily active analysts, feedback sentiment, and training completion rates.
+- **System Reliability**: Monitor availability, latency, and error budgets; report monthly to leadership.
+- **Compliance Health**: Percentage of ledger entries with valid signatures, audit findings closed on time.
+
+## Example Advisory Flow
+
+1. Analyst flags anomalous data exfiltration behavior; Observation Collector ingests and normalizes telemetry.
+2. Goal Hypothesizer ranks top intentions (data theft, credential staging) with confidence and precedent references.
+3. Digital Twin Orchestrator simulates branches for each hypothesis, projecting exfil paths and mitigation levers.
+4. Provenance Ledger Writer seals run artifacts; advisory assembled with recommended mitigations (network isolation, credential rotation).
+5. Analyst overlay surfaces timeline; analyst approves containment plan, triggering automation webhook to SOAR platform.
+6. Post-incident review exports provenance bundle for compliance and updates heuristics with actual outcomes.
+
+## Open Questions
+
+- How should we balance exploration depth against latency for near-real-time use cases, especially during mission spikes?
+- What governance model governs synthetic data produced by the twins when used for regulatory reporting across jurisdictions?
+- Can we re-use existing counterfactual analysis pipelines to reduce duplication in branch scoring without sacrificing fidelity?
+- How do we incorporate human feedback loops without degrading auditability or introducing bias in hypothesis priors?
+- What automated controls detect drift in digital twin fidelity, and how often should we recalibrate scenario models?
+
+## Future Enhancements
+
+- **Federated Twin Exchanges**: Share calibrated twin modules across partner organizations with policy-compliant wrappers.
+- **Adaptive Budgeting**: Dynamic compute credit allocation informed by mission priority and risk appetite.
+- **Explainable AI Tooling**: Expanded Shapley-value analysis for branch decisions and interactive causal graphs.
+- **Continuous Learning**: Closed-loop updates to hypothesis models based on mitigation outcomes and analyst feedback.
+- **Cross-Domain Fusion**: Combine intention forecasts with behavioral telemetry, intelligence overlays, and threat intel feeds for richer situational awareness.


### PR DESCRIPTION
## Summary
- add implementation blueprint detailing backlog, milestones, and build tasks for the intention imputation tool
- document deployment topology, contracts, playbooks, compliance controls, KPIs, and end-to-end advisory flow to enable execution

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d740bb6bb88333b9777ae0b8e94571