### PR TITLE
feat: add zero trust security controls

### DIFF
--- a/idp/oidc-config.md
+++ b/idp/oidc-config.md
@@ -1,0 +1,109 @@
+# Summit OIDC Configuration
+
+This document defines the OpenID Connect + JWT profile used by Summit services and third-party relying parties. It covers
+issuer metadata, client registration, token content, and security baselines that align with the platform's tenant isolation,
+attribute-based access control (ABAC), and privacy guardrails.
+
+## Issuer Metadata
+
+| Setting | Value |
+| --- | --- |
+| Issuer (`iss`) | `https://id.summit.example.com` |
+| Discovery | `https://id.summit.example.com/.well-known/openid-configuration` |
+| JWKS | `https://id.summit.example.com/.well-known/jwks.json` (ECDSA P-256, rotated every 24h) |
+| Supported Flows | Authorization Code + PKCE (public), Client Credentials (service-to-service) |
+| ID Token Signing | `ES256` (preferred) with deterministic `kid` rotation schedule |
+| Access Token Format | JWT (audience-scoped), 5 minute lifetime |
+| Refresh Tokens | Rotating, 12 hour absolute lifetime, pairwise pseudonymous subject | 
+
+### Environment-Specific Overrides
+
+* **Staging**: sandbox issuer `https://id.staging.summit.example.com`, JWKS rotated every 12h, audience limited to staging APIs.
+* **Production**: strict TLS (TLS 1.3 only), OCSP stapling enabled, AIA chasing disabled.
+
+## Client Registration
+
+All OIDC clients are registered via SCIM + admin API workflow. Each client is tagged with:
+
+* `tenant_id`: GUID referencing the Summit tenant.
+* `purpose_tags`: One or more approved processing purposes (e.g., `intel-analysis`, `fraud-monitoring`).
+* `data_classification`: Highest data classification the client may request.
+* `mfa_policy`: `required`, `step-up`, or `not-applicable` (service accounts only).
+
+Clients are provisioned with the following defaults:
+
+```json
+{
+  "application_type": "web",
+  "grant_types": ["authorization_code"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "private_key_jwt",
+  "redirect_uris": [
+    "https://app.summit.example.com/callback",
+    "https://*.tenant.summit.example.com/cb"
+  ],
+  "post_logout_redirect_uris": [
+    "https://app.summit.example.com/signed-out"
+  ],
+  "default_acr_values": ["urn:summit:mfa:webauthn"],
+  "default_max_age": 300
+}
+```
+
+## Token Claims
+
+### ID Token
+
+* `sub`: Pairwise subject derived from `tenant_id` + user GUID via HKDF (prevents cross-tenant correlation).
+* `tenant_id`: Tenant scope used by OPA policies.
+* `purpose`: Array of allowed processing purposes; mapped from SCIM `urn:ietf:params:scim:schemas:extension:enterprise:2.0:User.purposeTags`.
+* `acr`: Assurance level. `urn:summit:mfa:webauthn` when WebAuthn MFA is satisfied.
+* `amr`: Authentication methods, includes `pwd`, `webauthn`, `recovery-code`.
+* `legal_hold`: Optional claim asserted by compliance service to indicate records must be retained.
+* `iat`, `exp`, `auth_time`: Standard OIDC claims.
+
+### Access Token
+
+JWT access tokens carry ABAC attributes consumed by the OPA sidecar:
+
+| Claim | Description |
+| --- | --- |
+| `scp` | Fine-grained scopes (e.g., `reports:read`, `reports:classify`). |
+| `roles` | Array of Summit roles for the tenant (`analyst`, `manager`, `legal`, `global-admin`). |
+| `purpose` | Mirrored from ID token for purpose enforcement. |
+| `clearance` | Highest data classification the user can access. |
+| `mfa` | Boolean flag set to `true` only when strong MFA satisfied. |
+| `audit_session` | Immutable audit handle propagated to logging pipeline. |
+
+Tokens are signed with ECDSA keys stored in the Summit KMS HSM cluster. Access tokens are additionally wrapped using
+AES-256-GCM envelope encryption when stored in caches to satisfy at-rest encryption requirements.
+
+## Authorization Server Policies
+
+* **PKCE Required** for all public clients. Server rejects requests without `code_challenge_method=S256`.
+* **Nonce Validation**: Clients must send `nonce`; the AS stores hashes in Redis for replay detection (5 minute TTL).
+* **Tenant Isolation**: `tenant_id` claim derived from login context; cross-tenant token exchange is disallowed.
+* **Purpose Enforcement**: Requested scopes must map to registered purpose tags; mismatches yield `invalid_scope`.
+* **Short-Lived PII**: Access tokens with `pii` scopes expire in 5 minutes; refresh tokens rotate with binding to device key.
+
+## Session Management & MFA
+
+* Default Authentication Context Class Reference (`acr`): `urn:summit:mfa:webauthn`.
+* WebAuthn MFA binding enforced at first login; resident keys stored in Summit FIDO attestation service.
+* Recovery options: FIPS-compliant TOTP fallback or hardware key pair-of-keys. Recovery events logged with immutable audit IDs.
+* Session revocation triggers push to SCIM `active=false` and OPA bundle refresh.
+
+## Operational Controls
+
+* **Logging**: All token issuance events write to append-only ledger (`prov-ledger` service).
+* **Key Rotation**: JWKS rotated daily; previous key retained for 48 hours for token validation grace.
+* **Client Secrets**: Only service accounts receive client credentials; stored in Vault transit engine with one-hour TTL leases.
+* **Monitoring**: Prometheus alerts on anomalous token mint rates, issuer response latency, and JWKS drift.
+
+## Integration Checklist
+
+1. Register client via SCIM provisioning workflow.
+2. Configure redirect URIs and WebAuthn policy.
+3. Fetch discovery document and JWKS at deploy time; cache for 10 minutes.
+4. Implement Authorization Code + PKCE; validate `state`, `nonce`, `aud`, `azp`, `acr`.
+5. Forward JWT access token to OPA sidecar on each API call; include `audit_session` header for immutable audit linking.

