### PR TITLE
feat: add obligation tracker service

### DIFF
--- a/server/src/services/ObligationTrackerService.test.ts
+++ b/server/src/services/ObligationTrackerService.test.ts
@@ -1,0 +1,122 @@
+import {
+  ObligationTrackerService,
+  ObligationClause,
+  EvidenceWebhookPayload,
+} from './ObligationTrackerService';
+
+describe('ObligationTrackerService', () => {
+  const baseClause: ObligationClause = {
+    id: 'clause-1',
+    title: 'Timely data deletion',
+    description: 'Delete data within 24 hours of request',
+    rule: {
+      kind: 'task',
+      taskId: 'data-deletion',
+      name: 'Purge user record',
+      frequency: { type: 'once', at: '2024-01-01T00:00:00.000Z' },
+      slaHours: 24,
+      evidence: [
+        {
+          id: 'deletion-log',
+          description: 'System log showing deletion completion',
+        },
+      ],
+      escalations: [
+        { id: 'compliance', afterHours: 24, contact: 'compliance@example.com' },
+      ],
+    },
+  };
+
+  it('compiles clauses into deterministic scheduled tasks', () => {
+    const serviceA = new ObligationTrackerService(() =>
+      new Date('2023-12-31T00:00:00.000Z')
+    );
+    const serviceB = new ObligationTrackerService(() =>
+      new Date('2023-12-31T00:00:00.000Z')
+    );
+
+    const compiledA = serviceA.compileClauses([baseClause]);
+    const compiledB = serviceB.compileClauses([baseClause]);
+
+    expect(compiledA).toEqual(compiledB);
+    expect(compiledA).toHaveLength(1);
+    expect(compiledA[0]).toMatchObject({
+      clauseId: 'clause-1',
+      name: 'Purge user record',
+      dueAt: '2024-01-02T00:00:00.000Z',
+    });
+  });
+
+  it('emits escalations for overdue tasks', () => {
+    const service = new ObligationTrackerService(() =>
+      new Date('2024-01-05T00:00:00.000Z')
+    );
+
+    const clause: ObligationClause = {
+      ...baseClause,
+      rule: {
+        kind: 'task',
+        taskId: 'access-review',
+        name: 'Perform quarterly access review',
+        frequency: { type: 'once', at: '2023-12-01T00:00:00.000Z' },
+        slaHours: 48,
+        evidence: [
+          {
+            id: 'access-review-report',
+            description: 'Certification report signed by compliance lead',
+          },
+        ],
+        escalations: [
+          { id: 'manager', afterHours: 12, contact: 'manager@example.com' },
+          { id: 'director', afterHours: 36, contact: 'director@example.com' },
+        ],
+      },
+    };
+
+    const [task] = service.compileClauses([clause]);
+    expect(task.status).toBe('pending');
+
+    const escalations = service.checkForEscalations(new Date('2024-01-05T00:00:00.000Z'));
+
+    expect(escalations).toHaveLength(2);
+    expect(escalations.map((e) => e.level.id)).toEqual(['manager', 'director']);
+    expect(escalations.every((e) => e.taskId === task.id)).toBe(true);
+
+    const updatedTask = service.exportProofPack('clause-1').clauses[0].tasks[0];
+    expect(updatedTask.status).toBe('overdue');
+  });
+
+  it('exports proof packs that validate evidence completeness', () => {
+    const service = new ObligationTrackerService(() =>
+      new Date('2024-01-02T12:00:00.000Z')
+    );
+    const [task] = service.compileClauses([baseClause]);
+
+    const payload: EvidenceWebhookPayload = {
+      taskId: task.id,
+      requirementId: 'deletion-log',
+      evidenceId: 'log-123',
+      location: 's3://evidence/log-123.json',
+      submittedAt: '2024-01-01T18:00:00.000Z',
+      submittedBy: 'automation@system',
+    };
+
+    const result = service.ingestEvidence(payload);
+    expect(result.accepted).toBe(true);
+    expect(result.complete).toBe(true);
+    expect(result.taskStatus).toBe('completed');
+
+    const pack = service.exportProofPack();
+    expect(pack.complete).toBe(true);
+    expect(pack.clauses[0].complete).toBe(true);
+    expect(pack.clauses[0].tasks[0].evidence[0]).toMatchObject({
+      provided: true,
+      records: [
+        expect.objectContaining({
+          evidenceId: 'log-123',
+          location: 's3://evidence/log-123.json',
+        }),
+      ],
+    });
+  });
+});

