### PR TITLE
feat: add c2pa provenance bridge toolkit

### DIFF
--- a/ga-graphai/packages/c2pa-bridge/AGENTS.md
+++ b/ga-graphai/packages/c2pa-bridge/AGENTS.md
@@ -1,0 +1,4 @@
+- C2PA bridge toolkit.
+- Use 2-space indentation for TS/JS.
+- Run `npm test` in this package after changes.
+- Document new commands in the package README.

--- a/ga-graphai/packages/c2pa-bridge/README.md
+++ b/ga-graphai/packages/c2pa-bridge/README.md
@@ -1,0 +1,101 @@
+# C2PA Bridge Toolkit
+
+`@ga-graphai/c2pa-bridge` provides a TypeScript/Node.js toolkit for creating and verifying
+C2PA-inspired provenance manifests for generated images and documents. The toolkit can stamp
+assets with signing metadata, produce derivative manifests that respect chain-of-custody, and
+verify claims both on the command line and in the browser.
+
+## Features
+
+- **Stamping API** – generate manifests that capture tool chains, dataset lineage IDs, policy
+  hashes, signer identity, and deterministic content hashes.
+- **Redaction-safe derivatives** – re-sign child assets while linking back to parent manifests and
+  preserving tamper detection across the chain.
+- **Verifier CLI** – the `cpb` command validates manifest signatures, asset integrity, and
+  parent/child relationships.
+- **Browser verifier demo** – client-side verification powered by WebCrypto for interactive review
+  without uploading assets to a server.
+
+## Installation
+
+```bash
+cd ga-graphai/packages/c2pa-bridge
+npm install
+```
+
+## Building
+
+```bash
+npm run build
+```
+
+This produces Node-ready artifacts in `dist/` and a browser ES module bundle in `dist/browser/`.
+
+## CLI Usage
+
+```
+Usage: cpb [options] [command]
+
+C2PA provenance bridge toolkit
+
+Commands:
+  stamp [options] <asset>    Stamp an asset with provenance metadata
+  derive [options] <asset>   Create a derivative manifest that preserves chain of custody
+  verify [options]           Verify a provenance manifest against an asset
+  help [command]             display help for command
+```
+
+### Stamp
+
+```bash
+cpb stamp ./image.png \
+  --dataset dataset-123 \
+  --policy policy-hash \
+  --signer signer-id \
+  --private-key private.pem \
+  --public-key public.pem \
+  --tool "generator@1.0.0|prompt=text-to-image" \
+  --note "initial render"
+```
+
+### Derive
+
+```bash
+cpb derive ./image-redacted.png \
+  --parent ./image.png.cpb.json \
+  --signer signer-redactor \
+  --private-key redactor-private.pem \
+  --public-key redactor-public.pem \
+  --parent-public-key public.pem \
+  --parent-asset ./image.png \
+  --tool "redactor@0.3.0|technique=blur" \
+  --redaction "faces blurred"
+```
+
+### Verify
+
+```bash
+cpb verify \
+  --manifest ./image.png.cpb.json \
+  --asset ./image.png \
+  --public-key public.pem
+```
+
+Use `--parent-manifest`, `--parent-public-key`, and `--parent-asset` to validate derivative chains.
+Add `--json` to emit a structured verification report.
+
+## Browser Demo
+
+1. Build the package: `npm run build`.
+2. Serve the `demo/` folder (e.g., `npx http-server demo`).
+3. Load `index.html`, provide an asset, its manifest, and the signer public key. Verification runs
+   entirely in the browser via `verifyManifestInBrowser`.
+
+## Testing
+
+```bash
+npm test
+```
+
+The test suite exercises stamping, tamper detection, and derivative re-signing flows using Node's
+built-in test runner.

--- a/ga-graphai/packages/c2pa-bridge/demo/index.html
+++ b/ga-graphai/packages/c2pa-bridge/demo/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>C2PA Bridge Browser Verifier</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main>
+      <h1>C2PA Bridge Browser Verifier</h1>
+      <p>
+        Load an asset, its provenance manifest, and the trusted public key to verify the
+        signature and integrity chain entirely in the browser.
+      </p>
+      <section class="inputs">
+        <label>
+          Asset file
+          <input type="file" id="asset" />
+        </label>
+        <label>
+          Manifest JSON
+          <input type="file" id="manifest" accept="application/json" />
+        </label>
+        <label class="key-input">
+          Public key (PEM)
+          <textarea id="publicKey" rows="6" placeholder="-----BEGIN PUBLIC KEY-----"></textarea>
+        </label>
+        <button id="verify">Verify</button>
+      </section>
+      <section id="results" class="results" hidden>
+        <h2>Verification Results</h2>
+        <pre id="resultText"></pre>
+      </section>
+    </main>
+    <script type="module" src="./viewer.js"></script>
+  </body>
+</html>

--- a/ga-graphai/packages/c2pa-bridge/demo/styles.css
+++ b/ga-graphai/packages/c2pa-bridge/demo/styles.css
@@ -1,0 +1,85 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  margin: 0;
+  background: #0f172a;
+  color: #f8fafc;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 2rem;
+}
+
+main {
+  max-width: 760px;
+  width: 100%;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.45);
+}
+
+h1 {
+  margin-top: 0;
+  font-size: 1.8rem;
+}
+
+.inputs {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+input[type='file'],
+textarea {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  border-radius: 8px;
+  padding: 0.75rem;
+  color: #f8fafc;
+}
+
+textarea {
+  font-family: ui-monospace, SFMono-Regular, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+}
+
+button {
+  padding: 0.75rem 1.25rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #06b6d4, #6366f1);
+  color: #0f172a;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(99, 102, 241, 0.35);
+}
+
+.results {
+  margin-top: 2rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 1.5rem;
+}
+
+pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+}

