### PR TITLE
docs: add conductor summary backlog and raci for workstream 1

### DIFF
--- a/backlog/backlog.json
+++ b/backlog/backlog.json
@@ -1,0 +1,382 @@
+{
+  "workstream": "Workstream 1 — Maestro Conductor Summary",
+  "releases": [
+    {
+      "id": "R1",
+      "name": "Release 1",
+      "window": "Weeks 1-2",
+      "target_tag": "v24.1.0",
+      "objective": "Baseline guardrail instrumentation and publish Workstream 1 governance assets.",
+      "evidence": {
+        "logs": ["conductor-summary-r1.log"],
+        "metrics": ["prometheus://conductor_guardrails_latency_histogram"],
+        "tests": ["npm run lint:backlog", "npm run test:guardrails"],
+        "provenance": ["git tag v24.1.0", "backlog/backlog.json@R1"]
+      }
+    },
+    {
+      "id": "R2",
+      "name": "Release 2",
+      "window": "Weeks 3-4",
+      "target_tag": "v24.2.0",
+      "objective": "Automate cost/SLO alerting and finalize cross-workstream accountability handoffs.",
+      "evidence": {
+        "logs": ["conductor-summary-r2.log"],
+        "metrics": ["grafana://dashboards/conductor_guardrails"],
+        "tests": ["npm run lint:backlog", "npm run test:alerts"],
+        "provenance": ["git tag v24.2.0", "docs/raci.md@R2"]
+      }
+    }
+  ],
+  "epics": [
+    {
+      "id": "EP-WS1-001",
+      "name": "Guardrail Telemetry Blueprint",
+      "moscow": "Must",
+      "summary": "Define and validate SLO and cost telemetry hooks supporting Workstreams 2–8.",
+      "release": "R1",
+      "dependencies": ["Workstream 2", "Workstream 3", "Workstream 4", "Workstream 5"],
+      "evidence": {
+        "logs": ["telemetry-blueprint.log"],
+        "metrics": ["neo4j://latency/p95", "billing://env_costs"],
+        "tests": ["npm run test:telemetry"],
+        "provenance": ["ADR-telemetry-link"],
+        "hooks": ["SLO_histograms", "cost_alert_thresholds"]
+      },
+      "stories": [
+        {
+          "id": "ST-WS1-001A",
+          "name": "Document latency metric contracts",
+          "moscow": "Must",
+          "description": "Capture API, subscription, and Neo4j latency contracts with owners and sampling plans.",
+          "dependencies": ["Workstream 2", "Workstream 3"],
+          "acceptance_criteria": [
+            "SLO table lists owners, metric names, and collection frequency for reads, writes, subscriptions, Neo4j hops.",
+            "Sampling plan references existing Prometheus jobs and Neo4j tracing exporters.",
+            "Evidence hooks mapped to dashboard panels consumed by Workstream 5 (Observability)."
+          ],
+          "testability_notes": "Validate using markdown lint and jsonschema check for metric references; cross-verify with Grafana API snapshot.",
+          "verification": {
+            "steps": [
+              "Run npm run lint:docs on docs/conductor-summary.md",
+              "Execute scripts/validate_slo_schema.js",
+              "Confirm Grafana snapshot saved with timestamp and owner"
+            ]
+          },
+          "evidence": {
+            "logs": ["slo-contracts.log"],
+            "metrics": ["prometheus://conductor_slo_latency"],
+            "tests": ["npm run lint:docs"],
+            "provenance": ["Notion export -> repo commit"]
+          },
+          "tasks": [
+            {
+              "id": "TK-WS1-001A-1",
+              "description": "Create SLO contract table in docs/conductor-summary.md with metric IDs and owners.",
+              "moscow": "Must",
+              "evidence": {
+                "logs": ["git log -1 --stat"],
+                "metrics": ["conductor_slo_contract_table"],
+                "tests": ["npm run lint:docs"],
+                "provenance": ["docs/conductor-summary.md"]
+              }
+            },
+            {
+              "id": "TK-WS1-001A-2",
+              "description": "Update Grafana dashboard JSON with new panels and label Workstream 5 dependency.",
+              "moscow": "Should",
+              "evidence": {
+                "logs": ["grafana-dashboard-update.log"],
+                "metrics": ["grafana://dashboard_validation"],
+                "tests": ["scripts/validate_dashboard.py"],
+                "provenance": ["grafana-dashboard.json"]
+              }
+            }
+          ]
+        },
+        {
+          "id": "ST-WS1-001B",
+          "name": "Align cost guardrail instrumentation",
+          "moscow": "Must",
+          "description": "Specify cost telemetry collection for Dev, Staging, Prod, and LLM usage with 80% alerts.",
+          "dependencies": ["Workstream 6"],
+          "acceptance_criteria": [
+            "Cost data sources for all environments documented with API endpoints and refresh cadence.",
+            "Alert thresholds for 80% spend automatically notify Slack channel and PagerDuty runbook.",
+            "Link to Workstream 6 backlog item covering FinOps automation." 
+          ],
+          "testability_notes": "Use mock billing exporter to simulate spend and assert alert triggers in staging sandbox.",
+          "verification": {
+            "steps": [
+              "Run npm run test:alerts",
+              "Replay cost mock data via scripts/cost/mock.sh",
+              "Verify PagerDuty webhook receipts logged"
+            ]
+          },
+          "evidence": {
+            "logs": ["cost-guardrails.log"],
+            "metrics": ["billing://monthly_spend"],
+            "tests": ["npm run test:alerts"],
+            "provenance": ["runbooks/cost-guardrail.md"]
+          },
+          "tasks": [
+            {
+              "id": "TK-WS1-001B-1",
+              "description": "Publish cost telemetry matrix referencing Workstream 6 FinOps automation backlog.",
+              "moscow": "Must",
+              "evidence": {
+                "logs": ["cost-matrix.log"],
+                "metrics": ["finops://cost_threshold"],
+                "tests": ["npm run lint:docs"],
+                "provenance": ["docs/conductor-summary.md#cost-guardrails"]
+              }
+            },
+            {
+              "id": "TK-WS1-001B-2",
+              "description": "Configure alert routing with staging Slack webhook and PagerDuty service key.",
+              "moscow": "Could",
+              "evidence": {
+                "logs": ["alert-routing-test.log"],
+                "metrics": ["pagerduty://alerts_sent"],
+                "tests": ["scripts/test_alert_routing.sh"],
+                "provenance": ["ops/alert-routing.md"]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "EP-WS1-002",
+      "name": "Backlog & Governance Delivery",
+      "moscow": "Must",
+      "summary": "Publish prioritized backlog, acceptance criteria, and validation tooling for Workstreams 2–8 handoff.",
+      "release": "R1",
+      "dependencies": ["Workstream 7", "Workstream 8"],
+      "evidence": {
+        "logs": ["backlog-delivery.log"],
+        "metrics": ["ci://lint_backlog_pass"],
+        "tests": ["npm run lint:backlog"],
+        "provenance": ["backlog/backlog.json"]
+      },
+      "stories": [
+        {
+          "id": "ST-WS1-002A",
+          "name": "Author backlog schema and automation",
+          "moscow": "Must",
+          "description": "Define JSON schema, lint command, and provenance fields for backlog/backlog.json.",
+          "dependencies": ["Workstream 7"],
+          "acceptance_criteria": [
+            "backlog/backlog.json validates against documented schema with MoSCoW and evidence fields.",
+            "CI command documented (npm run lint:backlog) and runnable locally.",
+            "Backlog references Workstreams 2–8 in dependency metadata."
+          ],
+          "testability_notes": "Implement schema validation script; ensure failing schema blocks release candidate in CI dry run.",
+          "verification": {
+            "steps": [
+              "Execute npm run lint:backlog",
+              "Review generated schema report in artifacts/backlog-schema.json",
+              "Capture screenshot of validation passing for audit"
+            ]
+          },
+          "evidence": {
+            "logs": ["lint-backlog.log"],
+            "metrics": ["ci://backlog_schema_pass_rate"],
+            "tests": ["npm run lint:backlog"],
+            "provenance": ["backlog/backlog.json"]
+          },
+          "tasks": [
+            {
+              "id": "TK-WS1-002A-1",
+              "description": "Draft backlog JSON with epics/stories/tasks and evidence metadata.",
+              "moscow": "Must",
+              "evidence": {
+                "logs": ["backlog-draft.log"],
+                "metrics": ["git_diff_lines"],
+                "tests": ["npm run lint:backlog"],
+                "provenance": ["backlog/backlog.json@draft"]
+              }
+            },
+            {
+              "id": "TK-WS1-002A-2",
+              "description": "Add npm script entry for backlog schema validation (ties to Workstream 7 CI hardening).",
+              "moscow": "Should",
+              "evidence": {
+                "logs": ["package-json-update.log"],
+                "metrics": ["ci://lint_backlog_runs"],
+                "tests": ["npm run lint:backlog"],
+                "provenance": ["package.json"]
+              }
+            }
+          ]
+        },
+        {
+          "id": "ST-WS1-002B",
+          "name": "Publish RACI accountability links",
+          "moscow": "Must",
+          "description": "Ensure docs/raci.md aligns with backlog and Workstream 8 governance requirements.",
+          "dependencies": ["Workstream 8"],
+          "acceptance_criteria": [
+            "RACI table lists Dev, Sec, SRE, Data, Docs for each milestone week.",
+            "Milestones align to release plan (R1/R2) and include dependency callouts to Workstreams 2–8.",
+            "Evidence hooks for sign-off recorded in docs/raci.md."
+          ],
+          "testability_notes": "Manual review plus markdown lint; cross-reference with backlog IDs.",
+          "verification": {
+            "steps": [
+              "Run npm run lint:docs",
+              "Cross-check backlog story IDs referenced in docs/raci.md",
+              "Record approvals in provenance register"
+            ]
+          },
+          "evidence": {
+            "logs": ["raci-publication.log"],
+            "metrics": ["governance://raci_alignment"],
+            "tests": ["npm run lint:docs"],
+            "provenance": ["docs/raci.md"]
+          },
+          "tasks": [
+            {
+              "id": "TK-WS1-002B-1",
+              "description": "Draft docs/raci.md with week-level milestones and role assignments.",
+              "moscow": "Must",
+              "evidence": {
+                "logs": ["raci-draft.log"],
+                "metrics": ["docs://raci_completion"],
+                "tests": ["npm run lint:docs"],
+                "provenance": ["docs/raci.md@draft"]
+              }
+            },
+            {
+              "id": "TK-WS1-002B-2",
+              "description": "Link backlog story references (e.g., ST-WS1-002B) inside docs/raci.md footnotes.",
+              "moscow": "Should",
+              "evidence": {
+                "logs": ["raci-backlog-link.log"],
+                "metrics": ["docs://linkcheck"],
+                "tests": ["npm run lint:docs"],
+                "provenance": ["docs/raci.md#references"]
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "EP-WS1-003",
+      "name": "Release 2 Alerting & Accountability",
+      "moscow": "Should",
+      "summary": "Finalize automated alerting, provenance capture, and cross-workstream handoffs for Release 2.",
+      "release": "R2",
+      "dependencies": ["Workstream 4", "Workstream 5", "Workstream 6", "Workstream 7", "Workstream 8"],
+      "evidence": {
+        "logs": ["release2-alerting.log"],
+        "metrics": ["alertmanager://guardrail_alerts"],
+        "tests": ["npm run test:alerts"],
+        "provenance": ["docs/raci.md#release-2"]
+      },
+      "stories": [
+        {
+          "id": "ST-WS1-003A",
+          "name": "Automate guardrail alert verification",
+          "moscow": "Should",
+          "description": "Implement weekly synthetic checks that validate latency and cost guardrails prior to staging cut.",
+          "dependencies": ["Workstream 4", "Workstream 5"],
+          "acceptance_criteria": [
+            "Synthetic job runs weekly with pass/fail summary published to observability Slack channel.",
+            "Neo4j query traces for 1-hop and 3-hop scenarios captured and stored for 30 days.",
+            "Cost alert dry run generates notification without paging when below threshold."
+          ],
+          "testability_notes": "Use CI pipeline to schedule synthetic check; confirm fail path triggers issue creation.",
+          "verification": {
+            "steps": [
+              "Configure GitHub workflow synthetic-check.yml",
+              "Review Slack notification logs",
+              "Inspect Neo4j trace retention via cypher query"
+            ]
+          },
+          "evidence": {
+            "logs": ["synthetic-guardrail-check.log"],
+            "metrics": ["synthetics://guardrail_pass_rate"],
+            "tests": ["npm run test:synthetics"],
+            "provenance": [".github/workflows/synthetic-check.yml"]
+          },
+          "tasks": [
+            {
+              "id": "TK-WS1-003A-1",
+              "description": "Author synthetic check workflow referencing Workstream 5 observability modules.",
+              "moscow": "Should",
+              "evidence": {
+                "logs": ["synthetic-workflow.log"],
+                "metrics": ["ci://synthetic_runs"],
+                "tests": ["npm run test:synthetics"],
+                "provenance": [".github/workflows/synthetic-check.yml@draft"]
+              }
+            },
+            {
+              "id": "TK-WS1-003A-2",
+              "description": "Record Neo4j trace retention query outputs in provenance folder.",
+              "moscow": "Could",
+              "evidence": {
+                "logs": ["neo4j-trace-retention.log"],
+                "metrics": ["neo4j://trace_storage"],
+                "tests": ["scripts/test_neo4j_retention.sh"],
+                "provenance": ["provenance/neo4j-trace-retention.md"]
+              }
+            }
+          ]
+        },
+        {
+          "id": "ST-WS1-003B",
+          "name": "Capture release provenance and sign-offs",
+          "moscow": "Should",
+          "description": "Define provenance logging pattern for release tags and RACI approvals with Workstream 8 compliance.",
+          "dependencies": ["Workstream 7", "Workstream 8"],
+          "acceptance_criteria": [
+            "Release checklist captures commit SHA, tag, and approver signatures.",
+            "Docs team publishes sign-off summary with links to guardrail evidence.",
+            "Security review artifact attached before production push."
+          ],
+          "testability_notes": "Manual review of provenance log entries and automated link checker on docs.",
+          "verification": {
+            "steps": [
+              "Update provenance/release-log.md",
+              "Run npm run lint:docs",
+              "Confirm security artifact accessible via docs/security directory"
+            ]
+          },
+          "evidence": {
+            "logs": ["release-provenance.log"],
+            "metrics": ["governance://signoff_latency"],
+            "tests": ["npm run lint:docs"],
+            "provenance": ["provenance/release-log.md"]
+          },
+          "tasks": [
+            {
+              "id": "TK-WS1-003B-1",
+              "description": "Draft provenance template referencing Workstream 8 compliance controls.",
+              "moscow": "Should",
+              "evidence": {
+                "logs": ["provenance-template.log"],
+                "metrics": ["compliance://template_usage"],
+                "tests": ["npm run lint:docs"],
+                "provenance": ["provenance/release-log.md@template"]
+              }
+            },
+            {
+              "id": "TK-WS1-003B-2",
+              "description": "Integrate tag verification step into release checklist referencing Workstream 7 CI pipeline.",
+              "moscow": "Could",
+              "evidence": {
+                "logs": ["release-checklist.log"],
+                "metrics": ["ci://tag_verification"],
+                "tests": ["scripts/test_release_checklist.sh"],
+                "provenance": ["docs/raci.md#release-2"]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/docs/conductor-summary.md
+++ b/docs/conductor-summary.md
@@ -1,0 +1,39 @@
+# Maestro Conductor – Workstream 1 Summary
+
+## Goals
+- Deliver a single-screen Conductor control summary that translates product intent into actionable guardrails, backlog, and accountability for the next two releases.
+- Embed observability hooks for SLO, cost, and cadence guardrails so downstream workstreams inherit unified targets.
+- Provide release-ready backlog and RACI assets that align with trunk-based delivery and weekly/biweekly cut cadence.
+
+## Non-Goals
+- Implementing Workstreams 2–8 deliverables (only referencing dependencies and evidence requirements).
+- Changing existing runtime infrastructure or deployment tooling beyond instrumentation called out in this workstream.
+- Redefining org-wide governance beyond cost/SLO guardrails supplied above.
+
+## Assumptions
+- Core Maestro Conductor architecture and integrations defined in prior PRDs remain valid.
+- Telemetry stack (Grafana/Prometheus, Neo4j query tracing, billing exporter) is available for new evidence hooks.
+- Workstreams 2–8 will consume the backlog dependencies defined here without schedule slippage.
+
+## Constraints
+- **SLO Guardrails:** API reads p95 ≤ 350 ms, writes p95 ≤ 700 ms; subscriptions p95 ≤ 250 ms; Neo4j 1-hop p95 ≤ 300 ms and 2–3 hop p95 ≤ 1200 ms.
+- **Cost Guardrails:** Dev ≤ $1k/mo, Staging ≤ $3k/mo, Prod ≤ $18k/mo (LLM spend ≤ $5k/mo) with 80% alert threshold.
+- **Release Cadence:** Trunk-based development; weekly cut to staging, biweekly to production; semantic tags `vX.Y.Z`.
+- **Evidence Hooks:** All backlog items must emit logs, metrics, automated tests, and provenance breadcrumbs for audit.
+
+## Risks & Mitigations
+| Risk | Impact | Mitigation | Owner |
+| --- | --- | --- | --- |
+| Telemetry gaps prevent SLO verification | Medium | Instrument GraphQL resolvers and Neo4j driver with p95 histograms; validate dashboards before release gates. | SRE Lead |
+| Cost telemetry delayed from FinOps exporter | High | Integrate cost collector mock in Dev/Staging, set 80% alert automation, escalate to Workstream 6 (Cost Automation) if variance persists. | Data Lead |
+| Dependencies from Workstream 3 (Data model) slip | Medium | Align milestone syncs weekly; adjust backlog with contingency tasks for schema contract tests. | Dev Lead |
+| Security review lags ahead of biweekly prod release | Medium | Pre-book Sec sign-off in week 3; include threat model delta checklist task. | Sec Lead |
+| Documentation debt blocks go/no-go approval | Low | Create Docs review tasks per release with automated link checking and template compliance. | Docs Lead |
+
+## Definition of Done
+- Conductor Summary, backlog JSON, and RACI published in repo with traceable evidence hook references.
+- Guardrail instrumentation requirements enumerated and linked to verification procedures for both releases.
+- Risks assigned with owners and mitigations tracked in backlog tasks.
+- Release 1 and Release 2 milestones mapped to RACI responsibilities with status dashboards referenced.
+- Automated validation (lint/JSON schema check) added for backlog structure and executed in CI or documented in verification steps.
+- Sign-offs captured via provenance log entries referencing commits/tags per release.

--- a/docs/raci.md
+++ b/docs/raci.md
@@ -1,0 +1,28 @@
+# Workstream 1 RACI – Releases 1 & 2
+
+| Milestone | Week | Release | Key Deliverables | Dependencies (WS2-WS8) | Dev | Sec | SRE | Data | Docs | Evidence Hooks |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| M1. Guardrail telemetry charter (ST-WS1-001A) | Week 1 | R1 | Publish latency SLO contracts and owner table. | WS2 data API schema; WS3 knowledge graph plan; WS5 observability dashboards. | R | C | A | C | I | `telemetry-blueprint.log`, Grafana snapshot, `scripts/validate_slo_schema.js` report |
+| M2. Cost instrumentation spec (ST-WS1-001B) | Week 1 | R1 | Define cost data sources, 80% alert routing. | WS6 FinOps automation; WS8 compliance audit inputs. | R | C | C | A | I | `cost-guardrails.log`, PagerDuty webhook receipts, mock billing test results |
+| M3. Backlog schema & lint automation (ST-WS1-002A) | Week 2 | R1 | Checked-in backlog/backlog.json and validation script. | WS7 CI/CD governance; WS8 audit registry. | R | I | C | C | A | `lint-backlog.log`, CI lint artifact, provenance commit |
+| M4. RACI publication & governance alignment (ST-WS1-002B) | Week 2 | R1 | docs/raci.md published with dependencies to WS2-WS8. | WS8 governance charter | C | C | I | I | R | `raci-publication.log`, markdown lint report, approval notes |
+| M5. Synthetic guardrail checks live (ST-WS1-003A) | Week 3 | R2 | GitHub workflow validating latency/cost guardrails weekly. | WS4 platform runtime readiness; WS5 observability modules. | R | I | A | C | C | `synthetic-guardrail-check.log`, workflow run artifact, Slack notification export |
+| M6. Release provenance log (ST-WS1-003B) | Week 4 | R2 | Provenance template + tag verification integrated with RACI sign-offs. | WS7 release automation; WS8 compliance evidence. | C | A | C | I | R | `release-provenance.log`, security review artifact, tag verification script output |
+
+**RACI Legend:** R = Responsible, A = Accountable, C = Consulted, I = Informed.
+
+## Timeline Notes
+- Weekly cadence aligns with trunk-based development; staging cuts every Friday (Weeks 1 & 3) and production pushes on even weeks (Weeks 2 & 4).
+- Release 1 sign-off requires M1–M4 evidence hooks attached in provenance register before tag `v24.1.0`.
+- Release 2 sign-off requires M5–M6 evidence with guardrail synthetic results and compliance approvals prior to tag `v24.2.0`.
+
+## Evidence & Provenance Expectations
+- **Logs:** Upload log artifacts to `runs/workstream-1/` with milestone identifier (e.g., `runs/workstream-1/m5-synthetic.log`).
+- **Metrics:** Snapshot Grafana dashboards and cost reports; link export URLs in backlog evidence arrays.
+- **Tests:** Capture CI run URLs for `npm run lint:backlog`, `npm run test:alerts`, and synthetic workflows.
+- **Provenance:** Update `provenance/release-log.md` with milestone references, signatories, and tag mapping per Definition of Done.
+
+## Coordination Rhythm
+- Monday sync with Workstreams 2–8 to confirm dependency readiness.
+- Wednesday checkpoint with SRE/Data for telemetry validation.
+- Thursday documentation review with Docs + Sec for compliance adjustments before staging cut.


### PR DESCRIPTION
## Summary
- document workstream 1 conductor summary with guardrails, risks, and definition of done
- introduce backlog/backlog.json with MoSCoW-prioritized epics, stories, tasks, and evidence metadata
- add docs/raci.md capturing week-by-week RACI across releases 1 and 2 and required evidence hooks

## Testing
- jq . backlog/backlog.json

------
https://chatgpt.com/codex/tasks/task_e_68d75f508bdc8333a9885793a1df697b