--- a/server/src/services/ObligationTrackerService.ts
+++ b/server/src/services/ObligationTrackerService.ts
@@ -1,0 +1,415 @@
+import { createHash } from 'crypto';
+
+export type ObligationClause = {
+  id: string;
+  title: string;
+  description?: string;
+  rule: ClauseRule;
+};
+
+export type ClauseRule = TaskClauseRule | CompositeClauseRule;
+
+export type FrequencyRule =
+  | { type: 'once'; at: string }
+  | { type: 'recurring'; start: string; intervalHours: number };
+
+export interface EvidenceRequirement {
+  id: string;
+  description: string;
+  optional?: boolean;
+}
+
+export interface EscalationLevel {
+  id: string;
+  afterHours: number;
+  contact: string;
+  instructions?: string;
+}
+
+export interface TaskClauseRule {
+  kind: 'task';
+  taskId: string;
+  name: string;
+  summary?: string;
+  frequency: FrequencyRule;
+  slaHours: number;
+  evidence: EvidenceRequirement[];
+  escalations: EscalationLevel[];
+}
+
+export interface CompositeClauseRule {
+  kind: 'composite';
+  strategy: 'all' | 'any';
+  tasks: TaskClauseRule[];
+}
+
+export type TaskStatus = 'pending' | 'completed' | 'overdue';
+
+export interface EvidenceRecord {
+  requirementId: string;
+  evidenceId: string;
+  location: string;
+  submittedAt: string;
+  submittedBy: string;
+  provider?: string;
+}
+
+export interface ScheduledTask {
+  id: string;
+  clauseId: string;
+  clauseTitle: string;
+  ruleTaskId: string;
+  name: string;
+  summary?: string;
+  scheduledAt: string;
+  dueAt: string;
+  status: TaskStatus;
+  evidenceRequirements: EvidenceRequirement[];
+  evidenceLog: EvidenceRecord[];
+  escalations: EscalationLevel[];
+  triggeredEscalations: string[];
+  completedAt?: string;
+}
+
+export interface EvidenceWebhookPayload {
+  taskId: string;
+  requirementId: string;
+  evidenceId: string;
+  location: string;
+  submittedAt: string;
+  submittedBy: string;
+  provider?: string;
+}
+
+export interface EvidenceIngestionResult {
+  accepted: boolean;
+  taskStatus: TaskStatus;
+  complete: boolean;
+}
+
+export interface EscalationNotice {
+  taskId: string;
+  clauseId: string;
+  clauseTitle: string;
+  level: EscalationLevel;
+  triggeredAt: string;
+  overdueHours: number;
+}
+
+export interface ProofPack {
+  generatedAt: string;
+  complete: boolean;
+  clauses: ProofPackClause[];
+}
+
+export interface ProofPackClause {
+  clauseId: string;
+  title: string;
+  description?: string;
+  complete: boolean;
+  tasks: ProofPackTask[];
+}
+
+export interface ProofPackTask {
+  taskId: string;
+  name: string;
+  status: TaskStatus;
+  dueAt: string;
+  completedAt?: string;
+  evidence: ProofPackEvidence[];
+}
+
+export interface ProofPackEvidence {
+  requirementId: string;
+  description: string;
+  provided: boolean;
+  records: EvidenceRecord[];
+}
+
+type Clock = () => Date;
+
+interface CompileOptions {
+  horizonHours?: number;
+}
+
+const HOURS_IN_MS = 60 * 60 * 1000;
+
+export class ObligationTrackerService {
+  private readonly clock: Clock;
+  private readonly clauses = new Map<string, ObligationClause>();
+  private readonly tasks = new Map<string, ScheduledTask>();
+
+  constructor(clock: Clock = () => new Date()) {
+    this.clock = clock;
+  }
+
+  compileClauses(
+    clauses: ObligationClause[],
+    options: CompileOptions = {}
+  ): ScheduledTask[] {
+    const horizon = options.horizonHours ?? 24 * 90;
+    const compiled: ScheduledTask[] = [];
+
+    for (const clause of clauses) {
+      this.clauses.set(clause.id, clause);
+      const clauseTasks = this.expandRule(clause, clause.rule, horizon);
+      for (const task of clauseTasks) {
+        this.tasks.set(task.id, task);
+        compiled.push(task);
+      }
+    }
+
+    return compiled;
+  }
+
+  ingestEvidence(payload: EvidenceWebhookPayload): EvidenceIngestionResult {
+    const task = this.tasks.get(payload.taskId);
+    if (!task) {
+      throw new Error(`Task ${payload.taskId} is not registered`);
+    }
+
+    const requirement = task.evidenceRequirements.find(
+      (req) => req.id === payload.requirementId
+    );
+
+    if (!requirement) {
+      throw new Error(
+        `Requirement ${payload.requirementId} not found for task ${payload.taskId}`
+      );
+    }
+
+    const record: EvidenceRecord = {
+      requirementId: payload.requirementId,
+      evidenceId: payload.evidenceId,
+      location: payload.location,
+      submittedAt: payload.submittedAt,
+      submittedBy: payload.submittedBy,
+      provider: payload.provider,
+    };
+
+    task.evidenceLog.push(record);
+
+    const complete = this.isTaskEvidenceComplete(task);
+    if (complete) {
+      task.status = 'completed';
+      task.completedAt = payload.submittedAt;
+    }
+
+    return {
+      accepted: true,
+      taskStatus: task.status,
+      complete,
+    };
+  }
+
+  checkForEscalations(now: Date = this.clock()): EscalationNotice[] {
+    const notices: EscalationNotice[] = [];
+
+    for (const task of this.tasks.values()) {
+      if (task.status === 'completed') {
+        continue;
+      }
+
+      const dueAt = new Date(task.dueAt);
+      const overdueMs = now.getTime() - dueAt.getTime();
+
+      if (overdueMs <= 0) {
+        continue;
+      }
+
+      task.status = 'overdue';
+      const overdueHours = overdueMs / HOURS_IN_MS;
+
+      const sortedLevels = [...task.escalations].sort(
+        (a, b) => a.afterHours - b.afterHours
+      );
+
+      for (const level of sortedLevels) {
+        if (overdueHours >= level.afterHours && !task.triggeredEscalations.includes(level.id)) {
+          task.triggeredEscalations.push(level.id);
+          const notice: EscalationNotice = {
+            taskId: task.id,
+            clauseId: task.clauseId,
+            clauseTitle: task.clauseTitle,
+            level,
+            triggeredAt: now.toISOString(),
+            overdueHours,
+          };
+          notices.push(notice);
+        }
+      }
+    }
+
+    return notices;
+  }
+
+  exportProofPack(clauseId?: string): ProofPack {
+    const clauseIds = clauseId
+      ? [clauseId]
+      : Array.from(this.clauses.keys()).sort();
+
+    const clauses: ProofPackClause[] = clauseIds.map((id) => {
+      const clause = this.clauses.get(id);
+      if (!clause) {
+        throw new Error(`Clause ${id} not found`);
+      }
+
+      const clauseTasks = [...this.tasks.values()]
+        .filter((task) => task.clauseId === id)
+        .sort((a, b) => a.dueAt.localeCompare(b.dueAt));
+
+      const tasks: ProofPackTask[] = clauseTasks.map((task) => ({
+        taskId: task.id,
+        name: task.name,
+        status: task.status,
+        dueAt: task.dueAt,
+        completedAt: task.completedAt,
+        evidence: task.evidenceRequirements.map((requirement) => {
+          const records = task.evidenceLog.filter(
+            (record) => record.requirementId === requirement.id
+          );
+          return {
+            requirementId: requirement.id,
+            description: requirement.description,
+            provided: records.length > 0 || Boolean(requirement.optional),
+            records,
+          };
+        }),
+      }));
+
+      const complete = tasks.every((task) => {
+        if (task.status !== 'completed') {
+          return false;
+        }
+
+        return task.evidence.every((entry) => entry.provided);
+      });
+
+      return {
+        clauseId: id,
+        title: clause.title,
+        description: clause.description,
+        complete,
+        tasks,
+      };
+    });
+
+    const complete = clauses.every((clause) => clause.complete);
+
+    return {
+      generatedAt: this.clock().toISOString(),
+      complete,
+      clauses,
+    };
+  }
+
+  private expandRule(
+    clause: ObligationClause,
+    rule: ClauseRule,
+    horizonHours: number
+  ): ScheduledTask[] {
+    if (rule.kind === 'task') {
+      return this.createTasksForRule(clause, rule, horizonHours);
+    }
+
+    if (rule.strategy === 'any') {
+      throw new Error('The "any" strategy is not supported yet.');
+    }
+
+    return rule.tasks.flatMap((taskRule) =>
+      this.createTasksForRule(clause, taskRule, horizonHours)
+    );
+  }
+
+  private createTasksForRule(
+    clause: ObligationClause,
+    rule: TaskClauseRule,
+    horizonHours: number
+  ): ScheduledTask[] {
+    const occurrences = this.buildOccurrences(rule.frequency, horizonHours);
+
+    return occurrences.map((occurrence) => {
+      const scheduledAt = occurrence.toISOString();
+      const dueAt = new Date(
+        occurrence.getTime() + rule.slaHours * HOURS_IN_MS
+      ).toISOString();
+      const taskId = this.computeTaskId(
+        clause.id,
+        rule.taskId,
+        scheduledAt,
+        dueAt
+      );
+
+      const existing = this.tasks.get(taskId);
+      if (existing) {
+        return existing;
+      }
+
+      return {
+        id: taskId,
+        clauseId: clause.id,
+        clauseTitle: clause.title,
+        ruleTaskId: rule.taskId,
+        name: rule.name,
+        summary: rule.summary,
+        scheduledAt,
+        dueAt,
+        status: 'pending',
+        evidenceRequirements: [...rule.evidence],
+        evidenceLog: [],
+        escalations: [...rule.escalations],
+        triggeredEscalations: [],
+      };
+    });
+  }
+
+  private buildOccurrences(
+    frequency: FrequencyRule,
+    horizonHours: number
+  ): Date[] {
+    if (frequency.type === 'once') {
+      return [this.requireValidDate(frequency.at)];
+    }
+
+    const occurrences: Date[] = [];
+    let cursor = this.requireValidDate(frequency.start);
+    const limit = cursor.getTime() + horizonHours * HOURS_IN_MS;
+
+    while (cursor.getTime() <= limit) {
+      occurrences.push(new Date(cursor));
+      cursor = new Date(cursor.getTime() + frequency.intervalHours * HOURS_IN_MS);
+    }
+
+    return occurrences;
+  }
+
+  private requireValidDate(input: string): Date {
+    const date = new Date(input);
+    if (Number.isNaN(date.getTime())) {
+      throw new Error(`Invalid date value: ${input}`);
+    }
+    return date;
+  }
+
+  private computeTaskId(
+    clauseId: string,
+    ruleTaskId: string,
+    scheduledAt: string,
+    dueAt: string
+  ): string {
+    const hash = createHash('sha1');
+    hash.update([clauseId, ruleTaskId, scheduledAt, dueAt].join('|'));
+    return hash.digest('hex');
+  }
+
+  private isTaskEvidenceComplete(task: ScheduledTask): boolean {
+    return task.evidenceRequirements.every((requirement) => {
+      if (requirement.optional) {
+        return true;
+      }
+      return task.evidenceLog.some(
+        (record) => record.requirementId === requirement.id
+      );
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add an obligation tracker service that compiles clauses into scheduled tasks with SLA, evidence, and escalation metadata
- support webhook evidence ingestion and proof pack exports for clause verification
- cover deterministic compilation, escalation behavior, and proof pack generation with targeted Jest tests

## Testing
- npm test -- ObligationTrackerService *(fails: local Jest workspace dependencies unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d747c91174833395d82fe16d1a9fb8