### PR TITLE
feat: enforce tenant ABAC with OIDC and SCIM

### DIFF
--- a/services/authz-gateway/BREAK_GLASS_RUNBOOK.md
+++ b/services/authz-gateway/BREAK_GLASS_RUNBOOK.md
@@ -1,0 +1,42 @@
+# Break-Glass Account & Rotation Runbook
+
+## Overview
+The break-glass account provides emergency console and API access when OIDC or SCIM dependencies are unavailable. It is disabled by default and must only be enabled under documented incident conditions. Access is logged through the AuthZ Gateway audit trail.
+
+## Account Profile
+- **Username:** `cos-breakglass`
+- **Roles:** `admin`, `writer`, `reader`
+- **Tenant scope:** Determined by incident commander before activation; must match incident ticket.
+- **Purpose tag:** `break-glass` (OPA policy restricts usage to emergency flows).
+- **Storage:** Credentials are stored in the sealed secrets manager entry `authz-gateway/breakglass` (hardware-backed KMS).
+
+## Activation Procedure
+1. **Initiate incident:** Declare a SEV-1 incident and assign an incident commander (IC).
+2. **Approval:** Obtain dual approval from the IC and Security Duty Officer (SDO).
+3. **Audit prep:** Notify Audit & Compliance channel and start bridge recording. Capture ticket, reason, and tenant.
+4. **Retrieve credentials:**
+   - IC runs `sops -d secrets/breakglass.yaml` from the secure bastion.
+   - Extract temporary password and tenant binding.
+5. **Enable account:**
+   - Set `BREAKGLASS_ENABLED=true` in AuthZ Gateway environment (kubectl patch or feature flag API).
+   - Run `npm run breakglass:issue -- --tenant <TENANT_ID> --purpose break-glass` to mint a 15-minute JWT signed by the gateway keys.
+6. **Access systems:** Use the issued JWT for console/API access. All requests must include header `x-purpose: break-glass`.
+7. **Real-time monitoring:** Security monitors the audit stream for `break-glass` purpose and confirms OPA decisions.
+
+## Deactivation & Rotation
+1. **Expire token:** IC triggers `npm run breakglass:revoke` to invalidate outstanding tokens.
+2. **Disable flag:** Reset `BREAKGLASS_ENABLED=false` and redeploy to ensure in-memory cache cleared.
+3. **Rotate secrets:**
+   - Generate new password with `openssl rand -base64 32`.
+   - Update `secrets/breakglass.yaml` using `sops` (dual control required).
+   - Record rotation in ticketing system and attach hash of new secret bundle.
+4. **Post-incident review:**
+   - Export `audit.log` entries filtered by `purpose="break-glass"`.
+   - Confirm SCIM and OIDC restored; remove temporary tenant binding from OPA bundles.
+   - Document timeline, approvals, and data touched in the incident record.
+
+## Quarterly Drill Checklist
+- [ ] Run tabletop exercise covering activation and rotation.
+- [ ] Validate `breakglass:issue` script mints auditable tokens.
+- [ ] Ensure SCIM directory marks account as `inactive` outside drills.
+- [ ] Verify audit pipeline retains `break-glass` purpose entries ≥ 1 year.

