### PR TITLE
feat: add public GraphQL contracts

### DIFF
--- a/server/src/graphql/contracts/index.ts
+++ b/server/src/graphql/contracts/index.ts
@@ -1,0 +1,8 @@
+export { contractsTypeDefs } from './typeDefs';
+export { contractsResolvers } from './resolvers';
+export {
+  publicPersistedOperations,
+  publicPersistedOperationMap,
+  getPublicPersistedOperation,
+  listPublicPersistedOperations,
+} from './persisted-queries';

--- a/server/src/graphql/contracts/persisted-queries.ts
+++ b/server/src/graphql/contracts/persisted-queries.ts
@@ -1,0 +1,329 @@
+import crypto from 'crypto';
+
+export type OperationType = 'query' | 'mutation' | 'subscription';
+
+export interface PersistedOperationCost {
+  complexity: number;
+  estimatedMs: number;
+  targetSLOMs: number;
+}
+
+export interface PublicPersistedOperation {
+  id: string;
+  operationName: string;
+  operationType: OperationType;
+  document: string;
+  sha256Hash: string;
+  description: string;
+  cost: PersistedOperationCost;
+}
+
+function normalize(document: string): string {
+  return document.replace(/\s+/g, ' ').trim();
+}
+
+function hash(document: string): string {
+  return crypto.createHash('sha256').update(normalize(document)).digest('hex');
+}
+
+const rawOperations: Array<Omit<PublicPersistedOperation, 'sha256Hash' | 'id'>> = [
+  {
+    operationName: 'PublicEntityById',
+    operationType: 'query',
+    description: 'Fetch a single entity with policy envelope and diagnostics.',
+    document: `
+      query PublicEntityById($id: ID!, $backpressure: BackpressureInput) {
+        publicEntity(id: $id, backpressure: $backpressure) {
+          entity {
+            id
+            tenantId
+            kind
+            labels
+            confidence
+            degree
+            createdAt
+            updatedAt
+            retentionClass
+            geographicScope
+            investigation {
+              id
+              status
+              ownerId
+            }
+          }
+          policy {
+            allow
+            reason
+          }
+          diagnostics {
+            durationMs
+            estimatedCostMs
+            sloTargetMs
+          }
+          errors {
+            code
+            message
+            retryable
+          }
+        }
+      }
+    `,
+    cost: { complexity: 45, estimatedMs: 120, targetSLOMs: 350 },
+  },
+  {
+    operationName: 'PublicEntitySearch',
+    operationType: 'query',
+    description: 'List entities for a tenant using canonical pagination.',
+    document: `
+      query PublicEntitySearch($filter: PublicEntityFilter!, $pagination: PaginationInput, $sort: PublicEntitySort) {
+        publicEntities(filter: $filter, pagination: $pagination, sort: $sort) {
+          nodes {
+            id
+            kind
+            labels
+            confidence
+            updatedAt
+          }
+          edges {
+            cursor
+            node {
+              id
+              kind
+              properties
+            }
+            policy {
+              allow
+            }
+          }
+          totalCount
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          diagnostics {
+            durationMs
+            estimatedCostMs
+            sloTargetMs
+          }
+        }
+      }
+    `,
+    cost: { complexity: 120, estimatedMs: 220, targetSLOMs: 350 },
+  },
+  {
+    operationName: 'PublicRelationshipListing',
+    operationType: 'query',
+    description: 'List relationships for an entity with policy metadata.',
+    document: `
+      query PublicRelationshipListing($filter: PublicRelationshipFilter!, $pagination: PaginationInput) {
+        publicRelationships(filter: $filter, pagination: $pagination) {
+          nodes {
+            id
+            type
+            confidence
+            createdAt
+            source { id kind }
+            target { id kind }
+          }
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          diagnostics { durationMs estimatedCostMs }
+        }
+      }
+    `,
+    cost: { complexity: 95, estimatedMs: 210, targetSLOMs: 350 },
+  },
+  {
+    operationName: 'PublicInvestigations',
+    operationType: 'query',
+    description: 'Retrieve investigations for a tenant including counts.',
+    document: `
+      query PublicInvestigations($filter: PublicInvestigationFilter!, $pagination: PaginationInput) {
+        publicInvestigations(filter: $filter, pagination: $pagination) {
+          nodes {
+            id
+            name
+            status
+            priority
+            entityCount
+            relationshipCount
+          }
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          diagnostics { durationMs estimatedCostMs }
+        }
+      }
+    `,
+    cost: { complexity: 80, estimatedMs: 180, targetSLOMs: 350 },
+  },
+  {
+    operationName: 'PublicInvestigationTimeline',
+    operationType: 'query',
+    description: 'Fetch investigation timeline events for audit parity.',
+    document: `
+      query PublicInvestigationTimeline($filter: PublicTimelineFilter!, $pagination: PaginationInput) {
+        publicInvestigationTimeline(filter: $filter, pagination: $pagination) {
+          nodes {
+            id
+            kind
+            occurredAt
+            actorId
+            payload
+          }
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          errors { code message }
+        }
+      }
+    `,
+    cost: { complexity: 70, estimatedMs: 160, targetSLOMs: 350 },
+  },
+  {
+    operationName: 'PublicEntityNeighborhood',
+    operationType: 'query',
+    description: 'Graph traversal bootstrap around an entity node.',
+    document: `
+      query PublicEntityNeighborhood($input: PublicNeighborhoodInput!) {
+        publicEntityNeighborhood(input: $input) {
+          center { id kind }
+          entities { id kind labels }
+          relationships { id type source { id } target { id } }
+          backpressure { throttleSeconds recommendedPageSize }
+          errors { code message }
+        }
+      }
+    `,
+    cost: { complexity: 200, estimatedMs: 320, targetSLOMs: 350 },
+  },
+  {
+    operationName: 'PublicUpsertEntity',
+    operationType: 'mutation',
+    description: 'Create or update an entity with ABAC validation.',
+    document: `
+      mutation PublicUpsertEntity($input: PublicUpsertEntityInput!) {
+        publicUpsertEntity(input: $input) {
+          ok
+          policy { allow reason }
+          diagnostics { durationMs estimatedCostMs sloTargetMs }
+          errors { code message retryable }
+        }
+      }
+    `,
+    cost: { complexity: 110, estimatedMs: 420, targetSLOMs: 700 },
+  },
+  {
+    operationName: 'PublicLinkEntities',
+    operationType: 'mutation',
+    description: 'Create a relationship between two entities.',
+    document: `
+      mutation PublicLinkEntities($input: PublicLinkEntitiesInput!) {
+        publicLinkEntities(input: $input) {
+          ok
+          diagnostics { durationMs estimatedCostMs }
+          errors { code message }
+        }
+      }
+    `,
+    cost: { complexity: 95, estimatedMs: 480, targetSLOMs: 700 },
+  },
+  {
+    operationName: 'PublicAddInvestigationNote',
+    operationType: 'mutation',
+    description: 'Append an operator note to an investigation.',
+    document: `
+      mutation PublicAddInvestigationNote($input: PublicAddInvestigationNoteInput!) {
+        publicAddInvestigationNote(input: $input) {
+          ok
+          errors { code message }
+          diagnostics { durationMs estimatedCostMs }
+        }
+      }
+    `,
+    cost: { complexity: 60, estimatedMs: 260, targetSLOMs: 700 },
+  },
+  {
+    operationName: 'PublicAcknowledgeInvestigation',
+    operationType: 'mutation',
+    description: 'Update investigation lifecycle state with audit trail.',
+    document: `
+      mutation PublicAcknowledgeInvestigation($input: PublicAcknowledgeInvestigationInput!) {
+        publicAcknowledgeInvestigation(input: $input) {
+          ok
+          errors { code message }
+          diagnostics { durationMs estimatedCostMs }
+        }
+      }
+    `,
+    cost: { complexity: 70, estimatedMs: 280, targetSLOMs: 700 },
+  },
+  {
+    operationName: 'PublicBatchIngestEntities',
+    operationType: 'mutation',
+    description: 'Batch ingest entities with backpressure-friendly metrics.',
+    document: `
+      mutation PublicBatchIngestEntities($input: [PublicUpsertEntityInput!]!, $options: PublicBatchOptions) {
+        publicBatchIngestEntities(input: $input, options: $options) {
+          ok
+          accepted
+          failed
+          failures {
+            input { tenantId kind }
+            errors { code message }
+          }
+          diagnostics { durationMs estimatedCostMs }
+        }
+      }
+    `,
+    cost: { complexity: 240, estimatedMs: 640, targetSLOMs: 700 },
+  },
+  {
+    operationName: 'PublicInvestigationsSubscription',
+    operationType: 'subscription',
+    description: 'Subscribe to investigation events for a tenant.',
+    document: `
+      subscription PublicInvestigationsSubscription($investigationId: ID!, $tenantId: String!) {
+        publicInvestigationEvents(investigationId: $investigationId, tenantId: $tenantId) {
+          id
+          kind
+          occurredAt
+          payload
+        }
+      }
+    `,
+    cost: { complexity: 40, estimatedMs: 120, targetSLOMs: 250 },
+  },
+];
+
+export const publicPersistedOperations: PublicPersistedOperation[] = rawOperations.map((operation) => {
+  const sha256Hash = hash(operation.document);
+  return {
+    ...operation,
+    sha256Hash,
+    id: sha256Hash,
+  };
+});
+
+export const publicPersistedOperationMap = new Map<string, PublicPersistedOperation>(
+  publicPersistedOperations.map((operation) => [operation.sha256Hash, operation]),
+);
+
+export function getPublicPersistedOperation(id: string): PublicPersistedOperation | undefined {
+  return publicPersistedOperationMap.get(id) ??
+    publicPersistedOperations.find((operation) => operation.operationName === id);
+}
+
+export function listPublicPersistedOperations(): Array<{
+  sha256Hash: string;
+  operationName: string;
+  operationType: OperationType;
+  cost: PersistedOperationCost;
+}> {
+  return publicPersistedOperations.map(({ sha256Hash, operationName, operationType, cost }) => ({
+    sha256Hash,
+    operationName,
+    operationType,
+    cost,
+  }));
+}
+
+export default publicPersistedOperations;