--- a/idp/scim-profile.md
+++ b/idp/scim-profile.md
@@ -1,0 +1,121 @@
+# Summit SCIM Provisioning Profile
+
+This profile describes how Summit automates workforce and service-account lifecycle management using SCIM 2.0. The goal is to
+ensure tenant isolation, rapid deprovisioning, and synchronized attributes for ABAC, WebAuthn MFA, and privacy controls.
+
+## Base Endpoints
+
+| Resource | Endpoint | Notes |
+| --- | --- | --- |
+| Users | `/scim/v2/Tenants/{tenantId}/Users` | Tenant-scoped, requires OIDC client with `scim:write` scope. |
+| Groups | `/scim/v2/Tenants/{tenantId}/Groups` | Used for role assignment + purpose tags. |
+| Service Principals | `/scim/v2/Tenants/{tenantId}/ServicePrincipals` | Machine identities, `client_credentials` only. |
+| Bulk | `/scim/v2/Tenants/{tenantId}/Bulk` | Limited to 100 operations per request, rate-limited (see misuse tests). |
+
+All endpoints require:
+
+* `Authorization: Bearer <access_token>` signed by Summit OIDC issuer with `scp` containing `scim:write` or `scim:read`.
+* `X-Summit-Audit-Session` header to correlate with immutable audit logs.
+* mTLS for transport + TLS 1.3.
+
+## Schema Extensions
+
+### User Resource
+
+```json
+{
+  "schemas": [
+    "urn:ietf:params:scim:schemas:core:2.0:User",
+    "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User",
+    "urn:summit:scim:schemas:security:1.0"
+  ],
+  "urn:summit:scim:schemas:security:1.0": {
+    "tenantId": "8e73a3f4-...",
+    "roles": ["analyst", "manager"],
+    "purposeTags": ["intel-analysis"],
+    "clearance": "restricted",
+    "mfa": {
+      "enrolled": true,
+      "methods": ["webauthn", "totp"],
+      "recoveryCodesIssued": "2025-03-01T00:00:00Z"
+    },
+    "legalHold": false
+  }
+}
+```
+
+Additional fields:
+
+* `mfa.methods`: MUST include `webauthn` once a credential is registered.
+* `purposeTags`: Drives OPA purpose enforcement and privacy minimisation maps.
+* `legalHold`: When true, overrides 30-day retention expiry for affected resources.
+
+### Group Resource
+
+Groups encapsulate Summit roles and application access policies.
+
+```json
+{
+  "displayName": "tenant-a:reports-analyst",
+  "members": [{ "value": "user-guid" }],
+  "urn:summit:scim:schemas:governance:1.0": {
+    "role": "analyst",
+    "purposeTags": ["intel-analysis"],
+    "dataClassification": "confidential"
+  }
+}
+```
+
+## Provisioning Flows
+
+### Onboarding
+
+1. HRIS triggers SCIM POST `/Users` with base profile + WebAuthn placeholder (`mfa.enrolled=false`).
+2. Summit issues invitation; user must enroll WebAuthn before `active=true` is set.
+3. Once WebAuthn attestation completes, `mfa.enrolled` toggled to `true` and `methods` includes credential `credentialId` hash.
+4. Group assignments propagate roles + purpose tags; OPA bundle refresh occurs within 60 seconds.
+
+### Update
+
+* Attribute updates use PATCH with `path` operations (RFC 7644). Only changed fields are accepted.
+* Purpose changes require governance approval; SCIM PATCH validated by policy engine before commit.
+* When `mfa.enrolled` transitions to `false`, Summit forces session revocation and sets `force_reauth=true` in ID token session store.
+
+### Deprovisioning
+
+1. SCIM PATCH `active=false` triggers:
+   * Immediate token revocation via OIDC back-channel logout.
+   * WebAuthn credential disablement + attestation log entry.
+   * Data minimisation workflow to wipe PII beyond 30 days while respecting `legalHold`.
+2. After 30 days of inactivity, user record is cryptographically tombstoned (hash of subject ID stored for audit).
+
+### Service Account Lifecycle
+
+* Service principals require Vault-managed signing keys; `mfa` omitted.
+* `purposeTags` limited to machine-to-machine contexts (e.g., `etl-ingest`).
+* Rotation: SCIM PATCH rotates signing certificates every 7 days via `x509Certificates` attribute.
+
+## SCIM -> Summit Mapping
+
+| SCIM Field | Summit Target | Notes |
+| --- | --- | --- |
+| `userName` | Login username (lowercase) | Unique per tenant. |
+| `externalId` | HRIS identifier | Stored encrypted-at-rest using envelope keys. |
+| `emails[type eq "work"].value` | Notification address | Verified via challenge email on onboarding. |
+| `phoneNumbers[type eq "mobile"].value` | WebAuthn recovery SMS (optional) | Stored encrypted with per-tenant DEK. |
+| `urn:summit:scim:schemas:security:1.0.purposeTags` | OPA `purpose` claim + privacy map | Max 5 tags per identity. |
+| `groups` | Roles & scopes | Each group maps to OPA role/purpose statements. |
+
+## Error Handling & Monitoring
+
+* SCIM responses include `schemas: ["urn:ietf:params:scim:api:messages:2.0:Error"]` with correlation ID header `X-Summit-Correlation`.
+* Rate limit: 120 write ops/min per tenant; violation returns HTTP 429 with retry-after.
+* Provisioning audit events stored in append-only ledger and forwarded to SIEM via syslog over TLS.
+* SCIM bulk operations validated against OPA simulation pipeline before commit; failing operations rolled back atomically.
+
+## Privacy & Security Controls
+
+* PII attributes flagged in catalog are encrypted in transit (TLS 1.3) and at rest (field-level AES-256-GCM + KMS envelope keys).
+* Purpose tags enforced for every SCIM mutating call; mismatches rejected with `403`.
+* Immutable audit: every SCIM change writes to ledger with event hash anchored in Summit transparency log.
+* Legal hold support: `legalHold=true` prevents automated deletion until compliance system clears the flag.

