### PR TITLE
feat: add consent-aware experiment allocator

### DIFF
--- a/cea/README.md
+++ b/cea/README.md
@@ -1,0 +1,35 @@
+# Consent-Aware Experiment Allocator (CEA)
+
+CEA provides a deterministic experiment allocator implemented in Go with a matching TypeScript SDK. The system enforces consent and exclusion constraints per tenant and purpose, supports stratified traffic splits, sticky bucketing, and automatically rebalances cohorts when consent updates occur. Every assignment transition is persisted in an auditable ledger.
+
+## Go Allocator
+
+The Go package lives in `allocator/` and exposes:
+
+- `Allocator`: in-memory allocator with consent-aware assignment logic.
+- `Subject`, `ExperimentConfig`, and related types for describing subjects and experiments.
+- `InMemoryLedger`: thread-safe ledger implementation suitable for tests and local workloads.
+
+Run tests from the module root:
+
+```bash
+cd cea
+go test ./...
+```
+
+## TypeScript SDK
+
+The SDK mirrors the allocator contract for client applications. It ships in `sdk/` as an ES module and provides:
+
+- `ConsentAwareAllocator` with the same behaviors as the Go implementation.
+- Type definitions for subjects, experiments, assignments, and ledger events.
+
+Build typings from the SDK directory:
+
+```bash
+cd cea/sdk
+npm install
+npm run build
+```
+
+Both implementations guarantee deterministic assignments for identical inputs while respecting consent boundaries and maintaining statistical power within tolerance even as participants opt in or out.

