### PR TITLE
feat: add schema evolution simulator tool

### DIFF
--- a/.github/workflows/ses.yml
+++ b/.github/workflows/ses.yml
@@ -1,0 +1,35 @@
+name: SES Gate
+
+on:
+  pull_request:
+    paths:
+      - 'tools/ses/**'
+      - '.github/workflows/ses.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'tools/ses/**'
+      - '.github/workflows/ses.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: tools/ses/package-lock.json
+
+      - name: Install dependencies
+        working-directory: tools/ses
+        run: npm install
+
+      - name: Run SES tests
+        working-directory: tools/ses
+        run: npm test

--- a/tools/ses/README.md
+++ b/tools/ses/README.md
@@ -1,0 +1,51 @@
+# Schema Evolution Simulator (SES)
+
+SES is a TypeScript tool for simulating schema evolution scenarios before applying changes to production systems. It ingests structured schema definitions, consumer usage telemetry, and a list of proposed changes to forecast downstream impact.
+
+## Features
+
+- **Compatibility Matrix** — summarizes the effect of proposed changes per consumer.
+- **Migration Bundle** — auto-generates SQL statements and TypeScript migration stubs.
+- **Risk Assessment** — deterministic score based on observed usage and change severity.
+- **Rollout Planning** — staged rollout plan with pass/fail gates for each phase.
+- **Fixture Validation** — optional dataset fixtures validate generated migrations.
+
+## Getting Started
+
+```
+cd tools/ses
+npm install
+npm run build
+```
+
+Run the simulator by pointing it at a configuration file:
+
+```
+npx ses ./configs/example.json
+```
+
+The configuration file supports the following keys:
+
+```json
+{
+  "schemaPath": "./fixtures/schema.json",
+  "telemetryPath": "./fixtures/telemetry.json",
+  "changesPath": "./fixtures/changes.json",
+  "fixturePath": "./fixtures/data.json",
+  "outputPath": "./runs/latest.json"
+}
+```
+
+## Testing
+
+SES uses [Vitest](https://vitest.dev). Run the suite with:
+
+```
+npm test
+```
+
+Tests validate that breaking changes are flagged, migrations execute against fixtures, and rollout gates are deterministic.
+
+## GitHub Action Gate
+
+A GitHub Action workflow (`.github/workflows/ses.yml`) runs the SES tests to block regressions when changes are introduced.

--- a/tools/ses/fixtures/changes.json
+++ b/tools/ses/fixtures/changes.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "rename",
+    "table": "customers",
+    "from": "email",
+    "to": "primary_email",
+    "rationale": "Clarify primary contact channel"
+  },
+  {
+    "type": "split",
+    "table": "customers",
+    "column": "full_name",
+    "into": [
+      { "name": "first_name", "type": "string" },
+      { "name": "last_name", "type": "string" }
+    ],
+    "rationale": "Support personalization workflows"
+  },
+  {
+    "type": "widen",
+    "table": "orders",
+    "column": "total_amount",
+    "newType": "float",
+    "rationale": "Capture fractional currency"
+  }
+]

--- a/tools/ses/fixtures/config.json
+++ b/tools/ses/fixtures/config.json
@@ -1,0 +1,6 @@
+{
+  "schemaPath": "./schema.json",
+  "telemetryPath": "./telemetry.json",
+  "changesPath": "./changes.json",
+  "fixturePath": "./data.json"
+}

--- a/tools/ses/fixtures/data.json
+++ b/tools/ses/fixtures/data.json
@@ -1,0 +1,12 @@
+{
+  "tables": {
+    "customers": [
+      { "id": 1, "full_name": "Ada Lovelace", "email": "ada@example.com", "signup_date": "2024-01-12" },
+      { "id": 2, "full_name": "Grace Hopper", "email": "grace@example.com", "signup_date": "2024-01-20" }
+    ],
+    "orders": [
+      { "id": 100, "customer_id": 1, "total_amount": 25 },
+      { "id": 101, "customer_id": 2, "total_amount": 42 }
+    ]
+  }
+}

--- a/tools/ses/fixtures/schema.json
+++ b/tools/ses/fixtures/schema.json
@@ -1,0 +1,22 @@
+{
+  "version": "1.0.0",
+  "tables": [
+    {
+      "name": "customers",
+      "columns": [
+        { "name": "id", "type": "integer" },
+        { "name": "full_name", "type": "string" },
+        { "name": "email", "type": "string" },
+        { "name": "signup_date", "type": "date" }
+      ]
+    },
+    {
+      "name": "orders",
+      "columns": [
+        { "name": "id", "type": "integer" },
+        { "name": "customer_id", "type": "integer" },
+        { "name": "total_amount", "type": "integer" }
+      ]
+    }
+  ]
+}

--- a/tools/ses/fixtures/telemetry.json
+++ b/tools/ses/fixtures/telemetry.json
@@ -1,0 +1,23 @@
+{
+  "windowDays": 14,
+  "usages": [
+    {
+      "consumer": "billing-service",
+      "table": "customers",
+      "columns": ["id", "full_name", "email"],
+      "frequency": 120
+    },
+    {
+      "consumer": "marketing-dashboard",
+      "table": "customers",
+      "columns": ["email", "signup_date"],
+      "frequency": 40
+    },
+    {
+      "consumer": "analytics-pipeline",
+      "table": "orders",
+      "columns": ["total_amount", "customer_id"],
+      "frequency": 200
+    }
+  ]
+}

--- a/tools/ses/package.json
+++ b/tools/ses/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@summit/ses",
+  "version": "0.1.0",
+  "description": "Schema Evolution Simulator (SES) for what-if planning and migrations",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "ses": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist",
+    "test": "vitest run",
+    "dev": "vitest",
+    "start": "node dist/index.js"
+  },
+  "keywords": ["schema", "migration", "simulator", "what-if"],
+  "author": "Summit Platform",
+  "license": "MIT",
+  "dependencies": {
+    "chalk": "^5.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.17",
+    "typescript": "^5.4.3",
+    "vitest": "^1.5.3"
+  }
+}

--- a/tools/ses/src/analyzer.ts
+++ b/tools/ses/src/analyzer.ts
@@ -1,0 +1,148 @@
+import type {
+  SchemaDefinition,
+  Telemetry,
+  SchemaChange,
+  ConsumerImpact,
+  CompatibilityMatrix,
+  CompatibilityLevel,
+  RiskAssessment,
+} from './types.js';
+
+interface ChangeImpact {
+  change: SchemaChange;
+  impactedConsumers: ConsumerImpact[];
+}
+
+function getTableColumns(schema: SchemaDefinition, tableName: string): string[] {
+  const table = schema.tables.find((t) => t.name === tableName);
+  if (!table) return [];
+  return table.columns.map((c) => c.name);
+}
+
+function evaluateChange(
+  schema: SchemaDefinition,
+  telemetry: Telemetry,
+  change: SchemaChange,
+): ChangeImpact {
+  const impacted: ConsumerImpact[] = [];
+  const tableColumns = getTableColumns(schema, change.table);
+  const relevantUsages = telemetry.usages.filter((usage) => usage.table === change.table);
+
+  for (const usage of relevantUsages) {
+    const reasons: string[] = [];
+    const affectedColumns: string[] = [];
+    let status: CompatibilityLevel = 'compatible';
+
+    if (change.type === 'rename') {
+      const usesColumn = usage.columns.includes(change.from);
+      if (usesColumn) {
+        status = 'needs-migration';
+        reasons.push(`Column ${change.from} renamed to ${change.to}`);
+        affectedColumns.push(change.from);
+      }
+    }
+
+    if (change.type === 'split') {
+      const usesColumn = usage.columns.includes(change.column);
+      if (usesColumn) {
+        status = 'breaking';
+        reasons.push(`Column ${change.column} split into ${change.into.map((c) => c.name).join(', ')}`);
+        affectedColumns.push(change.column);
+      }
+    }
+
+    if (change.type === 'widen') {
+      const usesColumn = usage.columns.includes(change.column);
+      if (usesColumn) {
+        status = 'compatible';
+        reasons.push(`Column ${change.column} widened to ${change.newType}`);
+        affectedColumns.push(change.column);
+      }
+    }
+
+    if (!tableColumns.includes(change.type === 'rename' ? change.from : change.column)) {
+      reasons.push('Change references missing column');
+      status = 'breaking';
+    }
+
+    if (reasons.length > 0) {
+      impacted.push({
+        consumer: usage.consumer,
+        table: usage.table,
+        status,
+        reasons,
+        affectedColumns,
+      });
+    }
+  }
+
+  return { change, impactedConsumers: impacted };
+}
+
+export function buildCompatibilityMatrix(
+  schema: SchemaDefinition,
+  telemetry: Telemetry,
+  changes: SchemaChange[],
+): CompatibilityMatrix {
+  const impacts: ConsumerImpact[] = [];
+  for (const change of changes) {
+    const result = evaluateChange(schema, telemetry, change);
+    impacts.push(...result.impactedConsumers);
+  }
+
+  // Deduplicate consumer impacts by keeping highest severity per consumer-table
+  const deduped = new Map<string, ConsumerImpact>();
+  for (const impact of impacts) {
+    const key = `${impact.consumer}:${impact.table}`;
+    const existing = deduped.get(key);
+    if (!existing) {
+      deduped.set(key, impact);
+      continue;
+    }
+
+    const severityOrder: CompatibilityLevel[] = ['compatible', 'needs-migration', 'breaking'];
+    if (severityOrder.indexOf(impact.status) > severityOrder.indexOf(existing.status)) {
+      deduped.set(key, {
+        ...impact,
+        reasons: Array.from(new Set([...existing.reasons, ...impact.reasons])),
+        affectedColumns: Array.from(new Set([...existing.affectedColumns, ...impact.affectedColumns])),
+      });
+    }
+  }
+
+  return { impacts: Array.from(deduped.values()) };
+}
+
+function scoreForImpact(impact: ConsumerImpact, telemetry: Telemetry): number {
+  const usage = telemetry.usages.find(
+    (entry) => entry.consumer === impact.consumer && entry.table === impact.table,
+  );
+  const baseFrequency = usage?.frequency ?? 0;
+  const severityMultiplier = impact.status === 'breaking' ? 1 : impact.status === 'needs-migration' ? 0.6 : 0.2;
+  return baseFrequency * severityMultiplier;
+}
+
+export function assessRisk(
+  matrix: CompatibilityMatrix,
+  telemetry: Telemetry,
+  changes: SchemaChange[],
+): RiskAssessment {
+  const changeNotes = changes.map((change) => {
+    if (change.type === 'rename') return `Rename ${change.table}.${change.from} -> ${change.to}`;
+    if (change.type === 'split')
+      return `Split ${change.table}.${change.column} into ${change.into.map((c) => c.name).join(', ')}`;
+    return `Widen ${change.table}.${change.column} to ${change.newType}`;
+  });
+
+  const rawScore = matrix.impacts.reduce((acc, impact) => acc + scoreForImpact(impact, telemetry), 0);
+  const normalized = Number((rawScore / Math.max(telemetry.windowDays, 1)).toFixed(2));
+  let severity: RiskAssessment['severity'] = 'low';
+  if (normalized > 25) severity = 'high';
+  else if (normalized > 10) severity = 'medium';
+
+  return {
+    score: normalized,
+    severity,
+    notes: [...changeNotes, `Aggregate normalized impact score: ${normalized}`],
+  };
+}

--- a/tools/ses/src/index.ts
+++ b/tools/ses/src/index.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import chalk from 'chalk';
+import { normalizePaths, loadSchema, loadTelemetry, loadChanges, loadFixtureDataset } from './loader.js';
+import type { SimulationConfig } from './types.js';
+import { runSimulation } from './simulator.js';
+
+function printUsage(): void {
+  console.log(`Schema Evolution Simulator (SES)\nUsage: ses <config.json>`);
+}
+
+function readConfig(path: string): SimulationConfig {
+  try {
+    const raw = loadConfigFile(path);
+    return normalizePaths(raw, dirname(path));
+  } catch (error) {
+    throw new Error(`Failed to read configuration ${path}: ${(error as Error).message}`);
+  }
+}
+
+function loadConfigFile(path: string): SimulationConfig {
+  const raw = readFileSync(path, 'utf-8');
+  return JSON.parse(raw) as SimulationConfig;
+}
+
+function ensureOutputPath(path: string): void {
+  const folder = dirname(path);
+  if (!existsSync(folder)) {
+    mkdirSync(folder, { recursive: true });
+  }
+}
+
+function run(): void {
+  const [, , configPath] = process.argv;
+  if (!configPath) {
+    printUsage();
+    process.exit(1);
+  }
+
+  const absoluteConfig = resolve(process.cwd(), configPath);
+  const config = readConfig(absoluteConfig);
+
+  const schema = loadSchema(config.schemaPath);
+  const telemetry = loadTelemetry(config.telemetryPath);
+  const changes = loadChanges(config.changesPath);
+  const fixture = loadFixtureDataset(config.fixturePath);
+
+  const result = runSimulation({ schema, telemetry, changes, fixture });
+
+  if (config.outputPath) {
+    ensureOutputPath(config.outputPath);
+    writeFileSync(config.outputPath, JSON.stringify(result, null, 2));
+    console.log(chalk.green(`Simulation results written to ${config.outputPath}`));
+  } else {
+    console.log(JSON.stringify(result, null, 2));
+  }
+}
+
+run();

--- a/tools/ses/src/loader.ts
+++ b/tools/ses/src/loader.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type {
+  SchemaDefinition,
+  Telemetry,
+  SchemaChange,
+  SimulationConfig,
+  FixtureDataset,
+} from './types.js';
+
+function loadJson<T>(path: string): T {
+  const contents = readFileSync(path, 'utf-8');
+  return JSON.parse(contents) as T;
+}
+
+export function loadSchema(schemaPath: string): SchemaDefinition {
+  return loadJson<SchemaDefinition>(schemaPath);
+}
+
+export function loadTelemetry(telemetryPath: string): Telemetry {
+  return loadJson<Telemetry>(telemetryPath);
+}
+
+export function loadChanges(changesPath: string): SchemaChange[] {
+  return loadJson<SchemaChange[]>(changesPath);
+}
+
+export function loadFixtureDataset(fixturePath: string | undefined): FixtureDataset | undefined {
+  if (!fixturePath) return undefined;
+  return loadJson<FixtureDataset>(fixturePath);
+}
+
+export function normalizePaths(config: SimulationConfig, baseDir: string): SimulationConfig {
+  return {
+    ...config,
+    schemaPath: resolve(baseDir, config.schemaPath),
+    telemetryPath: resolve(baseDir, config.telemetryPath),
+    changesPath: resolve(baseDir, config.changesPath),
+    fixturePath: config.fixturePath ? resolve(baseDir, config.fixturePath) : undefined,
+    outputPath: config.outputPath ? resolve(baseDir, config.outputPath) : undefined,
+  };
+}

--- a/tools/ses/src/migrator.ts
+++ b/tools/ses/src/migrator.ts
@@ -1,0 +1,173 @@
+import type {
+  SchemaDefinition,
+  SchemaChange,
+  MigrationBundle,
+  MigrationScript,
+  FixtureDataset,
+  RenameChange,
+  SplitChange,
+  WidenChange,
+} from './types.js';
+
+function buildRenameSQL(table: string, from: string, to: string): string {
+  return `ALTER TABLE ${table} RENAME COLUMN ${from} TO ${to};`;
+}
+
+function buildSplitSQL(table: string, column: string, into: { name: string; type: string }[]): string {
+  const addColumns = into.map((target) => `ALTER TABLE ${table} ADD COLUMN ${target.name} ${target.type.toUpperCase()};`);
+  const dropSource = `-- Manual verification required before dropping column ${column}`;
+  return [...addColumns, dropSource].join('\n');
+}
+
+function buildWidenSQL(table: string, column: string, newType: string): string {
+  return `ALTER TABLE ${table} ALTER COLUMN ${column} TYPE ${newType.toUpperCase()};`;
+}
+
+function buildRenameStub(table: string, from: string, to: string): string {
+  return `export async function migrate_${table}_${from}_to_${to}(row: Record<string, unknown>) {
+  if (Object.prototype.hasOwnProperty.call(row, '${from}')) {
+    row['${to}'] = row['${from}'];
+    delete row['${from}'];
+  }
+  return row;
+}`;
+}
+
+function buildSplitStub(table: string, column: string, into: { name: string }[]): string {
+  const assignments = into
+    .map((target, index) => `  row['${target.name}'] = parts[${index}] ?? null;`)
+    .join('\n');
+  return `export async function migrate_${table}_${column}_split(row: Record<string, unknown>) {
+  if (typeof row['${column}'] === 'string') {
+    const parts = String(row['${column}']).split(/\\s+/);
+${assignments}
+  }
+  return row;
+}`;
+}
+
+function buildWidenStub(table: string, column: string, newType: string): string {
+  return `export async function migrate_${table}_${column}_widen(row: Record<string, unknown>) {
+  // Type widening handled by database; ensure downstream typing to ${newType}
+  return row;
+}`;
+}
+
+function assertTableExists(schema: SchemaDefinition, table: string): void {
+  const exists = schema.tables.some((t) => t.name === table);
+  if (!exists) {
+    throw new Error(`Table ${table} does not exist in schema definition`);
+  }
+}
+
+function assertColumnExists(schema: SchemaDefinition, table: string, column: string): void {
+  const tbl = schema.tables.find((t) => t.name === table);
+  if (!tbl) {
+    throw new Error(`Table ${table} does not exist in schema definition`);
+  }
+  const exists = tbl.columns.some((col) => col.name === column);
+  if (!exists) {
+    throw new Error(`Column ${table}.${column} does not exist in schema definition`);
+  }
+}
+
+export function generateMigrationScripts(
+  schema: SchemaDefinition,
+  changes: SchemaChange[],
+): MigrationBundle {
+  const migrations: MigrationScript[] = [];
+
+  for (const change of changes) {
+    assertTableExists(schema, change.table);
+    if (change.type === 'rename') {
+      const rename = change as RenameChange;
+      assertColumnExists(schema, rename.table, rename.from);
+      migrations.push({
+        table: rename.table,
+        changeType: rename.type,
+        sql: buildRenameSQL(rename.table, rename.from, rename.to),
+        codeStub: buildRenameStub(rename.table, rename.from, rename.to),
+        details: { from: rename.from, to: rename.to },
+      });
+    }
+
+    if (change.type === 'split') {
+      const split = change as SplitChange;
+      assertColumnExists(schema, split.table, split.column);
+      migrations.push({
+        table: split.table,
+        changeType: split.type,
+        sql: buildSplitSQL(split.table, split.column, split.into),
+        codeStub: buildSplitStub(split.table, split.column, split.into),
+        details: { column: split.column, into: split.into.map((target) => target.name) },
+      });
+    }
+
+    if (change.type === 'widen') {
+      const widen = change as WidenChange;
+      assertColumnExists(schema, widen.table, widen.column);
+      migrations.push({
+        table: widen.table,
+        changeType: widen.type,
+        sql: buildWidenSQL(widen.table, widen.column, widen.newType),
+        codeStub: buildWidenStub(widen.table, widen.column, widen.newType),
+        details: { column: widen.column, newType: widen.newType },
+      });
+    }
+  }
+
+  return { migrations };
+}
+
+function cloneDataset(dataset: FixtureDataset): FixtureDataset {
+  const tables: FixtureDataset['tables'] = {};
+  for (const [tableName, rows] of Object.entries(dataset.tables)) {
+    tables[tableName] = rows.map((row) => ({ ...row }));
+  }
+  return { tables };
+}
+
+export function applyMigrationsToFixture(
+  dataset: FixtureDataset,
+  bundle: MigrationBundle,
+): FixtureDataset {
+  const result = cloneDataset(dataset);
+
+  for (const migration of bundle.migrations) {
+    const rows = result.tables[migration.table];
+    if (!rows) continue;
+
+    if (migration.changeType === 'rename') {
+      const from = (migration.details as { from?: string })?.from;
+      const to = (migration.details as { to?: string })?.to;
+      for (const row of rows) {
+        if (from && to && row[from] !== undefined) {
+          row[to] = row[from];
+          delete row[from];
+        }
+      }
+    }
+
+    if (migration.changeType === 'split') {
+      const column = (migration.details as { column?: string })?.column;
+      const into = ((migration.details as { into?: string[] })?.into ?? []) as string[];
+      for (const row of rows) {
+        if (!column) continue;
+        const sourceValue = row[column];
+        if (typeof sourceValue === 'string') {
+          const parts = String(sourceValue).split(/\s+/);
+          into.forEach((target, index) => {
+            row[target] = parts[index] ?? null;
+          });
+        }
+      }
+    }
+
+    if (migration.changeType === 'widen') {
+      // No data mutation required for widening in fixtures.
+      continue;
+    }
+  }
+
+  return result;
+}

--- a/tools/ses/src/rollout.ts
+++ b/tools/ses/src/rollout.ts
@@ -1,0 +1,57 @@
+import type { CompatibilityMatrix, RiskAssessment, RolloutPlan, RolloutPhase } from './types.js';
+
+function gateFromRisk(score: number): 'pass' | 'fail' {
+  return score > 15 ? 'fail' : 'pass';
+}
+
+function phaseRiskMultiplier(name: string): number {
+  switch (name) {
+    case 'Shadow validation':
+      return 0.4;
+    case 'Dual write':
+      return 0.7;
+    case 'Cutover':
+      return 1;
+    default:
+      return 0.2;
+  }
+}
+
+export function buildRolloutPlan(matrix: CompatibilityMatrix, risk: RiskAssessment): RolloutPlan {
+  const baseScore = risk.score;
+  const phases: RolloutPhase[] = [
+    {
+      name: 'Readiness & contract updates',
+      goals: [
+        'Distribute compatibility matrix to consumers',
+        'Approve migration scripts with owning teams',
+      ],
+      gate: gateFromRisk(baseScore * phaseRiskMultiplier('Readiness & contract updates')),
+      riskScore: Number((baseScore * phaseRiskMultiplier('Readiness & contract updates')).toFixed(2)),
+    },
+    {
+      name: 'Shadow validation',
+      goals: ['Replay telemetry to validate shape', 'Monitor for schema violations'],
+      gate: gateFromRisk(baseScore * phaseRiskMultiplier('Shadow validation')),
+      riskScore: Number((baseScore * phaseRiskMultiplier('Shadow validation')).toFixed(2)),
+    },
+    {
+      name: 'Dual write',
+      goals: ['Enable new writes alongside legacy', 'Backfill derived columns'],
+      gate: gateFromRisk(baseScore * phaseRiskMultiplier('Dual write')),
+      riskScore: Number((baseScore * phaseRiskMultiplier('Dual write')).toFixed(2)),
+    },
+    {
+      name: 'Cutover',
+      goals: ['Switch consumers to new contract', 'Decommission legacy columns'],
+      gate: gateFromRisk(baseScore * phaseRiskMultiplier('Cutover')),
+      riskScore: Number((baseScore * phaseRiskMultiplier('Cutover')).toFixed(2)),
+    },
+  ];
+
+  if (matrix.impacts.some((impact) => impact.status === 'breaking')) {
+    phases[0].goals.push('Escalate breaking changes to change advisory board');
+  }
+
+  return { phases };
+}

--- a/tools/ses/src/simulator.ts
+++ b/tools/ses/src/simulator.ts
@@ -1,0 +1,35 @@
+import { buildCompatibilityMatrix, assessRisk } from './analyzer.js';
+import { generateMigrationScripts, applyMigrationsToFixture } from './migrator.js';
+import { buildRolloutPlan } from './rollout.js';
+import type {
+  SchemaDefinition,
+  Telemetry,
+  SchemaChange,
+  SimulationOutput,
+  FixtureDataset,
+} from './types.js';
+
+export interface SimulationContext {
+  schema: SchemaDefinition;
+  telemetry: Telemetry;
+  changes: SchemaChange[];
+  fixture?: FixtureDataset;
+}
+
+export function runSimulation(context: SimulationContext): SimulationOutput {
+  const compatibility = buildCompatibilityMatrix(context.schema, context.telemetry, context.changes);
+  const migrationBundle = generateMigrationScripts(context.schema, context.changes);
+  const fixturePreview = context.fixture
+    ? applyMigrationsToFixture(context.fixture, migrationBundle)
+    : undefined;
+  const risk = assessRisk(compatibility, context.telemetry, context.changes);
+  const rollout = buildRolloutPlan(compatibility, risk);
+
+  return {
+    compatibility,
+    migrationBundle,
+    risk,
+    rollout,
+    fixturePreview,
+  };
+}

--- a/tools/ses/src/types.ts
+++ b/tools/ses/src/types.ts
@@ -1,0 +1,126 @@
+export type PrimitiveType = 'string' | 'integer' | 'float' | 'boolean' | 'date';
+
+export interface Column {
+  name: string;
+  type: PrimitiveType;
+  nullable?: boolean;
+}
+
+export interface Table {
+  name: string;
+  columns: Column[];
+}
+
+export interface SchemaDefinition {
+  version: string;
+  tables: Table[];
+}
+
+export interface ConsumerUsage {
+  consumer: string;
+  table: string;
+  columns: string[];
+  frequency: number; // per day
+}
+
+export interface Telemetry {
+  windowDays: number;
+  usages: ConsumerUsage[];
+}
+
+export type ChangeKind = 'rename' | 'split' | 'widen';
+
+export interface BaseChange {
+  type: ChangeKind;
+  table: string;
+  rationale?: string;
+}
+
+export interface RenameChange extends BaseChange {
+  type: 'rename';
+  from: string;
+  to: string;
+}
+
+export interface SplitTargetColumn {
+  name: string;
+  type: PrimitiveType;
+  nullable?: boolean;
+}
+
+export interface SplitChange extends BaseChange {
+  type: 'split';
+  column: string;
+  into: SplitTargetColumn[];
+}
+
+export interface WidenChange extends BaseChange {
+  type: 'widen';
+  column: string;
+  newType: PrimitiveType;
+}
+
+export type SchemaChange = RenameChange | SplitChange | WidenChange;
+
+export interface SimulationConfig {
+  schemaPath: string;
+  telemetryPath: string;
+  changesPath: string;
+  fixturePath?: string;
+  outputPath?: string;
+}
+
+export type CompatibilityLevel = 'compatible' | 'needs-migration' | 'breaking';
+
+export interface ConsumerImpact {
+  consumer: string;
+  table: string;
+  status: CompatibilityLevel;
+  reasons: string[];
+  affectedColumns: string[];
+}
+
+export interface CompatibilityMatrix {
+  impacts: ConsumerImpact[];
+}
+
+export interface MigrationScript {
+  table: string;
+  sql: string;
+  codeStub: string;
+  changeType: ChangeKind;
+  details?: Record<string, unknown>;
+}
+
+export interface MigrationBundle {
+  migrations: MigrationScript[];
+}
+
+export interface RiskAssessment {
+  score: number;
+  severity: 'low' | 'medium' | 'high';
+  notes: string[];
+}
+
+export interface RolloutPhase {
+  name: string;
+  goals: string[];
+  gate: 'pass' | 'fail';
+  riskScore: number;
+}
+
+export interface RolloutPlan {
+  phases: RolloutPhase[];
+}
+
+export interface SimulationOutput {
+  compatibility: CompatibilityMatrix;
+  migrationBundle: MigrationBundle;
+  risk: RiskAssessment;
+  rollout: RolloutPlan;
+  fixturePreview?: FixtureDataset;
+}
+
+export interface FixtureDataset {
+  tables: Record<string, Record<string, unknown>[]>;
+}

--- a/tools/ses/tests/simulator.test.ts
+++ b/tools/ses/tests/simulator.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { loadSchema, loadTelemetry, loadChanges, loadFixtureDataset, normalizePaths } from '../src/loader.js';
+import { runSimulation } from '../src/simulator.js';
+import type { SimulationConfig } from '../src/types.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+function loadConfig(): SimulationConfig {
+  const baseDir = resolve(__dirname, '../fixtures');
+  const raw = JSON.parse(readFileSync(resolve(baseDir, 'config.json'), 'utf-8')) as SimulationConfig;
+  return normalizePaths(raw, baseDir);
+}
+
+describe('Schema Evolution Simulator', () => {
+  const config = loadConfig();
+  const schema = loadSchema(config.schemaPath);
+  const telemetry = loadTelemetry(config.telemetryPath);
+  const changes = loadChanges(config.changesPath);
+  const fixture = loadFixtureDataset(config.fixturePath);
+
+  const output = runSimulation({ schema, telemetry, changes, fixture });
+
+  it('flags seeded breaking changes in compatibility matrix', () => {
+    const billingImpact = output.compatibility.impacts.find(
+      (impact) => impact.consumer === 'billing-service' && impact.table === 'customers',
+    );
+    expect(billingImpact).toBeDefined();
+    expect(billingImpact?.status).toBe('breaking');
+    expect(billingImpact?.reasons.some((reason) => reason.includes('split'))).toBe(true);
+  });
+
+  it('generates migrations with SQL and code stubs for each change', () => {
+    expect(output.migrationBundle.migrations).toHaveLength(3);
+    const rename = output.migrationBundle.migrations.find((migration) => migration.changeType === 'rename');
+    expect(rename?.sql).toContain('RENAME COLUMN email TO primary_email');
+    const split = output.migrationBundle.migrations.find((migration) => migration.changeType === 'split');
+    expect(split?.sql).toContain('ADD COLUMN first_name');
+    const widen = output.migrationBundle.migrations.find((migration) => migration.changeType === 'widen');
+    expect(widen?.sql).toContain('ALTER COLUMN total_amount TYPE FLOAT');
+  });
+
+  it('applies generated migrations to fixture data without throwing and returns preview', () => {
+    expect(output.fixturePreview).toBeDefined();
+    const customers = output.fixturePreview?.tables.customers ?? [];
+    expect(customers[0]).toHaveProperty('primary_email', 'ada@example.com');
+    expect(customers[0]).not.toHaveProperty('email');
+    expect(customers[0]).toHaveProperty('first_name', 'Ada');
+    expect(customers[0]).toHaveProperty('last_name', 'Lovelace');
+  });
+
+  it('produces deterministic risk assessment and rollout gating', () => {
+    expect(output.risk.score).toBeCloseTo(13.14, 2);
+    expect(output.risk.severity).toBe('medium');
+    const cutoverPhase = output.rollout.phases.find((phase) => phase.name === 'Cutover');
+    expect(cutoverPhase?.gate).toBe('pass');
+    expect(cutoverPhase?.riskScore).toBeCloseTo(13.14, 2);
+  });
+});

--- a/tools/ses/tsconfig.json
+++ b/tools/ses/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "tests", "fixtures"]
+}

--- a/tools/ses/vitest.config.ts
+++ b/tools/ses/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'lcov'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a TypeScript-based Schema Evolution Simulator (SES) CLI that evaluates schema changes, generates migrations, and plans rollouts
- include fixtures and Vitest coverage to ensure breaking changes are flagged and migrations transform sample data
- add a GitHub Action workflow to gate SES changes with automated tests

## Testing
- npm test (from tools/ses)


------
https://chatgpt.com/codex/tasks/task_e_68d75ae9bcec833391ec8cd7cac9fc36