--- a/policies/opa/tenant_role_abac.rego
+++ b/policies/opa/tenant_role_abac.rego
@@ -1,0 +1,177 @@
+package summit.authz
+
+# Attribute-based and role-aware access controls for Summit tenants.
+# The policy enforces tenant boundaries, least privilege, purpose-based
+# scoping, data minimisation, immutable auditing, and encryption guards
+# for sensitive attributes.
+
+default allow = false
+
+action_roles := {
+  "read": ["analyst", "manager", "admin", "legal", "global-admin"],
+  "write": ["manager", "admin", "global-admin"],
+  "delete": ["admin", "global-admin"],
+  "tag": ["manager", "admin", "legal", "global-admin"]
+}
+
+classification_order := {
+  "public": 0,
+  "internal": 1,
+  "confidential": 2,
+  "restricted": 3,
+  "secret": 4
+}
+
+sensitive_field_tags := {"pii", "phi", "credential", "financial"}
+
+allow {
+  tenant_scoped
+  role_allows_action
+  purpose_compatible
+  classification_allows
+  mfa_enforced
+  encryption_verified
+  retention_enforced
+  legal_hold_allows
+  audit_present
+}
+
+tenant_scoped {
+  input.subject.roles[_] == "global-admin"
+}
+
+tenant_scoped {
+  input.subject.tenant == input.resource.tenant
+}
+
+role_allows_action {
+  required := action_roles[input.action]
+  role := input.subject.roles[_]
+  required[_] == role
+}
+
+classification_allows {
+  not input.resource.classification
+}
+
+classification_allows {
+  not input.subject.attributes.clearance
+  not input.resource.classification
+}
+
+classification_allows {
+  subject_clearance := classification_order[input.subject.attributes.clearance]
+  resource_level := classification_order[input.resource.classification]
+  subject_clearance >= resource_level
+}
+
+purpose_compatible {
+  resource_tags := {tag |
+    tag := input.resource.purpose_tags[_]
+    tag != ""
+  }
+  subject_tags := {tag |
+    tag := input.subject.attributes.purpose_tags[_]
+    tag != ""
+  }
+  count(resource_tags) > 0
+  some tag
+  resource_tags[tag]
+  subject_tags[tag]
+}
+
+purpose_compatible {
+  resource_tags := {tag |
+    tag := input.resource.purpose_tags[_]
+    tag != ""
+  }
+  count(resource_tags) == 0
+  input.subject.roles[_] == "global-admin"
+}
+
+purpose_compatible {
+  not input.resource.purpose_tags
+  input.subject.roles[_] == "global-admin"
+}
+
+purpose_compatible {
+  input.resource.legal_hold
+  subject_has_role("legal")
+}
+
+purpose_compatible {
+  input.resource.legal_hold
+  subject_has_role("global-admin")
+}
+
+subject_has_role(role) {
+  input.subject.roles[_] == role
+}
+
+mfa_enforced {
+  not input.environment.require_mfa
+}
+
+mfa_enforced {
+  input.environment.require_mfa
+  input.subject.attributes.mfa_enrolled
+  input.environment.mfa_satisfied
+}
+
+encryption_verified {
+  not input.resource.fields
+}
+
+encryption_verified {
+  fields := input.resource.fields
+  not fields_unprotected(fields)
+}
+
+fields_unprotected(fields) {
+  field := fields[_]
+  not field_protected(field)
+}
+
+field_protected(field) {
+  not field.sensitive
+}
+
+field_protected(field) {
+  field.sensitive
+  field.tags[_] == tag
+  sensitive_field_tags[tag]
+  field.encrypted
+  field.algorithm != ""
+  field.kms_key_id != ""
+}
+
+retention_enforced {
+  not input.resource.pii
+}
+
+retention_enforced {
+  input.resource.pii
+  input.resource.legal_hold
+}
+
+retention_enforced {
+  input.resource.pii
+  input.resource.retention_days <= 30
+}
+
+legal_hold_allows {
+  not input.resource.legal_hold
+}
+
+legal_hold_allows {
+  input.resource.legal_hold
+  some role
+  input.subject.roles[_] == role
+  {"legal", "global-admin"}[role]
+}
+
+audit_present {
+  audit := input.environment.audit
+  audit.event_id != ""
+  audit.immutable
+}