--- a/cea/allocator/allocator.go
+++ b/cea/allocator/allocator.go
@@ -1,0 +1,558 @@
+package allocator
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	errNoSubject              = errors.New("subject not registered with allocator")
+	errConsentMissing         = errors.New("subject has not granted consent for purpose")
+	errTenantMismatch         = errors.New("tenant mismatch between subject and experiment")
+	errVariantWeightsInvalid  = errors.New("experiment must define positive weights for variants")
+	errPowerToleranceExceeded = errors.New("rebalance tolerance exceeded")
+)
+
+// Allocator executes consent-aware assignments with deterministic stickiness.
+type Allocator struct {
+	mu          sync.Mutex
+	ledger      Ledger
+	subjects    map[string]Subject
+	experiments map[string]ExperimentConfig
+	assignments map[string]Assignment
+}
+
+// NewAllocator constructs an allocator that records every change into the supplied ledger.
+func NewAllocator(ledger Ledger) *Allocator {
+	return &Allocator{
+		ledger:      ledger,
+		subjects:    map[string]Subject{},
+		experiments: map[string]ExperimentConfig{},
+		assignments: map[string]Assignment{},
+	}
+}
+
+func subjectKey(tenantID, subjectID string) string {
+	return tenantID + ":" + subjectID
+}
+
+func assignmentKey(experimentID, tenantID, subjectID string) string {
+	return experimentID + "|" + subjectKey(tenantID, subjectID)
+}
+
+// UpsertSubject registers or updates a subject and triggers rebalancing when consent changes.
+func (a *Allocator) UpsertSubject(subject Subject) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if subject.Attributes == nil {
+		subject.Attributes = map[string]string{}
+	}
+	if subject.Consents == nil {
+		subject.Consents = map[string]ConsentGrant{}
+	}
+
+	key := subjectKey(subject.TenantID, subject.SubjectID)
+	prev, hadPrev := a.subjects[key]
+	a.subjects[key] = subject
+
+	for _, exp := range a.experiments {
+		if exp.TenantID != subject.TenantID {
+			continue
+		}
+		prevConsent := hadPrev && prev.Consents != nil && prev.Consents[exp.Purpose].Granted
+		newConsent := subject.Consents != nil && subject.Consents[exp.Purpose].Granted
+		if prevConsent != newConsent {
+			_ = a.rebalanceLocked(exp.ID)
+		}
+	}
+}
+
+// RemoveSubject removes any stored subject information and clears assignments.
+func (a *Allocator) RemoveSubject(tenantID, subjectID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	key := subjectKey(tenantID, subjectID)
+	delete(a.subjects, key)
+
+	for assignKey, assignment := range a.assignments {
+		if assignment.SubjectID != subjectID || assignment.TenantID != tenantID {
+			continue
+		}
+		delete(a.assignments, assignKey)
+		a.ledger.Record(LedgerEntry{
+			Timestamp:    time.Now().UTC(),
+			Event:        "revoked",
+			ExperimentID: assignment.ExperimentID,
+			SubjectID:    assignment.SubjectID,
+			TenantID:     assignment.TenantID,
+			Variant:      assignment.Variant,
+			Stratum:      assignment.Stratum,
+			Reason:       "subject removed",
+		})
+	}
+}
+
+// Assign returns a consent-aware assignment for the provided subject in the supplied experiment.
+func (a *Allocator) Assign(experiment ExperimentConfig, tenantID, subjectID string) (Assignment, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	a.experiments[experiment.ID] = normalizeExperiment(experiment)
+
+	sKey := subjectKey(tenantID, subjectID)
+	subject, ok := a.subjects[sKey]
+	if !ok {
+		return Assignment{}, errNoSubject
+	}
+	if subject.TenantID != experiment.TenantID {
+		return Assignment{}, errTenantMismatch
+	}
+
+	if err := a.rebalanceLocked(experiment.ID); err != nil {
+		return Assignment{}, err
+	}
+
+	aKey := assignmentKey(experiment.ID, tenantID, subjectID)
+	assignment, ok := a.assignments[aKey]
+	if !ok {
+		return Assignment{}, errConsentMissing
+	}
+	return assignment, nil
+}
+
+// LedgerEntries returns a copy of the underlying ledger events.
+func (a *Allocator) LedgerEntries() []LedgerEntry {
+	return a.ledger.Entries()
+}
+
+func normalizeExperiment(exp ExperimentConfig) ExperimentConfig {
+	if exp.PowerTolerance <= 0 {
+		exp.PowerTolerance = 0.05
+	}
+	return exp
+}
+
+func (a *Allocator) rebalanceLocked(experimentID string) error {
+	exp := a.experiments[experimentID]
+
+	stratumSubjects := map[string][]subjectState{}
+
+	// Remove assignments for missing or non-consenting subjects.
+	for key, assignment := range a.assignments {
+		if assignment.ExperimentID != experimentID {
+			continue
+		}
+		sKey := subjectKey(assignment.TenantID, assignment.SubjectID)
+		subject, ok := a.subjects[sKey]
+		if !ok || subject.TenantID != exp.TenantID || !hasConsent(subject, exp.Purpose) || matchesExclusion(exp.Exclusions, subject) {
+			delete(a.assignments, key)
+			reason := "consent or exclusion updated"
+			if !ok {
+				reason = "subject missing"
+			}
+			a.ledger.Record(LedgerEntry{
+				Timestamp:    time.Now().UTC(),
+				Event:        "revoked",
+				ExperimentID: experimentID,
+				SubjectID:    assignment.SubjectID,
+				TenantID:     assignment.TenantID,
+				Variant:      assignment.Variant,
+				Stratum:      assignment.Stratum,
+				Reason:       reason,
+			})
+			continue
+		}
+	}
+
+	for _, subject := range a.subjects {
+		if subject.TenantID != exp.TenantID {
+			continue
+		}
+		if !hasConsent(subject, exp.Purpose) {
+			continue
+		}
+		if matchesExclusion(exp.Exclusions, subject) {
+			continue
+		}
+		stratum := resolveStratum(exp, subject)
+		hash := stableHash(exp, stratum, subject)
+		aKey := assignmentKey(experimentID, subject.TenantID, subject.SubjectID)
+		assignment, exists := a.assignments[aKey]
+		if exists && assignment.Stratum != stratum {
+			delete(a.assignments, aKey)
+			a.ledger.Record(LedgerEntry{
+				Timestamp:    time.Now().UTC(),
+				Event:        "rebalanced",
+				ExperimentID: experimentID,
+				SubjectID:    subject.SubjectID,
+				TenantID:     subject.TenantID,
+				Variant:      assignment.Variant,
+				Stratum:      assignment.Stratum,
+				Reason:       "stratum changed",
+			})
+			exists = false
+		}
+		stratumSubjects[stratum] = append(stratumSubjects[stratum], subjectState{
+			Subject:         subject,
+			Hash:            hash,
+			Existing:        exists,
+			ExistingVariant: assignment.Variant,
+		})
+	}
+
+	for stratum, subjects := range stratumSubjects {
+		if err := a.rebalanceStratum(experimentID, exp, stratum, subjects); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type subjectState struct {
+	Subject         Subject
+	Hash            uint64
+	Existing        bool
+	ExistingVariant string
+}
+
+func (a *Allocator) rebalanceStratum(experimentID string, exp ExperimentConfig, stratum string, subjects []subjectState) error {
+	if len(subjects) == 0 {
+		return nil
+	}
+
+	weights, err := weightMapForStratum(exp, stratum)
+	if err != nil {
+		return err
+	}
+	targetCounts := computeTargetCounts(len(subjects), exp.Variants, weights)
+
+	currentCounts := map[string]int{}
+	assignmentsByVariant := map[string][]subjectState{}
+	var unassigned []subjectState
+
+	for _, s := range subjects {
+		if s.Existing {
+			currentCounts[s.ExistingVariant]++
+			assignmentsByVariant[s.ExistingVariant] = append(assignmentsByVariant[s.ExistingVariant], s)
+			continue
+		}
+		unassigned = append(unassigned, s)
+	}
+
+	sort.Slice(unassigned, func(i, j int) bool {
+		if unassigned[i].Hash == unassigned[j].Hash {
+			return unassigned[i].Subject.SubjectID < unassigned[j].Subject.SubjectID
+		}
+		return unassigned[i].Hash < unassigned[j].Hash
+	})
+
+	for _, s := range unassigned {
+		variant := nextVariantWithDeficit(exp.Variants, targetCounts, currentCounts)
+		currentCounts[variant]++
+		assignmentsByVariant[variant] = append(assignmentsByVariant[variant], subjectState{
+			Subject: s.Subject,
+			Hash:    s.Hash,
+		})
+		a.applyAssignment(experimentID, exp, variant, stratum, s.Subject, "assigned")
+	}
+
+	iterationGuard := len(subjects) * len(exp.Variants)
+	for iterationGuard > 0 {
+		iterationGuard--
+		surplusVariant, deficitVariant := findSurplusAndDeficit(exp.Variants, targetCounts, currentCounts)
+		if surplusVariant == "" || deficitVariant == "" {
+			break
+		}
+
+		candidates := assignmentsByVariant[surplusVariant]
+		if len(candidates) == 0 {
+			break
+		}
+		sort.Slice(candidates, func(i, j int) bool {
+			if candidates[i].Hash == candidates[j].Hash {
+				return candidates[i].Subject.SubjectID > candidates[j].Subject.SubjectID
+			}
+			return candidates[i].Hash > candidates[j].Hash
+		})
+
+		moving := candidates[0]
+		assignmentsByVariant[surplusVariant] = candidates[1:]
+		currentCounts[surplusVariant]--
+		currentCounts[deficitVariant]++
+		assignmentsByVariant[deficitVariant] = append(assignmentsByVariant[deficitVariant], subjectState{
+			Subject: moving.Subject,
+			Hash:    moving.Hash,
+		})
+		a.applyAssignment(experimentID, exp, deficitVariant, stratum, moving.Subject, "rebalanced")
+	}
+
+	if !withinTolerance(exp, stratum, currentCounts) {
+		return fmt.Errorf("%w for experiment %s stratum %s", errPowerToleranceExceeded, experimentID, stratum)
+	}
+
+	return nil
+}
+
+func (a *Allocator) applyAssignment(experimentID string, exp ExperimentConfig, variant, stratum string, subject Subject, event string) {
+	key := assignmentKey(experimentID, subject.TenantID, subject.SubjectID)
+	prev, hadPrev := a.assignments[key]
+
+	assignment := Assignment{
+		ExperimentID: experimentID,
+		SubjectID:    subject.SubjectID,
+		TenantID:     subject.TenantID,
+		Variant:      variant,
+		Stratum:      stratum,
+		AssignedAt:   time.Now().UTC(),
+		Reason:       event,
+	}
+	a.assignments[key] = assignment
+
+	if hadPrev && prev.Variant == variant && prev.Stratum == stratum {
+		return
+	}
+
+	reason := event
+	if hadPrev && prev.Variant != variant {
+		reason = "variant updated via " + event
+	}
+	if hadPrev && prev.Stratum != stratum {
+		reason = "stratum updated via " + event
+	}
+
+	a.ledger.Record(LedgerEntry{
+		Timestamp:    assignment.AssignedAt,
+		Event:        event,
+		ExperimentID: experimentID,
+		SubjectID:    subject.SubjectID,
+		TenantID:     subject.TenantID,
+		Variant:      variant,
+		Stratum:      stratum,
+		Reason:       reason,
+	})
+}
+
+func hasConsent(subject Subject, purpose string) bool {
+	if subject.Consents == nil {
+		return false
+	}
+	grant, ok := subject.Consents[purpose]
+	return ok && grant.Granted
+}
+
+func matchesExclusion(rules []ExclusionRule, subject Subject) bool {
+	for _, rule := range rules {
+		value := subject.Attributes[rule.Attribute]
+		for _, v := range rule.Values {
+			if strings.EqualFold(v, value) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func resolveStratum(exp ExperimentConfig, subject Subject) string {
+	for _, stratum := range exp.Strata {
+		matches := true
+		for key, value := range stratum.Criteria {
+			if subject.Attributes[key] != value {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return stratum.Name
+		}
+	}
+	return "default"
+}
+
+func weightMapForStratum(exp ExperimentConfig, stratum string) (map[string]float64, error) {
+	weights := map[string]float64{}
+	for _, variant := range exp.Variants {
+		weights[variant.Name] = variant.Weight
+	}
+
+	for _, s := range exp.Strata {
+		if s.Name == stratum {
+			for name, weight := range s.Weights {
+				weights[name] = weight
+			}
+			break
+		}
+	}
+
+	sum := 0.0
+	for _, variant := range exp.Variants {
+		weight := weights[variant.Name]
+		if weight <= 0 {
+			return nil, errVariantWeightsInvalid
+		}
+		sum += weight
+	}
+	if sum <= 0 {
+		return nil, errVariantWeightsInvalid
+	}
+
+	return weights, nil
+}
+
+func computeTargetCounts(totalSubjects int, variants []VariantConfig, weights map[string]float64) map[string]int {
+	sumWeights := 0.0
+	for _, variant := range variants {
+		sumWeights += weights[variant.Name]
+	}
+
+	counts := map[string]int{}
+	remainders := make([]struct {
+		Name     string
+		Fraction float64
+	}, 0, len(variants))
+
+	assigned := 0
+	for _, variant := range variants {
+		expected := float64(totalSubjects) * weights[variant.Name] / sumWeights
+		base := int(expected)
+		counts[variant.Name] = base
+		remainders = append(remainders, struct {
+			Name     string
+			Fraction float64
+		}{
+			Name:     variant.Name,
+			Fraction: expected - float64(base),
+		})
+		assigned += base
+	}
+
+	remainder := totalSubjects - assigned
+	if remainder > 0 {
+		sort.SliceStable(remainders, func(i, j int) bool {
+			if remainders[i].Fraction == remainders[j].Fraction {
+				return remainders[i].Name < remainders[j].Name
+			}
+			return remainders[i].Fraction > remainders[j].Fraction
+		})
+		for i := 0; i < remainder && i < len(remainders); i++ {
+			counts[remainders[i].Name]++
+		}
+	}
+
+	return counts
+}
+
+func nextVariantWithDeficit(variants []VariantConfig, target, current map[string]int) string {
+	type candidate struct {
+		name string
+		diff int
+	}
+	candidates := make([]candidate, 0, len(variants))
+	for _, variant := range variants {
+		diff := target[variant.Name] - current[variant.Name]
+		candidates = append(candidates, candidate{name: variant.Name, diff: diff})
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].diff == candidates[j].diff {
+			return candidates[i].name < candidates[j].name
+		}
+		return candidates[i].diff > candidates[j].diff
+	})
+	return candidates[0].name
+}
+
+func findSurplusAndDeficit(variants []VariantConfig, target, current map[string]int) (string, string) {
+	surplusName := ""
+	surplusDiff := 0
+	deficitName := ""
+	deficitDiff := 0
+	for _, variant := range variants {
+		diff := current[variant.Name] - target[variant.Name]
+		if diff > surplusDiff {
+			surplusDiff = diff
+			surplusName = variant.Name
+		}
+		if -diff > deficitDiff {
+			deficitDiff = -diff
+			deficitName = variant.Name
+		}
+	}
+	if surplusDiff > 0 && deficitDiff > 0 {
+		return surplusName, deficitName
+	}
+	return "", ""
+}
+
+func withinTolerance(exp ExperimentConfig, stratum string, current map[string]int) bool {
+	total := 0
+	for _, count := range current {
+		total += count
+	}
+	if total == 0 {
+		return true
+	}
+
+	weights, err := weightMapForStratum(exp, stratum)
+	if err != nil {
+		weights = map[string]float64{}
+		for _, variant := range exp.Variants {
+			weights[variant.Name] = 1
+		}
+	}
+	sumWeights := 0.0
+	for _, variant := range exp.Variants {
+		sumWeights += weights[variant.Name]
+	}
+	if sumWeights == 0 {
+		sumWeights = float64(len(exp.Variants))
+	}
+
+	allowed := exp.PowerTolerance
+	sampleAllowance := 1.0 / float64(total)
+	if sampleAllowance > allowed {
+		allowed = sampleAllowance
+	}
+	for _, variant := range exp.Variants {
+		expectedShare := weights[variant.Name] / sumWeights
+		actualShare := float64(current[variant.Name]) / float64(total)
+		if actualShare < 0 {
+			actualShare = 0
+		}
+		if diff := absFloat(expectedShare - actualShare); diff > allowed+1e-9 {
+			return false
+		}
+	}
+	return true
+}
+
+func absFloat(v float64) float64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+func stableHash(exp ExperimentConfig, stratum string, subject Subject) uint64 {
+	stickKey := make([]string, 0, len(exp.StickinessKeys))
+	for _, key := range exp.StickinessKeys {
+		stickKey = append(stickKey, subject.Attributes[key])
+	}
+	payload := strings.Join([]string{
+		exp.ID,
+		exp.Purpose,
+		stratum,
+		subject.TenantID,
+		subject.SubjectID,
+		strings.Join(stickKey, "|"),
+	}, "|")
+	sum := sha256.Sum256([]byte(payload))
+	return binary.BigEndian.Uint64(sum[:8])
+}

--- a/cea/allocator/allocator_test.go
+++ b/cea/allocator/allocator_test.go
@@ -1,0 +1,164 @@
+package allocator
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestAllocatorRejectsWithoutConsent(t *testing.T) {
+	ledger := NewInMemoryLedger()
+	alloc := NewAllocator(ledger)
+
+	subject := Subject{
+		TenantID:  "tenant-1",
+		SubjectID: "user-1",
+		Attributes: map[string]string{
+			"region": "na",
+		},
+		Consents: map[string]ConsentGrant{
+			"analytics": {Granted: false},
+		},
+	}
+	alloc.UpsertSubject(subject)
+
+	experiment := ExperimentConfig{
+		ID:             "exp-1",
+		TenantID:       "tenant-1",
+		Purpose:        "analytics",
+		Variants:       []VariantConfig{{Name: "control", Weight: 1}, {Name: "treatment", Weight: 1}},
+		StickinessKeys: []string{"region"},
+	}
+
+	if _, err := alloc.Assign(experiment, "tenant-1", "user-1"); !errors.Is(err, errConsentMissing) {
+		t.Fatalf("expected errConsentMissing, got %v", err)
+	}
+
+	if got := len(ledger.Entries()); got != 0 {
+		t.Fatalf("expected no ledger entries, got %d", got)
+	}
+}
+
+func TestDeterministicAssignments(t *testing.T) {
+	ledger := NewInMemoryLedger()
+	alloc := NewAllocator(ledger)
+
+	subject := Subject{
+		TenantID:  "tenant-1",
+		SubjectID: "user-42",
+		Attributes: map[string]string{
+			"region": "emea",
+		},
+		Consents: map[string]ConsentGrant{
+			"analytics": {Granted: true},
+		},
+	}
+	alloc.UpsertSubject(subject)
+
+	experiment := ExperimentConfig{
+		ID:             "exp-1",
+		TenantID:       "tenant-1",
+		Purpose:        "analytics",
+		Variants:       []VariantConfig{{Name: "control", Weight: 1}, {Name: "treatment", Weight: 1}},
+		StickinessKeys: []string{"region"},
+	}
+
+	assignmentA, err := alloc.Assign(experiment, "tenant-1", "user-42")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	assignmentB, err := alloc.Assign(experiment, "tenant-1", "user-42")
+	if err != nil {
+		t.Fatalf("unexpected error on second assign: %v", err)
+	}
+
+	if assignmentA.Variant != assignmentB.Variant {
+		t.Fatalf("expected deterministic variant, got %q and %q", assignmentA.Variant, assignmentB.Variant)
+	}
+}
+
+func TestRebalanceMaintainsTolerance(t *testing.T) {
+	ledger := NewInMemoryLedger()
+	alloc := NewAllocator(ledger)
+
+	experiment := ExperimentConfig{
+		ID:             "exp-tolerance",
+		TenantID:       "tenant-1",
+		Purpose:        "analytics",
+		Variants:       []VariantConfig{{Name: "control", Weight: 1}, {Name: "treatment", Weight: 1}},
+		StickinessKeys: []string{"segment"},
+		PowerTolerance: 0.2,
+	}
+
+	subjectIDs := []string{"s1", "s2", "s3", "s4"}
+	for _, id := range subjectIDs {
+		alloc.UpsertSubject(Subject{
+			TenantID:  "tenant-1",
+			SubjectID: id,
+			Attributes: map[string]string{
+				"segment": "gold",
+			},
+			Consents: map[string]ConsentGrant{
+				"analytics": {Granted: true},
+			},
+		})
+		if _, err := alloc.Assign(experiment, "tenant-1", id); err != nil {
+			t.Fatalf("initial assignment failed for %s: %v", id, err)
+		}
+	}
+
+	alloc.UpsertSubject(Subject{
+		TenantID:  "tenant-1",
+		SubjectID: "s1",
+		Attributes: map[string]string{
+			"segment": "gold",
+		},
+		Consents: map[string]ConsentGrant{
+			"analytics": {Granted: false},
+		},
+	})
+
+	if _, err := alloc.Assign(experiment, "tenant-1", "s1"); !errors.Is(err, errConsentMissing) {
+		t.Fatalf("expected consent error after revocation, got %v", err)
+	}
+
+	counts := map[string]int{}
+	for _, id := range []string{"s2", "s3", "s4"} {
+		assignment, err := alloc.Assign(experiment, "tenant-1", id)
+		if err != nil {
+			t.Fatalf("assignment failed for %s: %v", id, err)
+		}
+		counts[assignment.Variant]++
+	}
+
+	total := 0
+	for _, v := range counts {
+		total += v
+	}
+	if total != 3 {
+		t.Fatalf("expected 3 consenting assignments, got %d", total)
+	}
+
+	expectedShare := 0.5
+	for variant, count := range counts {
+		share := float64(count) / float64(total)
+		diff := share - expectedShare
+		if diff < 0 {
+			diff = -diff
+		}
+		if diff > experiment.PowerTolerance+1e-9 {
+			t.Fatalf("variant %s deviates from target beyond tolerance: got %.2f", variant, share)
+		}
+	}
+
+	entries := ledger.Entries()
+	foundRevoked := false
+	for _, entry := range entries {
+		if entry.SubjectID == "s1" && entry.Event == "revoked" {
+			foundRevoked = true
+			break
+		}
+	}
+	if !foundRevoked {
+		t.Fatalf("expected ledger entry capturing consent revocation")
+	}
+}

--- a/cea/allocator/ledger.go
+++ b/cea/allocator/ledger.go
@@ -1,0 +1,30 @@
+package allocator
+
+import "sync"
+
+// InMemoryLedger is a thread-safe ledger implementation suitable for tests and single-process workloads.
+type InMemoryLedger struct {
+	mu      sync.RWMutex
+	entries []LedgerEntry
+}
+
+// NewInMemoryLedger constructs a ledger capable of storing assignment events.
+func NewInMemoryLedger() *InMemoryLedger {
+	return &InMemoryLedger{}
+}
+
+// Record appends an entry to the ledger.
+func (l *InMemoryLedger) Record(entry LedgerEntry) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, entry)
+}
+
+// Entries returns a copy of all ledger entries.
+func (l *InMemoryLedger) Entries() []LedgerEntry {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	out := make([]LedgerEntry, len(l.entries))
+	copy(out, l.entries)
+	return out
+}

--- a/cea/allocator/types.go
+++ b/cea/allocator/types.go
@@ -1,0 +1,78 @@
+package allocator
+
+import "time"
+
+// Subject represents an individual whose consent and attributes drive allocation decisions.
+type Subject struct {
+	TenantID   string                  `json:"tenantId"`
+	SubjectID  string                  `json:"subjectId"`
+	Attributes map[string]string       `json:"attributes"`
+	Consents   map[string]ConsentGrant `json:"consents"`
+}
+
+// ConsentGrant captures whether a subject has consented to a specific purpose.
+type ConsentGrant struct {
+	Granted   bool      `json:"granted"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// ExperimentConfig describes how an experiment should allocate variants.
+type ExperimentConfig struct {
+	ID             string          `json:"id"`
+	TenantID       string          `json:"tenantId"`
+	Purpose        string          `json:"purpose"`
+	Variants       []VariantConfig `json:"variants"`
+	Strata         []StratumConfig `json:"strata"`
+	Exclusions     []ExclusionRule `json:"exclusions"`
+	StickinessKeys []string        `json:"stickinessKeys"`
+	PowerTolerance float64         `json:"powerTolerance"`
+}
+
+// VariantConfig defines the weight for a specific variant arm.
+type VariantConfig struct {
+	Name   string  `json:"name"`
+	Weight float64 `json:"weight"`
+}
+
+// StratumConfig allows configuring stratified assignment with custom weights and match criteria.
+type StratumConfig struct {
+	Name     string             `json:"name"`
+	Criteria map[string]string  `json:"criteria"`
+	Weights  map[string]float64 `json:"weights"`
+}
+
+// ExclusionRule filters subjects based on attribute values.
+type ExclusionRule struct {
+	Attribute string   `json:"attribute"`
+	Values    []string `json:"values"`
+}
+
+// Assignment captures the outcome of an allocation.
+type Assignment struct {
+	ExperimentID string    `json:"experimentId"`
+	SubjectID    string    `json:"subjectId"`
+	TenantID     string    `json:"tenantId"`
+	Variant      string    `json:"variant"`
+	Stratum      string    `json:"stratum"`
+	AssignedAt   time.Time `json:"assignedAt"`
+	Reason       string    `json:"reason"`
+}
+
+// LedgerEntry represents an auditable change to subject assignment state.
+type LedgerEntry struct {
+	Timestamp    time.Time         `json:"timestamp"`
+	Event        string            `json:"event"`
+	ExperimentID string            `json:"experimentId"`
+	SubjectID    string            `json:"subjectId"`
+	TenantID     string            `json:"tenantId"`
+	Variant      string            `json:"variant,omitempty"`
+	Stratum      string            `json:"stratum,omitempty"`
+	Reason       string            `json:"reason"`
+	Metadata     map[string]string `json:"metadata,omitempty"`
+}
+
+// Ledger stores assignment changes for auditability.
+type Ledger interface {
+	Record(entry LedgerEntry)
+	Entries() []LedgerEntry
+}

--- a/cea/go.mod
+++ b/cea/go.mod
@@ -1,0 +1,3 @@
+module github.com/summit/cea
+
+go 1.21

--- a/cea/sdk/package.json
+++ b/cea/sdk/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@summit/cea-sdk",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for the consent-aware experiment allocator",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "tsc --noEmit"
+  },
+  "keywords": [
+    "experimentation",
+    "consent",
+    "allocator"
+  ],
+  "author": "Summit Platform",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/cea/sdk/src/index.ts
+++ b/cea/sdk/src/index.ts
@@ -1,0 +1,504 @@
+import { createHash } from 'crypto';
+
+export interface ConsentGrant {
+  granted: boolean;
+  updatedAt?: Date;
+}
+
+export interface Subject {
+  tenantId: string;
+  subjectId: string;
+  attributes?: Record<string, string>;
+  consents?: Record<string, ConsentGrant>;
+}
+
+export interface VariantConfig {
+  name: string;
+  weight: number;
+}
+
+export interface StratumConfig {
+  name: string;
+  criteria: Record<string, string>;
+  weights?: Record<string, number>;
+}
+
+export interface ExclusionRule {
+  attribute: string;
+  values: string[];
+}
+
+export interface ExperimentConfig {
+  id: string;
+  tenantId: string;
+  purpose: string;
+  variants: VariantConfig[];
+  strata?: StratumConfig[];
+  exclusions?: ExclusionRule[];
+  stickinessKeys?: string[];
+  powerTolerance?: number;
+}
+
+export interface Assignment {
+  experimentId: string;
+  tenantId: string;
+  subjectId: string;
+  variant: string;
+  stratum: string;
+  assignedAt: Date;
+  reason: string;
+}
+
+export interface LedgerEntry {
+  timestamp: Date;
+  event: 'assigned' | 'rebalanced' | 'revoked';
+  experimentId: string;
+  tenantId: string;
+  subjectId: string;
+  variant?: string;
+  stratum?: string;
+  reason: string;
+}
+
+interface SubjectState {
+  subject: Subject;
+  hash: bigint;
+  existing: boolean;
+  existingVariant?: string;
+}
+
+function subjectKey(tenantId: string, subjectId: string): string {
+  return `${tenantId}:${subjectId}`;
+}
+
+function assignmentKey(experimentId: string, tenantId: string, subjectId: string): string {
+  return `${experimentId}|${subjectKey(tenantId, subjectId)}`;
+}
+
+function normalizeExperiment(exp: ExperimentConfig): ExperimentConfig {
+  return {
+    ...exp,
+    stickinessKeys: exp.stickinessKeys ?? [],
+    strata: exp.strata ?? [],
+    exclusions: exp.exclusions ?? [],
+    powerTolerance: exp.powerTolerance && exp.powerTolerance > 0 ? exp.powerTolerance : 0.05,
+  };
+}
+
+export class ConsentAwareAllocator {
+  private subjects = new Map<string, Subject>();
+  private experiments = new Map<string, ExperimentConfig>();
+  private assignments = new Map<string, Assignment>();
+  private ledger: LedgerEntry[] = [];
+
+  upsertSubject(subject: Subject): void {
+    const normalized: Subject = {
+      tenantId: subject.tenantId,
+      subjectId: subject.subjectId,
+      attributes: subject.attributes ?? {},
+      consents: subject.consents ?? {},
+    };
+    const key = subjectKey(normalized.tenantId, normalized.subjectId);
+    const previous = this.subjects.get(key);
+    this.subjects.set(key, normalized);
+
+    for (const experiment of this.experiments.values()) {
+      if (experiment.tenantId !== normalized.tenantId) {
+        continue;
+      }
+      const prevConsent = previous?.consents?.[experiment.purpose]?.granted ?? false;
+      const newConsent = normalized.consents?.[experiment.purpose]?.granted ?? false;
+      if (prevConsent !== newConsent) {
+        this.rebalance(experiment.id).catch(() => {
+          /* swallow errors; surfaced during explicit assign */
+        });
+      }
+    }
+  }
+
+  removeSubject(tenantId: string, subjectId: string): void {
+    const key = subjectKey(tenantId, subjectId);
+    this.subjects.delete(key);
+    for (const [assignKey, assignment] of [...this.assignments.entries()]) {
+      if (assignment.tenantId === tenantId && assignment.subjectId === subjectId) {
+        this.assignments.delete(assignKey);
+        this.record({
+          timestamp: new Date(),
+          event: 'revoked',
+          experimentId: assignment.experimentId,
+          tenantId,
+          subjectId,
+          variant: assignment.variant,
+          stratum: assignment.stratum,
+          reason: 'subject removed',
+        });
+      }
+    }
+  }
+
+  async assign(experimentConfig: ExperimentConfig, tenantId: string, subjectId: string): Promise<Assignment> {
+    const experiment = normalizeExperiment(experimentConfig);
+    this.experiments.set(experiment.id, experiment);
+
+    const key = subjectKey(tenantId, subjectId);
+    const subject = this.subjects.get(key);
+    if (!subject) {
+      throw new Error('subject not registered with allocator');
+    }
+    if (subject.tenantId !== experiment.tenantId) {
+      throw new Error('tenant mismatch between subject and experiment');
+    }
+
+    await this.rebalance(experiment.id);
+
+    const aKey = assignmentKey(experiment.id, tenantId, subjectId);
+    const assignment = this.assignments.get(aKey);
+    if (!assignment) {
+      throw new Error('subject has not granted consent for purpose');
+    }
+    return assignment;
+  }
+
+  getLedger(): LedgerEntry[] {
+    return [...this.ledger];
+  }
+
+  private async rebalance(experimentId: string): Promise<void> {
+    const experiment = this.experiments.get(experimentId);
+    if (!experiment) {
+      return;
+    }
+
+    const stratumSubjects = new Map<string, SubjectState[]>();
+
+    for (const [key, assignment] of [...this.assignments.entries()]) {
+      if (assignment.experimentId !== experimentId) {
+        continue;
+      }
+      const subjKey = subjectKey(assignment.tenantId, assignment.subjectId);
+      const subject = this.subjects.get(subjKey);
+      if (!subject || subject.tenantId !== experiment.tenantId || !hasConsent(subject, experiment.purpose) || matchesExclusion(experiment.exclusions, subject)) {
+        this.assignments.delete(key);
+        this.record({
+          timestamp: new Date(),
+          event: 'revoked',
+          experimentId,
+          tenantId: assignment.tenantId,
+          subjectId: assignment.subjectId,
+          variant: assignment.variant,
+          stratum: assignment.stratum,
+          reason: subject ? 'consent or exclusion updated' : 'subject missing',
+        });
+      }
+    }
+
+    for (const subject of this.subjects.values()) {
+      if (subject.tenantId !== experiment.tenantId) {
+        continue;
+      }
+      if (!hasConsent(subject, experiment.purpose)) {
+        continue;
+      }
+      if (matchesExclusion(experiment.exclusions, subject)) {
+        continue;
+      }
+      const stratum = resolveStratum(experiment, subject);
+      const hash = stableHash(experiment, stratum, subject);
+      const key = assignmentKey(experimentId, subject.tenantId, subject.subjectId);
+      const assignment = this.assignments.get(key);
+      let existing = false;
+      let existingVariant: string | undefined;
+      if (assignment) {
+        if (assignment.stratum !== stratum) {
+          this.assignments.delete(key);
+          this.record({
+            timestamp: new Date(),
+            event: 'rebalanced',
+            experimentId,
+            tenantId: subject.tenantId,
+            subjectId: subject.subjectId,
+            variant: assignment.variant,
+            stratum: assignment.stratum,
+            reason: 'stratum changed',
+          });
+        } else {
+          existing = true;
+          existingVariant = assignment.variant;
+        }
+      }
+      const bucket = stratumSubjects.get(stratum) ?? [];
+      bucket.push({ subject, hash, existing, existingVariant });
+      stratumSubjects.set(stratum, bucket);
+    }
+
+    for (const [stratum, subjects] of stratumSubjects.entries()) {
+      this.rebalanceStratum(experiment, stratum, subjects);
+    }
+  }
+
+  private rebalanceStratum(experiment: ExperimentConfig, stratum: string, subjects: SubjectState[]): void {
+    if (subjects.length === 0) {
+      return;
+    }
+
+    const weights = weightMapForStratum(experiment, stratum);
+    const targetCounts = computeTargetCounts(subjects.length, experiment.variants, weights);
+    const currentCounts = new Map<string, number>();
+    const assignmentsByVariant = new Map<string, SubjectState[]>();
+    const unassigned: SubjectState[] = [];
+
+    for (const state of subjects) {
+      if (state.existing && state.existingVariant) {
+        currentCounts.set(state.existingVariant, (currentCounts.get(state.existingVariant) ?? 0) + 1);
+        const bucket = assignmentsByVariant.get(state.existingVariant) ?? [];
+        bucket.push(state);
+        assignmentsByVariant.set(state.existingVariant, bucket);
+      } else {
+        unassigned.push(state);
+      }
+    }
+
+    unassigned.sort((a, b) => {
+      if (a.hash === b.hash) {
+        return a.subject.subjectId.localeCompare(b.subject.subjectId);
+      }
+      return a.hash < b.hash ? -1 : 1;
+    });
+
+    for (const state of unassigned) {
+      const variant = nextVariantWithDeficit(experiment.variants, targetCounts, currentCounts);
+      currentCounts.set(variant, (currentCounts.get(variant) ?? 0) + 1);
+      const bucket = assignmentsByVariant.get(variant) ?? [];
+      bucket.push({ ...state, existing: true, existingVariant: variant });
+      assignmentsByVariant.set(variant, bucket);
+      this.applyAssignment(experiment, variant, stratum, state.subject, 'assigned');
+    }
+
+    let iterationGuard = subjects.length * experiment.variants.length;
+    while (iterationGuard > 0) {
+      iterationGuard--;
+      const { surplus, deficit } = findSurplusAndDeficit(experiment.variants, targetCounts, currentCounts);
+      if (!surplus || !deficit) {
+        break;
+      }
+      const candidates = assignmentsByVariant.get(surplus) ?? [];
+      if (candidates.length === 0) {
+        break;
+      }
+      candidates.sort((a, b) => {
+        if (a.hash === b.hash) {
+          return b.subject.subjectId.localeCompare(a.subject.subjectId);
+        }
+        return a.hash > b.hash ? -1 : 1;
+      });
+      const moving = candidates.shift()!;
+      assignmentsByVariant.set(surplus, candidates);
+      currentCounts.set(surplus, (currentCounts.get(surplus) ?? 1) - 1);
+      currentCounts.set(deficit, (currentCounts.get(deficit) ?? 0) + 1);
+      const bucket = assignmentsByVariant.get(deficit) ?? [];
+      bucket.push({ ...moving, existingVariant: deficit });
+      assignmentsByVariant.set(deficit, bucket);
+      this.applyAssignment(experiment, deficit, stratum, moving.subject, 'rebalanced');
+    }
+
+    if (!withinTolerance(experiment, stratum, currentCounts)) {
+      throw new Error(`rebalance tolerance exceeded for experiment ${experiment.id} stratum ${stratum}`);
+    }
+  }
+
+  private applyAssignment(experiment: ExperimentConfig, variant: string, stratum: string, subject: Subject, event: LedgerEntry['event']): void {
+    const key = assignmentKey(experiment.id, subject.tenantId, subject.subjectId);
+    const previous = this.assignments.get(key);
+    const assignment: Assignment = {
+      experimentId: experiment.id,
+      tenantId: subject.tenantId,
+      subjectId: subject.subjectId,
+      variant,
+      stratum,
+      assignedAt: new Date(),
+      reason: event,
+    };
+    this.assignments.set(key, assignment);
+
+    if (previous && previous.variant === variant && previous.stratum === stratum) {
+      return;
+    }
+
+    let reason = event;
+    if (previous && previous.variant !== variant) {
+      reason = `variant updated via ${event}`;
+    }
+    if (previous && previous.stratum !== stratum) {
+      reason = `stratum updated via ${event}`;
+    }
+
+    this.record({
+      timestamp: assignment.assignedAt,
+      event,
+      experimentId: experiment.id,
+      tenantId: subject.tenantId,
+      subjectId: subject.subjectId,
+      variant,
+      stratum,
+      reason,
+    });
+  }
+
+  private record(entry: LedgerEntry): void {
+    this.ledger.push(entry);
+  }
+}
+
+function hasConsent(subject: Subject, purpose: string): boolean {
+  return subject.consents?.[purpose]?.granted ?? false;
+}
+
+function matchesExclusion(rules: ExclusionRule[] | undefined, subject: Subject): boolean {
+  if (!rules?.length) {
+    return false;
+  }
+  return rules.some((rule) => {
+    const value = subject.attributes?.[rule.attribute];
+    return rule.values.some((candidate) => candidate.localeCompare(value ?? '', undefined, { sensitivity: 'accent' }) === 0);
+  });
+}
+
+function resolveStratum(experiment: ExperimentConfig, subject: Subject): string {
+  for (const stratum of experiment.strata ?? []) {
+    const matches = Object.entries(stratum.criteria).every(([key, value]) => subject.attributes?.[key] === value);
+    if (matches) {
+      return stratum.name;
+    }
+  }
+  return 'default';
+}
+
+function weightMapForStratum(experiment: ExperimentConfig, stratum: string): Map<string, number> {
+  const weights = new Map<string, number>();
+  for (const variant of experiment.variants) {
+    weights.set(variant.name, variant.weight);
+  }
+  for (const s of experiment.strata ?? []) {
+    if (s.name === stratum && s.weights) {
+      for (const [name, weight] of Object.entries(s.weights)) {
+        weights.set(name, weight);
+      }
+    }
+  }
+  for (const variant of experiment.variants) {
+    const weight = weights.get(variant.name) ?? 0;
+    if (weight <= 0) {
+      throw new Error('experiment must define positive weights for variants');
+    }
+  }
+  return weights;
+}
+
+function computeTargetCounts(total: number, variants: VariantConfig[], weights: Map<string, number>): Map<string, number> {
+  let sumWeights = 0;
+  for (const variant of variants) {
+    sumWeights += weights.get(variant.name) ?? 0;
+  }
+  const counts = new Map<string, number>();
+  const remainders: { name: string; fraction: number }[] = [];
+  let assigned = 0;
+  for (const variant of variants) {
+    const expected = ((weights.get(variant.name) ?? 0) / sumWeights) * total;
+    const base = Math.floor(expected);
+    counts.set(variant.name, base);
+    remainders.push({ name: variant.name, fraction: expected - base });
+    assigned += base;
+  }
+  let remainder = total - assigned;
+  if (remainder > 0) {
+    remainders.sort((a, b) => {
+      if (a.fraction === b.fraction) {
+        return a.name.localeCompare(b.name);
+      }
+      return b.fraction - a.fraction;
+    });
+    for (let i = 0; i < remainder && i < remainders.length; i += 1) {
+      counts.set(remainders[i].name, (counts.get(remainders[i].name) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+function nextVariantWithDeficit(variants: VariantConfig[], target: Map<string, number>, current: Map<string, number>): string {
+  const candidates = variants.map((variant) => ({
+    name: variant.name,
+    diff: (target.get(variant.name) ?? 0) - (current.get(variant.name) ?? 0),
+  }));
+  candidates.sort((a, b) => {
+    if (a.diff === b.diff) {
+      return a.name.localeCompare(b.name);
+    }
+    return b.diff - a.diff;
+  });
+  return candidates[0].name;
+}
+
+function findSurplusAndDeficit(variants: VariantConfig[], target: Map<string, number>, current: Map<string, number>): { surplus?: string; deficit?: string } {
+  let surplusName: string | undefined;
+  let surplusDiff = 0;
+  let deficitName: string | undefined;
+  let deficitDiff = 0;
+  for (const variant of variants) {
+    const diff = (current.get(variant.name) ?? 0) - (target.get(variant.name) ?? 0);
+    if (diff > surplusDiff) {
+      surplusDiff = diff;
+      surplusName = variant.name;
+    }
+    if (-diff > deficitDiff) {
+      deficitDiff = -diff;
+      deficitName = variant.name;
+    }
+  }
+  if (surplusDiff > 0 && deficitDiff > 0) {
+    return { surplus: surplusName, deficit: deficitName };
+  }
+  return {};
+}
+
+function withinTolerance(experiment: ExperimentConfig, stratum: string, current: Map<string, number>): boolean {
+  let total = 0;
+  for (const count of current.values()) {
+    total += count;
+  }
+  if (total === 0) {
+    return true;
+  }
+  const weights = weightMapForStratum(experiment, stratum);
+  let sumWeights = 0;
+  for (const variant of experiment.variants) {
+    sumWeights += weights.get(variant.name) ?? 0;
+  }
+  if (sumWeights === 0) {
+    sumWeights = experiment.variants.length;
+  }
+  const tolerance = experiment.powerTolerance ?? 0.05;
+  const sampleAllowance = 1 / total;
+  const allowed = sampleAllowance > tolerance ? sampleAllowance : tolerance;
+  for (const variant of experiment.variants) {
+    const expected = (weights.get(variant.name) ?? 0) / sumWeights;
+    const actual = (current.get(variant.name) ?? 0) / total;
+    if (Math.abs(expected - actual) > allowed + 1e-9) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function stableHash(experiment: ExperimentConfig, stratum: string, subject: Subject): bigint {
+  const stickinessValues = (experiment.stickinessKeys ?? []).map((key) => subject.attributes?.[key] ?? '');
+  const payload = [
+    experiment.id,
+    experiment.purpose,
+    stratum,
+    subject.tenantId,
+    subject.subjectId,
+    stickinessValues.join('|'),
+  ].join('|');
+  const digest = createHash('sha256').update(payload).digest();
+  return digest.readBigUInt64BE(0);
+}

--- a/cea/sdk/tsconfig.json
+++ b/cea/sdk/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- implement a Go allocator that enforces consent/exclusion rules, supports stratified sticky bucketing, and records auditable assignments
- add unit coverage around consent gating, deterministic stickiness, and rebalancing tolerance guarantees
- introduce a matching TypeScript SDK and README documentation for consumers

## Testing
- `cd cea && go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d76386653c8333b02174eafa785ae0