--- a/ga-graphai/packages/c2pa-bridge/demo/viewer.js
+++ b/ga-graphai/packages/c2pa-bridge/demo/viewer.js
@@ -1,0 +1,59 @@
+import { verifyManifestInBrowser } from '../dist/browser/browser.js';
+
+const assetInput = document.getElementById('asset');
+const manifestInput = document.getElementById('manifest');
+const publicKeyInput = document.getElementById('publicKey');
+const verifyButton = document.getElementById('verify');
+const resultsSection = document.getElementById('results');
+const resultText = document.getElementById('resultText');
+
+async function readSelectedFile(input) {
+  if (!input.files || input.files.length === 0) {
+    throw new Error('Missing required file input.');
+  }
+  return input.files[0];
+}
+
+function formatIssues(issues) {
+  if (!issues.length) {
+    return 'No issues detected.';
+  }
+  return issues.map((issue) => `- [${issue.level}] ${issue.message}`).join('\n');
+}
+
+verifyButton.addEventListener('click', async () => {
+  try {
+    const assetFile = await readSelectedFile(assetInput);
+    const manifestFile = await readSelectedFile(manifestInput);
+    const publicKey = publicKeyInput.value.trim();
+    if (!publicKey) {
+      throw new Error('Public key is required.');
+    }
+
+    const [assetBuffer, manifestText] = await Promise.all([
+      assetFile.arrayBuffer(),
+      manifestFile.text(),
+    ]);
+    const manifest = JSON.parse(manifestText);
+    const result = await verifyManifestInBrowser({
+      manifest,
+      publicKey,
+      asset: assetBuffer,
+    });
+
+    const lines = [
+      `Signature: ${result.validSignature ? 'valid' : 'INVALID'}`,
+      `Asset hash: ${result.validAssetHash ? 'valid' : 'INVALID'}`,
+      `Manifest hash: ${result.manifestHash}`,
+      `Claim hash: ${result.claimHash}`,
+      'Issues:',
+      formatIssues(result.issues),
+    ];
+
+    resultText.textContent = lines.join('\n');
+    resultsSection.hidden = false;
+  } catch (error) {
+    resultText.textContent = `Verification failed: ${(error && error.message) || error}`;
+    resultsSection.hidden = false;
+  }
+});

--- a/ga-graphai/packages/c2pa-bridge/package.json
+++ b/ga-graphai/packages/c2pa-bridge/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@ga-graphai/c2pa-bridge",
+  "version": "0.1.0",
+  "description": "Toolkit for stamping and verifying C2PA-style provenance manifests for generated assets.",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./browser": {
+      "import": "./dist/browser/browser.js",
+      "types": "./dist/browser/browser.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "demo",
+    "README.md",
+    "AGENTS.md"
+  ],
+  "bin": {
+    "cpb": "dist/cli/cpb.js"
+  },
+  "scripts": {
+    "build": "npm run build:node && npm run build:browser",
+    "build:node": "tsc -p tsconfig.json",
+    "build:browser": "tsc -p tsconfig.browser.json",
+    "clean": "rimraf dist",
+    "prepare": "npm run build",
+    "test": "npm run build && node --test \"tests/**/*.js\""
+  },
+  "keywords": [
+    "c2pa",
+    "provenance",
+    "signatures",
+    "chain-of-custody"
+  ],
+  "author": "Summit Engineering",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "commander": "^11.1.0",
+    "mime-types": "^2.1.35"
+  },
+  "devDependencies": {
+    "@types/mime-types": "^2.1.4",
+    "@types/node": "^20.11.28",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.4.5"
+  }
+}

--- a/ga-graphai/packages/c2pa-bridge/src/browser.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/browser.ts
@@ -1,0 +1,107 @@
+import { manifestCanonicalString, claimCanonicalString } from './common/manifest';
+import {
+  BrowserVerificationOptions,
+  BrowserVerificationResult,
+  VerificationIssue,
+} from './types';
+
+function collectIssue(message: string, level: VerificationIssue['level'] = 'error'): VerificationIssue {
+  return { message, level };
+}
+
+function pemToArrayBuffer(pem: string): ArrayBuffer {
+  const base64 = pem
+    .replace('-----BEGIN PUBLIC KEY-----', '')
+    .replace('-----END PUBLIC KEY-----', '')
+    .replace(/\s+/g, '');
+  const binary = atob(base64);
+  const buffer = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    buffer[i] = binary.charCodeAt(i);
+  }
+  return buffer.buffer;
+}
+
+async function fingerprintPublicKey(publicKey: string): Promise<string> {
+  const data = new TextEncoder().encode(publicKey.trim());
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function verifySignature(
+  manifestCanonical: string,
+  signature: string,
+  publicKey: string,
+  algorithm: string,
+): Promise<boolean> {
+  if (algorithm !== 'rsa-sha256') {
+    throw new Error(`Browser verification currently supports rsa-sha256 only. Requested: ${algorithm}`);
+  }
+  const keyData = pemToArrayBuffer(publicKey);
+  const cryptoKey = await crypto.subtle.importKey(
+    'spki',
+    keyData,
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      hash: 'SHA-256',
+    },
+    false,
+    ['verify'],
+  );
+  const signatureBuffer = Uint8Array.from(atob(signature), (c) => c.charCodeAt(0));
+  const data = new TextEncoder().encode(manifestCanonical);
+  return crypto.subtle.verify('RSASSA-PKCS1-v1_5', cryptoKey, signatureBuffer, data);
+}
+
+export async function verifyManifestInBrowser(
+  options: BrowserVerificationOptions,
+): Promise<BrowserVerificationResult> {
+  const manifest = options.manifest;
+  const manifestCanonical = manifestCanonicalString(manifest);
+  const issues: VerificationIssue[] = [];
+  const signatureValid = await verifySignature(
+    manifestCanonical,
+    manifest.signature,
+    options.publicKey,
+    manifest.claim.signer.algorithm,
+  );
+  if (!signatureValid) {
+    issues.push(collectIssue('Signature verification failed'));
+  }
+
+  const providedFingerprint = await fingerprintPublicKey(options.publicKey);
+  if (providedFingerprint !== manifest.claim.signer.publicKeyFingerprint) {
+    issues.push(collectIssue('Signer fingerprint mismatch with provided public key', 'warning'));
+  }
+
+  const digest = await crypto.subtle.digest('SHA-256', options.asset);
+  const assetHash = Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  const validAssetHash = assetHash === manifest.asset.hash;
+  if (!validAssetHash) {
+    issues.push(collectIssue('Asset hash does not match manifest'));
+  }
+
+  const manifestHash = await sha256(manifestCanonical);
+  const claimHash = await sha256(claimCanonicalString(manifest));
+
+  return {
+    validSignature: signatureValid,
+    validAssetHash,
+    issues,
+    claimHash,
+    manifestHash,
+  };
+}
+
+async function sha256(value: string): Promise<string> {
+  const data = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}