--- a/policies/opa/tests/tenant_role_abac_test.rego
+++ b/policies/opa/tests/tenant_role_abac_test.rego
@@ -1,0 +1,145 @@
+package summit.authz_test
+
+import data.summit.authz
+
+base_subject := {
+  "id": "user-1",
+  "tenant": "tenant-a",
+  "roles": ["manager"],
+  "attributes": {
+    "clearance": "restricted",
+    "mfa_enrolled": true,
+    "purpose_tags": ["intel-analysis", "legal-review"]
+  }
+}
+
+base_resource := {
+  "id": "report-1",
+  "tenant": "tenant-a",
+  "classification": "confidential",
+  "purpose_tags": ["intel-analysis"],
+  "pii": true,
+  "retention_days": 14,
+  "legal_hold": false,
+  "fields": [
+    {
+      "name": "ssn",
+      "sensitive": true,
+      "tags": ["pii"],
+      "encrypted": true,
+      "algorithm": "aes-256-gcm",
+      "kms_key_id": "kms/tenant-a/pii"
+    },
+    {
+      "name": "summary",
+      "sensitive": false,
+      "tags": []
+    }
+  ]
+}
+
+base_environment := {
+  "require_mfa": true,
+  "mfa_satisfied": true,
+  "audit": {
+    "event_id": "evt-123",
+    "immutable": true
+  }
+}
+
+allow_input := {
+  "subject": base_subject,
+  "resource": base_resource,
+  "action": "read",
+  "environment": base_environment
+}
+
+legal_hold_resource := object.union(base_resource, {"legal_hold": true})
+
+legal_hold_subject := {
+  "id": "counsel-1",
+  "tenant": "tenant-a",
+  "roles": ["legal"],
+  "attributes": {
+    "clearance": "secret",
+    "mfa_enrolled": true,
+    "purpose_tags": ["legal-review"]
+  }
+}
+
+cross_tenant_resource := object.union(base_resource, {"tenant": "tenant-b"})
+
+unencrypted_resource := object.union(base_resource, {
+  "fields": [
+    {
+      "name": "ssn",
+      "sensitive": true,
+      "tags": ["pii"],
+      "encrypted": false,
+      "algorithm": "",
+      "kms_key_id": ""
+    }
+  ]
+})
+
+retention_drift_resource := object.union(base_resource, {"retention_days": 60})
+
+mismatched_purpose_resource := object.union(base_resource, {"purpose_tags": ["fraud-monitoring"]})
+
+test_manager_can_read_confidential_report {
+  data.summit.authz.allow with input as allow_input
+}
+
+test_cross_tenant_access_denied {
+  not data.summit.authz.allow with input as {
+    "subject": base_subject,
+    "resource": cross_tenant_resource,
+    "action": "read",
+    "environment": base_environment
+  }
+}
+
+test_missing_encryption_denied {
+  not data.summit.authz.allow with input as {
+    "subject": base_subject,
+    "resource": unencrypted_resource,
+    "action": "read",
+    "environment": base_environment
+  }
+}
+
+test_retention_policy_enforced {
+  not data.summit.authz.allow with input as {
+    "subject": base_subject,
+    "resource": retention_drift_resource,
+    "action": "read",
+    "environment": base_environment
+  }
+}
+
+test_purpose_mismatch_denied {
+  not data.summit.authz.allow with input as {
+    "subject": base_subject,
+    "resource": mismatched_purpose_resource,
+    "action": "read",
+    "environment": base_environment
+  }
+}
+
+test_legal_hold_requires_legal_role {
+  not data.summit.authz.allow with input as {
+    "subject": base_subject,
+    "resource": legal_hold_resource,
+    "action": "read",
+    "environment": base_environment
+  }
+}
+
+test_legal_hold_allows_legal_role {
+  data.summit.authz.allow with input as {
+    "subject": legal_hold_subject,
+    "resource": legal_hold_resource,
+    "action": "read",
+    "environment": base_environment
+  }
+}

