### PR TITLE
feat: enforce retention tiers and rtbf workflow

### DIFF
--- a/jobs/retention/run.ts
+++ b/jobs/retention/run.ts
@@ -1,9 +1,11 @@
 #!/usr/bin/env ts-node
 
-import { pg } from '../../server/src/db/pg';
-import { neo } from '../../server/src/db/neo4j';
+import { randomUUID } from 'crypto';
 import { trace, Span } from '@opentelemetry/api';
 import { Counter, Gauge } from 'prom-client';
+import { pool } from '../../server/src/db/pg';
+import { neo } from '../../server/src/db/neo4j';
+import { buildDerivedPolicies, DerivedRetentionPolicy } from '../../server/src/privacy/retention';
 
 const tracer = trace.getTracer('retention-job', '24.2.0');
 
@@ -26,89 +28,54 @@ const retentionJobDuration = new Gauge({
   labelNames: ['mode']
 });
 
-interface RetentionPolicy {
-  name: string;
-  tableName: string;
-  timestampColumn: string;
-  retentionDays: number;
-  tenantColumn?: string;
-  labelColumn?: string;
-  labelOverrides?: Record<string, number>;
-}
-
 interface RetentionConfig {
   dryRun: boolean;
   batchSize: number;
   maxDeletes: number;
-  policies: RetentionPolicy[];
+  policies: DerivedRetentionPolicy[];
 }
 
