### PR TITLE
feat: add bgpr rollout controller and dashboard

### DIFF
--- a/client/src/App.router.jsx
+++ b/client/src/App.router.jsx
@@ -40,6 +40,7 @@ import {
   Map,
   Assessment,
   Settings,
+  Policy,
 } from '@mui/icons-material';
 import { getIntelGraphTheme } from './theme/intelgraphTheme';
 import { store } from './store';
@@ -64,6 +65,7 @@ import MCPRegistry from './pages/MCPRegistry.tsx';
 import { Security, Engineering, Description } from '@mui/icons-material';
 import ObservabilityPanel from './features/observability/ObservabilityPanel';
 import AdminStudio from './features/admin/AdminStudio';
+import BgprDashboard from './features/bgpr/BgprDashboard';
 import WorkBoard from './features/work/Board';
 import TicketDetails from './features/work/TicketDetails';
 import WorkflowEditor from './features/workflows/Editor';
@@ -110,6 +112,7 @@ const navigationItems = [
   { path: '/access-intel', label: 'Access Intel', icon: <Security /> },
   { path: '/geoint', label: 'GeoInt Map', icon: <Map /> },
   { path: '/reports', label: 'Reports', icon: <Assessment /> },
+  { path: '/bgpr', label: 'BGPR Rollouts', icon: <Policy /> },
   { path: '/system', label: 'System', icon: <Settings />, roles: ['ADMIN'] },
   {
     path: '/admin/osint-feeds',
@@ -664,6 +667,7 @@ function MainLayout() {
             <Route path="/access-intel" element={<AccessIntelPage />} />
             <Route path="/geoint" element={<InvestigationsPage />} />
             <Route path="/reports" element={<InvestigationsPage />} />
+            <Route path="/bgpr" element={<BgprDashboard />} />
             <Route element={<ProtectedRoute roles={['ADMIN']} />}>
               <Route path="/system" element={<InvestigationsPage />} />
               <Route path="/admin/osint-feeds" element={<OsintFeedConfig />} />

--- a/client/src/features/bgpr/BgprDashboard.tsx
+++ b/client/src/features/bgpr/BgprDashboard.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CircularProgress,
+  Divider,
+  Grid,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {
+  AuditEvent,
+  DryRunResult,
+  RolloutManifest,
+  RolloutResult,
+  StatusResponse,
+  createSampleManifest,
+  fetchStatus,
+  submitDryRun,
+  submitRollout,
+} from './api';
+
+function formatNumber(value: number, digits = 2): string {
+  return value.toLocaleString(undefined, {
+    maximumFractionDigits: digits,
+    minimumFractionDigits: digits,
+  });
+}
+
+function formatTimestamp(timestamp: string): string {
+  return new Date(timestamp).toLocaleString();
+}
+
+function manifestToString(manifest: RolloutManifest): string {
+  return JSON.stringify(manifest, null, 2);
+}
+
+function parseManifest(input: string): RolloutManifest {
+  const parsed = JSON.parse(input) as RolloutManifest;
+  if (!parsed.id || !parsed.signature) {
+    throw new Error('Manifest must include an id and signature');
+  }
+  return parsed;
+}
+
+interface MetricsPanelProps {
+  title: string;
+  metrics: RolloutResult['metrics'];
+}
+
+function MetricsPanel({ title, metrics }: MetricsPanelProps) {
+  return (
+    <Card variant="outlined">
+      <CardHeader title={title} />
+      <CardContent>
+        <Grid container spacing={2}>
+          <Grid item xs={12} md={4}>
+            <Typography variant="subtitle2">Block Rate</Typography>
+            <Typography variant="h5">{formatNumber(metrics.canary.blockRate)}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Control: {formatNumber(metrics.control.blockRate)}
+            </Typography>
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <Typography variant="subtitle2">FN Canary Catches</Typography>
+            <Typography variant="h5">{formatNumber(metrics.canary.fnCanaryCatches)}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Control: {formatNumber(metrics.control.fnCanaryCatches)}
+            </Typography>
+          </Grid>
+          <Grid item xs={12} md={4}>
+            <Typography variant="subtitle2">Latency (ms)</Typography>
+            <Typography variant="h5">{formatNumber(metrics.canary.latencyMs)}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Control: {formatNumber(metrics.control.latencyMs)}
+            </Typography>
+          </Grid>
+        </Grid>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AuditTrail({ entries }: { entries: AuditEvent[] }) {
+  if (!entries.length) {
+    return <Typography color="text.secondary">No audit activity recorded yet.</Typography>;
+  }
+
+  return (
+    <Stack spacing={1} divider={<Divider flexItem orientation="horizontal" />}>
+      {entries
+        .slice()
+        .reverse()
+        .map((entry) => (
+          <Box key={`${entry.manifestId}-${entry.timestamp}`}>
+            <Typography variant="subtitle2">{entry.outcome.toUpperCase()}</Typography>
+            <Typography variant="body2" color="text.secondary">
+              Manifest {entry.manifestId} · Policy {entry.policyVersion} · {formatTimestamp(entry.timestamp)}
+            </Typography>
+            <Typography variant="body1">{entry.reason}</Typography>
+          </Box>
+        ))}
+    </Stack>
+  );
+}
+
+function BgprDashboard() {
+  const [status, setStatus] = useState<StatusResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [manifestInput, setManifestInput] = useState(() => manifestToString(createSampleManifest()));
+  const [dryRunResult, setDryRunResult] = useState<DryRunResult | null>(null);
+  const [rolloutResult, setRolloutResult] = useState<RolloutResult | null>(null);
+
+  const latestMetrics = useMemo(() => {
+    if (rolloutResult) {
+      return rolloutResult.metrics;
+    }
+    if (dryRunResult) {
+      return {
+        canary: dryRunResult.metrics.canary,
+        control: dryRunResult.metrics.control,
+      };
+    }
+    return status?.lastResult?.metrics ?? null;
+  }, [dryRunResult, rolloutResult, status]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const nextStatus = await fetchStatus();
+        setStatus(nextStatus);
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    };
+    void load();
+  }, []);
+
+  const handleDryRun = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const manifest = parseManifest(manifestInput);
+      const result = await submitDryRun(manifest);
+      setDryRunResult(result);
+      const refreshed = await fetchStatus();
+      setStatus(refreshed);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRollout = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const manifest = parseManifest(manifestInput);
+      const result = await submitRollout(manifest);
+      setRolloutResult(result);
+      const refreshed = await fetchStatus();
+      setStatus(refreshed);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Box padding={3} display="flex" flexDirection="column" gap={3}>
+      <Typography variant="h4">Blue/Green Policy Rollouts</Typography>
+      <Typography variant="body1" color="text.secondary">
+        Manage signed manifests, observe deterministic canary metrics, and rely on auto-revert guardrails.
+      </Typography>
+
+      {error ? (
+        <Alert severity="error" onClose={() => setError(null)}>
+          {error}
+        </Alert>
+      ) : null}
+
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={6}>
+          <Card variant="outlined">
+            <CardHeader title="Rollout Manifest" subheader="Update signature after generating with your signing tool." />
+            <CardContent>
+              <Stack spacing={2}>
+                <TextField
+                  multiline
+                  minRows={14}
+                  value={manifestInput}
+                  onChange={(event) => setManifestInput(event.target.value)}
+                  fullWidth
+                  InputProps={{ sx: { fontFamily: 'monospace', fontSize: 14 } }}
+                />
+                <Stack direction="row" spacing={2}>
+                  <Button variant="outlined" onClick={handleDryRun} disabled={loading}>
+                    {loading ? <CircularProgress size={20} /> : 'Dry Run'}
+                  </Button>
+                  <Button variant="contained" onClick={handleRollout} disabled={loading}>
+                    {loading ? <CircularProgress size={20} /> : 'Apply Rollout'}
+                  </Button>
+                </Stack>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+        <Grid item xs={12} md={6}>
+          <Card variant="outlined">
+            <CardHeader title="Current Status" />
+            <CardContent>
+              <Stack spacing={1}>
+                <Typography variant="subtitle1">Active Policy</Typography>
+                <Typography variant="h6">{status?.currentPolicy ?? 'Loading...'}</Typography>
+                <Divider />
+                <Typography variant="subtitle1">Last Rollout Outcome</Typography>
+                <Typography>
+                  {status?.lastResult
+                    ? status.lastResult.reverted
+                      ? 'Auto-reverted'
+                      : 'Rolled out'
+                    : 'No rollouts yet'}
+                </Typography>
+                {status?.lastResult ? (
+                  <Typography variant="body2" color="text.secondary">
+                    {status.lastResult.auditEvent.reason}
+                  </Typography>
+                ) : null}
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+
+      {latestMetrics ? <MetricsPanel title="Latest Metrics" metrics={latestMetrics} /> : null}
+
+      <Card variant="outlined">
+        <CardHeader title="Audit Trail" />
+        <CardContent>
+          <AuditTrail entries={status?.auditTrail ?? []} />
+        </CardContent>
+      </Card>
+    </Box>
+  );
+}
+
+export default BgprDashboard;
+

--- a/client/src/features/bgpr/__tests__/BgprDashboard.test.tsx
+++ b/client/src/features/bgpr/__tests__/BgprDashboard.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import BgprDashboard from '../BgprDashboard';
+import type {
+  DryRunResult,
+  RolloutManifest,
+  RolloutResult,
+  StatusResponse,
+} from '../api';
+import {
+  createSampleManifest,
+  fetchStatus,
+  submitDryRun,
+  submitRollout,
+} from '../api';
+
+jest.mock('../api');
+
+const sampleManifest: RolloutManifest = {
+  id: 'rollout-demo',
+  policyVersion: 'policy-v2',
+  canaryPopulation: ['tenant-a', 'tenant-b'],
+  controlPopulation: ['tenant-c', 'tenant-d'],
+  thresholds: {
+    minBlockRate: 0.72,
+    maxLatencyMs: 110,
+    maxFnDelta: 4,
+  },
+  createdAt: '2025-01-01T00:00:00.000Z',
+  signature: 'signed-manifest',
+};
+
+const baseStatus: StatusResponse = {
+  currentPolicy: 'policy-v1',
+  lastResult: null,
+  auditTrail: [],
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  (createSampleManifest as jest.Mock).mockReturnValue(sampleManifest);
+});
+
+test('renders current policy and empty audit trail', async () => {
+  (fetchStatus as jest.Mock).mockResolvedValue(baseStatus);
+
+  render(<BgprDashboard />);
+
+  await waitFor(() => expect(fetchStatus).toHaveBeenCalled());
+  expect(screen.getByText('policy-v1')).toBeInTheDocument();
+  expect(screen.getByText('No audit activity recorded yet.')).toBeInTheDocument();
+});
+
+test('displays dry-run metrics after execution', async () => {
+  const dryRun: DryRunResult = {
+    manifest: sampleManifest,
+    metrics: {
+      canary: { blockRate: 0.81, fnCanaryCatches: 3, latencyMs: 75 },
+      control: { blockRate: 0.79, fnCanaryCatches: 4, latencyMs: 80 },
+    },
+  };
+  (fetchStatus as jest.Mock)
+    .mockResolvedValueOnce(baseStatus)
+    .mockResolvedValueOnce(baseStatus);
+  (submitDryRun as jest.Mock).mockResolvedValue(dryRun);
+
+  render(<BgprDashboard />);
+
+  await waitFor(() => expect(fetchStatus).toHaveBeenCalled());
+  fireEvent.click(screen.getByRole('button', { name: 'Dry Run' }));
+
+  await waitFor(() => expect(submitDryRun).toHaveBeenCalledTimes(1));
+  expect(screen.getByText('0.81')).toBeInTheDocument();
+  expect(screen.getByText('0.79')).toBeInTheDocument();
+});
+
+test('shows auto-revert outcome after rollout breach', async () => {
+  const revertedResult: RolloutResult = {
+    manifest: sampleManifest,
+    metrics: {
+      canary: { blockRate: 0.6, fnCanaryCatches: 8, latencyMs: 120 },
+      control: { blockRate: 0.9, fnCanaryCatches: 2, latencyMs: 60 },
+    },
+    breaches: ['block rate below minimum'],
+    reverted: true,
+    auditEvent: {
+      manifestId: sampleManifest.id,
+      policyVersion: sampleManifest.policyVersion,
+      outcome: 'reverted',
+      reason: 'auto-reverted due to breaches',
+      timestamp: '2025-01-02T00:00:00.000Z',
+    },
+  };
+  const statusAfterRollout: StatusResponse = {
+    currentPolicy: 'policy-v1',
+    lastResult: revertedResult,
+    auditTrail: [revertedResult.auditEvent],
+  };
+
+  (fetchStatus as jest.Mock)
+    .mockResolvedValueOnce(baseStatus)
+    .mockResolvedValueOnce(baseStatus)
+    .mockResolvedValueOnce(statusAfterRollout);
+  (submitRollout as jest.Mock).mockResolvedValue(revertedResult);
+
+  render(<BgprDashboard />);
+
+  await waitFor(() => expect(fetchStatus).toHaveBeenCalled());
+  fireEvent.click(screen.getByRole('button', { name: 'Apply Rollout' }));
+
+  await waitFor(() => expect(submitRollout).toHaveBeenCalledTimes(1));
+  await waitFor(() => expect(fetchStatus).toHaveBeenCalledTimes(3));
+  expect(screen.getByText('Auto-reverted')).toBeInTheDocument();
+  expect(screen.getByText('auto-reverted due to breaches')).toBeInTheDocument();
+});
+

--- a/client/src/features/bgpr/api.ts
+++ b/client/src/features/bgpr/api.ts
@@ -1,0 +1,103 @@
+export interface GuardrailThresholds {
+  minBlockRate: number;
+  maxLatencyMs: number;
+  maxFnDelta: number;
+}
+
+export interface RolloutManifest {
+  id: string;
+  policyVersion: string;
+  canaryPopulation: string[];
+  controlPopulation: string[];
+  thresholds: GuardrailThresholds;
+  createdAt: string;
+  signature: string;
+}
+
+export interface Metrics {
+  blockRate: number;
+  fnCanaryCatches: number;
+  latencyMs: number;
+}
+
+export interface MetricsComparison {
+  canary: Metrics;
+  control: Metrics;
+}
+
+export interface DryRunResult {
+  manifest: RolloutManifest;
+  metrics: MetricsComparison;
+}
+
+export interface RolloutResult {
+  manifest: RolloutManifest;
+  metrics: MetricsComparison;
+  breaches: string[];
+  reverted: boolean;
+  auditEvent: AuditEvent;
+}
+
+export interface AuditEvent {
+  manifestId: string;
+  policyVersion: string;
+  outcome: 'rolled_out' | 'reverted' | 'dry_run';
+  reason: string;
+  timestamp: string;
+}
+
+export interface StatusResponse {
+  currentPolicy: string;
+  lastResult: RolloutResult | null;
+  auditTrail: AuditEvent[];
+}
+
+const DEFAULT_BASE_URL = import.meta.env.VITE_BGPR_BASE_URL ?? 'http://localhost:8085';
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${DEFAULT_BASE_URL}${path}`, {
+    headers: { 'Content-Type': 'application/json', ...(init?.headers ?? {}) },
+    ...init,
+  });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || 'BGPR request failed');
+  }
+  return (await response.json()) as T;
+}
+
+export async function fetchStatus(): Promise<StatusResponse> {
+  return request<StatusResponse>('/api/bgpr/status');
+}
+
+export async function submitDryRun(manifest: RolloutManifest): Promise<DryRunResult> {
+  return request<DryRunResult>('/api/bgpr/dry-run', {
+    method: 'POST',
+    body: JSON.stringify({ manifest }),
+  });
+}
+
+export async function submitRollout(manifest: RolloutManifest): Promise<RolloutResult> {
+  return request<RolloutResult>('/api/bgpr/rollouts', {
+    method: 'POST',
+    body: JSON.stringify({ manifest }),
+  });
+}
+
+export function createSampleManifest(): RolloutManifest {
+  const now = new Date().toISOString();
+  return {
+    id: 'rollout-demo',
+    policyVersion: 'policy-v2',
+    canaryPopulation: ['tenant-a', 'tenant-b'],
+    controlPopulation: ['tenant-c', 'tenant-d'],
+    thresholds: {
+      minBlockRate: 0.72,
+      maxLatencyMs: 110,
+      maxFnDelta: 4,
+    },
+    createdAt: now,
+    signature: 'replace-with-valid-signature',
+  };
+}
+

--- a/services/bgpr-controller/README.md
+++ b/services/bgpr-controller/README.md
@@ -1,0 +1,20 @@
+# BGPR Controller Service
+
+The BGPR controller exposes deterministic policy rollout orchestration with audit logging and guardrail enforcement.
+
+## Running Locally
+
+```bash
+export BGPR_MANIFEST_SECRET="super-secret"
+cd services/bgpr-controller
+go run . --port 8085 --policy policy-v1
+```
+
+The service exposes the following endpoints:
+
+- `POST /api/bgpr/dry-run` – simulate a rollout using a signed manifest without committing changes.
+- `POST /api/bgpr/rollouts` – apply a rollout; guardrails automatically revert the policy if breached.
+- `GET /api/bgpr/status` – inspect the current policy, last rollout metrics, and audit trail entries.
+
+See `client/src/features/bgpr` for a TypeScript dashboard that drives these endpoints.
+

--- a/services/bgpr-controller/controller/controller.go
+++ b/services/bgpr-controller/controller/controller.go
@@ -1,0 +1,176 @@
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type AuditOutcome string
+
+const (
+	OutcomeRolledOut AuditOutcome = "rolled_out"
+	OutcomeReverted  AuditOutcome = "reverted"
+	OutcomeDryRun    AuditOutcome = "dry_run"
+)
+
+type AuditEvent struct {
+	ManifestID    string       `json:"manifestId"`
+	PolicyVersion string       `json:"policyVersion"`
+	Outcome       AuditOutcome `json:"outcome"`
+	Reason        string       `json:"reason"`
+	Timestamp     time.Time    `json:"timestamp"`
+}
+
+type RolloutResult struct {
+	Manifest   RolloutManifest   `json:"manifest"`
+	Metrics    MetricsComparison `json:"metrics"`
+	Breaches   []string          `json:"breaches"`
+	Reverted   bool              `json:"reverted"`
+	AuditEvent AuditEvent        `json:"auditEvent"`
+}
+
+type DryRunResult struct {
+	Manifest RolloutManifest   `json:"manifest"`
+	Metrics  MetricsComparison `json:"metrics"`
+}
+
+type Controller struct {
+	mu               sync.Mutex
+	currentPolicy    string
+	secret           string
+	auditTrail       []AuditEvent
+	lastResult       *RolloutResult
+	dryRunSelections map[string][]string
+}
+
+func NewController(initialPolicy, secret string) (*Controller, error) {
+	if secret == "" {
+		return nil, errors.New("controller requires a manifest verification secret")
+	}
+	return &Controller{
+		currentPolicy:    initialPolicy,
+		secret:           secret,
+		auditTrail:       make([]AuditEvent, 0),
+		dryRunSelections: make(map[string][]string),
+	}, nil
+}
+
+func (c *Controller) DryRun(manifest RolloutManifest) (DryRunResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	manifest.Normalize()
+	if err := manifest.VerifySignature(c.secret); err != nil {
+		return DryRunResult{}, err
+	}
+	metrics := computeMetrics(manifest, c.currentPolicy)
+	c.dryRunSelections[manifest.ID] = append([]string{}, manifest.CanaryPopulation...)
+	event := AuditEvent{
+		ManifestID:    manifest.ID,
+		PolicyVersion: manifest.PolicyVersion,
+		Outcome:       OutcomeDryRun,
+		Reason:        "dry run simulation completed",
+		Timestamp:     time.Now().UTC(),
+	}
+	c.auditTrail = append(c.auditTrail, event)
+	return DryRunResult{
+		Manifest: manifest,
+		Metrics:  metrics,
+	}, nil
+}
+
+func (c *Controller) Apply(manifest RolloutManifest) (RolloutResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	manifest.Normalize()
+	if err := manifest.VerifySignature(c.secret); err != nil {
+		return RolloutResult{}, err
+	}
+	expectedSelection, hasDryRun := c.dryRunSelections[manifest.ID]
+	if hasDryRun && !equalStrings(expectedSelection, manifest.CanaryPopulation) {
+		return RolloutResult{}, fmt.Errorf("canary selection does not match dry-run for manifest %s", manifest.ID)
+	}
+
+	metrics := computeMetrics(manifest, c.currentPolicy)
+	breaches := evaluateBreaches(metrics, manifest.Thresholds)
+	now := time.Now().UTC()
+	event := AuditEvent{
+		ManifestID:    manifest.ID,
+		PolicyVersion: manifest.PolicyVersion,
+		Outcome:       OutcomeRolledOut,
+		Reason:        "rollout completed within guardrails",
+		Timestamp:     now,
+	}
+	reverted := false
+	if len(breaches) > 0 {
+		event.Outcome = OutcomeReverted
+		event.Reason = fmt.Sprintf("auto-reverted due to breaches: %v", breaches)
+		reverted = true
+	} else {
+		c.currentPolicy = manifest.PolicyVersion
+	}
+	c.auditTrail = append(c.auditTrail, event)
+	result := RolloutResult{
+		Manifest:   manifest,
+		Metrics:    metrics,
+		Breaches:   breaches,
+		Reverted:   reverted,
+		AuditEvent: event,
+	}
+	c.lastResult = &result
+	return result, nil
+}
+
+func evaluateBreaches(metrics MetricsComparison, thresholds GuardrailThresholds) []string {
+	breaches := make([]string, 0)
+	if metrics.Canary.BlockRate < thresholds.MinBlockRate {
+		breaches = append(breaches, fmt.Sprintf("block rate %.4f below minimum %.4f", metrics.Canary.BlockRate, thresholds.MinBlockRate))
+	}
+	if metrics.Canary.LatencyMs > thresholds.MaxLatencyMs {
+		breaches = append(breaches, fmt.Sprintf("latency %.2fms above maximum %.2fms", metrics.Canary.LatencyMs, thresholds.MaxLatencyMs))
+	}
+	fnDelta := metrics.Canary.FnCanaryCatches - metrics.Control.FnCanaryCatches
+	if fnDelta > thresholds.MaxFnDelta {
+		breaches = append(breaches, fmt.Sprintf("fn delta %.2f exceeds maximum %.2f", fnDelta, thresholds.MaxFnDelta))
+	}
+	return breaches
+}
+
+// EvaluateBreachesForSimulator exposes the guardrail evaluation logic for the simulator package
+// without duplicating the deterministic breach computation.
+func EvaluateBreachesForSimulator(metrics MetricsComparison, thresholds GuardrailThresholds) []string {
+	return evaluateBreaches(metrics, thresholds)
+}
+
+func (c *Controller) AuditTrail() []AuditEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	copied := make([]AuditEvent, len(c.auditTrail))
+	copy(copied, c.auditTrail)
+	return copied
+}
+
+func (c *Controller) CurrentStatus() (string, *RolloutResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.lastResult == nil {
+		return c.currentPolicy, nil
+	}
+	snapshot := *c.lastResult
+	return c.currentPolicy, &snapshot
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/services/bgpr-controller/controller/controller_test.go
+++ b/services/bgpr-controller/controller/controller_test.go
@@ -1,0 +1,108 @@
+package controller_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/summit/bgpr/controller"
+)
+
+const secret = "super-secret"
+
+func signedManifest(t *testing.T, id, version string, canary, control []string, thresholds controller.GuardrailThresholds) controller.RolloutManifest {
+	t.Helper()
+	manifest := controller.RolloutManifest{
+		ID:                id,
+		PolicyVersion:     version,
+		CanaryPopulation:  append([]string{}, canary...),
+		ControlPopulation: append([]string{}, control...),
+		Thresholds:        thresholds,
+		CreatedAt:         time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+	manifest.Normalize()
+	sig, err := manifest.ComputeSignature(secret)
+	if err != nil {
+		t.Fatalf("compute signature: %v", err)
+	}
+	manifest.Signature = sig
+	return manifest
+}
+
+func TestDeterministicMetrics(t *testing.T) {
+	ctrl, err := controller.NewController("policy-v1", secret)
+	if err != nil {
+		t.Fatalf("new controller: %v", err)
+	}
+	thresholds := controller.GuardrailThresholds{MinBlockRate: 0.7, MaxLatencyMs: 110, MaxFnDelta: 5}
+	manifest := signedManifest(t, "m-1", "policy-v2", []string{"a", "b"}, []string{"c", "d"}, thresholds)
+
+	dryRun1, err := ctrl.DryRun(manifest)
+	if err != nil {
+		t.Fatalf("dry run 1: %v", err)
+	}
+	dryRun2, err := ctrl.DryRun(manifest)
+	if err != nil {
+		t.Fatalf("dry run 2: %v", err)
+	}
+	if dryRun1.Metrics != dryRun2.Metrics {
+		t.Fatalf("expected deterministic metrics, got %#v and %#v", dryRun1.Metrics, dryRun2.Metrics)
+	}
+}
+
+func TestGuardrailBreachTriggersRevert(t *testing.T) {
+	ctrl, err := controller.NewController("policy-v1", secret)
+	if err != nil {
+		t.Fatalf("new controller: %v", err)
+	}
+	thresholds := controller.GuardrailThresholds{MinBlockRate: 0.95, MaxLatencyMs: 50, MaxFnDelta: 0}
+	manifest := signedManifest(t, "m-2", "policy-v2", []string{"c1", "c2"}, []string{"d1", "d2"}, thresholds)
+
+	if _, err := ctrl.DryRun(manifest); err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+
+	result, err := ctrl.Apply(manifest)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if !result.Reverted {
+		t.Fatalf("expected rollout to revert due to guardrail breach")
+	}
+	if len(result.Breaches) == 0 {
+		t.Fatalf("expected breaches to be reported")
+	}
+	audit := ctrl.AuditTrail()
+	if len(audit) == 0 {
+		t.Fatalf("expected audit trail entries")
+	}
+	last := audit[len(audit)-1]
+	if last.Outcome != controller.OutcomeReverted {
+		t.Fatalf("expected last audit outcome reverted, got %s", last.Outcome)
+	}
+}
+
+func TestDryRunSelectionMustMatch(t *testing.T) {
+	ctrl, err := controller.NewController("policy-v1", secret)
+	if err != nil {
+		t.Fatalf("new controller: %v", err)
+	}
+	thresholds := controller.GuardrailThresholds{MinBlockRate: 0.7, MaxLatencyMs: 110, MaxFnDelta: 5}
+	manifest := signedManifest(t, "m-3", "policy-v2", []string{"p1", "p2"}, []string{"q1", "q2"}, thresholds)
+
+	if _, err := ctrl.DryRun(manifest); err != nil {
+		t.Fatalf("dry run: %v", err)
+	}
+
+	// Change the canary selection to trigger mismatch.
+	manifest.CanaryPopulation = []string{"p2", "p3"}
+	manifest.Normalize()
+	sig, err := manifest.ComputeSignature(secret)
+	if err != nil {
+		t.Fatalf("compute signature: %v", err)
+	}
+	manifest.Signature = sig
+
+	if _, err := ctrl.Apply(manifest); err == nil {
+		t.Fatalf("expected apply to fail when selection differs from dry-run")
+	}
+}

--- a/services/bgpr-controller/controller/manifest.go
+++ b/services/bgpr-controller/controller/manifest.go
@@ -1,0 +1,78 @@
+package controller
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"time"
+)
+
+type GuardrailThresholds struct {
+	MinBlockRate float64 `json:"minBlockRate"`
+	MaxLatencyMs float64 `json:"maxLatencyMs"`
+	MaxFnDelta   float64 `json:"maxFnDelta"`
+}
+
+type RolloutManifest struct {
+	ID                string              `json:"id"`
+	PolicyVersion     string              `json:"policyVersion"`
+	CanaryPopulation  []string            `json:"canaryPopulation"`
+	ControlPopulation []string            `json:"controlPopulation"`
+	Thresholds        GuardrailThresholds `json:"thresholds"`
+	CreatedAt         time.Time           `json:"createdAt"`
+	Signature         string              `json:"signature"`
+}
+
+func (m *RolloutManifest) Normalize() {
+	sort.Strings(m.CanaryPopulation)
+	sort.Strings(m.ControlPopulation)
+}
+
+func (m RolloutManifest) payloadForSignature() ([]byte, error) {
+	payload := struct {
+		ID                string              `json:"id"`
+		PolicyVersion     string              `json:"policyVersion"`
+		CanaryPopulation  []string            `json:"canaryPopulation"`
+		ControlPopulation []string            `json:"controlPopulation"`
+		Thresholds        GuardrailThresholds `json:"thresholds"`
+		CreatedAt         time.Time           `json:"createdAt"`
+	}{
+		ID:                m.ID,
+		PolicyVersion:     m.PolicyVersion,
+		CanaryPopulation:  append([]string{}, m.CanaryPopulation...),
+		ControlPopulation: append([]string{}, m.ControlPopulation...),
+		Thresholds:        m.Thresholds,
+		CreatedAt:         m.CreatedAt,
+	}
+	return json.Marshal(payload)
+}
+
+func (m RolloutManifest) ComputeSignature(secret string) (string, error) {
+	if secret == "" {
+		return "", errors.New("manifest signing secret must not be empty")
+	}
+	payload, err := m.payloadForSignature()
+	if err != nil {
+		return "", err
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	if _, err := mac.Write(payload); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(mac.Sum(nil)), nil
+}
+
+func (m RolloutManifest) VerifySignature(secret string) error {
+	expected, err := m.ComputeSignature(secret)
+	if err != nil {
+		return err
+	}
+	if !hmac.Equal([]byte(expected), []byte(strings.ToLower(m.Signature))) {
+		return errors.New("manifest signature verification failed")
+	}
+	return nil
+}

--- a/services/bgpr-controller/controller/metrics.go
+++ b/services/bgpr-controller/controller/metrics.go
@@ -1,0 +1,56 @@
+package controller
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+)
+
+type Metrics struct {
+	BlockRate       float64 `json:"blockRate"`
+	FnCanaryCatches float64 `json:"fnCanaryCatches"`
+	LatencyMs       float64 `json:"latencyMs"`
+}
+
+type MetricsComparison struct {
+	Canary  Metrics `json:"canary"`
+	Control Metrics `json:"control"`
+}
+
+func deterministicFloat(seed string, min, max float64) float64 {
+	hash := sha256.Sum256([]byte(seed))
+	num := binary.BigEndian.Uint64(hash[:8])
+	ratio := float64(num) / float64(math.MaxUint64)
+	if ratio < 0 {
+		ratio = 0
+	}
+	return min + ratio*(max-min)
+}
+
+func computeMetrics(manifest RolloutManifest, currentPolicy string) MetricsComparison {
+	canarySeed := manifest.ID + "|" + manifest.PolicyVersion + "|" + join(manifest.CanaryPopulation)
+	controlSeed := currentPolicy + "|" + join(manifest.ControlPopulation)
+	return MetricsComparison{
+		Canary: Metrics{
+			BlockRate:       deterministicFloat(canarySeed+"block", 0.6, 0.999),
+			FnCanaryCatches: deterministicFloat(canarySeed+"fn", 0, 25),
+			LatencyMs:       deterministicFloat(canarySeed+"latency", 45, 120),
+		},
+		Control: Metrics{
+			BlockRate:       deterministicFloat(controlSeed+"block", 0.6, 0.999),
+			FnCanaryCatches: deterministicFloat(controlSeed+"fn", 0, 25),
+			LatencyMs:       deterministicFloat(controlSeed+"latency", 45, 120),
+		},
+	}
+}
+
+func join(values []string) string {
+	result := make([]byte, 0)
+	for i, v := range values {
+		if i > 0 {
+			result = append(result, ',')
+		}
+		result = append(result, v...)
+	}
+	return string(result)
+}

--- a/services/bgpr-controller/go.mod
+++ b/services/bgpr-controller/go.mod
@@ -1,0 +1,4 @@
+module github.com/summit/bgpr
+
+go 1.22.0
+

--- a/services/bgpr-controller/httpapi/server.go
+++ b/services/bgpr-controller/httpapi/server.go
@@ -1,0 +1,104 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/summit/bgpr/controller"
+)
+
+type Server struct {
+	ctrl *controller.Controller
+}
+
+type dryRunRequest struct {
+	Manifest controller.RolloutManifest `json:"manifest"`
+}
+
+type applyRequest struct {
+	Manifest controller.RolloutManifest `json:"manifest"`
+}
+
+type statusResponse struct {
+	CurrentPolicy string                    `json:"currentPolicy"`
+	LastResult    *controller.RolloutResult `json:"lastResult"`
+	AuditTrail    []controller.AuditEvent   `json:"auditTrail"`
+}
+
+func New(ctrl *controller.Controller) *Server {
+	return &Server{ctrl: ctrl}
+}
+
+func (s *Server) Register(mux *http.ServeMux) {
+	mux.HandleFunc("/api/bgpr/dry-run", s.handleDryRun)
+	mux.HandleFunc("/api/bgpr/rollouts", s.handleApply)
+	mux.HandleFunc("/api/bgpr/status", s.handleStatus)
+}
+
+func (s *Server) handleDryRun(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req dryRunRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	result, err := s.ctrl.DryRun(req.Manifest)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	respondJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) handleApply(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req applyRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	result, err := s.ctrl.Apply(req.Manifest)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	respondJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) handleStatus(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	policy, result := s.ctrl.CurrentStatus()
+	audit := s.ctrl.AuditTrail()
+	respondJSON(w, http.StatusOK, statusResponse{
+		CurrentPolicy: policy,
+		LastResult:    result,
+		AuditTrail:    audit,
+	})
+}
+
+func respondJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	_ = encoder.Encode(body)
+}
+
+func MustReadSecret() string {
+	secret := os.Getenv("BGPR_MANIFEST_SECRET")
+	if secret == "" {
+		log.Fatal("BGPR_MANIFEST_SECRET must be set")
+	}
+	return secret
+}

--- a/services/bgpr-controller/main.go
+++ b/services/bgpr-controller/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/summit/bgpr/controller"
+	"github.com/summit/bgpr/httpapi"
+)
+
+func main() {
+	var port int
+	var initialPolicy string
+	flag.IntVar(&port, "port", 8085, "port to listen on")
+	flag.StringVar(&initialPolicy, "policy", "policy-v1", "initial active policy version")
+	flag.Parse()
+
+	secret := os.Getenv("BGPR_MANIFEST_SECRET")
+	if secret == "" {
+		log.Fatal("BGPR_MANIFEST_SECRET must be set")
+	}
+
+	ctrl, err := controller.NewController(initialPolicy, secret)
+	if err != nil {
+		log.Fatalf("failed to create controller: %v", err)
+	}
+
+	mux := http.NewServeMux()
+	api := httpapi.New(ctrl)
+	api.Register(mux)
+
+	srv := &http.Server{
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           mux,
+		ReadTimeout:       5 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	log.Printf("bgpr controller listening on %s (policy=%s)", srv.Addr, initialPolicy)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/services/bgpr-controller/simulator/simulator.go
+++ b/services/bgpr-controller/simulator/simulator.go
@@ -1,0 +1,30 @@
+package simulator
+
+import "github.com/summit/bgpr/controller"
+
+type Simulator struct {
+	ctrl *controller.Controller
+}
+
+func New(ctrl *controller.Controller) *Simulator {
+	return &Simulator{ctrl: ctrl}
+}
+
+type SimulationResult struct {
+	DryRun   controller.DryRunResult `json:"dryRun"`
+	Breaches []string                `json:"breaches"`
+}
+
+func (s *Simulator) Execute(manifest controller.RolloutManifest) (SimulationResult, error) {
+	dryRun, err := s.ctrl.DryRun(manifest)
+	if err != nil {
+		return SimulationResult{}, err
+	}
+	guardrails := controller.GuardrailThresholds{
+		MinBlockRate: manifest.Thresholds.MinBlockRate,
+		MaxLatencyMs: manifest.Thresholds.MaxLatencyMs,
+		MaxFnDelta:   manifest.Thresholds.MaxFnDelta,
+	}
+	breaches := controller.EvaluateBreachesForSimulator(dryRun.Metrics, guardrails)
+	return SimulationResult{DryRun: dryRun, Breaches: breaches}, nil
+}

--- a/services/bgpr-controller/simulator/simulator_test.go
+++ b/services/bgpr-controller/simulator/simulator_test.go
@@ -1,0 +1,50 @@
+package simulator_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/summit/bgpr/controller"
+	"github.com/summit/bgpr/simulator"
+)
+
+const manifestSecret = "super-secret"
+
+func TestSimulatorMatchesDryRun(t *testing.T) {
+	ctrl, err := controller.NewController("policy-v1", manifestSecret)
+	if err != nil {
+		t.Fatalf("new controller: %v", err)
+	}
+	sim := simulator.New(ctrl)
+	manifest := controller.RolloutManifest{
+		ID:                "sim-1",
+		PolicyVersion:     "policy-v2",
+		CanaryPopulation:  []string{"x1", "x2"},
+		ControlPopulation: []string{"y1", "y2"},
+		Thresholds: controller.GuardrailThresholds{
+			MinBlockRate: 0.7,
+			MaxLatencyMs: 110,
+			MaxFnDelta:   5,
+		},
+		CreatedAt: time.Date(2025, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+	manifest.Normalize()
+	sig, err := manifest.ComputeSignature(manifestSecret)
+	if err != nil {
+		t.Fatalf("compute signature: %v", err)
+	}
+	manifest.Signature = sig
+
+	result, err := sim.Execute(manifest)
+	if err != nil {
+		t.Fatalf("simulate: %v", err)
+	}
+	if len(result.Breaches) != 0 {
+		t.Fatalf("expected no breaches during simulation, got %v", result.Breaches)
+	}
+
+	// Applying after simulation should succeed because selection matches.
+	if _, err := ctrl.Apply(manifest); err != nil {
+		t.Fatalf("apply after simulation: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go-based BGPR rollout controller with deterministic metrics, guardrail enforcement, HTTP endpoints, and a simulator interface
- add a TypeScript dashboard that drives manifests, surfaces rollout metrics, and visualizes the audit trail
- cover controller and simulator behavior with unit tests and add a Jest dashboard test harness

## Testing
- go test ./...
- pnpm test:jest BgprDashboard *(fails: jest binary missing without client node_modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d75afebce48333872d04c5554bc4ff