### PR TITLE
feat: add pipeline flakiness detector toolkit

### DIFF
--- a/tools/pfd/README.md
+++ b/tools/pfd/README.md
@@ -1,0 +1,52 @@
+# Pipeline Flakiness Detector (PFD)
+
+PFD is a lightweight toolkit for characterising pipeline non-determinism. It repeatedly
+executes each step of a pipeline on identical inputs and seeds, estimates per-step
+variance, and reports a flakiness score that highlights the most unstable components.
+
+## Features
+
+- Deterministic orchestration that seeds common RNGs before each run.
+- Statistical summaries per step (difference ratio, variance, failure rate).
+- HTML reporting that includes blame file/line information for each step.
+- Pytest integration via the `pfd_session` fixture and CLI flags.
+
+## Usage
+
+```python
+from pfd import PipelineFlakinessDetector, PipelineStep
+
+steps = [
+    PipelineStep("load", load_data),
+    PipelineStep("transform", transform_data),
+]
+
+detector = PipelineFlakinessDetector(steps, runs=10, seed=123)
+analyses = detector.run(initial_input=None)
+```
+
+Generate a report:
+
+```python
+from pfd import HTMLReportBuilder
+
+builder = HTMLReportBuilder(analyses, runs=detector.runs, threshold=detector.threshold)
+builder.to_file("pfd-report.html")
+```
+
+### Pytest plugin
+
+Enable the pytest plugin by installing the package in your environment and running
+pytest with the provided fixture:
+
+```python
+def test_pipeline(pfd_session):
+    steps = [PipelineStep("step", lambda x: x)]
+    pfd_session.run_pipeline(steps, initial_input=None, name="pipeline")
+```
+
+Command line options:
+
+- `--pfd-runs` (default 5)
+- `--pfd-threshold` (default 0.2)
+- `--pfd-report` (default `pfd-report.html`)

--- a/tools/pfd/pfd/__init__.py
+++ b/tools/pfd/pfd/__init__.py
@@ -1,0 +1,11 @@
+"""Pipeline Flakiness Detector (PFD) public API."""
+from .core import PipelineFlakinessDetector, PipelineStep, StepAnalysis, StepRun
+from .report import HTMLReportBuilder
+
+__all__ = [
+    "PipelineFlakinessDetector",
+    "PipelineStep",
+    "StepAnalysis",
+    "StepRun",
+    "HTMLReportBuilder",
+]