-// Default retention policies
-const DEFAULT_POLICIES: RetentionPolicy[] = [
-  {
-    name: 'coherence-scores-standard',
-    tableName: 'coherence_scores',
-    timestampColumn: 'updated_at',
-    retentionDays: 365, // standard-365d
-    tenantColumn: 'tenant_id'
-  },
-  {
-    name: 'audit-logs-short',
-    tableName: 'audit_logs',
-    timestampColumn: 'created_at',
-    retentionDays: 30, // short-30d for audit
-    tenantColumn: 'tenant_id',
-    labelColumn: 'retention_label',
-    labelOverrides: {
-      'short-30d': 30,
-      'standard-365d': 365
-    }
-  }
-];
+type PolicyRunStatus = 'running' | 'completed' | 'error';
+
+type RetentionModeLabel = 'dry_run' | 'delete';
 
 class RetentionJobRunner {
   private config: RetentionConfig;
+  private runId: string;
+  private modeLabel: RetentionModeLabel;
 
   constructor(config: RetentionConfig) {
     this.config = config;
+    this.runId = randomUUID();
+    this.modeLabel = config.dryRun ? 'dry_run' : 'delete';
   }
 
   async run(): Promise<void> {
     return tracer.startActiveSpan('retention.job_run', async (span: Span) => {
       const startTime = Date.now();
-      
+
       span.setAttributes({
-        'dry_run': this.config.dryRun,
-        'batch_size': this.config.batchSize,
-        'policies_count': this.config.policies.length
+        dry_run: this.config.dryRun,
+        batch_size: this.config.batchSize,
+        policies_count: this.config.policies.length,
+        run_id: this.runId
       });
 
+      console.log(`🗑️  Starting retention job ${this.runId} (${this.config.dryRun ? 'DRY RUN' : 'DELETE MODE'})`);
+
       try {
-        console.log(`🗑️  Starting retention job (${this.config.dryRun ? 'DRY RUN' : 'DELETE MODE'})`);
-        
         for (const policy of this.config.policies) {
           await this.processPolicy(policy);
         }
 
         const duration = (Date.now() - startTime) / 1000;
-        retentionJobDuration.set({ mode: this.config.dryRun ? 'dry_run' : 'delete' }, duration);
-        
-        retentionJobRuns.inc({ 
-          mode: this.config.dryRun ? 'dry_run' : 'delete', 
-          status: 'success' 
-        });
-
-        console.log(`✅ Retention job completed successfully in ${duration.toFixed(2)}s`);
-
+        retentionJobDuration.set({ mode: this.modeLabel }, duration);
+        retentionJobRuns.inc({ mode: this.modeLabel, status: 'success' });
+        console.log(`✅ Retention job ${this.runId} completed successfully in ${duration.toFixed(2)}s`);
       } catch (error) {
         span.recordException(error as Error);
         span.setStatus({ code: 2, message: (error as Error).message });
-        
-        retentionJobRuns.inc({ 
-          mode: this.config.dryRun ? 'dry_run' : 'delete', 
-          status: 'error' 
-        });
-        
+        retentionJobRuns.inc({ mode: this.modeLabel, status: 'error' });
         console.error('❌ Retention job failed:', error);
         throw error;
       } finally {
@@ -117,23 +84,59 @@ class RetentionJobRunner {
     });
   }
 
-  private async processPolicy(policy: RetentionPolicy): Promise<void> {
+  private async processPolicy(policy: DerivedRetentionPolicy): Promise<void> {
     return tracer.startActiveSpan('retention.process_policy', async (span: Span) => {
       span.setAttributes({
-        'policy_name': policy.name,
-        'table': policy.tableName,
-        'retention_days': policy.retentionDays
+        policy_name: policy.name,
+        table: policy.tableName,
+        retention_days: policy.retentionDays,
+        retention_tier: policy.retentionTier,
+        action: policy.action,
+        run_id: this.runId
       });
+
+      const policyRowId = await this.createPolicyRunRecord(policy);
 
       console.log(`📋 Processing policy: ${policy.name}`);
 
       try {
-        if (policy.tableName.startsWith('coherence_') || policy.tableName === 'audit_logs') {
-          await this.processPostgresPolicy(policy);
-        } else if (policy.name.includes('signals')) {
+        if (policy.tableName.startsWith('neo4j:')) {
           await this.processNeo4jPolicy(policy);
+          await this.finalizePolicyRun(policyRowId, 'completed', 0, { skipped: true, reason: 'neo4j-policy-placeholder' });
+          return;
+        }
+
+        const cutoffDate = new Date();
+        cutoffDate.setDate(cutoffDate.getDate() - policy.retentionDays);
+        console.log(`  📅 Cutoff date: ${cutoffDate.toISOString()}`);
+
+        let processedRecords = 0;
+        if (policy.action === 'anonymize') {
+          processedRecords = await this.anonymizeRecords(policy, cutoffDate);
+        } else {
+          processedRecords = await this.deleteRecords(policy, cutoffDate);
+        }
+
+        retentionRecordsProcessed.inc(
+          { table: policy.tableName, action: this.config.dryRun ? 'dry_run' : policy.action, policy: policy.name },
+          processedRecords
+        );
+
+        await this.finalizePolicyRun(policyRowId, 'completed', processedRecords, {
+          cutoff: cutoffDate.toISOString(),
+          dryRun: this.config.dryRun,
+          categories: policy.dataCategories,
+          sensitivity: policy.sensitivity
+        });
+
+        if (processedRecords === 0) {
+          console.log('  ✅ No records to process');
+        } else {
+          const verb = policy.action === 'anonymize' ? 'Anonymized' : 'Deleted';
+          console.log(`  ✅ ${verb} ${processedRecords} records from ${policy.tableName}`);
         }
       } catch (error) {
+        await this.finalizePolicyRun(policyRowId, 'error', 0, { dryRun: this.config.dryRun }, error as Error);
         span.recordException(error as Error);
         span.setStatus({ code: 2, message: (error as Error).message });
         throw error;
@@ -143,172 +146,256 @@ class RetentionJobRunner {
     });
   }
 
-  private async processPostgresPolicy(policy: RetentionPolicy): Promise<void> {
-    const cutoffDate = new Date();
-    cutoffDate.setDate(cutoffDate.getDate() - policy.retentionDays);
+  private async createPolicyRunRecord(policy: DerivedRetentionPolicy): Promise<string> {
+    const { rows } = await pool.query(
+      `INSERT INTO privacy_retention_job_runs
+         (run_id, policy_name, action, retention_tier, mode, status, details)
+       VALUES ($1, $2, $3, $4, $5, 'running', $6::jsonb)
+       RETURNING id`,
+      [
+        this.runId,
+        policy.name,
+        policy.action,
+        policy.retentionTier,
+        this.modeLabel,
+        JSON.stringify({ table: policy.tableName, categories: policy.dataCategories })
+      ]
+    );
 
-    console.log(`  📅 Cutoff date: ${cutoffDate.toISOString()}`);
-
-    // Handle label-based overrides
-    if (policy.labelColumn && policy.labelOverrides) {
-      for (const [label, days] of Object.entries(policy.labelOverrides)) {
-        const labelCutoff = new Date();
-        labelCutoff.setDate(labelCutoff.getDate() - days);
-        
-        await this.processPostgresWithLabel(policy, labelCutoff, label);
-      }
-    } else {
-      await this.processPostgresStandard(policy, cutoffDate);
-    }
+    return rows[0].id;
   }
 
-  private async processPostgresStandard(policy: RetentionPolicy, cutoffDate: Date): Promise<void> {
-    // Count records to be affected
-    const countQuery = `
-      SELECT COUNT(*) as count 
-      FROM ${policy.tableName} 
-      WHERE ${policy.timestampColumn} < $1
-      ${policy.tenantColumn ? `AND ${policy.tenantColumn} IS NOT NULL` : ''}
-    `;
-    
-    const countResult = await pg.oneOrNone(countQuery, [cutoffDate]);
-    const recordCount = parseInt(countResult?.count || '0');
+  private async finalizePolicyRun(
+    policyRunId: string,
+    status: PolicyRunStatus,
+    recordsProcessed: number,
+    extraDetails: Record<string, unknown>,
+    error?: Error
+  ): Promise<void> {
+    const payload = {
+      ...extraDetails,
+      recordsProcessed,
+      error: error?.message || null
+    };
 
-    console.log(`  📊 Found ${recordCount} records older than ${cutoffDate.toISOString()}`);
+    await pool.query(
+      `UPDATE privacy_retention_job_runs
+         SET status = $2,
+             records_processed = $3,
+             completed_at = NOW(),
+             error = $4,
+             details = details || $5::jsonb
+       WHERE id = $1`,
+      [policyRunId, status, recordsProcessed, error?.message || null, JSON.stringify(payload)]
+    );
+  }
 
-    if (recordCount === 0) {
-      console.log('  ✅ No records to process');
-      return;
+  private async countEligibleRecords(policy: DerivedRetentionPolicy, cutoffDate: Date): Promise<number> {
+    const { rows } = await pool.query(
+      `SELECT COUNT(*)::int AS count
+         FROM ${policy.tableName}
+        WHERE ${policy.timestampColumn} < $1`,
+      [cutoffDate]
+    );
+
+    return rows[0]?.count ?? 0;
+  }
+
+  private async fetchBatchIds(policy: DerivedRetentionPolicy, cutoffDate: Date): Promise<string[]> {
+    const { rows } = await pool.query(
+      `SELECT ${policy.primaryKeyColumn}::text AS id
+         FROM ${policy.tableName}
+        WHERE ${policy.timestampColumn} < $1
+        ORDER BY ${policy.timestampColumn}
+        LIMIT $2`,
+      [cutoffDate, this.config.batchSize]
+    );
+
+    return rows.map(row => row.id as string);
+  }
+
+  private async insertTombstones(
+    policy: DerivedRetentionPolicy,
+    recordIds: string[],
+    action: 'delete' | 'anonymize'
+  ): Promise<void> {
+    if (this.config.dryRun || recordIds.length === 0) return;
+
+    await pool.query(
+      `INSERT INTO privacy_tombstones (table_name, primary_key_column, record_id, action, metadata)
+       SELECT $1, $2, UNNEST($3::text[]), $4, $5::jsonb
+       ON CONFLICT (table_name, primary_key_column, record_id)
+       DO UPDATE SET
+         action = EXCLUDED.action,
+         metadata = privacy_tombstones.metadata || EXCLUDED.metadata,
+         created_at = LEAST(privacy_tombstones.created_at, EXCLUDED.created_at)`,
+      [
+        policy.tableName,
+        policy.primaryKeyColumn,
+        recordIds,
+        action,
+        JSON.stringify({ runId: this.runId, retentionTier: policy.retentionTier })
+      ]
+    );
+  }
+
+  private generateAnonymizedValues(policy: DerivedRetentionPolicy, recordId: string): Record<string, string> {
+    const token = recordId.replace(/-/g, '').slice(0, 16);
+    const values: Record<string, string> = {};
+
+    for (const field of policy.anonymizeFields) {
+      const lower = field.toLowerCase();
+      if (lower.includes('email')) {
+        values[field] = `anonymized+${token}@privacy.invalid`;
+      } else if (lower.includes('username') || lower.includes('user')) {
+        values[field] = `anon_${token}`;
+      } else if (lower.includes('name')) {
+        values[field] = 'Redacted';
+      } else {
+        values[field] = '[REDACTED]';
+      }
     }
 
-    if (recordCount > this.config.maxDeletes) {
-      throw new Error(`Record count ${recordCount} exceeds max deletes limit ${this.config.maxDeletes}`);
+    return values;
+  }
+
+  private async anonymizeRecords(policy: DerivedRetentionPolicy, cutoffDate: Date): Promise<number> {
+    const totalRecords = await this.countEligibleRecords(policy, cutoffDate);
+
+    if (totalRecords === 0) {
+      return 0;
     }
 
     if (this.config.dryRun) {
-      console.log(`  🔍 DRY RUN: Would delete ${recordCount} records`);
-      retentionRecordsProcessed.inc({ 
-        table: policy.tableName, 
-        action: 'dry_run', 
-        policy: policy.name 
-      }, recordCount);
-      return;
+      console.log(`  🔍 DRY RUN: Would anonymize ${totalRecords} records`);
+      return totalRecords;
     }
 
-    // Perform deletion in batches
-    let deletedTotal = 0;
-    let batchCount = 0;
+    let processed = 0;
 
-    while (deletedTotal < recordCount) {
-      const batchDeleteQuery = `
-        DELETE FROM ${policy.tableName}
-        WHERE ctid IN (
-          SELECT ctid FROM ${policy.tableName}
-          WHERE ${policy.timestampColumn} < $1
-          LIMIT $2
-        )
-      `;
+    while (processed < totalRecords) {
+      const batchIds = await this.fetchBatchIds(policy, cutoffDate);
+      if (batchIds.length === 0) break;
 
-      const result = await pg.oneOrNone(batchDeleteQuery, [cutoffDate, this.config.batchSize]);
-      const deletedInBatch = result?.rowCount || 0;
-      
-      deletedTotal += deletedInBatch;
-      batchCount++;
+      for (const recordId of batchIds) {
+        const anonymizedValues = this.generateAnonymizedValues(policy, recordId);
+        const assignments: string[] = [];
+        const values: unknown[] = [recordId];
+        let placeholderIndex = 2;
 
-      console.log(`  🗑️  Batch ${batchCount}: Deleted ${deletedInBatch} records (Total: ${deletedTotal})`);
+        for (const [column, value] of Object.entries(anonymizedValues)) {
+          assignments.push(`${column} = $${placeholderIndex}`);
+          values.push(value);
+          placeholderIndex++;
+        }
 
-      if (deletedInBatch === 0) {
-        break; // No more records to delete
+        if (policy.labelColumn) {
+          assignments.push(`${policy.labelColumn} = $${placeholderIndex}`);
+          values.push('rtbf-anonymize');
+          placeholderIndex++;
+        }
+
+        if (policy.expiresColumn) {
+          assignments.push(`${policy.expiresColumn} = NULL`);
+        }
+
+        if (policy.tombstoneColumn) {
+          assignments.push(`${policy.tombstoneColumn} = COALESCE(${policy.tombstoneColumn}, NOW())`);
+        }
+
+        assignments.push(`updated_at = NOW()`);
+
+        await pool.query(
+          `UPDATE ${policy.tableName}
+              SET ${assignments.join(', ')}
+            WHERE ${policy.primaryKeyColumn}::text = $1`,
+          values
+        );
       }
 
-      // Brief pause between batches to avoid overwhelming the database
+      await this.insertTombstones(policy, batchIds, 'anonymize');
+      processed += batchIds.length;
+
+      if (batchIds.length < this.config.batchSize) {
+        break;
+      }
+    }
+
+    return processed;
+  }
+
+  private async deleteRecords(policy: DerivedRetentionPolicy, cutoffDate: Date): Promise<number> {
+    const totalRecords = await this.countEligibleRecords(policy, cutoffDate);
+
+    if (totalRecords === 0) {
+      return 0;
+    }
+
+    if (totalRecords > this.config.maxDeletes) {
+      throw new Error(`Record count ${totalRecords} exceeds max deletes limit ${this.config.maxDeletes}`);
+    }
+
+    if (this.config.dryRun) {
+      console.log(`  🔍 DRY RUN: Would delete ${totalRecords} records`);
+      return totalRecords;
+    }
+
+    let deletedTotal = 0;
+
+    while (deletedTotal < totalRecords) {
+      const batchIds = await this.fetchBatchIds(policy, cutoffDate);
+      if (batchIds.length === 0) break;
+
+      await this.insertTombstones(policy, batchIds, 'delete');
+
+      const result = await pool.query(
+        `DELETE FROM ${policy.tableName}
+          WHERE ${policy.primaryKeyColumn}::text = ANY($1::text[])`,
+        [batchIds]
+      );
+
+      deletedTotal += result.rowCount;
+
+      console.log(
+        `  🗑️  Batch ${Math.ceil(deletedTotal / this.config.batchSize)}: Deleted ${result.rowCount} records (Total: ${deletedTotal})`
+      );
+
+      if (result.rowCount === 0 || result.rowCount < this.config.batchSize) {
+        break;
+      }
+
       await new Promise(resolve => setTimeout(resolve, 100));
     }
 
-    retentionRecordsProcessed.inc({ 
-      table: policy.tableName, 
-      action: 'delete', 
-      policy: policy.name 
-    }, deletedTotal);
-
-    console.log(`  ✅ Deleted ${deletedTotal} records from ${policy.tableName}`);
+    return deletedTotal;
   }
 
-  private async processPostgresWithLabel(policy: RetentionPolicy, cutoffDate: Date, label: string): Promise<void> {
-    const countQuery = `
-      SELECT COUNT(*) as count 
-      FROM ${policy.tableName} 
-      WHERE ${policy.timestampColumn} < $1 
-        AND ${policy.labelColumn} = $2
-    `;
-    
-    const countResult = await pg.oneOrNone(countQuery, [cutoffDate, label]);
-    const recordCount = parseInt(countResult?.count || '0');
-
-    console.log(`  📊 Found ${recordCount} records with label '${label}' older than ${cutoffDate.toISOString()}`);
-
-    if (recordCount === 0) return;
-
-    if (this.config.dryRun) {
-      console.log(`  🔍 DRY RUN: Would delete ${recordCount} records with label '${label}'`);
-      retentionRecordsProcessed.inc({ 
-        table: policy.tableName, 
-        action: 'dry_run', 
-        policy: `${policy.name}-${label}` 
-      }, recordCount);
-      return;
-    }
-
-    const deleteQuery = `
-      DELETE FROM ${policy.tableName}
-      WHERE ${policy.timestampColumn} < $1 AND ${policy.labelColumn} = $2
-    `;
-
-    await pg.oneOrNone(deleteQuery, [cutoffDate, label]);
-
-    retentionRecordsProcessed.inc({ 
-      table: policy.tableName, 
-      action: 'delete', 
-      policy: `${policy.name}-${label}` 
-    }, recordCount);
-
-    console.log(`  ✅ Deleted ${recordCount} records with label '${label}'`);
-  }
-
-  private async processNeo4jPolicy(policy: RetentionPolicy): Promise<void> {
+  private async processNeo4jPolicy(policy: DerivedRetentionPolicy): Promise<void> {
+    const retentionDays = policy.retentionDays;
     const cutoffDate = new Date();
-    cutoffDate.setDate(cutoffDate.getDate() - policy.retentionDays);
+    cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
 
     console.log(`  📅 Neo4j cutoff date: ${cutoffDate.toISOString()}`);
 
-    // Count nodes to be deleted
-    const countQuery = `
-      MATCH (n:Signal)
-      WHERE datetime(n.timestamp) < datetime($cutoffDate)
-      RETURN count(n) as count
-    `;
+    const countResult = await neo.run(
+      `MATCH (n:Signal)
+       WHERE datetime(n.timestamp) < datetime($cutoffDate)
+       RETURN count(n) as count`,
+      { cutoffDate: cutoffDate.toISOString() }
+    );
 
-    const countResult = await neo.run(countQuery, { cutoffDate: cutoffDate.toISOString() });
     const recordCount = countResult.records[0]?.get('count')?.toNumber() || 0;
-
     console.log(`  📊 Found ${recordCount} Signal nodes older than ${cutoffDate.toISOString()}`);
 
-    if (recordCount === 0) {
-      console.log('  ✅ No Signal nodes to process');
+    if (recordCount === 0 || this.config.dryRun) {
+      if (recordCount > 0) {
+        console.log(`  🔍 DRY RUN: Would delete ${recordCount} Signal nodes`);
+      } else {
+        console.log('  ✅ No Signal nodes to process');
+      }
       return;
     }
 
-    if (this.config.dryRun) {
-      console.log(`  🔍 DRY RUN: Would delete ${recordCount} Signal nodes`);
-      retentionRecordsProcessed.inc({ 
-        table: 'neo4j_signals', 
-        action: 'dry_run', 
-        policy: policy.name 
-      }, recordCount);
-      return;
-    }
-
-    // Delete in batches
     const deleteQuery = `
       MATCH (n:Signal)
       WHERE datetime(n.timestamp) < datetime($cutoffDate)
@@ -318,32 +405,20 @@ class RetentionJobRunner {
     `;
 
     let totalDeleted = 0;
-    let batchCount = 0;
 
     while (totalDeleted < recordCount) {
-      const deleteResult = await neo.run(deleteQuery, { 
+      const deleteResult = await neo.run(deleteQuery, {
         cutoffDate: cutoffDate.toISOString(),
-        batchSize: this.config.batchSize 
+        batchSize: this.config.batchSize
       });
-      
+
       const deletedInBatch = deleteResult.records[0]?.get('deleted')?.toNumber() || 0;
       totalDeleted += deletedInBatch;
-      batchCount++;
-
-      console.log(`  🗑️  Neo4j Batch ${batchCount}: Deleted ${deletedInBatch} nodes (Total: ${totalDeleted})`);
+      console.log(`  🗑️  Neo4j Batch: Deleted ${deletedInBatch} nodes (Total: ${totalDeleted})`);
 
       if (deletedInBatch === 0) break;
-
-      await new Promise(resolve => setTimeout(resolve, 500)); // Longer pause for Neo4j
+      await new Promise(resolve => setTimeout(resolve, 500));
     }
-
-    retentionRecordsProcessed.inc({ 
-      table: 'neo4j_signals', 
-      action: 'delete', 
-      policy: policy.name 
-    }, totalDeleted);
-
-    console.log(`  ✅ Deleted ${totalDeleted} Signal nodes from Neo4j`);
   }
 }
 
@@ -351,18 +426,20 @@ class RetentionJobRunner {
 async function main() {
   const args = process.argv.slice(2);
   const dryRun = args.includes('--dry-run');
-  const batchSize = parseInt(args.find(arg => arg.startsWith('--batch-size='))?.split('=')[1] || '1000');
-  const maxDeletes = parseInt(args.find(arg => arg.startsWith('--max-deletes='))?.split('=')[1] || '100000');
+  const batchSize = parseInt(args.find(arg => arg.startsWith('--batch-size='))?.split('=')[1] || '1000', 10);
+  const maxDeletes = parseInt(args.find(arg => arg.startsWith('--max-deletes='))?.split('=')[1] || '100000', 10);
+
+  const policies = buildDerivedPolicies();
 
   const config: RetentionConfig = {
     dryRun,
     batchSize,
     maxDeletes,
-    policies: DEFAULT_POLICIES
+    policies
   };
 
   const runner = new RetentionJobRunner(config);
-  
+
   try {
     await runner.run();
     process.exit(0);
@@ -376,4 +453,4 @@ if (require.main === module) {
   main().catch(console.error);
 }
 
-export { RetentionJobRunner, DEFAULT_POLICIES };
+export { RetentionJobRunner };

--- a/policy/packs/retention.json
+++ b/policy/packs/retention.json
@@ -1,0 +1,41 @@
+{
+  "version": "2025-10-01",
+  "tiers": {
+    "short-30d": {
+      "days": 30,
+      "action": "delete",
+      "description": "Default retention for PII and high-risk telemetry.",
+      "appliesTo": ["pii", "session", "token", "audit"],
+      "legalBasis": "minimization"
+    },
+    "standard-365d": {
+      "days": 365,
+      "action": "delete",
+      "description": "Operational analytics and derived intelligence artifacts.",
+      "appliesTo": ["analytics", "operational"],
+      "legalBasis": "business-operations"
+    },
+    "long-1825d": {
+      "days": 1825,
+      "action": "delete",
+      "description": "Extended retention for compliance-hold datasets.",
+      "appliesTo": ["compliance", "legal"],
+      "legalBasis": "compliance"
+    },
+    "rtbf-anonymize": {
+      "days": 0,
+      "action": "anonymize",
+      "description": "Immediate anonymization tier used for RTBF execution.",
+      "appliesTo": ["pii"],
+      "legalBasis": "subject-right"
+    }
+  },
+  "defaults": {
+    "pii": "short-30d",
+    "session": "short-30d",
+    "token": "short-30d",
+    "audit": "short-30d",
+    "analytics": "standard-365d",
+    "compliance": "long-1825d"
+  }
+}

--- a/schemas/privacy/entities.json
+++ b/schemas/privacy/entities.json
@@ -1,0 +1,64 @@
+{
+  "entities": [
+    {
+      "entity": "user_profile",
+      "table": "users",
+      "primaryKey": "id",
+      "primaryKeyType": "uuid",
+      "timestampColumn": "updated_at",
+      "subjectKey": "id",
+      "sensitivity": "pii",
+      "dataCategories": ["contact", "account"],
+      "defaultRetentionTier": "short-30d",
+      "retentionLabelColumn": "retention_label",
+      "retentionExpiresColumn": "retention_expires_at",
+      "tombstoneColumn": "tombstoned_at",
+      "anonymizeFields": ["email", "username", "first_name", "last_name"],
+      "description": "Primary user directory record containing direct identifiers and account metadata."
+    },
+    {
+      "entity": "user_session",
+      "table": "user_sessions",
+      "primaryKey": "id",
+      "primaryKeyType": "uuid",
+      "timestampColumn": "created_at",
+      "subjectKey": "user_id",
+      "sensitivity": "pii",
+      "dataCategories": ["session", "token"],
+      "defaultRetentionTier": "short-30d",
+      "retentionLabelColumn": "retention_label",
+      "retentionExpiresColumn": "retention_expires_at",
+      "tombstoneColumn": "tombstoned_at",
+      "description": "Opaque refresh tokens bound to user identity; retained for revocation checks only."
+    },
+    {
+      "entity": "audit_log",
+      "table": "audit_logs",
+      "primaryKey": "id",
+      "primaryKeyType": "uuid",
+      "timestampColumn": "created_at",
+      "sensitivity": "internal",
+      "dataCategories": ["audit"],
+      "defaultRetentionTier": "short-30d",
+      "retentionLabelColumn": "retention_label",
+      "retentionExpiresColumn": "retention_expires_at",
+      "tombstoneColumn": "tombstoned_at",
+      "description": "Immutable access trail used for compliance attestations and incident response."
+    },
+    {
+      "entity": "analysis_result",
+      "table": "analysis_results",
+      "primaryKey": "id",
+      "primaryKeyType": "uuid",
+      "timestampColumn": "created_at",
+      "subjectKey": "investigation_id",
+      "sensitivity": "internal",
+      "dataCategories": ["analytics"],
+      "defaultRetentionTier": "standard-365d",
+      "retentionLabelColumn": "retention_label",
+      "retentionExpiresColumn": "retention_expires_at",
+      "tombstoneColumn": "tombstoned_at",
+      "description": "Derived analytics artifacts used for investigations and reporting."
+    }
+  ]
+}

--- a/scripts/dr/restore_check.sh
+++ b/scripts/dr/restore_check.sh
@@ -11,6 +11,27 @@ SELECT to_regclass('public.pipelines') IS NOT NULL AS has_pipelines;
 SELECT to_regclass('public.executors') IS NOT NULL AS has_executors;
 SELECT to_regclass('public.mcp_servers') IS NOT NULL AS has_mcp_servers;
 SELECT to_regclass('public.mcp_sessions') IS NOT NULL AS has_mcp_sessions;
+SELECT to_regclass('privacy_tombstones') IS NOT NULL AS has_privacy_tombstones;
+
+DO $$
+DECLARE
+  rec RECORD;
+  resurrected_count INTEGER;
+BEGIN
+  IF to_regclass('privacy_tombstones') IS NULL THEN
+    RETURN;
+  END IF;
+
+  FOR rec IN SELECT table_name, primary_key_column, record_id, action FROM privacy_tombstones LOOP
+    EXECUTE format('SELECT COUNT(*)::int FROM %I WHERE %I::text = $1', rec.table_name, rec.primary_key_column)
+      INTO resurrected_count
+      USING rec.record_id;
+
+    IF rec.action = 'delete' AND resurrected_count > 0 THEN
+      RAISE EXCEPTION 'Tombstoned record % in % resurrected during restore', rec.record_id, rec.table_name;
+    END IF;
+  END LOOP;
+END$$;
 SQL
 
 echo "[DR] Restore verification completed"

--- a/server/src/db/migrations/postgres/009_privacy_retention_rtbf.sql
+++ b/server/src/db/migrations/postgres/009_privacy_retention_rtbf.sql
@@ -1,0 +1,81 @@
+-- Add retention metadata columns
+ALTER TABLE IF EXISTS users
+  ADD COLUMN IF NOT EXISTS retention_label TEXT NOT NULL DEFAULT 'short-30d',
+  ADD COLUMN IF NOT EXISTS retention_expires_at TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN IF NOT EXISTS tombstoned_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE IF EXISTS user_sessions
+  ADD COLUMN IF NOT EXISTS retention_label TEXT NOT NULL DEFAULT 'short-30d',
+  ADD COLUMN IF NOT EXISTS retention_expires_at TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN IF NOT EXISTS tombstoned_at TIMESTAMP WITH TIME ZONE;
+
+ALTER TABLE IF EXISTS audit_logs
+  ADD COLUMN IF NOT EXISTS retention_label TEXT NOT NULL DEFAULT 'short-30d',
+  ADD COLUMN IF NOT EXISTS retention_expires_at TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN IF NOT EXISTS tombstoned_at TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN IF NOT EXISTS previous_hash TEXT,
+  ADD COLUMN IF NOT EXISTS signature TEXT;
+
+ALTER TABLE IF EXISTS analysis_results
+  ADD COLUMN IF NOT EXISTS retention_label TEXT NOT NULL DEFAULT 'standard-365d',
+  ADD COLUMN IF NOT EXISTS retention_expires_at TIMESTAMP WITH TIME ZONE,
+  ADD COLUMN IF NOT EXISTS tombstoned_at TIMESTAMP WITH TIME ZONE;
+
+UPDATE users SET retention_label = 'short-30d' WHERE retention_label IS NULL;
+UPDATE user_sessions SET retention_label = 'short-30d' WHERE retention_label IS NULL;
+UPDATE audit_logs SET retention_label = 'short-30d' WHERE retention_label IS NULL;
+UPDATE analysis_results SET retention_label = 'standard-365d' WHERE retention_label IS NULL;
+
+-- Retention run audit table
+CREATE TABLE IF NOT EXISTS privacy_retention_job_runs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id UUID NOT NULL,
+  policy_name TEXT NOT NULL,
+  action TEXT NOT NULL,
+  retention_tier TEXT NOT NULL,
+  records_processed INTEGER NOT NULL DEFAULT 0,
+  mode TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'running',
+  started_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  completed_at TIMESTAMP WITH TIME ZONE,
+  error TEXT,
+  details JSONB DEFAULT '{}'::jsonb
+);
+CREATE INDEX IF NOT EXISTS idx_privacy_retention_runs_run_id ON privacy_retention_job_runs(run_id);
+CREATE INDEX IF NOT EXISTS idx_privacy_retention_runs_policy ON privacy_retention_job_runs(policy_name);
+
+-- RTBF request tracking
+CREATE TABLE IF NOT EXISTS privacy_rtbf_requests (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  subject_id TEXT NOT NULL,
+  tenant TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued',
+  requested_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  requested_by UUID,
+  attestation_signature TEXT NOT NULL,
+  attestation_issued_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  attestation_payload JSONB DEFAULT '{}'::jsonb,
+  authority_verified_at TIMESTAMP WITH TIME ZONE,
+  verified_by UUID,
+  processed_at TIMESTAMP WITH TIME ZONE,
+  audit_reference TEXT,
+  result JSONB DEFAULT '{}'::jsonb,
+  retention_tier_snapshot TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_privacy_rtbf_status ON privacy_rtbf_requests(status);
+CREATE INDEX IF NOT EXISTS idx_privacy_rtbf_subject ON privacy_rtbf_requests(subject_id);
+
+-- Tombstones to exclude deleted data from restores
+CREATE TABLE IF NOT EXISTS privacy_tombstones (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  table_name TEXT NOT NULL,
+  primary_key_column TEXT NOT NULL,
+  record_id TEXT NOT NULL,
+  action TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  rtbf_request_id UUID REFERENCES privacy_rtbf_requests(id) ON DELETE SET NULL,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  UNIQUE (table_name, primary_key_column, record_id)
+);
+CREATE INDEX IF NOT EXISTS idx_privacy_tombstones_table ON privacy_tombstones(table_name);
+CREATE INDEX IF NOT EXISTS idx_privacy_tombstones_record ON privacy_tombstones(record_id);

--- a/server/src/privacy/__tests__/retention.test.ts
+++ b/server/src/privacy/__tests__/retention.test.ts
@@ -1,0 +1,33 @@
+import { buildDerivedPolicies, getRetentionTierDefinition, resetRetentionPackCache } from '../retention';
+import { resetPrivacyEntityCache } from '../entities';
+
+describe('retention policy pack integration', () => {
+  beforeEach(() => {
+    resetRetentionPackCache();
+    resetPrivacyEntityCache();
+  });
+
+  it('builds derived policies using pack tiers', () => {
+    const policies = buildDerivedPolicies();
+    const userPolicy = policies.find(policy => policy.tableName === 'users');
+    const auditPolicy = policies.find(policy => policy.tableName === 'audit_logs');
+
+    expect(userPolicy).toBeDefined();
+    expect(userPolicy?.retentionDays).toBe(30);
+    expect(userPolicy?.action).toBe('anonymize');
+    expect(userPolicy?.retentionTier).toBe('short-30d');
+    expect(userPolicy?.subjectKey).toBe('id');
+
+    expect(auditPolicy).toBeDefined();
+    expect(auditPolicy?.retentionDays).toBe(30);
+    expect(auditPolicy?.action).toBe('delete');
+    expect(auditPolicy?.retentionTier).toBe('short-30d');
+  });
+
+  it('returns tier definitions from policy pack', () => {
+    const tier = getRetentionTierDefinition('short-30d');
+    expect(tier).toBeDefined();
+    expect(tier?.days).toBe(30);
+    expect(tier?.action).toBe('delete');
+  });
+});

--- a/server/src/privacy/entities.ts
+++ b/server/src/privacy/entities.ts
@@ -1,0 +1,68 @@
+import fs from 'fs';
+import path from 'path';
+
+export type SensitivityLevel = 'pii' | 'internal' | 'public' | 'restricted';
+
+export interface PrivacyEntity {
+  entity: string;
+  table: string;
+  primaryKey: string;
+  primaryKeyType: 'uuid' | 'text' | 'bigint';
+  timestampColumn: string;
+  subjectKey?: string;
+  sensitivity: SensitivityLevel;
+  dataCategories: string[];
+  defaultRetentionTier?: string;
+  retentionLabelColumn?: string;
+  retentionExpiresColumn?: string;
+  tombstoneColumn?: string;
+  anonymizeFields?: string[];
+  description?: string;
+}
+
+interface EntitySchemaFile {
+  entities: PrivacyEntity[];
+}
+
+const DEFAULT_ENTITIES_PATH = path.resolve(
+  process.cwd(),
+  'schemas/privacy/entities.json'
+);
+
+let cachedEntities: PrivacyEntity[] | null = null;
+
+function resolveEntitiesPath(): string {
+  return process.env.PRIVACY_ENTITIES_PATH || DEFAULT_ENTITIES_PATH;
+}
+
+export function loadPrivacyEntities(): PrivacyEntity[] {
+  if (cachedEntities) {
+    return cachedEntities;
+  }
+
+  const filePath = resolveEntitiesPath();
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const parsed = JSON.parse(raw) as EntitySchemaFile;
+
+  if (!Array.isArray(parsed.entities)) {
+    throw new Error('Invalid privacy entity schema: missing entities array');
+  }
+
+  cachedEntities = parsed.entities.map(entity => ({
+    ...entity,
+    dataCategories: entity.dataCategories || []
+  }));
+
+  return cachedEntities;
+}
+
+export function findPrivacyEntity(tableName: string): PrivacyEntity | undefined {
+  return loadPrivacyEntities().find(
+    entity => entity.table.toLowerCase() === tableName.toLowerCase()
+  );
+}
+
+export function resetPrivacyEntityCache(): void {
+  cachedEntities = null;
+}
+

--- a/server/src/privacy/retention.ts
+++ b/server/src/privacy/retention.ts
@@ -1,0 +1,132 @@
+import fs from 'fs';
+import path from 'path';
+import { loadPrivacyEntities, PrivacyEntity } from './entities';
+
+export type RetentionAction = 'delete' | 'anonymize';
+
+export interface RetentionTierDefinition {
+  days: number;
+  action: RetentionAction;
+  description?: string;
+  appliesTo?: string[];
+  legalBasis?: string;
+}
+
+export interface RetentionPolicyPack {
+  version?: string;
+  tiers: Record<string, RetentionTierDefinition>;
+  defaults: Record<string, string>;
+}
+
+export interface DerivedRetentionPolicy {
+  name: string;
+  tableName: string;
+  primaryKeyColumn: string;
+  primaryKeyType: PrivacyEntity['primaryKeyType'];
+  timestampColumn: string;
+  subjectKey?: string;
+  retentionDays: number;
+  retentionTier: string;
+  action: RetentionAction;
+  labelColumn?: string;
+  expiresColumn?: string;
+  tombstoneColumn?: string;
+  anonymizeFields: string[];
+  dataCategories: string[];
+  sensitivity: PrivacyEntity['sensitivity'];
+}
+
+const DEFAULT_PACK_PATH = path.resolve(process.cwd(), 'policy/packs/retention.json');
+
+let cachedPack: RetentionPolicyPack | null = null;
+
+function resolvePackPath(): string {
+  return process.env.RETENTION_POLICY_PACK || DEFAULT_PACK_PATH;
+}
+
+export function loadRetentionPack(): RetentionPolicyPack {
+  if (cachedPack) {
+    return cachedPack;
+  }
+
+  const filePath = resolvePackPath();
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const parsed = JSON.parse(raw) as RetentionPolicyPack;
+
+  if (!parsed.tiers || typeof parsed.tiers !== 'object') {
+    throw new Error('Invalid retention policy pack: missing tiers');
+  }
+
+  if (!parsed.defaults || typeof parsed.defaults !== 'object') {
+    throw new Error('Invalid retention policy pack: missing defaults');
+  }
+
+  cachedPack = parsed;
+  return cachedPack;
+}
+
+function resolveTierForEntity(entity: PrivacyEntity, pack: RetentionPolicyPack): string {
+  if (entity.defaultRetentionTier && pack.tiers[entity.defaultRetentionTier]) {
+    return entity.defaultRetentionTier;
+  }
+
+  for (const category of entity.dataCategories || []) {
+    const tier = pack.defaults[category];
+    if (tier && pack.tiers[tier]) {
+      return tier;
+    }
+  }
+
+  const sensitivityDefault = pack.defaults[entity.sensitivity];
+  if (sensitivityDefault && pack.tiers[sensitivityDefault]) {
+    return sensitivityDefault;
+  }
+
+  return Object.keys(pack.tiers)[0];
+}
+
+export function buildDerivedPolicies(): DerivedRetentionPolicy[] {
+  const entities = loadPrivacyEntities();
+  const pack = loadRetentionPack();
+
+  return entities.map(entity => {
+    const retentionTier = resolveTierForEntity(entity, pack);
+    const tierDefinition = pack.tiers[retentionTier];
+
+    if (!tierDefinition) {
+      throw new Error(`Retention tier '${retentionTier}' is not defined in policy pack`);
+    }
+
+    const action = entity.anonymizeFields && entity.anonymizeFields.length > 0
+      ? 'anonymize'
+      : tierDefinition.action;
+
+    return {
+      name: `${entity.entity}-${retentionTier}`,
+      tableName: entity.table,
+      primaryKeyColumn: entity.primaryKey,
+      primaryKeyType: entity.primaryKeyType,
+      timestampColumn: entity.timestampColumn,
+      subjectKey: entity.subjectKey,
+      retentionDays: tierDefinition.days,
+      retentionTier,
+      action,
+      labelColumn: entity.retentionLabelColumn,
+      expiresColumn: entity.retentionExpiresColumn,
+      tombstoneColumn: entity.tombstoneColumn,
+      anonymizeFields: entity.anonymizeFields || [],
+      dataCategories: entity.dataCategories,
+      sensitivity: entity.sensitivity
+    };
+  });
+}
+
+export function getRetentionTierDefinition(tier: string): RetentionTierDefinition | undefined {
+  const pack = loadRetentionPack();
+  return pack.tiers[tier];
+}
+
+export function resetRetentionPackCache(): void {
+  cachedPack = null;
+}
+

--- a/services/compliance/dsar.ts
+++ b/services/compliance/dsar.ts
@@ -1,7 +1,99 @@
 import { Router } from 'express';
 import { Pool } from 'pg';
-const r = Router(),
-  db = new Pool({ connectionString: process.env.DATABASE_URL });
+import { z } from 'zod';
+import crypto from 'crypto';
+
+const r = Router();
+const db = new Pool({ connectionString: process.env.DATABASE_URL });
+
+type RequestUser = {
+  id?: string;
+  role?: string;
+  tenantId?: string;
+  email?: string;
+};
+
+const rtbfAttestationSchema = z.object({
+  signature: z.string().min(10, 'attestation signature required'),
+  issued_at: z
+    .string()
+    .refine(value => !Number.isNaN(Date.parse(value)), 'issued_at must be ISO timestamp'),
+  expires_at: z
+    .string()
+    .optional()
+    .refine(value => !value || !Number.isNaN(Date.parse(value)), 'expires_at must be ISO timestamp'),
+  authority: z.string().optional()
+});
+
+const rtbfRequestSchema = z.object({
+  subject_id: z.string().min(1),
+  tenant: z.string().min(1),
+  reason: z.string().optional(),
+  attestation: rtbfAttestationSchema
+});
+
+function safeEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a);
+  const bBuf = Buffer.from(b);
+  if (aBuf.length !== bBuf.length) return false;
+  return crypto.timingSafeEqual(aBuf, bBuf);
+}
+
+function verifyRtbfAuthority(payload: z.infer<typeof rtbfRequestSchema>, actor: RequestUser): void {
+  if (!actor?.id) {
+    const error = new Error('Authentication required for RTBF');
+    (error as any).status = 401;
+    throw error;
+  }
+
+  const allowedRoles = ['ADMIN', 'admin', 'COMPLIANCE', 'PRIVACY_OFFICER', 'PRIVACY'];
+  if (!allowedRoles.includes(actor.role || '')) {
+    const error = new Error('Insufficient role for RTBF request');
+    (error as any).status = 403;
+    throw error;
+  }
+
+  if (actor.tenantId && actor.tenantId !== payload.tenant) {
+    const error = new Error('Actor tenant mismatch');
+    (error as any).status = 403;
+    throw error;
+  }
+
+  const issuedAt = new Date(payload.attestation.issued_at);
+  const now = new Date();
+  const maxAgeMinutes = parseInt(process.env.RTBF_ATTESTATION_MAX_AGE_MINUTES || '1440', 10);
+  const ageMinutes = Math.abs(now.getTime() - issuedAt.getTime()) / (1000 * 60);
+  if (ageMinutes > maxAgeMinutes) {
+    const error = new Error('Attestation is expired');
+    (error as any).status = 400;
+    throw error;
+  }
+
+  if (payload.attestation.expires_at) {
+    const expiresAt = new Date(payload.attestation.expires_at);
+    if (expiresAt.getTime() < now.getTime()) {
+      const error = new Error('Attestation token already expired');
+      (error as any).status = 400;
+      throw error;
+    }
+  }
+
+  const attestationSecret = process.env.RTBF_ATTESTATION_SECRET || 'rtbf-dev-secret';
+  const expected = crypto
+    .createHmac('sha256', attestationSecret)
+    .update(`${payload.subject_id}:${payload.tenant}:${payload.attestation.issued_at}`)
+    .digest('hex');
+
+  if (!safeEqual(expected, payload.attestation.signature)) {
+    const error = new Error('Invalid RTBF attestation signature');
+    (error as any).status = 403;
+    throw error;
+  }
+}
+
+function getRequestUser(req: any): RequestUser {
+  return (req?.user || {}) as RequestUser;
+}
 
 r.post('/dsar/request', async (req, res) => {
   const { subject_id, tenant } = req.body;
@@ -21,13 +113,56 @@ r.get('/dsar/export/:id', async (req, res) => {
 });
 
 r.post('/rtbf', async (req, res) => {
-  const { subject_id, tenant } = req.body;
-  // mark & tombstone; actual delete via async worker with audit & policy checks
-  await db.query('insert into rtbf_queue(subject_id, tenant, requested_at) values ($1,$2, now())', [
-    subject_id,
-    tenant,
-  ]);
-  res.status(202).json({ queued: true });
+  try {
+    const payload = rtbfRequestSchema.parse(req.body);
+    const actor = getRequestUser(req);
+
+    verifyRtbfAuthority(payload, actor);
+
+    const existing = await db.query(
+      `SELECT id, status FROM privacy_rtbf_requests
+        WHERE subject_id = $1 AND tenant = $2 AND status IN ('queued', 'processing')`,
+      [payload.subject_id, payload.tenant]
+    );
+
+    if (existing.rows.length > 0) {
+      return res.status(409).json({
+        queued: true,
+        request_id: existing.rows[0].id,
+        status: existing.rows[0].status,
+        message: 'RTBF request already in progress'
+      });
+    }
+
+    const attestationPayload = {
+      authority: payload.attestation.authority || actor.email || actor.id,
+      issued_at: payload.attestation.issued_at,
+      expires_at: payload.attestation.expires_at || null,
+      reason: payload.reason || null
+    };
+
+    const { rows } = await db.query(
+      `INSERT INTO privacy_rtbf_requests
+         (subject_id, tenant, status, requested_by, attestation_signature, attestation_issued_at,
+          attestation_payload, authority_verified_at, verified_by, retention_tier_snapshot)
+       VALUES ($1, $2, 'queued', $3, $4, $5, $6::jsonb, NOW(), $3, $7)
+       RETURNING id`,
+      [
+        payload.subject_id,
+        payload.tenant,
+        actor.id || null,
+        payload.attestation.signature,
+        payload.attestation.issued_at,
+        attestationPayload,
+        'rtbf-anonymize'
+      ]
+    );
+
+    res.status(202).json({ queued: true, request_id: rows[0].id });
+  } catch (error) {
+    const status = (error as any)?.status || 400;
+    res.status(status).json({ error: (error as Error).message });
+  }
 });
 
 export default r;

--- a/services/compliance/evidence_collector.ts
+++ b/services/compliance/evidence_collector.ts
@@ -1,21 +1,74 @@
+import crypto from 'crypto';
 import { Pool } from 'pg';
 
-const pg = new Pool({ connectionString: process.env.DATABASE_URL });
+const pgPool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 interface Evidence {
   tenant: string;
   action: string;
   subject: string;
   details: Record<string, any>;
+  resourceType?: string;
+  resourceId?: string;
+  actorId?: string;
+  ipAddress?: string;
+  userAgent?: string;
 }
 
-// This function would write to your immutable audit_log table
-// and ensure the event is anchored in the next Merkle root.
-export async function createEvidence(evidence: Evidence): Promise<void> {
-  console.log('Creating audit evidence:', evidence);
-  await pg.query(
-    'INSERT INTO audit_log (tenant, action, subject, details) VALUES ($1, $2, $3, $4)',
-    [evidence.tenant, evidence.action, evidence.subject, evidence.details],
-  );
-  console.log('Audit evidence created.');
+function computeSignature(payload: Record<string, unknown>, secret?: string): string | null {
+  if (!secret) return null;
+  const hmac = crypto.createHmac('sha256', secret);
+  hmac.update(Buffer.from(JSON.stringify(payload)));
+  return hmac.digest('hex');
 }
+
+export async function createEvidence(evidence: Evidence): Promise<{ id: string; signature: string | null }> {
+  const client = await pgPool.connect();
+
+  try {
+    const lastSignatureResult = await client.query(
+      'SELECT signature FROM audit_logs ORDER BY created_at DESC LIMIT 1'
+    );
+    const previousHash: string | null = lastSignatureResult.rows[0]?.signature || null;
+
+    const auditDetails = {
+      tenant: evidence.tenant,
+      subject: evidence.subject,
+      ...evidence.details
+    };
+
+    const signingSecret = process.env.AUDIT_SIGNING_SECRET;
+    const signaturePayload = {
+      tenant: evidence.tenant,
+      subject: evidence.subject,
+      action: evidence.action,
+      resourceType: evidence.resourceType || null,
+      resourceId: evidence.resourceId || null,
+      previousHash
+    };
+    const signature = computeSignature(signaturePayload, signingSecret);
+
+    const insertResult = await client.query(
+      `INSERT INTO audit_logs
+         (user_id, action, resource_type, resource_id, details, ip_address, user_agent, previous_hash, signature)
+       VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9)
+       RETURNING id, signature`,
+      [
+        evidence.actorId || null,
+        evidence.action,
+        evidence.resourceType || 'privacy_event',
+        evidence.resourceId || null,
+        auditDetails,
+        evidence.ipAddress || null,
+        evidence.userAgent || null,
+        previousHash,
+        signature
+      ]
+    );
+
+    return { id: insertResult.rows[0].id, signature: insertResult.rows[0].signature };
+  } finally {
+    client.release();
+  }
+}
+

--- a/services/compliance/workers/rtbf_worker.ts
+++ b/services/compliance/workers/rtbf_worker.ts
@@ -1,54 +1,200 @@
 import { Worker, Job } from 'bullmq';
 import { Pool } from 'pg';
+import { buildDerivedPolicies, DerivedRetentionPolicy } from '../../../server/src/privacy/retention';
 import { createEvidence } from './evidence_collector';
 
-const pg = new Pool({ connectionString: process.env.DATABASE_URL });
+const pgPool = new Pool({ connectionString: process.env.DATABASE_URL });
 
-// This is a mock worker. In a real implementation, this would:
-// 1. Fan out requests to all data stores (Postgres, Neo4j, S3, etc.) to find and tombstone data.
-// 2. Use an auditable, two-phase commit process.
-// 3. Ensure that data is anonymized or deleted according to the defined policy.
+const subjectPolicies = buildDerivedPolicies().filter(policy => Boolean(policy.subjectKey));
+
+function generateAnonymizedValues(policy: DerivedRetentionPolicy, recordId: string): Record<string, string> {
+  const token = recordId.replace(/-/g, '').slice(0, 16);
+  const values: Record<string, string> = {};
+  for (const field of policy.anonymizeFields) {
+    const lower = field.toLowerCase();
+    if (lower.includes('email')) {
+      values[field] = `anonymized+${token}@privacy.invalid`;
+    } else if (lower.includes('username') || lower.includes('user')) {
+      values[field] = `anon_${token}`;
+    } else if (lower.includes('name')) {
+      values[field] = 'Redacted';
+    } else {
+      values[field] = '[REDACTED]';
+    }
+  }
+  return values;
+}
+
+async function insertTombstones(
+  policy: DerivedRetentionPolicy,
+  recordIds: string[],
+  requestId: string,
+  action: 'delete' | 'anonymize'
+): Promise<void> {
+  if (recordIds.length === 0) return;
+
+  await pgPool.query(
+    `INSERT INTO privacy_tombstones (table_name, primary_key_column, record_id, action, rtbf_request_id, metadata)
+     SELECT $1, $2, UNNEST($3::text[]), $4, $5::uuid, $6::jsonb
+     ON CONFLICT (table_name, primary_key_column, record_id)
+     DO UPDATE SET
+       action = EXCLUDED.action,
+       rtbf_request_id = EXCLUDED.rtbf_request_id,
+       metadata = privacy_tombstones.metadata || EXCLUDED.metadata,
+       created_at = NOW()`,
+    [
+      policy.tableName,
+      policy.primaryKeyColumn,
+      recordIds,
+      action,
+      requestId,
+      JSON.stringify({ trigger: 'rtbf', retentionTier: policy.retentionTier })
+    ]
+  );
+}
+
+async function processPolicyForSubject(
+  policy: DerivedRetentionPolicy,
+  subjectId: string,
+  requestId: string
+): Promise<{ policy: string; action: string; affected: number }> {
+  if (!policy.subjectKey) {
+    return { policy: policy.name, action: policy.action, affected: 0 };
+  }
+
+  if (policy.action === 'anonymize' && policy.anonymizeFields.length === 0) {
+    return { policy: policy.name, action: policy.action, affected: 0 };
+  }
+
+  if (policy.action === 'anonymize') {
+    const anonymizedValues = generateAnonymizedValues(policy, subjectId);
+    const assignments: string[] = [];
+    const values: unknown[] = [subjectId];
+    let placeholder = 2;
+
+    for (const [column, value] of Object.entries(anonymizedValues)) {
+      assignments.push(`${column} = $${placeholder}`);
+      values.push(value);
+      placeholder++;
+    }
+
+    if (policy.labelColumn) {
+      assignments.push(`${policy.labelColumn} = 'rtbf-anonymize'`);
+    }
+    if (policy.expiresColumn) {
+      assignments.push(`${policy.expiresColumn} = NULL`);
+    }
+    if (policy.tombstoneColumn) {
+      assignments.push(`${policy.tombstoneColumn} = COALESCE(${policy.tombstoneColumn}, NOW())`);
+    }
+
+    assignments.push(`updated_at = NOW()`);
+
+    const updateResult = await pgPool.query(
+      `UPDATE ${policy.tableName}
+          SET ${assignments.join(', ')}
+        WHERE ${policy.subjectKey}::text = $1
+        RETURNING ${policy.primaryKeyColumn}::text AS id`,
+      values
+    );
+
+    const ids = updateResult.rows.map(row => row.id as string);
+    await insertTombstones(policy, ids, requestId, 'anonymize');
+    return { policy: policy.name, action: 'anonymize', affected: ids.length };
+  }
+
+  const deleteResult = await pgPool.query(
+    `DELETE FROM ${policy.tableName}
+      WHERE ${policy.subjectKey}::text = $1
+      RETURNING ${policy.primaryKeyColumn}::text AS id`,
+    [subjectId]
+  );
+
+  const ids = deleteResult.rows.map(row => row.id as string);
+  await insertTombstones(policy, ids, requestId, 'delete');
+  return { policy: policy.name, action: 'delete', affected: ids.length };
+}
 
 const rtbfWorker = new Worker(
   'rtbf_queue',
   async (job: Job) => {
-    const { subject_id, tenant } = job.data;
+    const { subject_id, tenant, request_id } = job.data;
     console.log(`Processing RTBF request for subject ${subject_id}`);
 
-    try {
-      // 1. Simulate finding and tombstoning data in various systems
-      await new Promise((res) => setTimeout(res, 3000));
-      const systemsChecked = ['postgres', 'neo4j', 's3-artifacts'];
-      console.log(`Tombstoned data for ${subject_id} in ${systemsChecked.join(', ')}`);
+    const client = await pgPool.connect();
 
-      // 2. Update request status to 'completed'
-      await pg.query(
-        "UPDATE rtbf_queue SET status = 'completed', completed_at = now() WHERE subject_id = $1 AND tenant = $2",
-        [subject_id, tenant],
+    try {
+      const requestResult = request_id
+        ? await client.query('SELECT * FROM privacy_rtbf_requests WHERE id = $1', [request_id])
+        : await client.query(
+            `SELECT * FROM privacy_rtbf_requests
+               WHERE subject_id = $1 AND tenant = $2
+               ORDER BY requested_at DESC LIMIT 1`,
+            [subject_id, tenant]
+          );
+
+      if (requestResult.rows.length === 0) {
+        throw new Error('RTBF request not found');
+      }
+
+      const request = requestResult.rows[0];
+
+      await client.query(
+        `UPDATE privacy_rtbf_requests
+            SET status = 'processing', processed_at = NULL
+          WHERE id = $1`,
+        [request.id]
       );
 
-      // 3. Create audit evidence
-      await createEvidence({
+      const outcomes: { policy: string; action: string; affected: number }[] = [];
+      for (const policy of subjectPolicies) {
+        const outcome = await processPolicyForSubject(policy, subject_id, request.id);
+        outcomes.push(outcome);
+      }
+
+      const evidence = await createEvidence({
         tenant,
         action: 'rtbf_request_completed',
         subject: subject_id,
-        details: { systemsChecked },
+        resourceType: 'privacy_rtbf_request',
+        resourceId: request.id,
+        actorId: request.requested_by || undefined,
+        details: {
+          outcomes,
+          requestId: request.id,
+          tenant
+        }
       });
 
+      await client.query(
+        `UPDATE privacy_rtbf_requests
+            SET status = 'completed',
+                processed_at = NOW(),
+                result = $2::jsonb,
+                audit_reference = $3
+          WHERE id = $1`,
+        [request.id, { outcomes }, evidence.signature]
+      );
+
       console.log(`Successfully completed RTBF request for ${subject_id}`);
-      return { success: true };
+      return { success: true, outcomes };
     } catch (error) {
       console.error(`Failed to process RTBF request for ${subject_id}:`, error);
-      await pg.query(
-        "UPDATE rtbf_queue SET status = 'failed' WHERE subject_id = $1 AND tenant = $2",
-        [subject_id, tenant],
+      await client.query(
+        `UPDATE privacy_rtbf_requests
+            SET status = 'failed',
+                result = jsonb_build_object('error', $2)
+          WHERE subject_id = $1 AND status <> 'completed'`,
+        [subject_id, (error as Error).message]
       );
       throw error;
+    } finally {
+      client.release();
     }
   },
   {
-    connection: { host: process.env.REDIS_HOST, port: parseInt(process.env.REDIS_PORT || '6379') },
-  },
+    connection: { host: process.env.REDIS_HOST, port: parseInt(process.env.REDIS_PORT || '6379', 10) },
+  }
 );
 
 console.log('RTBF worker started.');


### PR DESCRIPTION
## Summary
- introduce a retention policy pack and entity metadata so short- and standard-tier data can be tagged with labels and anonymization fields
- overhaul the retention job to derive policies, log outcomes in privacy_retention_job_runs, and populate privacy_tombstones for deletions and anonymization
- add database schema support (columns, audit tables, tombstones), RTBF attestation validation, signed audit evidence, and stronger restore checks for tombstoned data

## Testing
- npm test -- --runTestsByPath server/src/privacy/__tests__/retention.test.ts *(fails: workspace packages missing node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d74ffbc4ac8333a3316e78452a02b4