--- a/server/src/graphql/contracts/resolvers.ts
+++ b/server/src/graphql/contracts/resolvers.ts
@@ -1,0 +1,1032 @@
+import { trace, Span } from '@opentelemetry/api';
+import type { GraphQLResolveInfo } from 'graphql';
+import { getPostgresPool } from '../../db/postgres.js';
+import { getNeo4jDriver } from '../../db/neo4j.js';
+import { EntityRepo, type Entity } from '../../repos/EntityRepo.js';
+import { RelationshipRepo, type Relationship } from '../../repos/RelationshipRepo.js';
+import { InvestigationRepo, type Investigation } from '../../repos/InvestigationRepo.js';
+import {
+  withAuthAndPolicy,
+  entityResource,
+  investigationResource,
+} from '../../middleware/withAuthAndPolicy.js';
+
+const tracer = trace.getTracer('public-graphql-contracts');
+
+const pg = getPostgresPool();
+const neo4j = getNeo4jDriver();
+const entityRepo = new EntityRepo(pg, neo4j);
+const relationshipRepo = new RelationshipRepo(pg, neo4j);
+const investigationRepo = new InvestigationRepo(pg);
+
+const READ_SLO = 350;
+const WRITE_SLO = 700;
+const SUBSCRIPTION_SLO = 250;
+
+interface ContractsUser {
+  id: string;
+  tenantId?: string;
+  orgId?: string;
+  teamId?: string;
+  roles?: string[];
+}
+
+interface PolicyEvaluator {
+  evaluate?: (policy: string, input: any) => Promise<any>;
+}
+
+export interface ContractsContext {
+  user?: ContractsUser;
+  req?: { headers?: Record<string, string>; ip?: string };
+  opa?: PolicyEvaluator;
+  neo4j?: ReturnType<typeof getNeo4jDriver>;
+  postgres?: ReturnType<typeof getPostgresPool>;
+}
+
+type ResolverDiagnostics = {
+  fromCache: boolean;
+  lastEvaluatedAt: string;
+  durationMs: number;
+  attempts: number;
+  estimatedCostMs: number;
+  sloTargetMs: number;
+};
+
+type PolicyDecision = {
+  allow: boolean;
+  reason?: string;
+  obligations: string[];
+};
+
+type PublicError = {
+  code: string;
+  message: string;
+  field?: string;
+  retryable: boolean;
+  context?: Record<string, unknown>;
+};
+
+type PublicEntityResult = {
+  entity: ReturnType<typeof toPublicEntity> | null;
+  policy: PolicyDecision;
+  diagnostics: ResolverDiagnostics;
+  errors: PublicError[];
+};
+
+type PublicMutationResult = {
+  ok: boolean;
+  policy: PolicyDecision;
+  diagnostics: ResolverDiagnostics;
+  errors: PublicError[];
+};
+
+function diagnostics(start: number, estimatedMs: number, slo: number): ResolverDiagnostics {
+  return {
+    fromCache: false,
+    lastEvaluatedAt: new Date().toISOString(),
+    durationMs: Math.max(1, Date.now() - start),
+    attempts: 1,
+    estimatedCostMs: estimatedMs,
+    sloTargetMs: slo,
+  };
+}
+
+async function evaluatePolicy(
+  context: ContractsContext,
+  span: Span,
+  action: string,
+  resource: Record<string, unknown>,
+): Promise<PolicyDecision> {
+  const decision: PolicyDecision = {
+    allow: true,
+    obligations: [],
+  };
+
+  if (!context.user) {
+    decision.allow = false;
+    decision.reason = 'unauthenticated';
+    return decision;
+  }
+
+  try {
+    const input = {
+      action,
+      resource,
+      user: context.user,
+    };
+
+    if (context.opa?.evaluate) {
+      const opaResult = await context.opa.evaluate('contracts/allow', input);
+      if (typeof opaResult === 'boolean') {
+        decision.allow = opaResult;
+      } else if (opaResult) {
+        decision.allow = Boolean(opaResult.allow ?? opaResult.result?.allow ?? true);
+        decision.reason = opaResult.reason || opaResult.result?.reason;
+        decision.obligations = opaResult.obligations || opaResult.result?.obligations || [];
+      }
+    }
+  } catch (error) {
+    decision.allow = false;
+    decision.reason = (error as Error).message;
+    decision.obligations = [];
+    span.recordException(error as Error);
+  }
+
+  span.setAttributes({
+    'opa.allow': decision.allow,
+    'opa.reason': decision.reason ?? 'n/a',
+    'opa.obligations.count': decision.obligations.length,
+  });
+
+  return decision;
+}
+
+async function loadInvestigationSummary(
+  investigationId: string | undefined,
+  tenantId: string | undefined,
+): Promise<ReturnType<typeof toPublicInvestigationSummary> | null> {
+  if (!investigationId || !tenantId) {
+    return null;
+  }
+  const investigation = await investigationRepo.findById(investigationId, tenantId);
+  return investigation ? toPublicInvestigationSummary(investigation) : null;
+}
+
+function toPublicInvestigationSummary(investigation: Investigation) {
+  return {
+    id: investigation.id,
+    name: investigation.name,
+    status: investigation.status.toUpperCase(),
+    priority: (investigation.props as any)?.priority ?? null,
+    ownerId: investigation.createdBy,
+  };
+}
+
+function toPublicInvestigation(investigation: Investigation) {
+  const props = (investigation.props ?? {}) as Record<string, any>;
+  return {
+    id: investigation.id,
+    tenantId: investigation.tenantId,
+    name: investigation.name,
+    description: investigation.description ?? null,
+    status: investigation.status.toUpperCase(),
+    priority: props.priority ?? null,
+    ownerId: investigation.createdBy,
+    tags: props.tags ?? [],
+    props,
+    createdAt: investigation.createdAt.toISOString(),
+    updatedAt: investigation.updatedAt.toISOString(),
+    entityCount: props.entityCount ?? 0,
+    relationshipCount: props.relationshipCount ?? 0,
+  };
+}
+
+function toPublicEntity(entity: Entity) {
+  const props = (entity.props ?? {}) as Record<string, any>;
+  return {
+    id: entity.id,
+    tenantId: entity.tenantId,
+    kind: entity.kind,
+    labels: entity.labels,
+    properties: entity.props,
+    confidence: typeof props.confidence === 'number' ? props.confidence : null,
+    degree: typeof props.degree === 'number' ? props.degree : null,
+    createdAt: entity.createdAt.toISOString(),
+    updatedAt: entity.updatedAt.toISOString(),
+    lastIngestedAt: props.lastIngestedAt ?? null,
+    retentionClass: props.retentionClass ?? props.retentionTier ?? null,
+    geographicScope: props.geographicScope ?? props.region ?? null,
+    piiTags: Array.isArray(props.piiTags) ? props.piiTags : [],
+    sourceSystems: Array.isArray(props.sourceSystems) ? props.sourceSystems : [],
+    investigation: props.investigationId
+      ? {
+          id: props.investigationId,
+          name: props.investigationName ?? 'Investigation',
+          status: (props.investigationStatus ?? 'ACTIVE').toString().toUpperCase(),
+          priority: props.priority ?? null,
+          ownerId: props.ownerId ?? null,
+        }
+      : null,
+  };
+}
+
+async function toPublicRelationship(
+  relationship: Relationship,
+  tenantId: string | undefined,
+): Promise<{
+  id: string;
+  tenantId: string;
+  type: string;
+  properties: Record<string, any>;
+  confidence: number | null;
+  createdAt: string;
+  updatedAt: string;
+  source: ReturnType<typeof toPublicEntity> | null;
+  target: ReturnType<typeof toPublicEntity> | null;
+}> {
+  const props = (relationship.props ?? {}) as Record<string, any>;
+  const source = await entityRepo.findById(relationship.srcId, tenantId || relationship.tenantId);
+  const target = await entityRepo.findById(relationship.dstId, tenantId || relationship.tenantId);
+
+  return {
+    id: relationship.id,
+    tenantId: relationship.tenantId,
+    type: relationship.type,
+    properties: relationship.props,
+    confidence: typeof props.confidence === 'number' ? props.confidence : null,
+    createdAt: relationship.createdAt.toISOString(),
+    updatedAt: relationship.updatedAt.toISOString(),
+    source: source ? toPublicEntity(source) : null,
+    target: target ? toPublicEntity(target) : null,
+  };
+}
+
+function mapPolicyDenied(decision: PolicyDecision, slo: number): PublicError {
+  return {
+    code: 'POLICY_DENIED',
+    message: decision.reason ?? 'Operation denied by policy',
+    retryable: false,
+    context: { slo },
+  };
+}
+
+function mapNotFound(type: string, id: string): PublicError {
+  return {
+    code: `${type.toUpperCase()}_NOT_FOUND`,
+    message: `${type} ${id} not found`,
+    field: 'id',
+    retryable: false,
+  };
+}
+
+function mapNotImplemented(operation: string, slo: number): PublicError {
+  return {
+    code: 'NOT_IMPLEMENTED',
+    message: `${operation} is not yet implemented`,
+    retryable: false,
+    context: { slo },
+  };
+}
+
+function withSpan<TResult>(
+  name: string,
+  resolver: (span: Span) => Promise<TResult>,
+): Promise<TResult> {
+  return tracer.startActiveSpan(name, async (span) => {
+    span.setAttributes({ 'graphql.resolver': name });
+    try {
+      const result = await resolver(span);
+      span.setStatus({ code: 1 });
+      return result;
+    } catch (error) {
+      span.recordException(error as Error);
+      span.setStatus({ code: 2, message: (error as Error).message });
+      throw error;
+    } finally {
+      span.end();
+    }
+  });
+}
+
+export const contractsResolvers = {
+  Query: {
+    publicEntity: withAuthAndPolicy('read:entity', (args: { id: string }, context: ContractsContext) =>
+      entityResource(args.id, undefined, context.user?.orgId, context.user?.teamId),
+    )(async (_parent, args: { id: string; backpressure?: any }, context: ContractsContext, info: GraphQLResolveInfo) => {
+      const start = Date.now();
+      return withSpan('contracts.publicEntity', async (span) => {
+        span.setAttributes({
+          'graphql.field': info.fieldName,
+          'entity.id': args.id,
+          'tenant.id': context.user?.tenantId ?? 'unknown',
+        });
+
+        const policy = await evaluatePolicy(context, span, 'read:entity', {
+          type: 'entity',
+          id: args.id,
+          tenantId: context.user?.tenantId,
+        });
+
+        if (!policy.allow) {
+          return {
+            entity: null,
+            policy,
+            diagnostics: diagnostics(start, 120, READ_SLO),
+            errors: [mapPolicyDenied(policy, READ_SLO)],
+          } satisfies PublicEntityResult;
+        }
+
+        const entity = await entityRepo.findById(args.id, context.user?.tenantId);
+        if (!entity) {
+          return {
+            entity: null,
+            policy,
+            diagnostics: diagnostics(start, 120, READ_SLO),
+            errors: [mapNotFound('entity', args.id)],
+          } satisfies PublicEntityResult;
+        }
+
+        const enriched = toPublicEntity(entity);
+        if (entity.props?.investigationId) {
+          enriched.investigation =
+            (await loadInvestigationSummary(entity.props.investigationId, entity.tenantId)) ??
+            enriched.investigation;
+        }
+
+        return {
+          entity: enriched,
+          policy,
+          diagnostics: diagnostics(start, 120, READ_SLO),
+          errors: [],
+        } satisfies PublicEntityResult;
+      });
+    }),
+
+    publicEntities: withAuthAndPolicy(
+      'read:entities',
+      (args: { filter: { tenantId: string; investigationId?: string } }, context: ContractsContext) =>
+        entityResource('collection', args.filter?.investigationId, context.user?.orgId, context.user?.teamId),
+    )(async (
+      _parent,
+      args: {
+        filter: {
+          tenantId: string;
+          ids?: string[];
+          kinds?: string[];
+          investigationId?: string;
+          sourceSystems?: string[];
+        };
+        pagination?: { first?: number; after?: string };
+        sort?: { field: string; direction?: string };
+        backpressure?: { maxWindowMs?: number };
+      },
+      context: ContractsContext,
+      info: GraphQLResolveInfo,
+    ) => {
+      const start = Date.now();
+      return withSpan('contracts.publicEntities', async (span) => {
+        span.setAttributes({
+          'graphql.field': info.fieldName,
+          'tenant.id': args.filter.tenantId,
+          'filter.kinds': (args.filter.kinds ?? []).join(','),
+        });
+
+        const policy = await evaluatePolicy(context, span, 'read:entities', {
+          type: 'entity_collection',
+          tenantId: args.filter.tenantId,
+          investigationId: args.filter.investigationId,
+        });
+
+        if (!policy.allow) {
+          return {
+            nodes: [],
+            edges: [],
+            totalCount: 0,
+            pageInfo: { hasNextPage: false, endCursor: null, throttleUntil: null },
+            backpressure: null,
+            policy,
+            diagnostics: diagnostics(start, 220, READ_SLO),
+            errors: [mapPolicyDenied(policy, READ_SLO)],
+          };
+        }
+
+        const tenantId = args.filter.tenantId;
+        const limit = Math.min(Math.max(args.pagination?.first ?? 25, 1), 200);
+        const offset = args.pagination?.after ? Number(args.pagination.after) || 0 : 0;
+
+        let entities: Entity[] = [];
+        if (args.filter.ids && args.filter.ids.length > 0) {
+          const batch = await entityRepo.batchByIds(args.filter.ids, tenantId);
+          entities = batch.filter((item): item is Entity => Boolean(item));
+        } else {
+          const props: Record<string, unknown> = {};
+          if (args.filter.investigationId) {
+            props.investigationId = args.filter.investigationId;
+          }
+          if (args.filter.sourceSystems?.length) {
+            props.sourceSystems = args.filter.sourceSystems;
+          }
+          entities = await entityRepo.search({
+            tenantId,
+            kind: args.filter.kinds?.[0],
+            props,
+            limit,
+            offset,
+          });
+        }
+
+        const nodes = await Promise.all(
+          entities.map(async (entity) => {
+            const mapped = toPublicEntity(entity);
+            if (entity.props?.investigationId) {
+              mapped.investigation =
+                (await loadInvestigationSummary(entity.props.investigationId, entity.tenantId)) ??
+                mapped.investigation;
+            }
+            return mapped;
+          }),
+        );
+
+        const edges = nodes.map((node) => ({
+          cursor: node.id,
+          node,
+          policy,
+        }));
+
+        return {
+          nodes,
+          edges,
+          totalCount: nodes.length,
+          pageInfo: {
+            hasNextPage: nodes.length === limit,
+            endCursor: nodes.length ? nodes[nodes.length - 1].id : null,
+            throttleUntil: null,
+          },
+          backpressure: args.backpressure
+            ? {
+                throttleSeconds: Math.max(0, Math.floor((args.backpressure.clientLagMs ?? 0) / 1000)),
+                recommendedPageSize: Math.min(limit, 100),
+                reason: 'client-signaled',
+              }
+            : null,
+          policy,
+          diagnostics: diagnostics(start, 220, READ_SLO),
+          errors: [],
+        };
+      });
+    }),
+
+    publicRelationships: withAuthAndPolicy(
+      'read:relationships',
+      (args: { filter: { tenantId: string; entityId?: string } }, context: ContractsContext) =>
+        entityResource(args.filter.entityId ?? 'collection', undefined, context.user?.orgId, context.user?.teamId),
+    )(async (
+      _parent,
+      args: {
+        filter: { tenantId: string; entityId?: string; types?: string[]; direction?: string };
+        pagination?: { first?: number; after?: string };
+        backpressure?: { maxWindowMs?: number };
+      },
+      context: ContractsContext,
+      info: GraphQLResolveInfo,
+    ) => {
+      const start = Date.now();
+      return withSpan('contracts.publicRelationships', async (span) => {
+        span.setAttributes({
+          'graphql.field': info.fieldName,
+          'tenant.id': args.filter.tenantId,
+          'entity.id': args.filter.entityId ?? 'n/a',
+        });
+
+        const policy = await evaluatePolicy(context, span, 'read:relationships', {
+          type: 'relationship_collection',
+          tenantId: args.filter.tenantId,
+          entityId: args.filter.entityId,
+        });
+
+        if (!policy.allow) {
+          return {
+            nodes: [],
+            edges: [],
+            totalCount: 0,
+            pageInfo: { hasNextPage: false, endCursor: null, throttleUntil: null },
+            backpressure: null,
+            policy,
+            diagnostics: diagnostics(start, 210, READ_SLO),
+            errors: [mapPolicyDenied(policy, READ_SLO)],
+          };
+        }
+
+        const limit = Math.min(Math.max(args.pagination?.first ?? 25, 1), 200);
+        const offset = args.pagination?.after ? Number(args.pagination.after) || 0 : 0;
+
+        let relationships: Relationship[] = [];
+        if (args.filter.entityId) {
+          const directionMap: Record<string, 'incoming' | 'outgoing' | 'both'> = {
+            INBOUND: 'incoming',
+            OUTBOUND: 'outgoing',
+            BIDIRECTIONAL: 'both',
+          };
+          relationships = await relationshipRepo.findByEntityId(
+            args.filter.entityId,
+            args.filter.tenantId,
+            directionMap[args.filter.direction ?? 'BIDIRECTIONAL'] ?? 'both',
+          );
+        } else {
+          relationships = await relationshipRepo.search({
+            tenantId: args.filter.tenantId,
+            type: args.filter.types?.[0],
+            limit,
+            offset,
+          });
+        }
+
+        const nodes = await Promise.all(
+          relationships.slice(0, limit).map((relationship) =>
+            toPublicRelationship(relationship, args.filter.tenantId),
+          ),
+        );
+
+        const edges = nodes.map((node) => ({ cursor: node?.id ?? '', node, policy }));
+
+        return {
+          nodes,
+          edges,
+          totalCount: nodes.length,
+          pageInfo: {
+            hasNextPage: relationships.length > limit,
+            endCursor: nodes.length ? nodes[nodes.length - 1]?.id ?? null : null,
+            throttleUntil: null,
+          },
+          backpressure: args.backpressure
+            ? {
+                throttleSeconds: Math.max(0, Math.floor((args.backpressure.maxWindowMs ?? 0) / 1000)),
+                recommendedPageSize: Math.min(limit, 100),
+                reason: 'window-saturated',
+              }
+            : null,
+          policy,
+          diagnostics: diagnostics(start, 210, READ_SLO),
+          errors: [],
+        };
+      });
+    }),
+
+    publicInvestigations: withAuthAndPolicy(
+      'read:investigations',
+      (args: { filter: { tenantId: string } }, context: ContractsContext) =>
+        investigationResource('collection', context.user?.orgId, context.user?.teamId),
+    )(async (
+      _parent,
+      args: { filter: { tenantId: string; status?: string[] }; pagination?: { first?: number; after?: string } },
+      context: ContractsContext,
+      info: GraphQLResolveInfo,
+    ) => {
+      const start = Date.now();
+      return withSpan('contracts.publicInvestigations', async (span) => {
+        span.setAttributes({
+          'graphql.field': info.fieldName,
+          'tenant.id': args.filter.tenantId,
+        });
+
+        const policy = await evaluatePolicy(context, span, 'read:investigations', {
+          type: 'investigation_collection',
+          tenantId: args.filter.tenantId,
+        });
+
+        if (!policy.allow) {
+          return {
+            nodes: [],
+            edges: [],
+            totalCount: 0,
+            pageInfo: { hasNextPage: false, endCursor: null, throttleUntil: null },
+            backpressure: null,
+            policy,
+            diagnostics: diagnostics(start, 180, READ_SLO),
+            errors: [mapPolicyDenied(policy, READ_SLO)],
+          };
+        }
+
+        const limit = Math.min(Math.max(args.pagination?.first ?? 25, 1), 100);
+        const offset = args.pagination?.after ? Number(args.pagination.after) || 0 : 0;
+        const [firstStatus] = args.filter.status ?? [];
+
+        const investigations = await investigationRepo.list({
+          tenantId: args.filter.tenantId,
+          status: firstStatus?.toLowerCase(),
+          limit,
+          offset,
+        });
+
+        const nodes = investigations.map(toPublicInvestigation);
+        const edges = nodes.map((node) => ({ cursor: node.id, node, policy }));
+
+        return {
+          nodes,
+          edges,
+          totalCount: nodes.length,
+          pageInfo: {
+            hasNextPage: investigations.length === limit,
+            endCursor: nodes.length ? nodes[nodes.length - 1].id : null,
+            throttleUntil: null,
+          },
+          backpressure: null,
+          policy,
+          diagnostics: diagnostics(start, 180, READ_SLO),
+          errors: [],
+        };
+      });
+    }),
+
+    publicInvestigationTimeline: withAuthAndPolicy(
+      'read:investigation_timeline',
+      (args: { filter: { investigationId: string } }, context: ContractsContext) =>
+        investigationResource(args.filter.investigationId, context.user?.orgId, context.user?.teamId),
+    )(async (
+      _parent,
+      args: { filter: { investigationId: string; tenantId: string } },
+      context: ContractsContext,
+      info: GraphQLResolveInfo,
+    ) => {
+      const start = Date.now();
+      return withSpan('contracts.publicInvestigationTimeline', async (span) => {
+        span.setAttributes({
+          'graphql.field': info.fieldName,
+          'investigation.id': args.filter.investigationId,
+        });
+
+        const policy = await evaluatePolicy(context, span, 'read:investigation_timeline', {
+          type: 'investigation',
+          id: args.filter.investigationId,
+          tenantId: args.filter.tenantId,
+        });
+
+        if (!policy.allow) {
+          return {
+            nodes: [],
+            edges: [],
+            totalCount: 0,
+            pageInfo: { hasNextPage: false, endCursor: null, throttleUntil: null },
+            backpressure: null,
+            policy,
+            diagnostics: diagnostics(start, 160, READ_SLO),
+            errors: [mapPolicyDenied(policy, READ_SLO)],
+          };
+        }
+
+        return {
+          nodes: [],
+          edges: [],
+          totalCount: 0,
+          pageInfo: { hasNextPage: false, endCursor: null, throttleUntil: null },
+          backpressure: null,
+          policy,
+          diagnostics: diagnostics(start, 160, READ_SLO),
+          errors: [mapNotImplemented('publicInvestigationTimeline', READ_SLO)],
+        };
+      });
+    }),
+
+    publicEntityNeighborhood: withAuthAndPolicy(
+      'read:entity_neighborhood',
+      (args: { input: { entityId: string } }, context: ContractsContext) =>
+        entityResource(args.input.entityId, undefined, context.user?.orgId, context.user?.teamId),
+    )(async (
+      _parent,
+      args: { input: { entityId: string; tenantId: string; relationshipTypes?: string[]; maxDepth?: number } },
+      context: ContractsContext,
+      info: GraphQLResolveInfo,
+    ) => {
+      const start = Date.now();
+      return withSpan('contracts.publicEntityNeighborhood', async (span) => {
+        span.setAttributes({
+          'graphql.field': info.fieldName,
+          'entity.id': args.input.entityId,
+          'tenant.id': args.input.tenantId,
+        });
+
+        const policy = await evaluatePolicy(context, span, 'read:entity_neighborhood', {
+          type: 'entity',
+          id: args.input.entityId,
+          tenantId: args.input.tenantId,
+        });
+
+        if (!policy.allow) {
+          return {
+            center: null,
+            entities: [],
+            relationships: [],
+            policy,
+            diagnostics: diagnostics(start, 320, READ_SLO),
+            backpressure: null,
+            errors: [mapPolicyDenied(policy, READ_SLO)],
+          };
+        }
+
+        const center = await entityRepo.findById(args.input.entityId, args.input.tenantId);
+        if (!center) {
+          return {
+            center: null,
+            entities: [],
+            relationships: [],
+            policy,
+            diagnostics: diagnostics(start, 320, READ_SLO),
+            backpressure: null,
+            errors: [mapNotFound('entity', args.input.entityId)],
+          };
+        }
+
+        const relationships = await relationshipRepo.findByEntityId(
+          args.input.entityId,
+          args.input.tenantId,
+          'both',
+        );
+
+        const relationshipNodes = await Promise.all(
+          relationships.map((relationship) => toPublicRelationship(relationship, args.input.tenantId)),
+        );
+
+        const neighborIds = new Set<string>();
+        for (const rel of relationships) {
+          neighborIds.add(rel.srcId);
+          neighborIds.add(rel.dstId);
+        }
+        neighborIds.delete(center.id);
+
+        const neighbors = await entityRepo.batchByIds([...neighborIds], args.input.tenantId);
+        const neighborNodes = neighbors
+          .filter((item): item is Entity => Boolean(item))
+          .map(toPublicEntity);
+
+        return {
+          center: toPublicEntity(center),
+          entities: neighborNodes,
+          relationships: relationshipNodes,
+          policy,
+          diagnostics: diagnostics(start, 320, READ_SLO),
+          backpressure: {
+            throttleSeconds: Math.max(0, Math.floor((args.input.maxDepth ?? 2) / 2)),
+            recommendedPageSize: Math.min(neighborNodes.length || 25, 100),
+            reason: 'degree-throttled',
+          },
+          errors: [],
+        };
+      });
+    }),
+  },
+
+  Mutation: {
+    publicUpsertEntity: withAuthAndPolicy(
+      'write:entity',
+      (args: { input: { id?: string; tenantId: string } }, context: ContractsContext) =>
+        entityResource(args.input.id ?? 'new', undefined, context.user?.orgId, context.user?.teamId),
+    )(async (
+      _parent,
+      args: { input: { id?: string; tenantId: string; kind: string; labels?: string[]; properties?: Record<string, any> } },
+      context: ContractsContext,
+      info: GraphQLResolveInfo,
+    ) => {
+      const start = Date.now();
+      return withSpan('contracts.publicUpsertEntity', async (span) => {
+        span.setAttributes({
+          'graphql.field': info.fieldName,
+          'tenant.id': args.input.tenantId,
+          'entity.id': args.input.id ?? 'new',
+        });
+
+        const policy = await evaluatePolicy(context, span, 'write:entity', {
+          type: 'entity',
+          id: args.input.id ?? 'new',
+          tenantId: args.input.tenantId,
+        });
+
+        if (!policy.allow) {
+          return {
+            ok: false,
+            policy,
+            diagnostics: diagnostics(start, 420, WRITE_SLO),
+            errors: [mapPolicyDenied(policy, WRITE_SLO)],
+          } satisfies PublicMutationResult;
+        }
+
+        span.addEvent('resolver.stub', { detail: 'write operations are stubbed' });
+
+        return {
+          ok: false,
+          policy,
+          diagnostics: diagnostics(start, 420, WRITE_SLO),
+          errors: [mapNotImplemented('publicUpsertEntity', WRITE_SLO)],
+        } satisfies PublicMutationResult;
+      });
+    }),
+
+    publicLinkEntities: withAuthAndPolicy(
+      'write:relationship',
+      (args: { input: { sourceId: string } }, context: ContractsContext) =>
+        entityResource(args.input.sourceId, undefined, context.user?.orgId, context.user?.teamId),
+    )(async (
+      _parent,
+      args: { input: { tenantId: string; sourceId: string; targetId: string } },
+      context: ContractsContext,
+      info: GraphQLResolveInfo,
+    ) => {
+      const start = Date.now();
+      return withSpan('contracts.publicLinkEntities', async (span) => {
+        span.setAttributes({
+          'graphql.field': info.fieldName,
+          'tenant.id': args.input.tenantId,
+        });
+
+        const policy = await evaluatePolicy(context, span, 'write:relationship', {
+          type: 'relationship',
+          tenantId: args.input.tenantId,
+          sourceId: args.input.sourceId,
+          targetId: args.input.targetId,
+        });
+
+        if (!policy.allow) {
+          return {
+            ok: false,
+            policy,
+            diagnostics: diagnostics(start, 480, WRITE_SLO),
+            errors: [mapPolicyDenied(policy, WRITE_SLO)],
+          } satisfies PublicMutationResult;
+        }
+
+        span.addEvent('resolver.stub', { detail: 'relationship creation deferred' });
+
+        return {
+          ok: false,
+          policy,
+          diagnostics: diagnostics(start, 480, WRITE_SLO),
+          errors: [mapNotImplemented('publicLinkEntities', WRITE_SLO)],
+        } satisfies PublicMutationResult;
+      });
+    }),
+
+    publicAddInvestigationNote: withAuthAndPolicy(
+      'write:investigation_note',
+      (args: { input: { investigationId: string } }, context: ContractsContext) =>
+        investigationResource(args.input.investigationId, context.user?.orgId, context.user?.teamId),
+    )(async (
+      _parent,
+      args: { input: { tenantId: string; investigationId: string } },
+      context: ContractsContext,
+      info: GraphQLResolveInfo,
+    ) => {
+      const start = Date.now();
+      return withSpan('contracts.publicAddInvestigationNote', async (span) => {
+        span.setAttributes({
+          'graphql.field': info.fieldName,
+          'investigation.id': args.input.investigationId,
+        });
+
+        const policy = await evaluatePolicy(context, span, 'write:investigation_note', {
+          type: 'investigation',
+          id: args.input.investigationId,
+          tenantId: args.input.tenantId,
+        });
+
+        if (!policy.allow) {
+          return {
+            ok: false,
+            policy,
+            diagnostics: diagnostics(start, 260, WRITE_SLO),
+            errors: [mapPolicyDenied(policy, WRITE_SLO)],
+          } satisfies PublicMutationResult;
+        }
+
+        return {
+          ok: false,
+          policy,
+          diagnostics: diagnostics(start, 260, WRITE_SLO),
+          errors: [mapNotImplemented('publicAddInvestigationNote', WRITE_SLO)],
+        } satisfies PublicMutationResult;
+      });
+    }),
+
+    publicAcknowledgeInvestigation: withAuthAndPolicy(
+      'write:investigation_state',
+      (args: { input: { investigationId: string } }, context: ContractsContext) =>
+        investigationResource(args.input.investigationId, context.user?.orgId, context.user?.teamId),
+    )(async (
+      _parent,
+      args: { input: { tenantId: string; investigationId: string } },
+      context: ContractsContext,
+      info: GraphQLResolveInfo,
+    ) => {
+      const start = Date.now();
+      return withSpan('contracts.publicAcknowledgeInvestigation', async (span) => {
+        span.setAttributes({
+          'graphql.field': info.fieldName,
+          'investigation.id': args.input.investigationId,
+        });
+
+        const policy = await evaluatePolicy(context, span, 'write:investigation_state', {
+          type: 'investigation',
+          id: args.input.investigationId,
+          tenantId: args.input.tenantId,
+        });
+
+        if (!policy.allow) {
+          return {
+            ok: false,
+            policy,
+            diagnostics: diagnostics(start, 280, WRITE_SLO),
+            errors: [mapPolicyDenied(policy, WRITE_SLO)],
+          } satisfies PublicMutationResult;
+        }
+
+        return {
+          ok: false,
+          policy,
+          diagnostics: diagnostics(start, 280, WRITE_SLO),
+          errors: [mapNotImplemented('publicAcknowledgeInvestigation', WRITE_SLO)],
+        } satisfies PublicMutationResult;
+      });
+    }),
+
+    publicBatchIngestEntities: withAuthAndPolicy(
+      'write:batch_entities',
+      (args: { input: Array<{ tenantId: string }> }, context: ContractsContext) =>
+        entityResource('batch', undefined, context.user?.orgId, context.user?.teamId),
+    )(async (
+      _parent,
+      args: { input: Array<{ tenantId: string }> },
+      context: ContractsContext,
+      info: GraphQLResolveInfo,
+    ) => {
+      const start = Date.now();
+      return withSpan('contracts.publicBatchIngestEntities', async (span) => {
+        span.setAttributes({
+          'graphql.field': info.fieldName,
+          'batch.size': args.input.length,
+        });
+
+        const tenantIds = Array.from(new Set(args.input.map((item) => item.tenantId)));
+        const policy = await evaluatePolicy(context, span, 'write:batch_entities', {
+          type: 'entity_batch',
+          tenantIds,
+        });
+
+        if (!policy.allow) {
+          return {
+            ok: false,
+            accepted: 0,
+            failed: args.input.length,
+            failures: [],
+            policy,
+            diagnostics: diagnostics(start, 640, WRITE_SLO),
+            errors: [mapPolicyDenied(policy, WRITE_SLO)],
+          };
+        }
+
+        return {
+          ok: false,
+          accepted: 0,
+          failed: args.input.length,
+          failures: args.input.map((input) => ({
+            input,
+            errors: [mapNotImplemented('publicBatchIngestEntities', WRITE_SLO)],
+          })),
+          policy,
+          diagnostics: diagnostics(start, 640, WRITE_SLO),
+          errors: [mapNotImplemented('publicBatchIngestEntities', WRITE_SLO)],
+        };
+      });
+    }),
+  },
+
+  Subscription: {
+    publicInvestigationEvents: {
+      subscribe: withAuthAndPolicy(
+        'read:investigation_events',
+        (args: { investigationId: string }, context: ContractsContext) =>
+          investigationResource(args.investigationId, context.user?.orgId, context.user?.teamId),
+      )(async (
+        _parent,
+        args: { investigationId: string; tenantId: string },
+        context: ContractsContext,
+      ) => {
+        return withSpan('contracts.publicInvestigationEvents.subscribe', async (span) => {
+          const policy = await evaluatePolicy(context, span, 'read:investigation_events', {
+            type: 'investigation',
+            id: args.investigationId,
+            tenantId: args.tenantId,
+          });
+
+          if (!policy.allow) {
+            throw new Error(policy.reason ?? 'Subscription denied by policy');
+          }
+
+          span.setAttributes({
+            'subscription.investigationId': args.investigationId,
+            'subscription.tenantId': args.tenantId,
+            'subscription.slo': SUBSCRIPTION_SLO,
+          });
+
+          // Placeholder async iterator
+          async function* iterator() {
+            yield {
+              id: 'bootstrap-event',
+              investigationId: args.investigationId,
+              entityId: null,
+              relationshipId: null,
+              kind: 'STATUS_CHANGED',
+              occurredAt: new Date().toISOString(),
+              actorId: context.user?.id ?? 'system',
+              payload: {
+                status: 'INITIALIZED',
+                message: 'subscription bootstrap event',
+              },
+            };
+          }
+
+          return iterator();
+        });
+      }),
+    },
+  },
+};
+
+export default contractsResolvers;

