### PR TITLE
feat: gate rollout promotion with mission control evidence

### DIFF
--- a/k8s/rollouts/analysis-templates.yaml
+++ b/k8s/rollouts/analysis-templates.yaml
@@ -32,3 +32,38 @@ spec:
           query: |
             histogram_quantile(0.95,
               sum(rate(http_request_duration_seconds_bucket{job="{{args.service}}", namespace="{{args.namespace}}"}[2m])) by (le))
+---
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: mc-evidence-ok
+spec:
+  args:
+    - name: releaseId
+    - name: evidenceQuery
+      valueFrom:
+        configMapKeyRef:
+          name: mc-evidence-queries
+          key: evidenceOkEndpoint
+    - name: token
+      valueFrom:
+        secretKeyRef:
+          name: mc-evidence-token
+          key: token
+  metrics:
+    - name: evidence-ok
+      successCondition: result.ok == true
+      failureCondition: result.ok == false
+      failureLimit: 1
+      failureMessage: result.reason
+      provider:
+        web:
+          url: "{{args.evidenceQuery}}?releaseId={{args.releaseId}}"
+          method: GET
+          timeoutSeconds: 20
+          jqFilter: "."
+          headers:
+            - key: Authorization
+              value: "Bearer {{args.token}}"
+            - key: Accept
+              value: application/json

--- a/k8s/rollouts/mc-evidence-config.yaml
+++ b/k8s/rollouts/mc-evidence-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mc-evidence-token
+  annotations:
+    description: Bearer token used to authenticate with Mission Control evidence APIs.
+type: Opaque
+stringData:
+  token: REPLACE_WITH_MISSION_CONTROL_TOKEN
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mc-evidence-queries
+  annotations:
+    description: Base endpoints for Mission Control evidence lookups used during canary promotion.
+data:
+  evidenceOkEndpoint: https://mission-control.intelgraph.svc.cluster.local/api/v1/evidence/ok

--- a/k8s/rollouts/rollout.yaml
+++ b/k8s/rollouts/rollout.yaml
@@ -11,28 +11,39 @@ spec:
       trafficRouting:
         nginx: {}
       steps:
-        - setWeight: 10
-        - pause: {duration: 120}
+        - setWeight: 20
+        - pause:
+            duration: 120
         - analysis:
             templates:
               - templateName: ig-slo-checks
+              - templateName: mc-evidence-ok
             args:
               - name: service
                 value: api
+              - name: releaseId
+                value: ${RELEASE_ID}
         - setWeight: 50
-        - pause: {duration: 180}
+        - pause:
+            duration: 180
         - analysis:
             templates:
               - templateName: ig-slo-checks
+              - templateName: mc-evidence-ok
             args:
               - name: service
                 value: api
+              - name: releaseId
+                value: ${RELEASE_ID}
         - setWeight: 100
-  selector:
-    matchLabels: { app: api }
-  template:
-    metadata:
-      labels: { app: api }
+    selector:
+      matchLabels:
+        app: api
+    template:
+      metadata:
+        labels:
+          app: api
+          release-id: ${RELEASE_ID}
     spec:
       containers:
         - name: api

--- a/ops/runbooks/rollback.md
+++ b/ops/runbooks/rollback.md
@@ -1,1 +1,43 @@
-**Rollback**: `helm rollback app <REVISION>`; confirm via health dashboard; capture audit ID.
+# Argo Rollout Evidence Gate Rollback Playbook
+
+This playbook documents the automatic rollback triggers and on-call steps for the API rollout that now gates promotions on Mission Control (MC) evidence checks.
+
+## Automatic rollback triggers
+
+- **MC evidence gate failure** – the `mc-evidence-ok` analysis template halts promotion whenever the evidence API returns `ok=false`. The failure message surfaces the reason provided by MC so operators know what evidence is missing or invalid.
+- **SLO regression** – the `ig-slo-checks` template still enforces latency and error rate thresholds. Breaching either metric causes the rollout to abort.
+
+When either trigger fires, Argo Rollouts aborts the canary, scales traffic back to the stable ReplicaSet, and posts the failure reason in the AnalysisRun status. With the current step durations (≤180s) the controller completes rollback in under five minutes without manual intervention.
+
+## On-call response checklist
+
+1. **Confirm rollback status**
+   ```bash
+   kubectl argo rollouts get rollout api -n <namespace>
+   ```
+   Ensure the rollout status reports `Degraded` with the analysis failure reason and that the stable revision matches the previous release.
+
+2. **Inspect evidence details**
+   ```bash
+   kubectl argo rollouts get analysisrun -n <namespace> --selector rollout=api
+   kubectl get analysisrun <name> -n <namespace> -o jsonpath='{.status.metricResults[*]}'
+   ```
+   Look for the `mc-evidence-ok` metric output, including the `failureMessage` propagated from MC.
+
+3. **Validate release identity** – the canary pods are labeled with `release-id=${RELEASE_ID}`. Confirm the release ID that failed matches the evidence payload before retrying.
+
+4. **Remediate and re-run**
+   - Resolve the evidence gap in Mission Control (e.g., attach missing test reports).
+   - If the failure was due to SLO regression, investigate service metrics and apply fixes.
+   - Once corrected, re-run the promotion:
+     ```bash
+     kubectl argo rollouts retry api -n <namespace>
+     ```
+
+5. **Escalation** – if rollback loops or the service remains degraded, escalate to the deployment lead and SRE within 15 minutes, providing the evidence failure reason and relevant dashboard screenshots.
+
+## Rollback verification before close-out
+
+- Stable pods should have the previous image tag and continue to report healthy probes.
+- Mission Control should show the prior release as the current production evidence bundle.
+- Update incident or change tickets with the failure cause, remediation, and link to the relevant AnalysisRun summary.


### PR DESCRIPTION
## Summary
- add a Mission Control evidence analysis template alongside token/config inputs
- require the API rollout to pause at 20% and 50% while SLO and evidence gates pass, and label pods with the release ID
- expand the rollback playbook to cover automatic triggers and on-call remediation steps tied to the new evidence gate

## Testing
- pre-commit run --files ops/runbooks/rollback.md *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d74ffa597483339b1d8efa6ad5891d