--- a/tools/pfd/pfd/core.py
+++ b/tools/pfd/pfd/core.py
@@ -1,0 +1,300 @@
+"""Core primitives for the Pipeline Flakiness Detector (PFD)."""
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import inspect
+import json
+import math
+import random
+import statistics
+import time
+from collections import Counter
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence
+
+try:  # Optional numpy support for better numeric handling.
+    import numpy as _np  # type: ignore
+except Exception:  # pragma: no cover - numpy is optional.
+    _np = None
+
+
+@dataclass(frozen=True)
+class PipelineStep:
+    """Represents a named unit of computation within a pipeline."""
+
+    name: str
+    func: Callable[[Any], Any]
+
+
+@dataclass(frozen=True)
+class StepRun:
+    """Captures the outcome of a step for a single pipeline run."""
+
+    step_name: str
+    value_repr: str
+    value_hash: str
+    numeric_vector: Optional[List[float]]
+    exception: Optional[str] = None
+    skipped: bool = False
+
+
+@dataclass(frozen=True)
+class StepAnalysis:
+    """Aggregate metrics for a pipeline step across multiple runs."""
+
+    name: str
+    flakiness_score: float
+    difference_ratio: float
+    failure_ratio: float
+    normalized_variance: float
+    mean: Optional[float]
+    variance: Optional[float]
+    num_runs: int
+    failures: int
+    unique_value_samples: List[Mapping[str, Any]]
+    flagged: bool
+    blame_file: Optional[str]
+    blame_line: Optional[int]
+    exceptions: List[str]
+
+
+def _seed_environment(base_seed: int, run_id: int) -> None:
+    """Best-effort seeding of common PRNGs for reproducibility."""
+
+    seed = (base_seed + run_id * 9973) & 0xFFFFFFFF
+    random.seed(seed)
+    try:
+        import numpy as np  # type: ignore
+
+        np.random.seed(seed % (2**32 - 1))
+    except Exception:  # pragma: no cover - numpy optional.
+        pass
+    try:
+        import torch  # type: ignore
+
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():  # type: ignore[attr-defined]
+            torch.cuda.manual_seed_all(seed)  # pragma: no cover - GPU not in CI.
+    except Exception:  # pragma: no cover - torch optional.
+        pass
+
+
+def _stable_default(obj: Any) -> str:
+    """Fallback serializer returning a deterministic representation."""
+
+    if dataclasses.is_dataclass(obj):
+        return json.dumps(
+            {field.name: getattr(obj, field.name) for field in dataclasses.fields(obj)},
+            sort_keys=True,
+            default=_stable_default,
+        )
+    if isinstance(obj, set):
+        return json.dumps(sorted(list(obj)), sort_keys=True, default=_stable_default)
+    return repr(obj)
+
+
+def _stable_serialize(value: Any) -> str:
+    """Serialize a value into a deterministic string suitable for hashing."""
+
+    try:
+        return json.dumps(value, sort_keys=True, default=_stable_default)
+    except TypeError:
+        return repr(value)
+
+
+def _stable_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()
+
+
+def _is_bool(value: Any) -> bool:
+    return isinstance(value, bool)
+
+
+def _extract_numeric_vector(value: Any) -> Optional[List[float]]:
+    """Attempt to flatten a value into a list of floats for statistics."""
+
+    if _is_bool(value):
+        return [1.0 if value else 0.0]
+    if isinstance(value, (int, float)):
+        return [float(value)]
+    if _np is not None and isinstance(value, _np.ndarray):  # pragma: no cover - numpy optional
+        try:
+            return _np.asarray(value, dtype=float).ravel().tolist()
+        except Exception:
+            return None
+    if isinstance(value, Mapping):
+        flattened: List[float] = []
+        for key in sorted(value.keys(), key=str):
+            component = _extract_numeric_vector(value[key])
+            if component is None:
+                return None
+            flattened.extend(component)
+        return flattened
+    if isinstance(value, (list, tuple)):
+        flattened_list: List[float] = []
+        for item in value:
+            component = _extract_numeric_vector(item)
+            if component is None:
+                return None
+            flattened_list.extend(component)
+        return flattened_list
+    return None
+
+
+def _compute_statistics(vectors: Iterable[Optional[List[float]]]) -> Mapping[str, Optional[float]]:
+    values: List[float] = []
+    for vector in vectors:
+        if vector is None:
+            continue
+        values.extend(vector)
+    if not values:
+        return {"mean": None, "variance": None, "normalized_variance": 0.0}
+    if len(values) == 1:
+        return {"mean": values[0], "variance": 0.0, "normalized_variance": 0.0}
+    mean = statistics.fmean(values)
+    variance = statistics.pvariance(values, mu=mean)
+    std = math.sqrt(variance)
+    denom = abs(mean) + std + 1e-9
+    normalized_variance = std / denom
+    return {"mean": mean, "variance": variance, "normalized_variance": normalized_variance}
+
+
+class PipelineFlakinessDetector:
+    """Executes a pipeline repeatedly to surface non-deterministic steps."""
+
+    def __init__(
+        self,
+        steps: Sequence[PipelineStep],
+        runs: int = 5,
+        seed: int = 0,
+        threshold: float = 0.2,
+        set_seeds: bool = True,
+    ) -> None:
+        if runs < 2:
+            raise ValueError("PFD requires at least two runs to estimate variance.")
+        self.steps = list(steps)
+        self.runs = runs
+        self.seed = seed
+        self.threshold = threshold
+        self.set_seeds = set_seeds
+
+    def run(self, initial_input: Any = None) -> List[StepAnalysis]:
+        """Execute the configured pipeline and return per-step analyses."""
+
+        step_runs: Dict[str, List[StepRun]] = {step.name: [] for step in self.steps}
+        for run_index in range(self.runs):
+            if self.set_seeds:
+                _seed_environment(self.seed, run_index)
+            context = initial_input
+            aborted = False
+            for step in self.steps:
+                if aborted:
+                    step_runs[step.name].append(
+                        StepRun(
+                            step_name=step.name,
+                            value_repr="<skipped>",
+                            value_hash=_stable_hash("<skipped>"),
+                            numeric_vector=None,
+                            exception=None,
+                            skipped=True,
+                        )
+                    )
+                    continue
+                try:
+                    value = step.func(context)
+                    value_repr = _stable_serialize(value)
+                    numeric_vector = _extract_numeric_vector(value)
+                    step_runs[step.name].append(
+                        StepRun(
+                            step_name=step.name,
+                            value_repr=value_repr,
+                            value_hash=_stable_hash(value_repr),
+                            numeric_vector=numeric_vector,
+                        )
+                    )
+                    context = value
+                except Exception as exc:  # noqa: BLE001
+                    exc_repr = f"{type(exc).__name__}: {exc}"
+                    step_runs[step.name].append(
+                        StepRun(
+                            step_name=step.name,
+                            value_repr=exc_repr,
+                            value_hash=_stable_hash(exc_repr),
+                            numeric_vector=None,
+                            exception=exc_repr,
+                        )
+                    )
+                    aborted = True
+            time.sleep(0)  # Yield to ensure consistent scheduling in tests.
+        return self._analyze_runs(step_runs)
+
+    def _analyze_runs(self, step_runs: Mapping[str, List[StepRun]]) -> List[StepAnalysis]:
+        analyses: List[StepAnalysis] = []
+        for step in self.steps:
+            runs = step_runs[step.name]
+            value_counter: Counter[str] = Counter(run.value_hash for run in runs)
+            most_common = value_counter.most_common(1)
+            most_common_count = most_common[0][1] if most_common else 0
+            difference_ratio = 1.0 - (most_common_count / max(1, len(runs)))
+            failures = sum(1 for run in runs if run.exception is not None)
+            failure_ratio = failures / len(runs)
+            stats = _compute_statistics(run.numeric_vector for run in runs)
+            normalized_variance = float(stats.get("normalized_variance", 0.0))
+            exceptions = sorted({run.exception for run in runs if run.exception})
+            unique_samples: List[Mapping[str, Any]] = []
+            # Deterministic order: by descending count then lexicographic repr.
+            for value_hash, count in sorted(
+                value_counter.items(),
+                key=lambda item: (-item[1], item[0]),
+            ):
+                # Retrieve representative repr deterministically.
+                repr_candidates = [run.value_repr for run in runs if run.value_hash == value_hash]
+                repr_candidates.sort()
+                sample_repr = repr_candidates[0] if repr_candidates else ""
+                unique_samples.append(
+                    {
+                        "count": count,
+                        "fraction": count / len(runs),
+                        "repr": sample_repr,
+                    }
+                )
+            flakiness_score = difference_ratio + normalized_variance + failure_ratio
+            flagged = flakiness_score >= self.threshold
+            blame_file: Optional[str] = None
+            blame_line: Optional[int] = None
+            try:
+                source_file = inspect.getsourcefile(step.func)
+                if source_file:
+                    blame_file = source_file
+                    _, first_line = inspect.getsourcelines(step.func)
+                    blame_line = first_line
+            except (OSError, TypeError):  # pragma: no cover - introspection edge cases.
+                pass
+            analyses.append(
+                StepAnalysis(
+                    name=step.name,
+                    flakiness_score=flakiness_score,
+                    difference_ratio=difference_ratio,
+                    failure_ratio=failure_ratio,
+                    normalized_variance=normalized_variance,
+                    mean=stats.get("mean"),
+                    variance=stats.get("variance"),
+                    num_runs=len(runs),
+                    failures=failures,
+                    unique_value_samples=unique_samples,
+                    flagged=flagged,
+                    blame_file=blame_file,
+                    blame_line=blame_line,
+                    exceptions=exceptions,
+                )
+            )
+        return analyses
+
+
+__all__ = [
+    "PipelineFlakinessDetector",
+    "PipelineStep",
+    "StepAnalysis",
+    "StepRun",
+]