--- a/security/crypto-plan.md
+++ b/security/crypto-plan.md
@@ -1,0 +1,75 @@
+# Summit Encryption & Key Management Plan
+
+This plan aligns Summit services with platform guardrails: field-level encryption for sensitive attributes, immutable audit
+logging, and short-lived retention for PII. It describes how encryption is applied in transit and at rest, and how keys are
+managed via Summit's multi-cloud KMS architecture.
+
+## Cryptographic Objectives
+
+1. **Confidentiality**: All PII/regulated data encrypted in transit (TLS 1.3) and at rest (AES-256-GCM or stronger).
+2. **Integrity**: Immutable audit ledger anchored with SHA-256 Merkle roots + periodic notarisation.
+3. **Availability**: Keys replicated across at least two HSM-backed KMS regions per jurisdiction.
+4. **Granularity**: Field-level encryption for PII columns with tenant-specific data encryption keys (DEKs).
+
+## Key Hierarchy
+
+```
+Root Key (Summit Master Key - stored in HSM, per region)
+ ├── Tenant Key Encryption Keys (KEKs) - AWS KMS multi-tenant CMKs with policy-bound tenants
+ │    ├── Data Encryption Keys (DEKs) for Postgres columns (rotated every 24 hours)
+ │    ├── DEKs for S3 object prefixes (rotated every 7 days)
+ │    └── DEKs for Vault secure KV entries (rotated on access)
+ └── Token Signing Keys (ECDSA P-256) - rotated every 24 hours, 48 hour overlap
+```
+
+* DEKs generated via AWS KMS `GenerateDataKeyWithoutPlaintext` and stored encrypted alongside ciphertext.
+* Legal hold data uses dedicated KEK alias (`alias/summit/legalhold`) preventing deletion until compliance clearance.
+
+## Field-Level Encryption Strategy
+
+| Data Store | Mechanism | Rotation | Notes |
+| --- | --- | --- | --- |
+| Postgres (`users`, `user_external_ids`) | `pgcrypto` AES-256-GCM via KMS-wrapped DEKs; columns tagged with `field_encryption=true` | Daily | Transparent to ORMs using `decrypt_at_runtime` helper. |
+| Prov-ledger (append-only) | AES-256-GCM chunk encryption + Merkle root per block | Immutable | Ledger hash published to transparency log hourly. |
+| Vault KV (recovery phone numbers) | Transit engine, Format Preserving Encryption for masked display | On read | Access requires purpose-tag `mfa-recovery`. |
+| Object storage (support attachments) | Client-side chunked AES-256-GCM + S3 SSE-KMS with CMK | Weekly | Object Lock in compliance mode for legal hold. |
+| Caches (Redis) | TLS 1.3 + key-wrapped values using libsodium sealed boxes | Daily | Prevents plaintext exposure if cache compromised. |
+
+## In-Transit Encryption
+
+* **Service-to-service**: mTLS enforced via SPIFFE identities; TLS 1.3 only, cipher suites `TLS_AES_256_GCM_SHA384`.
+* **Client connections**: HSTS, ALPN HTTP/2, OCSP stapling, certificate pinning in native clients.
+* **OPA Bundles**: Delivered over signed HTTPS with checksum verification prior to activation.
+
+## Key Management Lifecycle
+
+1. **Generation**: All keys created via KMS/HSM; software-generated keys prohibited except ephemeral session keys.
+2. **Rotation**: Automated by Terraform + Summit Key Orchestrator. Failing rotation raises PagerDuty alert.
+3. **Backup**: Encrypted backups stored in separate account with dual-control restore procedure.
+4. **Revocation**: Compromise triggers KEK disable + DEK re-encryption pipeline (`scripts/crypto/rekey.mjs`).
+5. **Monitoring**: CloudWatch metrics for key usage anomalies; SIEM ingest of KMS CloudTrail logs.
+
+## Secret Management
+
+* Operational secrets stored in Vault; short-lived tokens (1 hour) retrieved via OIDC auth method.
+* No secrets committed to source control (monitored by gitleaks in CI).
+* Build pipeline injects secrets via sealed secrets for Kubernetes deployments.
+
+## Compliance & Testing
+
+* **Policy Simulation**: `npm run policy:test` executes OPA regression suite before merge.
+* **Cryptographic Self-Test**: `scripts/crypto/selftest.ts` verifies cipher suites & key expiry nightly.
+* **Penetration Testing**: Annual CREST-certified assessment with focus on key compromise scenarios.
+* **Disaster Recovery**: Quarterly drills rotating KEKs and verifying data decryptability in isolated environment.
+
+## Legal Hold Handling
+
+* When `legalHold=true`, DEKs moved under `alias/summit/legalhold` KEK and object lifecycle rules paused.
+* Audit ledger retains entries indefinitely; deletion requires dual sign-off and new Merkle root attestation.
+* Support attachments under hold mirrored to isolated bucket with separate CMK; read access limited to `legal` + `security`.
+
+## Change Management
+
+* All crypto config changes require RFC ticket + peer review.
+* Terraform state stored encrypted with SOPS + KMS; plan diffs signed using Sigstore (`cosign`) prior to apply.
+* CI blocks merges if encryption metadata missing in Prisma/ORM migrations.