--- a/server/src/graphql/contracts/typeDefs.ts
+++ b/server/src/graphql/contracts/typeDefs.ts
@@ -1,0 +1,464 @@
+import { gql } from 'graphql-tag';
+
+export const contractsTypeDefs = gql`
+  """Common JSON scalar"""
+  scalar JSON
+  """ISO-8601 timestamp"""
+  scalar DateTime
+
+  """
+  Annotates a field with a static cost estimate that can be used by
+  persisted query tooling to enforce read/write SLOs.
+  """
+  directive @cost(
+    complexity: Int!
+    estimatedMs: Int!
+    scope: CostScope = FIELD
+  ) on FIELD_DEFINITION
+
+  """
+  Declares the target SLO for an operation. Enforcement occurs in the
+  resolver diagnostics emitted to observability sinks.
+  """
+  directive @slo(targetMs: Int!, percentile: Int!) on FIELD_DEFINITION | OBJECT
+
+  enum CostScope {
+    FIELD
+    OBJECT
+    CONNECTION
+  }
+
+  enum SortDirection {
+    ASC
+    DESC
+  }
+
+  enum PublicRelationshipDirection {
+    INBOUND
+    OUTBOUND
+    BIDIRECTIONAL
+  }
+
+  enum PublicInvestigationStatus {
+    ACTIVE
+    ARCHIVED
+    COMPLETED
+  }
+
+  enum PublicEntitySortField {
+    UPDATED_AT
+    CREATED_AT
+    CONFIDENCE
+    DEGREE
+  }
+
+  enum PublicTimelineEventKind {
+    ENTITY_CREATED
+    ENTITY_UPDATED
+    RELATIONSHIP_CREATED
+    RELATIONSHIP_DELETED
+    NOTE_ADDED
+    STATUS_CHANGED
+  }
+
+  type PolicyDecision {
+    allow: Boolean!
+    reason: String
+    obligations: [String!]!
+  }
+
+  type ResolverDiagnostics {
+    fromCache: Boolean!
+    lastEvaluatedAt: DateTime!
+    durationMs: Int!
+    attempts: Int!
+    estimatedCostMs: Int!
+    sloTargetMs: Int!
+  }
+
+  type BackpressureAdvice {
+    throttleSeconds: Int
+    recommendedPageSize: Int
+    reason: String
+  }
+
+  type PaginationInfo {
+    hasNextPage: Boolean!
+    endCursor: String
+    throttleUntil: DateTime
+  }
+
+  type PublicError {
+    code: String!
+    message: String!
+    field: String
+    retryable: Boolean!
+    context: JSON
+  }
+
+  type PublicInvestigationSummary {
+    id: ID!
+    name: String!
+    status: PublicInvestigationStatus!
+    priority: String
+    ownerId: String
+  }
+
+  type PublicEntity {
+    id: ID!
+    tenantId: String!
+    kind: String!
+    labels: [String!]!
+    properties: JSON!
+    confidence: Float
+    degree: Int
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    lastIngestedAt: DateTime
+    retentionClass: String
+    geographicScope: String
+    piiTags: [String!]!
+    sourceSystems: [String!]!
+    investigation: PublicInvestigationSummary
+  }
+
+  type PublicRelationship {
+    id: ID!
+    tenantId: String!
+    type: String!
+    properties: JSON!
+    confidence: Float
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    source: PublicEntity!
+    target: PublicEntity!
+  }
+
+  type PublicRelationshipEdge {
+    cursor: String!
+    node: PublicRelationship!
+    policy: PolicyDecision!
+  }
+
+  type PublicRelationshipConnection @slo(targetMs: 350, percentile: 95) {
+    nodes: [PublicRelationship!]!
+    edges: [PublicRelationshipEdge!]!
+    totalCount: Int!
+    pageInfo: PaginationInfo!
+    backpressure: BackpressureAdvice
+    policy: PolicyDecision!
+    diagnostics: ResolverDiagnostics!
+    errors: [PublicError!]!
+  }
+
+  type PublicEntityEdge {
+    cursor: String!
+    node: PublicEntity!
+    policy: PolicyDecision!
+  }
+
+  type PublicEntityConnection @slo(targetMs: 350, percentile: 95) {
+    nodes: [PublicEntity!]!
+    edges: [PublicEntityEdge!]!
+    totalCount: Int!
+    pageInfo: PaginationInfo!
+    backpressure: BackpressureAdvice
+    policy: PolicyDecision!
+    diagnostics: ResolverDiagnostics!
+    errors: [PublicError!]!
+  }
+
+  type PublicInvestigation {
+    id: ID!
+    tenantId: String!
+    name: String!
+    description: String
+    status: PublicInvestigationStatus!
+    priority: String
+    ownerId: String
+    tags: [String!]!
+    props: JSON!
+    createdAt: DateTime!
+    updatedAt: DateTime!
+    entityCount: Int!
+    relationshipCount: Int!
+  }
+
+  type PublicInvestigationEdge {
+    cursor: String!
+    node: PublicInvestigation!
+    policy: PolicyDecision!
+  }
+
+  type PublicInvestigationConnection @slo(targetMs: 350, percentile: 95) {
+    nodes: [PublicInvestigation!]!
+    edges: [PublicInvestigationEdge!]!
+    totalCount: Int!
+    pageInfo: PaginationInfo!
+    backpressure: BackpressureAdvice
+    policy: PolicyDecision!
+    diagnostics: ResolverDiagnostics!
+    errors: [PublicError!]!
+  }
+
+  type PublicTimelineEvent {
+    id: ID!
+    investigationId: ID!
+    entityId: ID
+    relationshipId: ID
+    kind: PublicTimelineEventKind!
+    occurredAt: DateTime!
+    actorId: ID
+    payload: JSON!
+  }
+
+  type PublicTimelineEdge {
+    cursor: String!
+    node: PublicTimelineEvent!
+  }
+
+  type PublicTimelineConnection @slo(targetMs: 350, percentile: 95) {
+    nodes: [PublicTimelineEvent!]!
+    edges: [PublicTimelineEdge!]!
+    totalCount: Int!
+    pageInfo: PaginationInfo!
+    backpressure: BackpressureAdvice
+    policy: PolicyDecision!
+    diagnostics: ResolverDiagnostics!
+    errors: [PublicError!]!
+  }
+
+  type PublicEntityResult {
+    entity: PublicEntity
+    policy: PolicyDecision!
+    diagnostics: ResolverDiagnostics!
+    errors: [PublicError!]!
+  }
+
+  type PublicNeighborhood {
+    center: PublicEntity
+    entities: [PublicEntity!]!
+    relationships: [PublicRelationship!]!
+    policy: PolicyDecision!
+    diagnostics: ResolverDiagnostics!
+    backpressure: BackpressureAdvice
+    errors: [PublicError!]!
+  }
+
+  type PublicMutationResult {
+    ok: Boolean!
+    policy: PolicyDecision!
+    diagnostics: ResolverDiagnostics!
+    errors: [PublicError!]!
+  }
+
+  type PublicBatchFailure {
+    input: PublicUpsertEntityInput!
+    errors: [PublicError!]!
+  }
+
+  type PublicBatchResult {
+    ok: Boolean!
+    accepted: Int!
+    failed: Int!
+    failures: [PublicBatchFailure!]!
+    policy: PolicyDecision!
+    diagnostics: ResolverDiagnostics!
+    errors: [PublicError!]!
+  }
+
+  input PaginationInput {
+    first: Int = 25
+    after: String
+  }
+
+  input BackpressureInput {
+    maxWindowMs: Int = 5000
+    clientLagMs: Int = 0
+  }
+
+  input PublicEntityFilter {
+    tenantId: String!
+    ids: [ID!]
+    kinds: [String!]
+    labels: [String!]
+    search: String
+    minConfidence: Float
+    maxConfidence: Float
+    investigationId: ID
+    sourceSystems: [String!]
+    piiTags: [String!]
+    updatedAfter: DateTime
+    updatedBefore: DateTime
+  }
+
+  input PublicEntitySort {
+    field: PublicEntitySortField!
+    direction: SortDirection = DESC
+  }
+
+  input PublicRelationshipFilter {
+    tenantId: String!
+    entityId: ID
+    types: [String!]
+    direction: PublicRelationshipDirection = BIDIRECTIONAL
+  }
+
+  input PublicInvestigationFilter {
+    tenantId: String!
+    status: [PublicInvestigationStatus!]
+    search: String
+    updatedAfter: DateTime
+    updatedBefore: DateTime
+    tags: [String!]
+  }
+
+  input PublicTimelineFilter {
+    tenantId: String!
+    investigationId: ID!
+    kinds: [PublicTimelineEventKind!]
+    since: DateTime
+  }
+
+  input PublicNeighborhoodInput {
+    tenantId: String!
+    entityId: ID!
+    maxDepth: Int = 2
+    maxDegree: Int = 200
+    relationshipTypes: [String!]
+    backpressure: BackpressureInput
+  }
+
+  input PublicUpsertEntityInput {
+    id: ID
+    tenantId: String!
+    kind: String!
+    labels: [String!] = []
+    properties: JSON = {}
+    confidence: Float
+    investigationId: ID
+    sourceSystems: [String!]
+    piiTags: [String!]
+    retentionClass: String
+  }
+
+  input PublicLinkEntitiesInput {
+    tenantId: String!
+    sourceId: ID!
+    targetId: ID!
+    type: String!
+    properties: JSON = {}
+    confidence: Float
+  }
+
+  input PublicAddInvestigationNoteInput {
+    tenantId: String!
+    investigationId: ID!
+    note: String!
+    visibility: String = "internal"
+  }
+
+  input PublicAcknowledgeInvestigationInput {
+    tenantId: String!
+    investigationId: ID!
+    state: PublicInvestigationStatus!
+    note: String
+  }
+
+  input PublicBatchOptions {
+    dedupe: Boolean = true
+    async: Boolean = false
+    dryRun: Boolean = false
+  }
+
+  type Query {
+    publicEntity(
+      id: ID!
+      backpressure: BackpressureInput
+    ): PublicEntityResult!
+      @cost(complexity: 45, estimatedMs: 120, scope: OBJECT)
+      @slo(targetMs: 350, percentile: 95)
+
+    publicEntities(
+      filter: PublicEntityFilter!
+      pagination: PaginationInput = {}
+      sort: PublicEntitySort
+      backpressure: BackpressureInput
+    ): PublicEntityConnection!
+      @cost(complexity: 120, estimatedMs: 220, scope: CONNECTION)
+      @slo(targetMs: 350, percentile: 95)
+
+    publicRelationships(
+      filter: PublicRelationshipFilter!
+      pagination: PaginationInput = {}
+      backpressure: BackpressureInput
+    ): PublicRelationshipConnection!
+      @cost(complexity: 95, estimatedMs: 210, scope: CONNECTION)
+      @slo(targetMs: 350, percentile: 95)
+
+    publicInvestigations(
+      filter: PublicInvestigationFilter!
+      pagination: PaginationInput = {}
+      backpressure: BackpressureInput
+    ): PublicInvestigationConnection!
+      @cost(complexity: 80, estimatedMs: 180, scope: CONNECTION)
+      @slo(targetMs: 350, percentile: 95)
+
+    publicInvestigationTimeline(
+      filter: PublicTimelineFilter!
+      pagination: PaginationInput = {}
+    ): PublicTimelineConnection!
+      @cost(complexity: 70, estimatedMs: 160, scope: CONNECTION)
+      @slo(targetMs: 350, percentile: 95)
+
+    publicEntityNeighborhood(
+      input: PublicNeighborhoodInput!
+    ): PublicNeighborhood!
+      @cost(complexity: 200, estimatedMs: 320, scope: OBJECT)
+      @slo(targetMs: 350, percentile: 95)
+  }
+
+  type Mutation {
+    publicUpsertEntity(
+      input: PublicUpsertEntityInput!
+    ): PublicMutationResult!
+      @cost(complexity: 110, estimatedMs: 420, scope: OBJECT)
+      @slo(targetMs: 700, percentile: 95)
+
+    publicLinkEntities(
+      input: PublicLinkEntitiesInput!
+    ): PublicMutationResult!
+      @cost(complexity: 95, estimatedMs: 480, scope: OBJECT)
+      @slo(targetMs: 700, percentile: 95)
+
+    publicAddInvestigationNote(
+      input: PublicAddInvestigationNoteInput!
+    ): PublicMutationResult!
+      @cost(complexity: 60, estimatedMs: 260, scope: FIELD)
+      @slo(targetMs: 700, percentile: 95)
+
+    publicAcknowledgeInvestigation(
+      input: PublicAcknowledgeInvestigationInput!
+    ): PublicMutationResult!
+      @cost(complexity: 70, estimatedMs: 280, scope: FIELD)
+      @slo(targetMs: 700, percentile: 95)
+
+    publicBatchIngestEntities(
+      input: [PublicUpsertEntityInput!]!
+      options: PublicBatchOptions
+    ): PublicBatchResult!
+      @cost(complexity: 240, estimatedMs: 640, scope: OBJECT)
+      @slo(targetMs: 700, percentile: 95)
+  }
+
+  type Subscription {
+    publicInvestigationEvents(
+      investigationId: ID!
+      tenantId: String!
+    ): PublicTimelineEvent!
+      @cost(complexity: 40, estimatedMs: 120, scope: FIELD)
+      @slo(targetMs: 250, percentile: 95)
+  }
+`;
+
+export default contractsTypeDefs;