--- a/tools/pfd/pfd/pytest_plugin.py
+++ b/tools/pfd/pfd/pytest_plugin.py
@@ -1,0 +1,102 @@
+"""Pytest plugin exposing fixtures for the Pipeline Flakiness Detector."""
+from __future__ import annotations
+
+import os
+from dataclasses import replace
+from typing import Iterable, List, Optional
+
+import pytest
+
+from .core import PipelineFlakinessDetector, PipelineStep, StepAnalysis
+from .report import HTMLReportBuilder
+
+
+class PFDSession:
+    """Holds flakiness analyses across a pytest session."""
+
+    def __init__(self, runs: int, threshold: float, report_path: str) -> None:
+        self.runs = runs
+        self.threshold = threshold
+        self.report_path = os.path.abspath(report_path)
+        self._records: List[StepAnalysis] = []
+
+    def run_pipeline(
+        self,
+        steps: Iterable[PipelineStep],
+        *,
+        initial_input: object = None,
+        seed: int = 0,
+        set_seeds: bool = True,
+        name: Optional[str] = None,
+    ) -> List[StepAnalysis]:
+        detector = PipelineFlakinessDetector(
+            list(steps),
+            runs=self.runs,
+            seed=seed,
+            threshold=self.threshold,
+            set_seeds=set_seeds,
+        )
+        analyses = detector.run(initial_input=initial_input)
+        label = name or "pipeline"
+        for analysis in analyses:
+            prefixed = replace(analysis, name=f"{label}::{analysis.name}")
+            self._records.append(prefixed)
+        return analyses
+
+    def finalize(self) -> None:
+        if not self.report_path:
+            return
+        os.makedirs(os.path.dirname(self.report_path) or ".", exist_ok=True)
+        builder = HTMLReportBuilder(
+            self._records,
+            runs=self.runs,
+            threshold=self.threshold,
+            title="Pipeline Flakiness Report",
+        )
+        builder.to_file(self.report_path)
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    group = parser.getgroup("pfd")
+    group.addoption(
+        "--pfd-runs",
+        action="store",
+        default=5,
+        type=int,
+        help="Number of executions per pipeline for the flakiness detector.",
+    )
+    group.addoption(
+        "--pfd-threshold",
+        action="store",
+        default=0.2,
+        type=float,
+        help="Flakiness score threshold to flag steps.",
+    )
+    group.addoption(
+        "--pfd-report",
+        action="store",
+        default="pfd-report.html",
+        help="Path to the generated HTML report.",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    runs = int(config.getoption("--pfd-runs"))
+    threshold = float(config.getoption("--pfd-threshold"))
+    report_path = str(config.getoption("--pfd-report"))
+    session = PFDSession(runs=runs, threshold=threshold, report_path=report_path)
+    config._pfd_session = session  # type: ignore[attr-defined]
+
+
+@pytest.fixture
+def pfd_session(request: pytest.FixtureRequest) -> PFDSession:
+    return request.config._pfd_session  # type: ignore[attr-defined]
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    session: Optional[PFDSession] = getattr(config, "_pfd_session", None)
+    if session is not None:
+        session.finalize()
+
+
+__all__ = ["PFDSession"]

--- a/tools/pfd/pfd/report.py
+++ b/tools/pfd/pfd/report.py
@@ -1,0 +1,141 @@
+"""HTML report generation for the Pipeline Flakiness Detector."""
+from __future__ import annotations
+
+import html
+import os
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .core import StepAnalysis
+
+
+@dataclass(frozen=True)
+class ReportContext:
+    title: str
+    runs: int
+    threshold: float
+    analyses: List[StepAnalysis]
+
+
+def _format_float(value: float) -> str:
+    return f"{value:.6f}"
+
+
+class HTMLReportBuilder:
+    """Produce deterministic HTML summaries for PFD runs."""
+
+    def __init__(self, analyses: Iterable[StepAnalysis], runs: int, threshold: float, title: str = "Pipeline Flakiness Report") -> None:
+        self.context = ReportContext(
+            title=title,
+            runs=runs,
+            threshold=threshold,
+            analyses=list(analyses),
+        )
+
+    def build(self) -> str:
+        ctx = self.context
+        flagged = [analysis for analysis in ctx.analyses if analysis.flagged]
+        rows = [self._render_row(analysis) for analysis in ctx.analyses]
+        summary = self._render_summary(len(flagged), len(ctx.analyses))
+        html_parts = [
+            "<!DOCTYPE html>",
+            "<html lang=\"en\">",
+            "<head>",
+            "<meta charset=\"utf-8\" />",
+            f"<title>{html.escape(ctx.title)}</title>",
+            "<style>",
+            "body { font-family: Arial, sans-serif; margin: 2rem; }",
+            "h1 { margin-bottom: 0.5rem; }",
+            "table { border-collapse: collapse; width: 100%; margin-top: 1rem; }",
+            "th, td { border: 1px solid #ccc; padding: 0.5rem; text-align: left; }",
+            "th { background: #f5f5f5; }",
+            ".flagged { background: #ffe6e6; }",
+            ".summary { margin-top: 0.5rem; font-weight: bold; }",
+            "code { font-family: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace; }",
+            "</style>",
+            "</head>",
+            "<body>",
+            f"<h1>{html.escape(ctx.title)}</h1>",
+            f"<div class=\"summary\">Runs: {ctx.runs} &mdash; Threshold: {_format_float(ctx.threshold)}</div>",
+            summary,
+            "<table>",
+            "<thead>",
+            "<tr>",
+            "<th>Step</th>",
+            "<th>Flakiness</th>",
+            "<th>Difference</th>",
+            "<th>Variance</th>",
+            "<th>Failures</th>",
+            "<th>Blame</th>",
+            "<th>Samples</th>",
+            "</tr>",
+            "</thead>",
+            "<tbody>",
+            *rows,
+            "</tbody>",
+            "</table>",
+            "</body>",
+            "</html>",
+        ]
+        return "\n".join(html_parts)
+
+    def _render_summary(self, flagged_count: int, total: int) -> str:
+        if total == 0:
+            return "<div class=\"summary\">No steps executed.</div>"
+        return (
+            "<div class=\"summary\">"
+            f"Flagged steps: {flagged_count} / {total}"
+            "</div>"
+        )
+
+    def _render_row(self, analysis: StepAnalysis) -> str:
+        row_class = " class=\"flagged\"" if analysis.flagged else ""
+        blame_text = self._format_blame(analysis)
+        samples_html = self._format_samples(analysis)
+        return (
+            f"<tr{row_class}>"
+            f"<td>{html.escape(analysis.name)}</td>"
+            f"<td>{_format_float(analysis.flakiness_score)}</td>"
+            f"<td>{_format_float(analysis.difference_ratio)}</td>"
+            f"<td>{self._format_variance(analysis)}</td>"
+            f"<td>{analysis.failures} ({_format_float(analysis.failure_ratio)})</td>"
+            f"<td>{blame_text}</td>"
+            f"<td>{samples_html}</td>"
+            "</tr>"
+        )
+
+    def _format_variance(self, analysis: StepAnalysis) -> str:
+        if analysis.variance is None:
+            return "n/a"
+        return _format_float(float(analysis.variance))
+
+    def _format_blame(self, analysis: StepAnalysis) -> str:
+        if not analysis.blame_file:
+            return "unknown"
+        rel = os.path.relpath(analysis.blame_file)
+        location = f"{rel}:{analysis.blame_line}" if analysis.blame_line else rel
+        return f"<code>{html.escape(location)}</code>"
+
+    def _format_samples(self, analysis: StepAnalysis) -> str:
+        pieces: List[str] = []
+        for sample in analysis.unique_value_samples:
+            pieces.append(
+                "<div>"
+                f"{int(sample['count'])}x ({_format_float(float(sample['fraction']))}): "
+                f"<code>{html.escape(sample['repr'])}</code>"
+                "</div>"
+            )
+        if analysis.exceptions:
+            for exc in analysis.exceptions:
+                pieces.append(f"<div><strong>Exception:</strong> {html.escape(exc)}</div>")
+        if not pieces:
+            pieces.append("<div>no samples</div>")
+        return "".join(pieces)
+
+    def to_file(self, path: str) -> None:
+        html_text = self.build()
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(html_text)
+
+
+__all__ = ["HTMLReportBuilder"]

--- a/tools/pfd/pyproject.toml
+++ b/tools/pfd/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pfd"
+version = "0.1.0"
+description = "Pipeline Flakiness Detector"
+authors = [{name = "Summit Autogen", email = "summit@example.com"}]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[project.entry-points."pytest11"]
+pfd = "pfd.pytest_plugin"
+
+[tool.pytest.ini_options]
+addopts = "-q"

--- a/tools/pfd/tests/test_detector.py
+++ b/tools/pfd/tests/test_detector.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import random
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))
+
+from pfd.core import PipelineFlakinessDetector, PipelineStep
+from pfd.report import HTMLReportBuilder
+from pfd.pytest_plugin import PFDSession
+
+
+def deterministic_step(value: int | None) -> int:
+    return (value or 0) + 1
+
+
+def nondeterministic_step(value: int) -> float:
+    return value + random.SystemRandom().random()
+
+
+def test_detector_flags_nondeterministic_step(tmp_path: Path) -> None:
+    steps = [
+        PipelineStep("increment", deterministic_step),
+        PipelineStep("jitter", nondeterministic_step),
+    ]
+    detector = PipelineFlakinessDetector(steps, runs=6, seed=42)
+    analyses = detector.run(initial_input=1)
+    increment, jitter = analyses
+    assert increment.flakiness_score == 0.0
+    assert increment.difference_ratio == 0.0
+    assert jitter.flakiness_score >= 0.85
+    assert jitter.difference_ratio >= 0.8
+    assert jitter.flagged
+
+
+def test_html_report_reproducible(tmp_path: Path) -> None:
+    steps = [PipelineStep("increment", deterministic_step)]
+    detector = PipelineFlakinessDetector(steps, runs=4, seed=123)
+    analyses = detector.run(initial_input=2)
+    builder = HTMLReportBuilder(analyses, runs=detector.runs, threshold=detector.threshold)
+    report_a = builder.build()
+    report_b = builder.build()
+    assert report_a == report_b
+    output = tmp_path / "report.html"
+    builder.to_file(output.as_posix())
+    assert output.read_text(encoding="utf-8") == report_a
+
+
+def test_pfd_session_generates_prefixed_report(tmp_path: Path) -> None:
+    session = PFDSession(runs=4, threshold=0.2, report_path=tmp_path / "session.html")
+    steps = [PipelineStep("increment", deterministic_step)]
+    session.run_pipeline(steps, initial_input=0, name="demo")
+    session.finalize()
+    report_text = (tmp_path / "session.html").read_text(encoding="utf-8")
+    assert "demo::increment" in report_text


### PR DESCRIPTION
## Summary
- add a reusable Pipeline Flakiness Detector core that seeds runs, computes per-step statistics, and builds deterministic HTML reports
- provide a pytest plugin and README guidance for integrating the detector into test suites
- cover the detector with tests for nondeterminism detection, report reproducibility, and session reporting

## Testing
- pytest tools/pfd/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d767be2fb083338ddabb51b06250a1