--- a/security/pii-catalog.md
+++ b/security/pii-catalog.md
@@ -1,0 +1,40 @@
+# Summit PII Catalog & Data Minimisation Map
+
+This catalog enumerates personal and sensitive attributes processed by Summit, their storage locations, retention timers, and
+required controls. It supports the `short-30d` policy for PII while accommodating legal hold directives.
+
+## Attribute Inventory
+
+| Attribute | Description | Source | Storage Location | Classification | Encryption | Retention | Purpose Tags |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `user.profile.fullName` | Legal first/last name | SCIM | Postgres `users` table | Confidential PII | Field-level AES-256-GCM using per-tenant DEK | 30 days after deactivation | `intel-analysis`, `ops-support` |
+| `user.profile.preferredName` | Display name | SCIM | Postgres `users` table | Internal | Transparent Data Encryption (cluster) | 30 days after deactivation | `collaboration` |
+| `user.contact.email` | Work email | SCIM | Postgres `users` (encrypted column) | Confidential PII | Field-level AES-256-GCM + envelope key in Summit KMS | 30 days after deactivation | `notifications`, `intel-analysis` |
+| `user.contact.phone` | Mobile phone for WebAuthn recovery | SCIM | Vault secure KV (per-tenant namespace) | Restricted PII | AES-256-GCM w/ derived DEK + phone hashing for index | 30 days after last use | `mfa-recovery` |
+| `user.identifiers.hrisId` | HR system identifier | SCIM | Postgres `user_external_ids` | Restricted | Field-level AES-256-GCM | 30 days after deactivation | `workforce-ops` |
+| `credential.webauthn.publicKey` | WebAuthn credential public key | WebAuthn Service | HSM-backed credential store | Secret | HSM (FIPS 140-2 level 3) | Until credential revoked + 30 days | `authn` |
+| `audit.trail` | Immutable audit entries containing PII references | Services | Prov-ledger append-only log | Restricted | AES-256-GCM, digest anchored in transparency log | 7 years (regulatory) or until legal hold cleared | `compliance` |
+| `analytics.event.geo` | Approx geolocation (city/region) | Client telemetry | BigQuery regional dataset | Internal | Column-level encryption (KMS-managed) | 30 days rolling window | `product-analytics` |
+| `support.ticket.attachments` | User-submitted files | Support portal | S3 w/ Object Lock | Confidential | Server-side encryption w/ customer-managed CMK + client-side chunk encryption | 30 days after resolution (extend via legal hold) | `support` |
+
+## Data Minimisation Map
+
+| Process | Input Data | Minimisation Strategy | Enforcement |
+| --- | --- | --- | --- |
+| Analyst workspace search | `fullName`, `email`, `purposeTags` | Hash identifiers; expose initials only unless analyst has `legal` role | Enforced via OPA policy + UI redaction service |
+| Alert notifications | `email`, `tenantId`, `audit_session` | Strip phone numbers, send via secure email only | Notification microservice enforces allowlist |
+| Usage analytics | `geo`, `tenantId`, `role` | Aggregate by cohort; drop PII after 24h before export | Data pipeline TTL + BigQuery row expiration |
+| MFA recovery | `phone` | Store salted hash, reveal last 2 digits only | Vault transform engine + UI masking |
+| Incident response | `audit.trail`, `webauthn` metadata | Provide read-only vault; access limited to `legal` + `security` roles | Access logged + OPA policy `legal_hold` clause |
+
+## Legal Hold & Exceptions
+
+* `legalHold=true` in SCIM profile pins associated records regardless of retention timers. Expiry resumes 7 days after flag cleared.
+* Audit log entries are never deleted; expungement requires security + legal co-approval and produces Merkle proof in ledger.
+* Support attachments under investigation are copied to isolated bucket with CMK rewrapped; deletion blocked until hold release.
+
+## Control Verification
+
+* Quarterly review of catalog with Data Protection Officer and Security Architect.
+* Automated scanner (`scripts/data-tag-audit.mjs`) validates that every column listed retains `field_encryption=true` metadata.
+* CI policy simulation ensures new data models declare `purposeTags` and `retention_days` metadata before migrations merge.