--- a/server/src/graphql/resolvers/index.ts
+++ b/server/src/graphql/resolvers/index.ts
@@ -12,6 +12,7 @@ import { triggerN8nFlow } from '../../integrations/n8n.js';
 import { checkN8nTriggerAllowed } from '../../integrations/n8n-policy.js';
 import { isEnabled as flagEnabled } from '../../featureFlags/flagsmith.js';
 import { doclingResolvers } from './docling.ts';
+import { contractsResolvers } from '../contracts/resolvers.ts';
 
 // Instantiate the WargameResolver
 const wargameResolver = new WargameResolver(); // WAR-GAMED SIMULATION - FOR DECISION SUPPORT ONLY
@@ -24,6 +25,7 @@ const resolvers = {
   Query: {
     // Production core resolvers (PostgreSQL + Neo4j)
     ...coreResolvers.Query,
+    ...contractsResolvers.Query,
     ...doclingResolvers.Query,
     async pipeline(_p: any, args: { id: string }) {
       const { getPipelineDef } = await import('../../db/repositories/pipelines.js');
@@ -62,6 +64,7 @@ const resolvers = {
   Mutation: {
     // Production core resolvers
     ...coreResolvers.Mutation,
+    ...contractsResolvers.Mutation,
     ...doclingResolvers.Mutation,
 
     // Legacy resolvers (will be phased out)
@@ -192,6 +195,10 @@ const resolvers = {
         inputs
       };
     },
+  },
+
+  Subscription: {
+    ...(contractsResolvers.Subscription || {}),
   },
 
   // Field resolvers from production core (temporarily disabled due to schema mismatch)

--- a/server/src/graphql/schema/index.ts
+++ b/server/src/graphql/schema/index.ts
@@ -6,6 +6,7 @@ import aiModule from '../schema.ai.js';
 import annotationsModule from '../schema.annotations.js';
 import graphragTypesModule from '../types/graphragTypes.js';
 import { crystalTypeDefs } from '../schema.crystal.js';
+import { contractsTypeDefs } from '../contracts/typeDefs.ts';
 
 const { copilotTypeDefs } = copilotModule as { copilotTypeDefs: any };
 const { graphTypeDefs } = graphModule as { graphTypeDefs: any };
@@ -33,6 +34,7 @@ const base = gql`
 export const typeDefs = [
   base,
   coreTypeDefs,
+  contractsTypeDefs,
   copilotTypeDefs,
   graphTypeDefs,
   graphragTypes,

--- a/server/tests/contracts/public-graphql.contract.test.ts
+++ b/server/tests/contracts/public-graphql.contract.test.ts
@@ -1,0 +1,78 @@
+import { buildASTSchema, parse, validate } from 'graphql';
+import { contractsTypeDefs } from '../../src/graphql/contracts/typeDefs';
+import {
+  publicPersistedOperations,
+  getPublicPersistedOperation,
+} from '../../src/graphql/contracts/persisted-queries';
+import { contractsResolvers, type ContractsContext } from '../../src/graphql/contracts/resolvers';
+
+describe('Public GraphQL contract', () => {
+  const schema = buildASTSchema(contractsTypeDefs);
+
+  it('exposes cost and slo directives', () => {
+    expect(schema.getDirective('cost')).toBeDefined();
+    expect(schema.getDirective('slo')).toBeDefined();
+  });
+
+  it('registers 10-15 persisted operations with valid hashes', () => {
+    expect(publicPersistedOperations.length).toBeGreaterThanOrEqual(10);
+    expect(publicPersistedOperations.length).toBeLessThanOrEqual(15);
+
+    const normalize = (document: string) => document.replace(/\s+/g, ' ').trim();
+
+    for (const operation of publicPersistedOperations) {
+      const hashed = require('crypto').createHash('sha256').update(normalize(operation.document)).digest('hex');
+      expect(operation.sha256Hash).toBe(hashed);
+      expect(operation.cost.estimatedMs).toBeLessThanOrEqual(operation.cost.targetSLOMs);
+
+      const doc = parse(operation.document);
+      const errors = validate(schema, doc);
+      expect(errors).toHaveLength(0);
+    }
+  });
+
+  it('allows lookup by hash and by name', () => {
+    const first = publicPersistedOperations[0];
+    expect(getPublicPersistedOperation(first.sha256Hash)).toBeDefined();
+    expect(getPublicPersistedOperation(first.operationName)).toBeDefined();
+  });
+
+  it('resolver stubs return structured errors and diagnostics', async () => {
+    const context: ContractsContext = {
+      user: { id: 'tester', tenantId: 'tenant-a', roles: ['analyst'] },
+      req: { headers: {} },
+      opa: { evaluate: async () => ({ allow: true }) },
+    };
+    const info = {
+      fieldName: 'publicEntity',
+      path: { key: 'publicEntity' },
+    } as any;
+
+    const result = await contractsResolvers.Query.publicEntity(
+      null,
+      { id: 'non-existent' },
+      context,
+      info,
+    );
+
+    expect(result.diagnostics).toBeDefined();
+    expect(result.diagnostics.sloTargetMs).toBe(350);
+    expect(result.errors[0].code).toBe('ENTITY_NOT_FOUND');
+
+    const mutationInfo = {
+      fieldName: 'publicUpsertEntity',
+      path: { key: 'publicUpsertEntity' },
+    } as any;
+
+    const mutation = await contractsResolvers.Mutation.publicUpsertEntity(
+      null,
+      { input: { tenantId: 'tenant-a', kind: 'Person', labels: [] } },
+      context,
+      mutationInfo,
+    );
+
+    expect(mutation.ok).toBe(false);
+    expect(mutation.errors[0].code).toBe('NOT_IMPLEMENTED');
+    expect(mutation.diagnostics.sloTargetMs).toBe(700);
+  });
+});


### PR DESCRIPTION
## Summary
- introduce a public GraphQL contract module with SDL that encodes SLO-aware directives, error shapes, and connection metadata
- scaffold OPA-aware resolvers with Neo4j/Postgres hooks plus OpenTelemetry spans and expose a persisted-query manifest with cost hints
- add contract tests that validate the SDL, persisted operations, and resolver stubs

## Testing
- pnpm install --filter v24-coherence-server *(fails: ERR_PNPM_INVALID_PACKAGE_NAME for apps/intelgraph-api)*

------
https://chatgpt.com/codex/tasks/task_e_68d7504da12c833392fc984034c870a1