--- a/services/authz-gateway/jest.config.cjs
+++ b/services/authz-gateway/jest.config.cjs
@@ -2,6 +2,9 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   roots: ['<rootDir>/tests'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],
+  },
   collectCoverageFrom: ['src/**/*.ts'],
   coverageThreshold: {
     global: { lines: 90 },

--- a/services/authz-gateway/src/audit.ts
+++ b/services/authz-gateway/src/audit.ts
@@ -5,6 +5,7 @@ export interface AuditEntry {
   action: string;
   resource: string;
   tenantId: string;
+  purpose: string;
   allowed: boolean;
   reason: string;
 }

--- a/services/authz-gateway/src/index.ts
+++ b/services/authz-gateway/src/index.ts
@@ -19,11 +19,18 @@ export async function createApp() {
 
   app.post('/auth/login', async (req, res) => {
     try {
-      const { username, password } = req.body;
-      const token = await login(username, password);
+      const { username, password, purpose } = req.body;
+      const token = await login(username, password, purpose);
       res.json({ token });
-    } catch {
-      res.status(401).json({ error: 'invalid_credentials' });
+    } catch (error) {
+      const message = (error as Error).message;
+      if (message === 'purpose_required' || message === 'tenant_missing') {
+        res.status(400).json({ error: message });
+      } else if (message === 'purpose_not_allowed') {
+        res.status(403).json({ error: message });
+      } else {
+        res.status(401).json({ error: 'invalid_credentials' });
+      }
     }
   });
 

--- a/services/authz-gateway/src/oidc.ts
+++ b/services/authz-gateway/src/oidc.ts
@@ -1,0 +1,120 @@
+import axios from 'axios';
+import { createRemoteJWKSet, jwtVerify } from 'jose';
+
+interface OidcConfig {
+  issuer: string;
+  tokenEndpoint: string;
+  jwksUri: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+let configPromise: Promise<OidcConfig> | undefined;
+let jwkSet: ReturnType<typeof createRemoteJWKSet> | undefined;
+
+async function getConfig(): Promise<OidcConfig> {
+  if (!configPromise) {
+    const issuerUrl = process.env.OIDC_ISSUER;
+    const clientId = process.env.OIDC_CLIENT_ID;
+    const clientSecret = process.env.OIDC_CLIENT_SECRET;
+    if (!issuerUrl || !clientId || !clientSecret) {
+      throw new Error('oidc_not_configured');
+    }
+    configPromise = (async () => {
+      try {
+        const discoveryUrl = new URL(
+          '/.well-known/openid-configuration',
+          issuerUrl,
+        ).toString();
+        const { data } = await axios.get(discoveryUrl);
+        const tokenEndpoint =
+          data.token_endpoint || new URL('/oauth/token', issuerUrl).toString();
+        const jwksUri =
+          data.jwks_uri ||
+          new URL('/.well-known/jwks.json', issuerUrl).toString();
+        return {
+          issuer: data.issuer || issuerUrl,
+          tokenEndpoint,
+          jwksUri,
+          clientId,
+          clientSecret,
+        };
+      } catch {
+        return {
+          issuer: issuerUrl,
+          tokenEndpoint: new URL('/oauth/token', issuerUrl).toString(),
+          jwksUri: new URL('/.well-known/jwks.json', issuerUrl).toString(),
+          clientId,
+          clientSecret,
+        };
+      }
+    })();
+  }
+  return configPromise;
+}
+
+async function getJwkSet(jwksUri: string) {
+  if (!jwkSet) {
+    jwkSet = createRemoteJWKSet(new URL(jwksUri));
+  }
+  return jwkSet;
+}
+
+export interface OidcProfile {
+  sub: string;
+  tenantId: string;
+  groups: string[];
+  acr?: string;
+}
+
+export async function loginWithOidc(
+  username: string,
+  password: string,
+): Promise<OidcProfile> {
+  const config = await getConfig();
+  const params = new URLSearchParams();
+  params.set('grant_type', 'password');
+  params.set('username', username);
+  params.set('password', password);
+  params.set('scope', 'openid profile groups tenant');
+  try {
+    const response = await axios.post(config.tokenEndpoint, params.toString(), {
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      auth: {
+        username: config.clientId,
+        password: config.clientSecret,
+      },
+    });
+    const idToken = response.data?.id_token as string | undefined;
+    if (!idToken) {
+      throw new Error('invalid_credentials');
+    }
+    const keySet = await getJwkSet(config.jwksUri);
+    const { payload } = await jwtVerify(idToken, keySet, {
+      issuer: config.issuer,
+      audience: config.clientId,
+    });
+    const tenantId =
+      (payload.tenant as string) || (payload['tenant_id'] as string);
+    if (!tenantId) {
+      throw new Error('tenant_missing');
+    }
+    return {
+      sub: String(payload.sub),
+      tenantId,
+      groups: Array.isArray(payload.groups)
+        ? (payload.groups as string[])
+        : typeof payload.groups === 'string'
+          ? [payload.groups]
+          : [],
+      acr: payload.acr as string | undefined,
+    };
+  } catch {
+    throw new Error('invalid_credentials');
+  }
+}
+
+export function resetOidcClient() {
+  configPromise = undefined;
+  jwkSet = undefined;
+}

--- a/services/authz-gateway/src/policy-pack.ts
+++ b/services/authz-gateway/src/policy-pack.ts
@@ -1,0 +1,46 @@
+export interface PolicyPack {
+  groupRoleMap: Record<string, string[]>;
+  purposeAllowList: Record<string, string[]>;
+}
+
+export const POLICY_PACK_V0: PolicyPack = {
+  groupRoleMap: {
+    'COS:Analyst': ['reader'],
+    'COS:Investigator': ['reader', 'writer'],
+    'COS:Lead': ['reader', 'writer'],
+    'COS:Admin': ['admin', 'writer', 'reader'],
+    'COS:Audit': ['auditor'],
+  },
+  purposeAllowList: {
+    reader: ['investigation', 'threat-intel', 'fraud', 'training', 'demo'],
+    writer: ['investigation', 'fraud'],
+    admin: ['investigation', 'threat-intel', 'fraud', 'audit'],
+    auditor: ['audit'],
+  },
+};
+
+export function rolesForGroups(groups: string[]): string[] {
+  const roles = new Set<string>();
+  for (const group of groups) {
+    const mapped = POLICY_PACK_V0.groupRoleMap[group];
+    if (mapped) {
+      for (const role of mapped) {
+        roles.add(role);
+      }
+    }
+  }
+  return Array.from(roles);
+}
+
+export function isPurposeAllowed(roles: string[], purpose: string): boolean {
+  if (!purpose) {
+    return false;
+  }
+  for (const role of roles) {
+    const allowed = POLICY_PACK_V0.purposeAllowList[role];
+    if (allowed && allowed.includes(purpose)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/services/authz-gateway/src/policy.ts
+++ b/services/authz-gateway/src/policy.ts
@@ -7,6 +7,7 @@ function opaUrl() {
 export interface UserContext {
   tenantId: string;
   roles: string[];
+  purpose?: string;
 }
 
 export interface ResourceContext {

--- a/services/authz-gateway/src/scim.ts
+++ b/services/authz-gateway/src/scim.ts
@@ -1,0 +1,82 @@
+import axios from 'axios';
+import { rolesForGroups } from './policy-pack';
+
+interface CacheEntry {
+  roles: string[];
+  expiresAt: number;
+}
+
+class ScimRoleMapper {
+  private cache = new Map<string, CacheEntry>();
+  private readonly ttlMs: number;
+
+  constructor(
+    private readonly baseUrl: string | undefined,
+    private readonly token: string | undefined,
+    ttlMs?: number,
+  ) {
+    this.ttlMs =
+      typeof ttlMs === 'number'
+        ? ttlMs
+        : Number(process.env.SCIM_CACHE_TTL_MS || 60000);
+  }
+
+  async getRolesForUser(
+    userId: string,
+    fallbackGroups: string[] = [],
+  ): Promise<string[]> {
+    if (!userId) {
+      return [];
+    }
+    const cached = this.cache.get(userId);
+    const now = Date.now();
+    if (cached && cached.expiresAt > now) {
+      return cached.roles;
+    }
+
+    let groups = fallbackGroups;
+
+    if (this.baseUrl && this.token) {
+      try {
+        const url = new URL('/scim/v2/Groups', this.baseUrl).toString();
+        const res = await axios.get(url, {
+          params: { filter: `members.value eq "${userId}"` },
+          headers: { Authorization: `Bearer ${this.token}` },
+        });
+        const resources: Array<{ displayName?: string; externalId?: string }> =
+          res.data?.Resources || [];
+        groups = resources
+          .map((resource) => resource.displayName || resource.externalId || '')
+          .filter((value): value is string => Boolean(value));
+      } catch {
+        // fall back to any groups supplied from the token if SCIM is unavailable
+        groups = fallbackGroups;
+      }
+    }
+
+    const roles = rolesForGroups(groups);
+    this.cache.set(userId, { roles, expiresAt: now + this.ttlMs });
+    return roles;
+  }
+
+  clear() {
+    this.cache.clear();
+  }
+}
+
+let mapper: ScimRoleMapper | undefined;
+
+export function getScimRoleMapper() {
+  if (!mapper) {
+    mapper = new ScimRoleMapper(
+      process.env.SCIM_BASE_URL,
+      process.env.SCIM_TOKEN,
+    );
+  }
+  return mapper;
+}
+
+export function resetScimRoleMapper() {
+  mapper?.clear();
+  mapper = undefined;
+}

--- a/services/authz-gateway/tests/auth.test.ts
+++ b/services/authz-gateway/tests/auth.test.ts
@@ -1,19 +1,68 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from '@jest/globals';
 import express from 'express';
 import request from 'supertest';
 import { createApp } from '../src/index';
 import { stopObservability } from '../src/observability';
-import type { AddressInfo } from 'net';
+import { startOidcServer } from './helpers/oidc';
+import { startScimServer } from './helpers/scim';
+import { resetOidcClient } from '../src/oidc';
+import { resetScimRoleMapper } from '../src/scim';
+import type { Server } from 'http';
 
 describe('token lifecycle', () => {
+  let oidcServer: Server;
+  let scimServer: Server;
+
+  beforeAll(async () => {
+    const oidc = await startOidcServer([
+      {
+        username: 'alice',
+        password: 'password123',
+        sub: 'alice',
+        tenant: 'tenantA',
+      },
+    ]);
+    oidcServer = oidc.server;
+    process.env.OIDC_ISSUER = oidc.issuer;
+    process.env.OIDC_CLIENT_ID = 'cos-client';
+    process.env.OIDC_CLIENT_SECRET = 'cos-secret';
+    const scim = await startScimServer(
+      { alice: ['COS:Analyst'] },
+      'scim-token',
+    );
+    scimServer = scim.server;
+    process.env.SCIM_BASE_URL = scim.baseUrl;
+    process.env.SCIM_TOKEN = 'scim-token';
+    process.env.SCIM_CACHE_TTL_MS = '200';
+  });
+
+  beforeEach(() => {
+    resetOidcClient();
+    resetScimRoleMapper();
+  });
+
   afterAll(async () => {
     await stopObservability();
+    oidcServer.close();
+    scimServer.close();
   });
   it('logs in and introspects', async () => {
     process.env.OPA_URL = 'http://localhost:8181/v1/data/authz/allow'; // unused in this test
     const app = await createApp();
     const loginRes = await request(app)
       .post('/auth/login')
-      .send({ username: 'alice', password: 'password123' });
+      .send({
+        username: 'alice',
+        password: 'password123',
+        purpose: 'investigation',
+      });
     expect(loginRes.status).toBe(200);
     const token = loginRes.body.token;
     const introspectRes = await request(app)
@@ -21,6 +70,7 @@ describe('token lifecycle', () => {
       .send({ token });
     expect(introspectRes.status).toBe(200);
     expect(introspectRes.body.sub).toBe('alice');
+    expect(introspectRes.body.purpose).toBe('investigation');
   });
 
   it('serves JWKS', async () => {
@@ -28,6 +78,15 @@ describe('token lifecycle', () => {
     const res = await request(app).get('/.well-known/jwks.json');
     expect(res.status).toBe(200);
     expect(res.body.keys[0].kty).toBe('RSA');
+  });
+
+  it('requires purpose on login', async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .post('/auth/login')
+      .send({ username: 'alice', password: 'password123' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('purpose_required');
   });
 
   it('rejects invalid introspection token', async () => {
@@ -39,26 +98,38 @@ describe('token lifecycle', () => {
   });
 
   it('performs step-up authentication', async () => {
-    const opa = express();
-    opa.use(express.json());
-    opa.post('/v1/data/authz/allow', (_req, res) => res.json({ result: true }));
-    const opaServer = opa.listen(0);
-    const opaPort = (opaServer.address() as AddressInfo).port;
+    const opaApp = startOpaAllowAll();
+    const opa = await new Promise<Server>((resolve) => {
+      const srv = opaApp.listen(0, () => resolve(srv));
+    });
+    const opaPort = (opa.address() as import('net').AddressInfo).port;
     process.env.OPA_URL = `http://localhost:${opaPort}/v1/data/authz/allow`;
     const app = await createApp();
     const loginRes = await request(app)
       .post('/auth/login')
-      .send({ username: 'alice', password: 'password123' });
+      .send({
+        username: 'alice',
+        password: 'password123',
+        purpose: 'investigation',
+      });
     const token = loginRes.body.token;
     const step = await request(app)
       .post('/auth/step-up')
-      .set('Authorization', `Bearer ${token}`);
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-purpose', 'investigation');
     expect(step.status).toBe(200);
     const introspectRes = await request(app)
       .post('/auth/introspect')
       .send({ token: step.body.token });
     expect(introspectRes.status).toBe(200);
     expect(introspectRes.body.acr).toBe('loa2');
-    opaServer.close();
+    opa.close();
   });
 });
+
+function startOpaAllowAll() {
+  const opa = express();
+  opa.use(express.json());
+  opa.post('/v1/data/authz/allow', (_req, res) => res.json({ result: true }));
+  return opa;
+}

--- a/services/authz-gateway/tests/helpers/oidc.ts
+++ b/services/authz-gateway/tests/helpers/oidc.ts
@@ -1,0 +1,101 @@
+import express from 'express';
+import { AddressInfo } from 'net';
+import { Server } from 'http';
+import { generateKeyPair, exportJWK, SignJWT } from 'jose';
+
+export interface OidcUser {
+  username: string;
+  password: string;
+  sub: string;
+  tenant: string;
+  acr?: string;
+}
+
+export interface OidcTestServer {
+  server: Server;
+  issuer: string;
+}
+
+export async function startOidcServer(
+  users: OidcUser[],
+): Promise<OidcTestServer> {
+  const { publicKey, privateKey } = await generateKeyPair('RS256');
+  const publicJwk = await exportJWK(publicKey);
+  publicJwk.alg = 'RS256';
+  publicJwk.use = 'sig';
+  publicJwk.kid = 'oidc-test';
+
+  const app = express();
+  app.use(express.urlencoded({ extended: false }));
+
+  const userMap = new Map(users.map((user) => [user.username, user]));
+
+  app.get('/.well-known/openid-configuration', (_req, res) => {
+    const issuer = getIssuer(res);
+    res.json({
+      issuer,
+      token_endpoint: `${issuer}/oauth/token`,
+      jwks_uri: `${issuer}/.well-known/jwks.json`,
+      grant_types_supported: ['password'],
+      token_endpoint_auth_methods_supported: ['client_secret_basic'],
+    });
+  });
+
+  app.get('/.well-known/jwks.json', (_req, res) => {
+    res.json({ keys: [publicJwk] });
+  });
+
+  app.post('/oauth/token', async (req, res) => {
+    const issuer = getIssuer(res);
+    const auth = req.headers.authorization || '';
+    const expected = `Basic ${Buffer.from('cos-client:cos-secret').toString('base64')}`;
+    const clientId = req.body.client_id as string | undefined;
+    const clientSecret = req.body.client_secret as string | undefined;
+    const hasBasicAuth = auth === expected;
+    const hasPostSecret =
+      clientId === 'cos-client' && clientSecret === 'cos-secret';
+    if (!hasBasicAuth && !hasPostSecret) {
+      return res.status(401).json({ error: 'invalid_client' });
+    }
+    if (req.body.grant_type !== 'password') {
+      return res.status(400).json({ error: 'unsupported_grant_type' });
+    }
+    const { username, password } = req.body;
+    const user = userMap.get(username as string);
+    if (!user || user.password !== password) {
+      return res.status(400).json({ error: 'invalid_grant' });
+    }
+    const idToken = await new SignJWT({
+      sub: user.sub,
+      tenant: user.tenant,
+      acr: user.acr || 'loa1',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'oidc-test' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .setIssuer(issuer)
+      .setAudience('cos-client')
+      .sign(privateKey);
+    res.json({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      expires_in: 3600,
+      id_token: idToken,
+      token_type: 'Bearer',
+    });
+  });
+
+  const server = await new Promise<Server>((resolve) => {
+    const srv = app.listen(0, () => resolve(srv));
+  });
+  const port = (server.address() as AddressInfo).port;
+  return { server, issuer: `http://localhost:${port}` };
+}
+
+function getIssuer(res: express.Response) {
+  const address = res.req?.socket.localAddress;
+  const port = res.req?.socket.localPort;
+  const host =
+    address === '::ffff:127.0.0.1' || address === '::1' ? 'localhost' : address;
+  return `http://${host}:${port}`;
+}

--- a/services/authz-gateway/tests/helpers/scim.ts
+++ b/services/authz-gateway/tests/helpers/scim.ts
@@ -1,0 +1,49 @@
+import express from 'express';
+import { AddressInfo } from 'net';
+import { Server } from 'http';
+
+interface ScimState {
+  [userId: string]: string[];
+}
+
+export interface ScimTestServer {
+  server: Server;
+  baseUrl: string;
+  setGroups: (userId: string, groups: string[]) => void;
+}
+
+export async function startScimServer(
+  initialState: ScimState,
+  expectedToken: string,
+): Promise<ScimTestServer> {
+  const state: ScimState = { ...initialState };
+  const app = express();
+
+  app.get('/scim/v2/Groups', (req, res) => {
+    if (req.headers.authorization !== `Bearer ${expectedToken}`) {
+      return res.status(401).json({ detail: 'unauthorized' });
+    }
+    const filter = String(req.query.filter || '');
+    const match = filter.match(/members\.value eq "([^"]+)"/);
+    const userId = match ? match[1] : '';
+    const groups = state[userId] || [];
+    res.json({
+      Resources: groups.map((group, index) => ({
+        id: `${index + 1}`,
+        displayName: group,
+      })),
+    });
+  });
+
+  const server = await new Promise<Server>((resolve) => {
+    const srv = app.listen(0, () => resolve(srv));
+  });
+  const port = (server.address() as AddressInfo).port;
+  return {
+    server,
+    baseUrl: `http://localhost:${port}`,
+    setGroups(userId: string, groups: string[]) {
+      state[userId] = groups;
+    },
+  };
+}

--- a/services/authz-gateway/tests/metrics.test.ts
+++ b/services/authz-gateway/tests/metrics.test.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect, afterAll } from '@jest/globals';
 import request from 'supertest';
 import { createApp } from '../src/index';
 import { stopObservability } from '../src/observability';

--- a/services/authz-gateway/tests/policy-scim.test.ts
+++ b/services/authz-gateway/tests/policy-scim.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach } from '@jest/globals';
+import { rolesForGroups, isPurposeAllowed } from '../src/policy-pack';
+import { getScimRoleMapper, resetScimRoleMapper } from '../src/scim';
+
+describe('policy pack helpers', () => {
+  it('expands COS groups to CompanyOS roles', () => {
+    const roles = rolesForGroups(['COS:Analyst', 'COS:Lead']);
+    expect(roles).toEqual(expect.arrayContaining(['reader', 'writer']));
+  });
+
+  it('enforces purpose allow list', () => {
+    expect(isPurposeAllowed(['reader'], 'investigation')).toBe(true);
+    expect(isPurposeAllowed(['reader'], 'audit')).toBe(false);
+  });
+});
+
+describe('SCIM role mapper', () => {
+  beforeEach(() => {
+    process.env.SCIM_BASE_URL = 'http://127.0.0.1:1';
+    process.env.SCIM_TOKEN = 'token';
+    resetScimRoleMapper();
+  });
+
+  it('falls back to token groups when SCIM is unavailable', async () => {
+    const mapper = getScimRoleMapper();
+    const roles = await mapper.getRolesForUser('alice', ['COS:Investigator']);
+    expect(roles).toContain('writer');
+  });
+});

--- a/services/authz-gateway/tests/proxy.test.ts
+++ b/services/authz-gateway/tests/proxy.test.ts
@@ -1,43 +1,88 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from '@jest/globals';
 import express from 'express';
 import request from 'supertest';
 import { createApp } from '../src/index';
 import { stopObservability } from '../src/observability';
+import { startOidcServer } from './helpers/oidc';
+import { startScimServer } from './helpers/scim';
+import { resetOidcClient } from '../src/oidc';
+import { resetScimRoleMapper } from '../src/scim';
 import type { Server } from 'http';
 import type { AddressInfo } from 'net';
 
 let upstreamServer: Server;
 let opaServer: Server;
+let oidcServer: Server;
+let scimServer: Server;
 
-beforeAll((done) => {
+beforeAll(async () => {
   const upstream = express();
   upstream.get('/resource', (_req, res) => res.json({ data: 'ok' }));
-  upstreamServer = upstream.listen(0, () => {
-    const port = (upstreamServer.address() as AddressInfo).port;
-    process.env.UPSTREAM = `http://localhost:${port}`;
-    const opa = express();
-    opa.use(express.json());
-    opa.post('/v1/data/authz/allow', (req, res) => {
-      const { user, resource } = req.body.input;
-      if (user.tenantId !== resource.tenantId) {
-        return res.json({ result: false });
-      }
-      if (resource.needToKnow && !user.roles.includes(resource.needToKnow)) {
-        return res.json({ result: false });
-      }
-      return res.json({ result: true });
-    });
-    opaServer = opa.listen(0, () => {
-      const opaPort = (opaServer.address() as AddressInfo).port;
-      process.env.OPA_URL = `http://localhost:${opaPort}/v1/data/authz/allow`;
-      done();
-    });
+  upstreamServer = await new Promise<Server>((resolve) => {
+    const srv = upstream.listen(0, () => resolve(srv));
   });
+  const upstreamPort = (upstreamServer.address() as AddressInfo).port;
+  process.env.UPSTREAM = `http://localhost:${upstreamPort}`;
+
+  const opaApp = express();
+  opaApp.use(express.json());
+  opaApp.post('/v1/data/authz/allow', (req, res) => {
+    const { user, resource } = req.body.input;
+    if (user.tenantId !== resource.tenantId) {
+      return res.json({ result: false });
+    }
+    if (resource.needToKnow && !user.roles.includes(resource.needToKnow)) {
+      return res.json({ result: false });
+    }
+    if (user.purpose !== 'investigation') {
+      return res.json({ result: false });
+    }
+    return res.json({ result: true });
+  });
+  opaServer = await new Promise<Server>((resolve) => {
+    const srv = opaApp.listen(0, () => resolve(srv));
+  });
+  const opaPort = (opaServer.address() as AddressInfo).port;
+  process.env.OPA_URL = `http://localhost:${opaPort}/v1/data/authz/allow`;
+
+  const oidc = await startOidcServer([
+    {
+      username: 'alice',
+      password: 'password123',
+      sub: 'alice',
+      tenant: 'tenantA',
+    },
+  ]);
+  oidcServer = oidc.server;
+  process.env.OIDC_ISSUER = oidc.issuer;
+  process.env.OIDC_CLIENT_ID = 'cos-client';
+  process.env.OIDC_CLIENT_SECRET = 'cos-secret';
+
+  const scim = await startScimServer({ alice: ['COS:Analyst'] }, 'scim-token');
+  scimServer = scim.server;
+  process.env.SCIM_BASE_URL = scim.baseUrl;
+  process.env.SCIM_TOKEN = 'scim-token';
+  process.env.SCIM_CACHE_TTL_MS = '50';
 });
 
 afterAll(async () => {
   upstreamServer.close();
   opaServer.close();
+  oidcServer.close();
+  scimServer.close();
   await stopObservability();
+});
+
+beforeEach(() => {
+  resetOidcClient();
+  resetScimRoleMapper();
 });
 
 describe('proxy', () => {
@@ -45,12 +90,17 @@ describe('proxy', () => {
     const app = await createApp();
     const loginRes = await request(app)
       .post('/auth/login')
-      .send({ username: 'alice', password: 'password123' });
+      .send({
+        username: 'alice',
+        password: 'password123',
+        purpose: 'investigation',
+      });
     const token = loginRes.body.token;
     const res = await request(app)
       .get('/protected/resource')
       .set('Authorization', `Bearer ${token}`)
-      .set('x-tenant-id', 'tenantA');
+      .set('x-tenant-id', 'tenantA')
+      .set('x-purpose', 'investigation');
     expect(res.status).toBe(200);
     expect(res.body.data).toBe('ok');
   });
@@ -59,12 +109,17 @@ describe('proxy', () => {
     const app = await createApp();
     const loginRes = await request(app)
       .post('/auth/login')
-      .send({ username: 'alice', password: 'password123' });
+      .send({
+        username: 'alice',
+        password: 'password123',
+        purpose: 'investigation',
+      });
     const token = loginRes.body.token;
     const res = await request(app)
       .get('/protected/resource')
       .set('Authorization', `Bearer ${token}`)
-      .set('x-tenant-id', 'tenantB');
+      .set('x-tenant-id', 'tenantB')
+      .set('x-purpose', 'investigation');
     expect(res.status).toBe(403);
   });
 });

--- a/services/authz-gateway/tests/security.test.ts
+++ b/services/authz-gateway/tests/security.test.ts
@@ -1,45 +1,97 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+} from '@jest/globals';
 import express from 'express';
 import request from 'supertest';
 import { createApp } from '../src/index';
 import { stopObservability } from '../src/observability';
 import { SignJWT } from 'jose';
 import { getPrivateKey } from '../src/keys';
+import { startOidcServer } from './helpers/oidc';
+import { startScimServer } from './helpers/scim';
+import { resetOidcClient } from '../src/oidc';
+import { resetScimRoleMapper } from '../src/scim';
+import { existsSync, readFileSync, unlinkSync } from 'fs';
 import type { Server } from 'http';
 import type { AddressInfo } from 'net';
 
 let opaServer: Server;
 let upstreamServer: Server;
+let oidcServer: Server;
+let scimServer: Server;
+let setScimGroups: ((userId: string, groups: string[]) => void) | undefined;
 
-beforeAll((done) => {
+beforeAll(async () => {
   const upstream = express();
   upstream.get('/resource', (_req, res) => res.json({ data: 'ok' }));
-  upstreamServer = upstream.listen(0, () => {
-    const port = (upstreamServer.address() as AddressInfo).port;
-    process.env.UPSTREAM = `http://localhost:${port}`;
-    const opa = express();
-    opa.use(express.json());
-    opa.post('/v1/data/authz/allow', (req, res) => {
-      const { user, resource } = req.body.input;
-      if (user.tenantId !== resource.tenantId) {
-        return res.json({ result: false });
-      }
-      if (resource.needToKnow && !user.roles.includes(resource.needToKnow)) {
-        return res.json({ result: false });
-      }
-      return res.json({ result: true });
-    });
-    opaServer = opa.listen(0, () => {
-      const opaPort = (opaServer.address() as AddressInfo).port;
-      process.env.OPA_URL = `http://localhost:${opaPort}/v1/data/authz/allow`;
-      done();
-    });
+  upstreamServer = await new Promise<Server>((resolve) => {
+    const srv = upstream.listen(0, () => resolve(srv));
   });
+  const upstreamPort = (upstreamServer.address() as AddressInfo).port;
+  process.env.UPSTREAM = `http://localhost:${upstreamPort}`;
+
+  const opaApp = express();
+  opaApp.use(express.json());
+  opaApp.post('/v1/data/authz/allow', (req, res) => {
+    const { user, resource } = req.body.input;
+    if (user.tenantId !== resource.tenantId) {
+      return res.json({ result: false });
+    }
+    if (resource.needToKnow && !user.roles.includes(resource.needToKnow)) {
+      return res.json({ result: false });
+    }
+    if (user.purpose !== 'investigation') {
+      return res.json({ result: false });
+    }
+    return res.json({ result: true });
+  });
+  opaServer = await new Promise<Server>((resolve) => {
+    const srv = opaApp.listen(0, () => resolve(srv));
+  });
+  const opaPort = (opaServer.address() as AddressInfo).port;
+  process.env.OPA_URL = `http://localhost:${opaPort}/v1/data/authz/allow`;
+
+  const oidc = await startOidcServer([
+    {
+      username: 'alice',
+      password: 'password123',
+      sub: 'alice',
+      tenant: 'tenantA',
+    },
+  ]);
+  oidcServer = oidc.server;
+  process.env.OIDC_ISSUER = oidc.issuer;
+  process.env.OIDC_CLIENT_ID = 'cos-client';
+  process.env.OIDC_CLIENT_SECRET = 'cos-secret';
+
+  const scim = await startScimServer({ alice: ['COS:Analyst'] }, 'scim-token');
+  scimServer = scim.server;
+  setScimGroups = scim.setGroups;
+  process.env.SCIM_BASE_URL = scim.baseUrl;
+  process.env.SCIM_TOKEN = 'scim-token';
+  process.env.SCIM_CACHE_TTL_MS = '50';
 });
 
 afterAll(async () => {
   upstreamServer.close();
   opaServer.close();
+  oidcServer.close();
+  scimServer.close();
   await stopObservability();
+});
+
+beforeEach(() => {
+  resetOidcClient();
+  resetScimRoleMapper();
+  setScimGroups?.('alice', ['COS:Analyst']);
+  if (existsSync('audit.log')) {
+    unlinkSync('audit.log');
+  }
 });
 
 describe('security', () => {
@@ -47,12 +99,17 @@ describe('security', () => {
     const app = await createApp();
     const loginRes = await request(app)
       .post('/auth/login')
-      .send({ username: 'alice', password: 'password123' });
+      .send({
+        username: 'alice',
+        password: 'password123',
+        purpose: 'investigation',
+      });
     const token = loginRes.body.token + 'tampered';
     const res = await request(app)
       .get('/protected/resource')
       .set('Authorization', `Bearer ${token}`)
-      .set('x-tenant-id', 'tenantA');
+      .set('x-tenant-id', 'tenantA')
+      .set('x-purpose', 'investigation');
     expect(res.status).toBe(401);
   });
 
@@ -70,21 +127,155 @@ describe('security', () => {
     const res = await request(app)
       .get('/protected/resource')
       .set('Authorization', `Bearer ${token}`)
-      .set('x-tenant-id', 'tenantA');
+      .set('x-tenant-id', 'tenantA')
+      .set('x-purpose', 'investigation');
     expect(res.status).toBe(401);
+  });
+
+  it('rejects missing authorization header', async () => {
+    const app = await createApp();
+    const res = await request(app)
+      .get('/protected/resource')
+      .set('x-tenant-id', 'tenantA')
+      .set('x-purpose', 'investigation');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects when purpose header is absent', async () => {
+    const app = await createApp();
+    const token = await new SignJWT({
+      sub: 'alice',
+      tenantId: 'tenantA',
+      roles: ['reader'],
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'authz-gateway-1' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(getPrivateKey());
+    const res = await request(app)
+      .get('/protected/resource')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', 'tenantA');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('purpose_required');
+  });
+
+  it('rejects when tenant context cannot be determined', async () => {
+    const app = await createApp();
+    const token = await new SignJWT({
+      sub: 'alice',
+      roles: ['reader'],
+      purpose: 'investigation',
+    })
+      .setProtectedHeader({ alg: 'RS256', kid: 'authz-gateway-1' })
+      .setIssuedAt()
+      .setExpirationTime('1h')
+      .sign(getPrivateKey());
+    const res = await request(app)
+      .get('/protected/resource')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-purpose', 'investigation');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('tenant_required');
   });
 
   it('prevents role escalation', async () => {
     const app = await createApp();
     const loginRes = await request(app)
       .post('/auth/login')
-      .send({ username: 'alice', password: 'password123' });
+      .send({
+        username: 'alice',
+        password: 'password123',
+        purpose: 'investigation',
+      });
     const token = loginRes.body.token;
     const res = await request(app)
       .get('/protected/resource')
       .set('Authorization', `Bearer ${token}`)
       .set('x-tenant-id', 'tenantA')
+      .set('x-purpose', 'investigation')
       .set('x-needtoknow', 'admin');
     expect(res.status).toBe(403);
+  });
+
+  it('allows same-tenant access with SCIM synchronized roles', async () => {
+    const app = await createApp();
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({
+        username: 'alice',
+        password: 'password123',
+        purpose: 'investigation',
+      });
+    const token = loginRes.body.token;
+    const res = await request(app)
+      .get('/protected/resource')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', 'tenantA')
+      .set('x-purpose', 'investigation');
+    expect(res.status).toBe(200);
+  });
+
+  it('denies cross-tenant access even after SCIM group change', async () => {
+    setScimGroups?.('alice', ['COS:Lead']);
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    const app = await createApp();
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({
+        username: 'alice',
+        password: 'password123',
+        purpose: 'investigation',
+      });
+    const token = loginRes.body.token;
+    const res = await request(app)
+      .get('/protected/resource')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', 'tenantB')
+      .set('x-purpose', 'investigation');
+    expect(res.status).toBe(403);
+  });
+
+  it('reflects new SCIM roles after cache expiry', async () => {
+    setScimGroups?.('alice', ['COS:Lead']);
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    const app = await createApp();
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({
+        username: 'alice',
+        password: 'password123',
+        purpose: 'investigation',
+      });
+    const token = loginRes.body.token;
+    const introspection = await request(app)
+      .post('/auth/introspect')
+      .send({ token });
+    expect(introspection.body.roles).toContain('writer');
+  });
+
+  it('records audit context with tenant and purpose', async () => {
+    const app = await createApp();
+    const loginRes = await request(app)
+      .post('/auth/login')
+      .send({
+        username: 'alice',
+        password: 'password123',
+        purpose: 'investigation',
+      });
+    const token = loginRes.body.token;
+    await request(app)
+      .get('/protected/resource')
+      .set('Authorization', `Bearer ${token}`)
+      .set('x-tenant-id', 'tenantA')
+      .set('x-purpose', 'investigation');
+    const entries = readFileSync('audit.log', 'utf-8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    const last = entries[entries.length - 1];
+    expect(last.subject).toBe('alice');
+    expect(last.tenantId).toBe('tenantA');
+    expect(last.purpose).toBe('investigation');
   });
 });

--- a/services/authz-gateway/tsconfig.spec.json
+++ b/services/authz-gateway/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "types": ["node", "jest"],
+    "noEmit": true
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary
- implement axios/jose-based OIDC password grant flow and SCIM v2 group mapper to provision CompanyOS roles
- apply policy pack purpose checks in login and middleware so ABAC requests include tenant/purpose context and are audited
- extend Jest configuration and suites with OIDC/SCIM fixtures plus break-glass runbook documentation

## Testing
- npm run lint
- npm run format
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d74da0a5188333a356f451c60f2a3c