--- a/tests/security/misuse/securityMisuse.spec.ts
+++ b/tests/security/misuse/securityMisuse.spec.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it } from '@jest/globals';
+
+type Role = 'analyst' | 'manager' | 'admin' | 'legal' | 'global-admin';
+
+type PolicySubject = {
+  id: string;
+  tenant: string;
+  roles: Role[];
+  attributes: {
+    clearance: 'public' | 'internal' | 'confidential' | 'restricted' | 'secret';
+    mfaEnrolled: boolean;
+    purposeTags: string[];
+  };
+};
+
+type ResourceField = {
+  name: string;
+  sensitive: boolean;
+  encrypted?: boolean;
+  algorithm?: string;
+  kmsKeyId?: string;
+  tags?: string[];
+};
+
+type PolicyResource = {
+  id: string;
+  tenant: string;
+  classification?: PolicySubject['attributes']['clearance'];
+  purposeTags?: string[];
+  pii?: boolean;
+  retentionDays?: number;
+  legalHold?: boolean;
+  fields?: ResourceField[];
+};
+
+type PolicyEnvironment = {
+  requireMfa: boolean;
+  mfaSatisfied: boolean;
+  audit: {
+    eventId: string;
+    immutable: boolean;
+  };
+};
+
+type PolicyInput = {
+  subject: PolicySubject;
+  resource: PolicyResource;
+  action: 'read' | 'write' | 'delete' | 'tag';
+  environment: PolicyEnvironment;
+};
+
+const ACTION_ROLES: Record<PolicyInput['action'], Set<Role>> = {
+  read: new Set(['analyst', 'manager', 'admin', 'legal', 'global-admin']),
+  write: new Set(['manager', 'admin', 'global-admin']),
+  delete: new Set(['admin', 'global-admin']),
+  tag: new Set(['manager', 'admin', 'legal', 'global-admin'])
+};
+
+const CLASSIFICATION_RANK: Record<string, number> = {
+  public: 0,
+  internal: 1,
+  confidential: 2,
+  restricted: 3,
+  secret: 4
+};
+
+function evaluatePolicy(input: PolicyInput): boolean {
+  const { subject, resource, action, environment } = input;
+  const allowedRoles = ACTION_ROLES[action];
+  if (!allowedRoles) {
+    return false;
+  }
+
+  if (!subject.roles.includes('global-admin') && subject.tenant !== resource.tenant) {
+    return false;
+  }
+
+  if (!subject.roles.some((role) => allowedRoles.has(role))) {
+    return false;
+  }
+
+  const subjectClearance = CLASSIFICATION_RANK[subject.attributes.clearance] ?? 0;
+  const resourceClearance = resource.classification ? CLASSIFICATION_RANK[resource.classification] ?? 0 : 0;
+  if (resource.classification && subjectClearance < resourceClearance) {
+    return false;
+  }
+
+  const subjectPurpose = new Set(subject.attributes.purposeTags ?? []);
+  const resourcePurpose = new Set((resource.purposeTags ?? []).filter(Boolean));
+  if (resourcePurpose.size > 0) {
+    const hasIntersection = Array.from(resourcePurpose).some((tag) => subjectPurpose.has(tag));
+    if (!hasIntersection && !subject.roles.includes('global-admin')) {
+      return false;
+    }
+  }
+
+  if (environment.requireMfa && (!subject.attributes.mfaEnrolled || !environment.mfaSatisfied)) {
+    return false;
+  }
+
+  const hasUnprotectedSensitiveField = (resource.fields ?? []).some((field) => {
+    if (!field.sensitive) {
+      return false;
+    }
+    return !field.encrypted || !field.algorithm || !field.kmsKeyId;
+  });
+  if (hasUnprotectedSensitiveField) {
+    return false;
+  }
+
+  if (resource.pii && !resource.legalHold && (resource.retentionDays ?? 0) > 30) {
+    return false;
+  }
+
+  if (resource.legalHold && !subject.roles.some((role) => role === 'legal' || role === 'global-admin')) {
+    return false;
+  }
+
+  if (!environment.audit?.eventId || !environment.audit.immutable) {
+    return false;
+  }
+
+  return true;
+}
+
+type EnumerationAttempt = {
+  timestamp: number;
+  principalId: string;
+  targetId: string;
+};
+
+function detectEnumeration(attempts: EnumerationAttempt[], windowMs: number, uniqueThreshold: number) {
+  const activity = new Map<string, { firstSeen: number; targets: Set<string> }>();
+
+  for (const attempt of attempts) {
+    const entry = activity.get(attempt.principalId);
+    if (!entry) {
+      activity.set(attempt.principalId, { firstSeen: attempt.timestamp, targets: new Set([attempt.targetId]) });
+      continue;
+    }
+
+    if (attempt.timestamp - entry.firstSeen > windowMs) {
+      entry.firstSeen = attempt.timestamp;
+      entry.targets = new Set([attempt.targetId]);
+    } else {
+      entry.targets.add(attempt.targetId);
+    }
+
+    if (entry.targets.size > uniqueThreshold) {
+      return {
+        flagged: true,
+        principalId: attempt.principalId,
+        uniqueCount: entry.targets.size
+      };
+    }
+  }
+
+  return { flagged: false };
+}
+
+function simulateTokenBucket(ratePerSecond: number, capacity: number, events: number[]) {
+  let tokens = capacity;
+  let lastRefill = events.length > 0 ? events[0] : Date.now();
+  let blocked = 0;
+
+  for (const eventTime of events) {
+    const elapsedSeconds = (eventTime - lastRefill) / 1000;
+    tokens = Math.min(capacity, tokens + elapsedSeconds * ratePerSecond);
+    lastRefill = eventTime;
+
+    if (tokens >= 1) {
+      tokens -= 1;
+    } else {
+      blocked += 1;
+    }
+  }
+
+  return {
+    allowed: events.length - blocked,
+    blocked
+  };
+}
+
+function detectInjection(payload: string) {
+  const patterns = [
+    /'\s*or\s*1=1/i,
+    /union\s+select/i,
+    /<script/i,
+    /;\s*drop\s+table/i,
+    /\$\{.*\}/
+  ];
+  const matched = patterns.find((pattern) => pattern.test(payload));
+  if (matched) {
+    return {
+      blocked: true,
+      pattern: matched.source
+    };
+  }
+  return { blocked: false };
+}
+
+describe('security misuse and abuse resilience', () => {
+  const baseInput: PolicyInput = {
+    subject: {
+      id: 'user-1',
+      tenant: 'tenant-a',
+      roles: ['manager'],
+      attributes: {
+        clearance: 'restricted',
+        mfaEnrolled: true,
+        purposeTags: ['intel-analysis', 'legal-review']
+      }
+    },
+    resource: {
+      id: 'report-7',
+      tenant: 'tenant-a',
+      classification: 'confidential',
+      purposeTags: ['intel-analysis'],
+      pii: true,
+      retentionDays: 14,
+      legalHold: false,
+      fields: [
+        {
+          name: 'ssn',
+          sensitive: true,
+          encrypted: true,
+          algorithm: 'aes-256-gcm',
+          kmsKeyId: 'kms/tenant-a/pii',
+          tags: ['pii']
+        }
+      ]
+    },
+    action: 'read',
+    environment: {
+      requireMfa: true,
+      mfaSatisfied: true,
+      audit: {
+        eventId: 'evt-123',
+        immutable: true
+      }
+    }
+  };
+
+  it('allows legitimate tenant manager access while enforcing safeguards', () => {
+    expect(evaluatePolicy(baseInput)).toBe(true);
+  });
+
+  it('blocks cross-tenant privilege escalation attempts', () => {
+    const crossTenant = {
+      ...baseInput,
+      resource: { ...baseInput.resource, tenant: 'tenant-b' }
+    };
+    expect(evaluatePolicy(crossTenant)).toBe(false);
+  });
+
+  it('flags enumeration bursts above the tenant threshold', () => {
+    const now = Date.now();
+    const attempts: EnumerationAttempt[] = [
+      { timestamp: now, principalId: 'user-1', targetId: 'record-1' },
+      { timestamp: now + 5, principalId: 'user-1', targetId: 'record-2' },
+      { timestamp: now + 10, principalId: 'user-1', targetId: 'record-3' },
+      { timestamp: now + 15, principalId: 'user-1', targetId: 'record-4' }
+    ];
+    const result = detectEnumeration(attempts, 60_000, 3);
+    expect(result.flagged).toBe(true);
+    expect(result.uniqueCount).toBe(4);
+  });
+
+  it('enforces rate limiting for high-volume requests', () => {
+    const start = Date.now();
+    const events = Array.from({ length: 10 }, (_, index) => start + index * 50);
+    const outcome = simulateTokenBucket(1, 5, events);
+    expect(outcome.allowed).toBeLessThan(events.length);
+    expect(outcome.blocked).toBeGreaterThan(0);
+  });
+
+  it('detects and blocks injection payloads', () => {
+    const result = detectInjection("admin' OR 1=1 --");
+    expect(result.blocked).toBe(true);
+    expect(result.pattern).toContain('1=1');
+  });
+});


### PR DESCRIPTION
## Summary
- implement an OPA ABAC policy for tenant and role scoped decisions with legal hold, encryption and purpose enforcement plus policy regression tests
- document the OIDC, SCIM, PII catalog, and crypto/key-management guardrails for privacy and retention compliance
- add misuse and abuse security tests covering privilege escalation, enumeration detection, rate limiting, and injection blocking

## Testing
- /tmp/opa_v0.64 test policies/opa/tenant_role_abac.rego policies/opa/tests/tenant_role_abac_test.rego -v

------
https://chatgpt.com/codex/tasks/task_e_68d76205a0508333984be372f9eba7d5