--- a/ga-graphai/packages/c2pa-bridge/src/cli/cpb.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/cli/cpb.ts
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+import { Command, Option } from 'commander';
+import { promises as fs } from 'fs';
+import {
+  createDerivativeStamp,
+  parseToolChainOption,
+  stampAsset,
+  verifyProvenance,
+} from '../node/index';
+import {
+  DerivativeStampOptions,
+  StampAssetOptions,
+  ToolChainEntry,
+  VerifyProvenanceOptions,
+} from '../types';
+
+const program = new Command();
+program.name('cpb').description('C2PA provenance bridge toolkit');
+
+function collectToolChain(values: string[]): ToolChainEntry[] {
+  return values.map((value) => parseToolChainOption(value));
+}
+
+program
+  .command('stamp')
+  .description('Stamp an asset with provenance metadata')
+  .argument('<asset>', 'Path to the asset file to stamp')
+  .requiredOption('--dataset <id>', 'Dataset lineage identifier')
+  .requiredOption('--policy <hash>', 'Policy hash associated with the claim')
+  .requiredOption('--signer <id>', 'Signer identifier')
+  .requiredOption('--private-key <path>', 'Path to the PEM encoded private key')
+  .requiredOption('--public-key <path>', 'Path to the PEM encoded public key')
+  .addOption(new Option('--algorithm <algo>', 'Signature algorithm').default('rsa-sha256'))
+  .option('--tool <spec...>', 'Tool chain entry in name@version|key=value format')
+  .option('--note <text>', 'Optional notes to embed in the claim')
+  .option('--mime <type>', 'Override asset MIME type')
+  .option('--output <path>', 'Output path for manifest (defaults to <asset>.cpb.json)')
+  .action(async (asset: string, options) => {
+    try {
+      const toolChain = options.tool ? collectToolChain(options.tool) : [];
+      const privateKey = await fs.readFile(options.privateKey, 'utf8');
+      const publicKey = await fs.readFile(options.publicKey, 'utf8');
+      const stampOptions: StampAssetOptions = {
+        assetPath: asset,
+        outputPath: options.output,
+        metadata: {
+          toolChain,
+          datasetLineageId: options.dataset,
+          policyHash: options.policy,
+          notes: options.note,
+        },
+        signer: {
+          id: options.signer,
+          algorithm: options.algorithm,
+          privateKey,
+          publicKey,
+          mimeType: options.mime,
+        },
+      };
+      const { manifestPath } = await stampAsset(stampOptions);
+      console.log(`Manifest written to ${manifestPath}`);
+    } catch (error) {
+      console.error((error as Error).message);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('derive')
+  .description('Create a derivative manifest that preserves chain of custody')
+  .argument('<asset>', 'Path to the derivative asset file')
+  .requiredOption('--parent <manifest>', 'Path to the parent manifest JSON file')
+  .requiredOption('--signer <id>', 'Signer identifier for the derivative claim')
+  .requiredOption('--private-key <path>', 'Path to the PEM encoded private key for the derivative signer')
+  .requiredOption('--public-key <path>', 'Path to the PEM encoded public key for the derivative signer')
+  .requiredOption('--parent-public-key <path>', 'Public key for verifying the parent manifest')
+  .option('--parent-asset <path>', 'Optional path to the original parent asset for hash verification')
+  .addOption(new Option('--algorithm <algo>', 'Signature algorithm').default('rsa-sha256'))
+  .option('--tool <spec...>', 'Additional tool chain entries for the derivative work')
+  .option('--dataset <id>', 'Override dataset lineage identifier')
+  .option('--policy <hash>', 'Override policy hash')
+  .option('--note <text>', 'Override notes')
+  .option('--redaction <text...>', 'Redaction description to include in the derivative claim')
+  .option('--output <path>', 'Output path for manifest (defaults to <asset>.cpb.json)')
+  .action(async (asset: string, options) => {
+    try {
+      const toolChain = options.tool ? collectToolChain(options.tool) : undefined;
+      const privateKey = await fs.readFile(options.privateKey, 'utf8');
+      const publicKey = await fs.readFile(options.publicKey, 'utf8');
+      const parentPublicKey = await fs.readFile(options.parentPublicKey, 'utf8');
+      const derivativeOptions: DerivativeStampOptions = {
+        assetPath: asset,
+        outputPath: options.output,
+        parentManifestPath: options.parent,
+        parentPublicKey,
+        parentAssetPath: options.parentAsset,
+        metadata: {
+          toolChain: toolChain ?? [],
+          datasetLineageId: options.dataset,
+          policyHash: options.policy,
+          notes: options.note,
+        },
+        redactions: options.redaction,
+        signer: {
+          id: options.signer,
+          algorithm: options.algorithm,
+          privateKey,
+          publicKey,
+        },
+      };
+      const { manifestPath } = await createDerivativeStamp(derivativeOptions);
+      console.log(`Derivative manifest written to ${manifestPath}`);
+    } catch (error) {
+      console.error((error as Error).message);
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('verify')
+  .description('Verify a provenance manifest against an asset')
+  .requiredOption('--manifest <path>', 'Manifest file to verify')
+  .requiredOption('--asset <path>', 'Asset file to verify against the manifest')
+  .requiredOption('--public-key <path>', 'Trusted public key for signature validation')
+  .option('--parent-manifest <path>', 'Path to the parent manifest when verifying derivatives')
+  .option('--parent-public-key <path>', 'Trusted public key for the parent manifest')
+  .option('--parent-asset <path>', 'Parent asset path when verifying derivatives')
+  .option('--json', 'Emit verification result as JSON')
+  .action(async (options) => {
+    try {
+      const publicKey = await fs.readFile(options.publicKey, 'utf8');
+      const verifyOptions: VerifyProvenanceOptions = {
+        manifestPath: options.manifest,
+        publicKey,
+        assetPath: options.asset,
+        parentManifestPath: options.parentManifest,
+        parentPublicKey: options.parentPublicKey
+          ? await fs.readFile(options.parentPublicKey, 'utf8')
+          : undefined,
+        parentAssetPath: options.parentAsset,
+      };
+      const result = await verifyProvenance(verifyOptions);
+      if (options.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`Signature: ${result.validSignature ? 'valid' : 'INVALID'}`);
+        console.log(`Asset Hash: ${result.validAssetHash ? 'valid' : 'INVALID'}`);
+        if (result.issues.length > 0) {
+          console.log('Issues:');
+          for (const issue of result.issues) {
+            console.log(`- [${issue.level}] ${issue.message}`);
+          }
+        } else {
+          console.log('No issues detected.');
+        }
+        console.log(`Manifest Hash: ${result.manifestHash}`);
+        console.log(`Claim Hash: ${result.claimHash}`);
+        if (result.parent) {
+          console.log('Parent verification succeeded.');
+        }
+      }
+      if (!result.validSignature || !result.validAssetHash || result.issues.some((i) => i.level === 'error')) {
+        process.exitCode = 2;
+      }
+    } catch (error) {
+      console.error((error as Error).message);
+      process.exitCode = 1;
+    }
+  });
+
+program.parseAsync(process.argv);

--- a/ga-graphai/packages/c2pa-bridge/src/common/canonical.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/common/canonical.ts
@@ -1,0 +1,32 @@
+export type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalize(value: unknown): JsonValue {
+  if (value === null || typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalize(item));
+  }
+  if (isObject(value)) {
+    const sortedKeys = Object.keys(value).sort();
+    const normalized: { [key: string]: JsonValue } = {};
+    for (const key of sortedKeys) {
+      const current = (value as Record<string, unknown>)[key];
+      if (current === undefined) {
+        continue;
+      }
+      normalized[key] = normalize(current);
+    }
+    return normalized;
+  }
+  return JSON.parse(JSON.stringify(value)) as JsonValue;
+}
+
+export function canonicalize(value: unknown): string {
+  const normalized = normalize(value);
+  return JSON.stringify(normalized);
+}

--- a/ga-graphai/packages/c2pa-bridge/src/common/manifest.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/common/manifest.ts
@@ -1,0 +1,15 @@
+import { ProvenanceManifest } from '../types';
+import { canonicalize } from './canonical';
+
+export function unsignedManifest(manifest: ProvenanceManifest): Omit<ProvenanceManifest, 'signature'> {
+  const { signature: _signature, ...rest } = manifest;
+  return rest;
+}
+
+export function manifestCanonicalString(manifest: ProvenanceManifest): string {
+  return canonicalize(unsignedManifest(manifest));
+}
+
+export function claimCanonicalString(manifest: ProvenanceManifest): string {
+  return canonicalize(manifest.claim);
+}

--- a/ga-graphai/packages/c2pa-bridge/src/index.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/index.ts
@@ -1,0 +1,2 @@
+export * from './types';
+export * from './node/index';

--- a/ga-graphai/packages/c2pa-bridge/src/node/index.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/node/index.ts
@@ -1,0 +1,3 @@
+export { stampAsset, createDerivativeStamp } from './stamp';
+export { verifyProvenance } from './verify';
+export { parseToolChainOption } from './tooling';

--- a/ga-graphai/packages/c2pa-bridge/src/node/signature.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/node/signature.ts
@@ -1,0 +1,25 @@
+import { createSign, createVerify, sign as edSign, verify as edVerify } from 'crypto';
+import { SignatureAlgorithm } from '../types';
+
+export function signPayload(payload: string, privateKey: string, algorithm: SignatureAlgorithm): string {
+  const data = Buffer.from(payload);
+  if (algorithm === 'ed25519') {
+    return edSign(null, data, privateKey).toString('base64');
+  }
+  const signer = createSign('RSA-SHA256');
+  signer.update(data);
+  signer.end();
+  return signer.sign(privateKey, 'base64');
+}
+
+export function verifyPayload(payload: string, signature: string, publicKey: string, algorithm: SignatureAlgorithm): boolean {
+  const data = Buffer.from(payload);
+  const sig = Buffer.from(signature, 'base64');
+  if (algorithm === 'ed25519') {
+    return edVerify(null, data, publicKey, sig);
+  }
+  const verifier = createVerify('RSA-SHA256');
+  verifier.update(data);
+  verifier.end();
+  return verifier.verify(publicKey, sig);
+}

--- a/ga-graphai/packages/c2pa-bridge/src/node/stamp.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/node/stamp.ts
@@ -1,0 +1,152 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import {
+  ClaimMetadata,
+  DerivativeStampOptions,
+  ProvenanceManifest,
+  StampAssetOptions,
+  ToolChainEntry,
+} from '../types';
+import { manifestCanonicalString } from '../common/manifest';
+import {
+  computeManifestHash,
+  defaultManifestPath,
+  determineMime,
+  ensureDirectory,
+  fingerprintPublicKey,
+  hashFile,
+} from './utils';
+import { signPayload } from './signature';
+import { verifyProvenance } from './verify';
+
+function sanitizeToolChain(toolChain: ToolChainEntry[]): ToolChainEntry[] {
+  return toolChain.map((entry) => ({
+    name: entry.name,
+    version: entry.version,
+    parameters: entry.parameters && Object.fromEntries(Object.entries(entry.parameters).sort()),
+  }));
+}
+
+function buildClaimMetadata(metadata: ClaimMetadata): ClaimMetadata {
+  return {
+    toolChain: sanitizeToolChain(metadata.toolChain),
+    datasetLineageId: metadata.datasetLineageId,
+    policyHash: metadata.policyHash,
+    notes: metadata.notes,
+  };
+}
+
+export async function stampAsset(options: StampAssetOptions): Promise<{ manifestPath: string; manifest: ProvenanceManifest }>
+{
+  const assetHash = await hashFile(options.assetPath);
+  const mimeType = determineMime(options.assetPath, options.signer.mimeType);
+  const fingerprint = fingerprintPublicKey(options.signer.publicKey);
+  const claimMetadata = buildClaimMetadata(options.metadata);
+  const timestamp = new Date().toISOString();
+
+  const manifest: ProvenanceManifest = {
+    version: '1.0',
+    asset: {
+      name: path.basename(options.assetPath),
+      hash: assetHash,
+      mimeType,
+    },
+    claim: {
+      toolChain: claimMetadata.toolChain,
+      datasetLineageId: claimMetadata.datasetLineageId,
+      policyHash: claimMetadata.policyHash,
+      timestamp,
+      signer: {
+        id: options.signer.id,
+        algorithm: options.signer.algorithm,
+        publicKeyFingerprint: fingerprint,
+      },
+      notes: claimMetadata.notes,
+    },
+    signature: '',
+  };
+
+  const payload = manifestCanonicalString(manifest);
+  manifest.signature = signPayload(payload, options.signer.privateKey, options.signer.algorithm);
+
+  const manifestPath = options.outputPath ?? defaultManifestPath(options.assetPath);
+  await ensureDirectory(manifestPath);
+  await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+  return { manifestPath, manifest };
+}
+
+export async function createDerivativeStamp(
+  options: DerivativeStampOptions,
+): Promise<{ manifestPath: string; manifest: ProvenanceManifest }>
+{
+  const parentRaw = await fs.readFile(options.parentManifestPath, 'utf8');
+  const parentManifest: ProvenanceManifest = JSON.parse(parentRaw);
+
+  const parentVerification = await verifyProvenance({
+    manifestPath: options.parentManifestPath,
+    publicKey: options.parentPublicKey,
+    assetPath: options.parentAssetPath,
+  });
+
+  if (!parentVerification.validSignature) {
+    throw new Error('Parent manifest signature verification failed.');
+  }
+
+  if (options.parentAssetPath && !parentVerification.validAssetHash) {
+    throw new Error('Parent asset hash verification failed.');
+  }
+
+  if (parentVerification.issues.some((issue) => issue.level === 'error')) {
+    throw new Error('Parent manifest contains blocking verification issues.');
+  }
+
+  const parentManifestHash = computeManifestHash(parentManifest);
+  const assetHash = await hashFile(options.assetPath);
+  const fingerprint = fingerprintPublicKey(options.signer.publicKey);
+  const mimeType = determineMime(options.assetPath, options.signer.mimeType);
+  const timestamp = new Date().toISOString();
+
+  const combinedToolChain = [
+    ...parentManifest.claim.toolChain,
+    ...(options.metadata?.toolChain ? sanitizeToolChain(options.metadata.toolChain) : []),
+  ];
+
+  const manifest: ProvenanceManifest = {
+    version: '1.0',
+    asset: {
+      name: path.basename(options.assetPath),
+      hash: assetHash,
+      mimeType,
+    },
+    claim: {
+      toolChain: combinedToolChain,
+      datasetLineageId: options.metadata?.datasetLineageId ?? parentManifest.claim.datasetLineageId,
+      policyHash: options.metadata?.policyHash ?? parentManifest.claim.policyHash,
+      timestamp,
+      signer: {
+        id: options.signer.id,
+        algorithm: options.signer.algorithm,
+        publicKeyFingerprint: fingerprint,
+      },
+      redactions: options.redactions && options.redactions.length > 0 ? [...options.redactions] : undefined,
+      notes: options.metadata?.notes ?? parentManifest.claim.notes,
+    },
+    parent: {
+      manifestHash: parentManifestHash,
+      assetHash: parentManifest.asset.hash,
+      signerId: parentManifest.claim.signer.id,
+      timestamp: parentManifest.claim.timestamp,
+    },
+    signature: '',
+  };
+
+  const payload = manifestCanonicalString(manifest);
+  manifest.signature = signPayload(payload, options.signer.privateKey, options.signer.algorithm);
+
+  const manifestPath = options.outputPath ?? defaultManifestPath(options.assetPath);
+  await ensureDirectory(manifestPath);
+  await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+  return { manifestPath, manifest };
+}

--- a/ga-graphai/packages/c2pa-bridge/src/node/tooling.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/node/tooling.ts
@@ -1,0 +1,27 @@
+import { ToolChainEntry } from '../types';
+
+export function parseToolChainOption(value: string): ToolChainEntry {
+  const [toolPart, paramPart] = value.split('|', 2);
+  const [name, version] = toolPart.split('@');
+  if (!name || !version) {
+    throw new Error(`Invalid tool specification: ${value}. Expected format name@version|key=value`);
+  }
+  const parameters: Record<string, string> = {};
+  if (paramPart) {
+    for (const pair of paramPart.split(',')) {
+      if (!pair.trim()) {
+        continue;
+      }
+      const [key, val] = pair.split('=');
+      if (!key || val === undefined) {
+        throw new Error(`Invalid tool parameter in "${value}"`);
+      }
+      parameters[key.trim()] = val.trim();
+    }
+  }
+  return {
+    name: name.trim(),
+    version: version.trim(),
+    parameters: Object.keys(parameters).length > 0 ? parameters : undefined,
+  };
+}

--- a/ga-graphai/packages/c2pa-bridge/src/node/utils.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/node/utils.ts
@@ -1,0 +1,55 @@
+import { createHash } from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+import mime from 'mime-types';
+import { canonicalize } from '../common/canonical';
+import { ProvenanceManifest } from '../types';
+import { manifestCanonicalString } from '../common/manifest';
+
+export async function hashFile(filePath: string): Promise<string> {
+  const file = await fs.readFile(filePath);
+  const hash = createHash('sha256');
+  hash.update(file);
+  return hash.digest('hex');
+}
+
+export function hashCanonical(value: unknown): string {
+  const hash = createHash('sha256');
+  if (typeof value === 'string') {
+    hash.update(value);
+  } else {
+    hash.update(canonicalize(value));
+  }
+  return hash.digest('hex');
+}
+
+export function fingerprintPublicKey(publicKey: string): string {
+  const hash = createHash('sha256');
+  hash.update(publicKey.trim());
+  return hash.digest('hex');
+}
+
+export function determineMime(assetPath: string, explicit?: string): string | undefined {
+  if (explicit) {
+    return explicit;
+  }
+  const guessed = mime.lookup(assetPath);
+  return guessed || undefined;
+}
+
+export function defaultManifestPath(assetPath: string): string {
+  return `${assetPath}.cpb.json`;
+}
+
+export function computeManifestHash(manifest: ProvenanceManifest): string {
+  return hashCanonical(manifestCanonicalString(manifest));
+}
+
+export function computeClaimHash(manifest: ProvenanceManifest): string {
+  return hashCanonical(manifest.claim);
+}
+
+export async function ensureDirectory(filePath: string): Promise<void> {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+}

--- a/ga-graphai/packages/c2pa-bridge/src/node/verify.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/node/verify.ts
@@ -1,0 +1,79 @@
+import { promises as fs } from 'fs';
+import { ProvenanceManifest, VerificationIssue, VerificationResult, VerifyProvenanceOptions } from '../types';
+import { manifestCanonicalString } from '../common/manifest';
+import { computeClaimHash, computeManifestHash, fingerprintPublicKey, hashFile } from './utils';
+import { verifyPayload } from './signature';
+
+async function readManifest(filePath: string): Promise<ProvenanceManifest> {
+  const raw = await fs.readFile(filePath, 'utf8');
+  return JSON.parse(raw) as ProvenanceManifest;
+}
+
+function collectIssue(message: string, level: VerificationIssue['level'] = 'error'): VerificationIssue {
+  return { message, level };
+}
+
+export async function verifyProvenance(options: VerifyProvenanceOptions): Promise<VerificationResult> {
+  const manifest = await readManifest(options.manifestPath);
+  const payload = manifestCanonicalString(manifest);
+  const issues: VerificationIssue[] = [];
+
+  const validSignature = verifyPayload(payload, manifest.signature, options.publicKey, manifest.claim.signer.algorithm);
+  if (!validSignature) {
+    issues.push(collectIssue('Signature verification failed'));
+  }
+
+  const providedFingerprint = fingerprintPublicKey(options.publicKey);
+  if (providedFingerprint !== manifest.claim.signer.publicKeyFingerprint) {
+    issues.push(collectIssue('Signer fingerprint mismatch with provided public key', 'warning'));
+  }
+
+  let validAssetHash = true;
+  if (options.assetPath) {
+    const assetHash = await hashFile(options.assetPath);
+    if (assetHash !== manifest.asset.hash) {
+      validAssetHash = false;
+      issues.push(collectIssue('Asset hash does not match manifest'));
+    }
+  } else {
+    validAssetHash = false;
+    issues.push(collectIssue('Asset path not provided for verification', 'warning'));
+  }
+
+  const manifestHash = computeManifestHash(manifest);
+  const claimHash = computeClaimHash(manifest);
+
+  let parent: VerificationResult | undefined;
+  if (manifest.parent) {
+    if (!options.parentManifestPath || !options.parentPublicKey) {
+      issues.push(collectIssue('Parent manifest/public key required for chain verification', 'warning'));
+    } else {
+      parent = await verifyProvenance({
+        manifestPath: options.parentManifestPath,
+        publicKey: options.parentPublicKey,
+        assetPath: options.parentAssetPath,
+      });
+      const expectedHash = manifest.parent.manifestHash;
+      if (parent.manifestHash !== expectedHash) {
+        issues.push(collectIssue('Parent manifest hash mismatch'));
+      }
+      if (manifest.parent.assetHash !== parent.manifest.asset.hash) {
+        issues.push(collectIssue('Parent asset hash mismatch'));
+      }
+      if (manifest.parent.signerId !== parent.manifest.claim.signer.id) {
+        issues.push(collectIssue('Parent signer mismatch'));
+      }
+    }
+  }
+
+  return {
+    manifest,
+    manifestHash,
+    claimHash,
+    validSignature,
+    validAssetHash,
+    issues,
+    signerId: manifest.claim.signer.id,
+    parent,
+  };
+}

--- a/ga-graphai/packages/c2pa-bridge/src/types.ts
+++ b/ga-graphai/packages/c2pa-bridge/src/types.ts
@@ -1,0 +1,114 @@
+export type SignatureAlgorithm = 'rsa-sha256' | 'ed25519';
+
+export interface ToolChainEntry {
+  name: string;
+  version: string;
+  parameters?: Record<string, string>;
+}
+
+export interface ClaimMetadata {
+  toolChain: ToolChainEntry[];
+  datasetLineageId: string;
+  policyHash: string;
+  notes?: string;
+}
+
+export interface SignerDescriptor {
+  id: string;
+  publicKeyFingerprint: string;
+  algorithm: SignatureAlgorithm;
+}
+
+export interface SignerInput extends Omit<SignerDescriptor, 'publicKeyFingerprint'> {
+  privateKey: string;
+  publicKey: string;
+  mimeType?: string;
+}
+
+export interface AssetDescriptor {
+  name: string;
+  hash: string;
+  mimeType?: string;
+}
+
+export interface ParentReference {
+  manifestHash: string;
+  assetHash: string;
+  signerId: string;
+  timestamp: string;
+}
+
+export interface ProvenanceClaim {
+  toolChain: ToolChainEntry[];
+  datasetLineageId: string;
+  policyHash: string;
+  timestamp: string;
+  signer: SignerDescriptor;
+  redactions?: string[];
+  notes?: string;
+}
+
+export interface ProvenanceManifest {
+  version: string;
+  asset: AssetDescriptor;
+  claim: ProvenanceClaim;
+  parent?: ParentReference;
+  signature: string;
+}
+
+export interface StampAssetOptions {
+  assetPath: string;
+  outputPath?: string;
+  metadata: ClaimMetadata;
+  signer: SignerInput;
+}
+
+export interface DerivativeStampOptions {
+  assetPath: string;
+  parentManifestPath: string;
+  parentPublicKey: string;
+  parentAssetPath?: string;
+  outputPath?: string;
+  redactions?: string[];
+  metadata?: Partial<ClaimMetadata>;
+  signer: SignerInput;
+}
+
+export interface VerifyProvenanceOptions {
+  manifestPath: string;
+  publicKey: string;
+  assetPath?: string;
+  parentManifestPath?: string;
+  parentPublicKey?: string;
+  parentAssetPath?: string;
+}
+
+export interface VerificationIssue {
+  level: 'error' | 'warning';
+  message: string;
+}
+
+export interface VerificationResult {
+  manifest: ProvenanceManifest;
+  manifestHash: string;
+  claimHash: string;
+  validSignature: boolean;
+  validAssetHash: boolean;
+  issues: VerificationIssue[];
+  signerId: string;
+  parent?: VerificationResult;
+}
+
+export interface BrowserVerificationOptions {
+  manifest: ProvenanceManifest;
+  publicKey: string;
+  asset: ArrayBuffer;
+}
+
+export interface BrowserVerificationResult {
+  validSignature: boolean;
+  validAssetHash: boolean;
+  issues: VerificationIssue[];
+  claimHash: string;
+  manifestHash: string;
+}

--- a/ga-graphai/packages/c2pa-bridge/tests/c2pa-bridge.test.js
+++ b/ga-graphai/packages/c2pa-bridge/tests/c2pa-bridge.test.js
@@ -1,0 +1,147 @@
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const { mkdtempSync, rmSync, writeFileSync, readFileSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const { generateKeyPairSync } = require('node:crypto');
+
+let tempDir;
+let privateKey;
+let publicKey;
+
+before(() => {
+  tempDir = mkdtempSync(path.join(tmpdir(), 'cpb-'));
+  const { privateKey: priv, publicKey: pub } = generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+  });
+  privateKey = priv.export({ type: 'pkcs1', format: 'pem' }).toString();
+  publicKey = pub.export({ type: 'spki', format: 'pem' }).toString();
+});
+
+after(() => {
+  if (tempDir) {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+function loadDist() {
+  // eslint-disable-next-line global-require, import/no-dynamic-require
+  return require('../dist/index.js');
+}
+
+async function createBaseStamp() {
+  const assetPath = path.join(tempDir, 'asset.txt');
+  writeFileSync(assetPath, 'original asset data');
+  const { stampAsset } = loadDist();
+  const result = await stampAsset({
+    assetPath,
+    metadata: {
+      toolChain: [
+        {
+          name: 'generator',
+          version: '1.0.0',
+          parameters: { prompt: 'demo' },
+        },
+      ],
+      datasetLineageId: 'dataset-123',
+      policyHash: 'policy-hash-abc',
+      notes: 'base asset',
+    },
+    signer: {
+      id: 'signer-a',
+      algorithm: 'rsa-sha256',
+      privateKey,
+      publicKey,
+    },
+  });
+  return { assetPath, manifestPath: result.manifestPath };
+}
+
+test('stamps and verifies an asset manifest', async () => {
+  const { verifyProvenance } = loadDist();
+  const { assetPath, manifestPath } = await createBaseStamp();
+  const result = await verifyProvenance({
+    manifestPath,
+    assetPath,
+    publicKey,
+  });
+  assert.ok(result.validSignature, 'signature should verify');
+  assert.ok(result.validAssetHash, 'asset hash should verify');
+  assert.strictEqual(result.issues.length, 0);
+});
+
+test('detects tampered asset contents', async () => {
+  const { verifyProvenance } = loadDist();
+  const { assetPath, manifestPath } = await createBaseStamp();
+  writeFileSync(assetPath, 'tampered data');
+  const result = await verifyProvenance({
+    manifestPath,
+    assetPath,
+    publicKey,
+  });
+  assert.ok(!result.validAssetHash, 'asset hash mismatch expected');
+  assert.ok(result.issues.some((i) => i.message.includes('Asset hash')));
+});
+
+test('detects tampered manifest claim', async () => {
+  const { verifyProvenance } = loadDist();
+  const { assetPath, manifestPath } = await createBaseStamp();
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  manifest.claim.datasetLineageId = 'malicious-change';
+  writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+  const result = await verifyProvenance({
+    manifestPath,
+    assetPath,
+    publicKey,
+  });
+  assert.ok(!result.validSignature, 'signature should fail after tamper');
+  assert.ok(result.issues.some((i) => i.message.includes('Signature verification failed')));
+});
+
+test('creates and verifies derivative manifest with chain of custody', async () => {
+  const { createDerivativeStamp, verifyProvenance } = loadDist();
+  const { assetPath: parentAsset, manifestPath: parentManifest } = await createBaseStamp();
+  const derivativePath = path.join(tempDir, 'derivative.txt');
+  writeFileSync(derivativePath, 'redacted derivative data');
+
+  const { manifestPath: derivativeManifest } = await createDerivativeStamp({
+    assetPath: derivativePath,
+    parentManifestPath: parentManifest,
+    parentPublicKey: publicKey,
+    parentAssetPath: parentAsset,
+    metadata: {
+      toolChain: [
+        {
+          name: 'redactor',
+          version: '0.2.0',
+          parameters: { fields: 'faces' },
+        },
+      ],
+      datasetLineageId: 'derivative-dataset',
+      policyHash: 'policy-derivative',
+      notes: 'redaction applied',
+    },
+    redactions: ['faces blurred'],
+    signer: {
+      id: 'signer-b',
+      algorithm: 'rsa-sha256',
+      privateKey,
+      publicKey,
+    },
+  });
+
+  const result = await verifyProvenance({
+    manifestPath: derivativeManifest,
+    assetPath: derivativePath,
+    publicKey,
+    parentManifestPath: parentManifest,
+    parentPublicKey: publicKey,
+    parentAssetPath: parentAsset,
+  });
+
+  assert.ok(result.validSignature, 'derivative signature should verify');
+  assert.ok(result.validAssetHash, 'derivative asset hash should verify');
+  assert.strictEqual(result.issues.length, 0);
+  assert.ok(result.parent, 'parent verification result expected');
+  assert.strictEqual(result.parent.manifestHash, result.manifest.parent.manifestHash);
+});

--- a/ga-graphai/packages/c2pa-bridge/tsconfig.browser.json
+++ b/ga-graphai/packages/c2pa-bridge/tsconfig.browser.json
@@ -1,0 +1,30 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist/browser",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false,
+    "types": [],
+    "lib": ["DOM", "ES2020"],
+    "allowImportingTsExtensions": false
+  },
+  "include": [
+    "src/browser.ts",
+    "src/common/**/*",
+    "src/types.ts"
+  ],
+  "exclude": [
+    "src/node/**/*",
+    "src/cli/**/*"
+  ]
+}

--- a/ga-graphai/packages/c2pa-bridge/tsconfig.json
+++ b/ga-graphai/packages/c2pa-bridge/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "noEmit": false,
+    "types": ["node"],
+    "sourceMap": true,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/browser.ts"]
+}


### PR DESCRIPTION
## Summary
- add a new @ga-graphai/c2pa-bridge workspace for stamping, verifying, and re-signing C2PA-style manifests
- expose a cpb CLI with stamp/derive/verify flows and supply a browser verification demo
- cover signing, tamper detection, and derivative chain validation with automated tests

## Testing
- npm test (from packages/c2pa-bridge)


------
https://chatgpt.com/codex/tasks/task_e_68d74c1341048333866460012f84e82b