### PR TITLE
feat: add plan mode to agent orchestrator

### DIFF
--- a/scripts/run-agents.js
+++ b/scripts/run-agents.js
@@ -13,8 +13,8 @@ function main() {
   const mode = process.argv[2] || 'ci';
   const options = parseArgs(process.argv.slice(3));
 
-  if (!['ci', 'pr', 'dev'].includes(mode)) {
-    console.error('❌ Invalid mode. Use: ci, pr, or dev');
+  if (!['ci', 'pr', 'dev', 'plan'].includes(mode)) {
+    console.error('❌ Invalid mode. Use: ci, pr, dev, or plan');
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- add a dedicated plan mode to the agent orchestrator that builds an actionable plan from critic analysis and skips remediation steps
- enrich planning output with diff summaries, static check counts, and human-readable action items for complex requests
- allow the run-agents CLI to invoke the new plan mode alongside existing ci, pr, and dev flows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d74fd9d3c083338fd1701c7557a727