### PR TITLE
feat: deliver human feedback arbitration workbench

### DIFF
--- a/client/src/App.router.jsx
+++ b/client/src/App.router.jsx
@@ -77,6 +77,7 @@ import ClaimsViewer from './features/conductor/ClaimsViewer';
 import RetractionQueue from './features/conductor/RetractionQueue';
 import CostAdvisor from './features/conductor/CostAdvisor';
 import RunSearch from './features/conductor/RunSearch';
+import HFAWorkbench from './features/hfa/HFAWorkbench';
 
 // Navigation items
 const navigationItems = [
@@ -110,6 +111,7 @@ const navigationItems = [
   { path: '/access-intel', label: 'Access Intel', icon: <Security /> },
   { path: '/geoint', label: 'GeoInt Map', icon: <Map /> },
   { path: '/reports', label: 'Reports', icon: <Assessment /> },
+  { path: '/hfa', label: 'HFA Workbench', icon: <Assessment /> },
   { path: '/system', label: 'System', icon: <Settings />, roles: ['ADMIN'] },
   {
     path: '/admin/osint-feeds',
@@ -664,6 +666,7 @@ function MainLayout() {
             <Route path="/access-intel" element={<AccessIntelPage />} />
             <Route path="/geoint" element={<InvestigationsPage />} />
             <Route path="/reports" element={<InvestigationsPage />} />
+            <Route path="/hfa" element={<HFAWorkbench />} />
             <Route element={<ProtectedRoute roles={['ADMIN']} />}>
               <Route path="/system" element={<InvestigationsPage />} />
               <Route path="/admin/osint-feeds" element={<OsintFeedConfig />} />

--- a/client/src/features/hfa/HFAWorkbench.tsx
+++ b/client/src/features/hfa/HFAWorkbench.tsx
@@ -1,0 +1,765 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  Divider,
+  Grid,
+  IconButton,
+  MenuItem,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from '@mui/material';
+import {
+  Download as DownloadIcon,
+  Upload as UploadIcon,
+  Refresh as RefreshIcon,
+  Gavel,
+  Warning as WarningIcon,
+  Insights,
+  AddCircle,
+} from '@mui/icons-material';
+
+interface DatasetSummary {
+  id: string;
+  name: string;
+  description?: string;
+  labelOptions?: string[];
+  totalAnnotations: number;
+  goldDecisions: number;
+}
+
+interface Metrics {
+  datasetId: string;
+  krippendorffAlpha: number;
+  averageCohenKappa: number | null;
+  unresolvedDisagreements: number;
+  adjudicatedSamples: number;
+  annotatedSamples: number;
+  totalAnnotations: number;
+  annotatorThroughput: Array<{ annotatorId: string; count: number }>;
+  pairwiseKappa: Array<{ annotators: [string, string]; kappa: number; support: number }>;
+}
+
+interface LabelRecord {
+  sampleId: string;
+  annotatorId: string;
+  label: string;
+  timestamp?: string;
+  metadata?: Record<string, unknown>;
+}
+
+interface Disagreement {
+  sampleId: string;
+  entropy: number;
+  totalAnnotations: number;
+  labelHistogram: Record<string, number>;
+  annotations: LabelRecord[];
+}
+
+interface GoldDecision {
+  sampleId: string;
+  label: string;
+  adjudicator: string;
+  rationale?: string;
+  decidedAt: string;
+}
+
+interface BiasAlert {
+  id: string;
+  annotatorId: string;
+  type: string;
+  magnitude: number;
+  triggeredAt: string;
+  resolved: boolean;
+  resolvedAt?: string;
+  details: string;
+}
+
+const API_ROOT = '/api/hfa';
+
+async function fetchJson<T>(input: RequestInfo, init?: RequestInit) {
+  const response = await fetch(input, {
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => ({}));
+    throw new Error(errorBody.error ?? response.statusText);
+  }
+  return (await response.json()) as T;
+}
+
+const formatNumber = (value: number | null | undefined) => {
+  if (value === null || value === undefined || Number.isNaN(value)) {
+    return '—';
+  }
+  return value.toFixed(2);
+};
+
+const emptyMetrics = Object.freeze({
+  datasetId: '',
+  krippendorffAlpha: 0,
+  averageCohenKappa: null,
+  unresolvedDisagreements: 0,
+  adjudicatedSamples: 0,
+  annotatedSamples: 0,
+  totalAnnotations: 0,
+  annotatorThroughput: [],
+  pairwiseKappa: [],
+});
+
+const HFAWorkbench: React.FC = () => {
+  const [datasets, setDatasets] = useState<DatasetSummary[]>([]);
+  const [selectedDatasetId, setSelectedDatasetId] = useState<string>('');
+  const [metrics, setMetrics] = useState<Metrics>(emptyMetrics as Metrics);
+  const [disagreements, setDisagreements] = useState<Disagreement[]>([]);
+  const [gold, setGold] = useState<GoldDecision[]>([]);
+  const [alerts, setAlerts] = useState<BiasAlert[]>([]);
+  const [status, setStatus] = useState<{ severity: 'success' | 'error' | 'info'; message: string } | null>(null);
+  const [creatingDataset, setCreatingDataset] = useState(false);
+  const [datasetName, setDatasetName] = useState('');
+  const [datasetDescription, setDatasetDescription] = useState('');
+  const [datasetLabels, setDatasetLabels] = useState('approve,reject,skip');
+  const [singleLabelDraft, setSingleLabelDraft] = useState({
+    sampleId: '',
+    annotatorId: '',
+    label: '',
+  });
+  const [bulkPayload, setBulkPayload] = useState('');
+  const [adjudicator, setAdjudicator] = useState('lead-arbiter');
+  const [adjudicationDrafts, setAdjudicationDrafts] = useState<Record<string, { label: string; rationale: string }>>({});
+  const [exportPreview, setExportPreview] = useState('');
+  const [importPayload, setImportPayload] = useState('');
+  const selectedDataset = useMemo(
+    () => datasets.find((dataset) => dataset.id === selectedDatasetId),
+    [datasets, selectedDatasetId],
+  );
+
+  const showStatus = (severity: 'success' | 'error' | 'info', message: string) => {
+    setStatus({ severity, message });
+  };
+
+  const loadDatasets = async () => {
+    try {
+      const response = await fetchJson<{ datasets: DatasetSummary[] }>(`${API_ROOT}/datasets`);
+      setDatasets(response.datasets);
+      if (!selectedDatasetId && response.datasets.length > 0) {
+        setSelectedDatasetId(response.datasets[0].id);
+      }
+    } catch (error) {
+      showStatus('error', (error as Error).message);
+    }
+  };
+
+  const loadDatasetDetails = async (datasetId: string) => {
+    if (!datasetId) {
+      return;
+    }
+    try {
+      const response = await fetchJson<{
+        dataset: DatasetSummary & { labelOptions?: string[] };
+        metrics: Metrics;
+        disagreements: Disagreement[];
+      }>(`${API_ROOT}/datasets/${datasetId}`);
+      setMetrics(response.metrics);
+      setDisagreements(response.disagreements);
+      const goldResponse = await fetchJson<{ gold: GoldDecision[] }>(`${API_ROOT}/datasets/${datasetId}/gold`);
+      setGold(goldResponse.gold);
+      const alertsResponse = await fetchJson<{ alerts: BiasAlert[] }>(`${API_ROOT}/datasets/${datasetId}/bias-alerts`);
+      setAlerts(alertsResponse.alerts);
+    } catch (error) {
+      showStatus('error', (error as Error).message);
+    }
+  };
+
+  useEffect(() => {
+    loadDatasets().catch((error) => {
+      showStatus('error', (error as Error).message);
+    });
+  }, []);
+
+  useEffect(() => {
+    if (selectedDatasetId) {
+      loadDatasetDetails(selectedDatasetId).catch((error) => {
+        showStatus('error', (error as Error).message);
+      });
+    }
+  }, [selectedDatasetId]);
+
+  const handleCreateDataset = async () => {
+    if (!datasetName.trim()) {
+      showStatus('error', 'Dataset name is required');
+      return;
+    }
+    setCreatingDataset(true);
+    try {
+      const labelOptions = datasetLabels
+        .split(',')
+        .map((label) => label.trim())
+        .filter(Boolean);
+      const response = await fetchJson<{ dataset: DatasetSummary }>(`${API_ROOT}/datasets`, {
+        method: 'POST',
+        body: JSON.stringify({
+          name: datasetName,
+          description: datasetDescription,
+          labelOptions,
+        }),
+      });
+      showStatus('success', `Dataset "${response.dataset.name}" created`);
+      setDatasetName('');
+      setDatasetDescription('');
+      await loadDatasets();
+      setSelectedDatasetId(response.dataset.id);
+    } catch (error) {
+      showStatus('error', (error as Error).message);
+    } finally {
+      setCreatingDataset(false);
+    }
+  };
+
+  const handleSingleIngest = async () => {
+    if (!selectedDatasetId) {
+      showStatus('error', 'Select a dataset before ingesting labels');
+      return;
+    }
+    if (!singleLabelDraft.sampleId || !singleLabelDraft.annotatorId || !singleLabelDraft.label) {
+      showStatus('error', 'Sample, annotator, and label are required');
+      return;
+    }
+    try {
+      await fetchJson(`${API_ROOT}/datasets/${selectedDatasetId}/labels`, {
+        method: 'POST',
+        body: JSON.stringify({ labels: [singleLabelDraft] }),
+      });
+      showStatus('success', 'Label recorded');
+      setSingleLabelDraft({ sampleId: '', annotatorId: '', label: '' });
+      await loadDatasetDetails(selectedDatasetId);
+    } catch (error) {
+      showStatus('error', (error as Error).message);
+    }
+  };
+
+  const handleBulkIngest = async () => {
+    if (!selectedDatasetId) {
+      showStatus('error', 'Select a dataset before ingesting labels');
+      return;
+    }
+    try {
+      const parsed = JSON.parse(bulkPayload) as LabelRecord[];
+      if (!Array.isArray(parsed) || parsed.length === 0) {
+        throw new Error('Paste an array of label records');
+      }
+      await fetchJson(`${API_ROOT}/datasets/${selectedDatasetId}/labels`, {
+        method: 'POST',
+        body: JSON.stringify({ labels: parsed }),
+      });
+      showStatus('success', `Ingested ${parsed.length} label(s)`);
+      setBulkPayload('');
+      await loadDatasetDetails(selectedDatasetId);
+    } catch (error) {
+      showStatus('error', (error as Error).message);
+    }
+  };
+
+  const handleAdjudicate = async (sampleId: string) => {
+    if (!selectedDatasetId) {
+      showStatus('error', 'Select a dataset first');
+      return;
+    }
+    const draft = adjudicationDrafts[sampleId];
+    if (!draft?.label) {
+      showStatus('error', 'Select a gold label before adjudicating');
+      return;
+    }
+    try {
+      const response = await fetchJson<{
+        metrics: Metrics;
+        disagreements: Disagreement[];
+        gold: GoldDecision[];
+      }>(`${API_ROOT}/datasets/${selectedDatasetId}/adjudicate`, {
+        method: 'POST',
+        body: JSON.stringify({
+          sampleId,
+          label: draft.label,
+          adjudicator,
+          rationale: draft.rationale,
+        }),
+      });
+      setMetrics(response.metrics);
+      setDisagreements(response.disagreements);
+      setGold(response.gold);
+      showStatus('success', `Adjudicated ${sampleId}`);
+    } catch (error) {
+      showStatus('error', (error as Error).message);
+    }
+  };
+
+  const handleExport = async () => {
+    if (!selectedDatasetId) {
+      showStatus('error', 'Select a dataset to export');
+      return;
+    }
+    try {
+      const payload = await fetchJson(`${API_ROOT}/datasets/${selectedDatasetId}/export`);
+      const pretty = JSON.stringify(payload, null, 2);
+      setExportPreview(pretty);
+      navigator.clipboard?.writeText(pretty).catch(() => {
+        // Clipboard might be unavailable in some environments; ignore errors
+      });
+      showStatus('success', 'Export ready (copied to clipboard when permitted)');
+    } catch (error) {
+      showStatus('error', (error as Error).message);
+    }
+  };
+
+  const handleImport = async () => {
+    try {
+      const parsed = JSON.parse(importPayload);
+      const response = await fetchJson<{ dataset: DatasetSummary }>(`${API_ROOT}/import`, {
+        method: 'POST',
+        body: JSON.stringify(parsed),
+      });
+      showStatus('success', `Imported dataset ${response.dataset.name}`);
+      setImportPayload('');
+      await loadDatasets();
+      setSelectedDatasetId(response.dataset.id);
+    } catch (error) {
+      showStatus('error', (error as Error).message);
+    }
+  };
+
+  const labelOptions = useMemo(() => {
+    if (selectedDataset?.labelOptions?.length) {
+      return selectedDataset.labelOptions;
+    }
+    const fromDisagreements = disagreements.flatMap((item) => Object.keys(item.labelHistogram));
+    const fromGold = gold.map((decision) => decision.label);
+    return Array.from(new Set([...fromDisagreements, ...fromGold]));
+  }, [selectedDataset, disagreements, gold]);
+
+  return (
+    <Box>
+      <Typography variant="h3" gutterBottom sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <Insights color="primary" /> Human Feedback Arbitration Workbench
+      </Typography>
+      <Typography variant="subtitle1" sx={{ mb: 3 }}>
+        Ingest annotator labels, measure agreement, triage disagreements, and maintain an auditable gold set with drift monitoring.
+      </Typography>
+
+      {status && (
+        <Alert severity={status.severity} sx={{ mb: 2 }} onClose={() => setStatus(null)}>
+          {status.message}
+        </Alert>
+      )}
+
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={4}>
+          <Card>
+            <CardContent>
+              <Stack direction="row" alignItems="center" justifyContent="space-between" sx={{ mb: 2 }}>
+                <Typography variant="h6">Datasets</Typography>
+                <IconButton aria-label="refresh datasets" onClick={() => loadDatasets()}>
+                  <RefreshIcon />
+                </IconButton>
+              </Stack>
+              <TextField
+                select
+                fullWidth
+                label="Select dataset"
+                value={selectedDatasetId}
+                onChange={(event) => setSelectedDatasetId(event.target.value)}
+                sx={{ mb: 2 }}
+              >
+                {datasets.map((dataset) => (
+                  <MenuItem key={dataset.id} value={dataset.id}>
+                    <Stack direction="row" spacing={1} alignItems="center">
+                      <Typography variant="body2">{dataset.name}</Typography>
+                      <Chip label={`${dataset.totalAnnotations} labels`} size="small" color="primary" />
+                    </Stack>
+                  </MenuItem>
+                ))}
+              </TextField>
+
+              <Divider sx={{ my: 2 }}>Create</Divider>
+
+              <Stack spacing={2}>
+                <TextField
+                  label="Dataset name"
+                  value={datasetName}
+                  onChange={(event) => setDatasetName(event.target.value)}
+                  fullWidth
+                />
+                <TextField
+                  label="Description"
+                  value={datasetDescription}
+                  onChange={(event) => setDatasetDescription(event.target.value)}
+                  fullWidth
+                  multiline
+                  minRows={2}
+                />
+                <TextField
+                  label="Label options (comma separated)"
+                  value={datasetLabels}
+                  onChange={(event) => setDatasetLabels(event.target.value)}
+                  helperText="Used to populate adjudication selectors"
+                />
+                <Button
+                  variant="contained"
+                  startIcon={<AddCircle />}
+                  onClick={handleCreateDataset}
+                  disabled={creatingDataset}
+                >
+                  Create dataset
+                </Button>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12} md={8}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Agreement Snapshot
+              </Typography>
+              <Grid container spacing={2}>
+                <Grid item xs={12} sm={6} md={3}>
+                  <Card variant="outlined">
+                    <CardContent>
+                      <Typography variant="body2" color="text.secondary">
+                        Krippendorff's α
+                      </Typography>
+                      <Typography variant="h4">{formatNumber(metrics.krippendorffAlpha)}</Typography>
+                    </CardContent>
+                  </Card>
+                </Grid>
+                <Grid item xs={12} sm={6} md={3}>
+                  <Card variant="outlined">
+                    <CardContent>
+                      <Typography variant="body2" color="text.secondary">
+                        Mean Cohen's κ
+                      </Typography>
+                      <Typography variant="h4">{formatNumber(metrics.averageCohenKappa)}</Typography>
+                    </CardContent>
+                  </Card>
+                </Grid>
+                <Grid item xs={12} sm={6} md={3}>
+                  <Card variant="outlined">
+                    <CardContent>
+                      <Typography variant="body2" color="text.secondary">
+                        Unresolved disagreements
+                      </Typography>
+                      <Typography variant="h4">{metrics.unresolvedDisagreements}</Typography>
+                    </CardContent>
+                  </Card>
+                </Grid>
+                <Grid item xs={12} sm={6} md={3}>
+                  <Card variant="outlined">
+                    <CardContent>
+                      <Typography variant="body2" color="text.secondary">
+                        Adjudicated samples
+                      </Typography>
+                      <Typography variant="h4">{metrics.adjudicatedSamples}</Typography>
+                    </CardContent>
+                  </Card>
+                </Grid>
+              </Grid>
+
+              {metrics.annotatorThroughput.length > 0 && (
+                <Box sx={{ mt: 3 }}>
+                  <Typography variant="subtitle2" gutterBottom>
+                    Annotator throughput
+                  </Typography>
+                  <Stack direction="row" spacing={1} flexWrap="wrap">
+                    {metrics.annotatorThroughput.map((entry) => (
+                      <Chip
+                        key={entry.annotatorId}
+                        label={`${entry.annotatorId}: ${entry.count}`}
+                        color="secondary"
+                        variant="outlined"
+                      />
+                    ))}
+                  </Stack>
+                </Box>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Ingest labels
+              </Typography>
+              <Stack spacing={2}>
+                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+                  <TextField
+                    label="Sample ID"
+                    value={singleLabelDraft.sampleId}
+                    onChange={(event) =>
+                      setSingleLabelDraft((prev) => ({ ...prev, sampleId: event.target.value }))
+                    }
+                    fullWidth
+                  />
+                  <TextField
+                    label="Annotator"
+                    value={singleLabelDraft.annotatorId}
+                    onChange={(event) =>
+                      setSingleLabelDraft((prev) => ({ ...prev, annotatorId: event.target.value }))
+                    }
+                    fullWidth
+                  />
+                </Stack>
+                <TextField
+                  select
+                  label="Label"
+                  value={singleLabelDraft.label}
+                  onChange={(event) =>
+                    setSingleLabelDraft((prev) => ({ ...prev, label: event.target.value }))
+                  }
+                >
+                  {labelOptions.length === 0 && <MenuItem value="">Add labels via settings</MenuItem>}
+                  {labelOptions.map((option) => (
+                    <MenuItem key={option} value={option}>
+                      {option}
+                    </MenuItem>
+                  ))}
+                </TextField>
+                <Button variant="contained" onClick={handleSingleIngest}>
+                  Record label
+                </Button>
+                <Divider>Bulk JSON</Divider>
+                <TextField
+                  label="[{ ...labelRecord }]"
+                  value={bulkPayload}
+                  onChange={(event) => setBulkPayload(event.target.value)}
+                  multiline
+                  minRows={4}
+                  placeholder='[
+  { "sampleId": "doc-1", "annotatorId": "ann-a", "label": "approve" }
+]'
+                />
+                <Button variant="outlined" onClick={handleBulkIngest}>
+                  Ingest bulk
+                </Button>
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Stack direction="row" justifyContent="space-between" alignItems="center">
+                <Typography variant="h6">Bias & drift alerts</Typography>
+                <WarningIcon color="warning" />
+              </Stack>
+              {alerts.length === 0 ? (
+                <Alert severity="success" sx={{ mt: 2 }}>
+                  No active alerts detected.
+                </Alert>
+              ) : (
+                <Stack spacing={1} sx={{ mt: 2 }}>
+                  {alerts.map((alert) => (
+                    <Alert
+                      key={alert.id}
+                      severity={alert.resolved ? 'info' : 'warning'}
+                      icon={<WarningIcon />}
+                    >
+                      <strong>{alert.annotatorId}</strong> · {alert.type.toUpperCase()} ·{' '}
+                      {alert.details} (m={formatNumber(alert.magnitude)})
+                      {!alert.resolved ? '' : ` · resolved ${new Date(alert.resolvedAt ?? '').toLocaleString()}`}
+                    </Alert>
+                  ))}
+                </Stack>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12}>
+          <Card>
+            <CardContent>
+              <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" sx={{ mb: 2 }}>
+                <Typography variant="h6" sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Gavel /> Active disagreements
+                </Typography>
+                <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2} alignItems={{ xs: 'stretch', sm: 'center' }}>
+                  <TextField
+                    label="Adjudicator"
+                    value={adjudicator}
+                    onChange={(event) => setAdjudicator(event.target.value)}
+                    size="small"
+                  />
+                  <Button
+                    variant="outlined"
+                    startIcon={<RefreshIcon />}
+                    onClick={() => selectedDatasetId && loadDatasetDetails(selectedDatasetId)}
+                  >
+                    Refresh
+                  </Button>
+                </Stack>
+              </Stack>
+              {disagreements.length === 0 ? (
+                <Alert severity="info">No disagreements to review.</Alert>
+              ) : (
+                <Table size="small">
+                  <TableHead>
+                    <TableRow>
+                      <TableCell>Sample</TableCell>
+                      <TableCell>Labels</TableCell>
+                      <TableCell>Entropy</TableCell>
+                      <TableCell width="25%">Adjudication</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {disagreements.map((item) => (
+                      <TableRow key={item.sampleId} hover>
+                        <TableCell>
+                          <Typography variant="subtitle2">{item.sampleId}</Typography>
+                          <Typography variant="caption" color="text.secondary">
+                            {item.totalAnnotations} annotations
+                          </Typography>
+                        </TableCell>
+                        <TableCell>
+                          <Stack spacing={1}>
+                            {Object.entries(item.labelHistogram).map(([label, count]) => (
+                              <Chip key={label} label={`${label}: ${count}`} color="primary" variant="outlined" />
+                            ))}
+                          </Stack>
+                        </TableCell>
+                        <TableCell>{formatNumber(item.entropy)}</TableCell>
+                        <TableCell>
+                          <Stack spacing={1}>
+                            <TextField
+                              select
+                              fullWidth
+                              size="small"
+                              value={adjudicationDrafts[item.sampleId]?.label ?? ''}
+                              onChange={(event) =>
+                                setAdjudicationDrafts((prev) => ({
+                                  ...prev,
+                                  [item.sampleId]: {
+                                    label: event.target.value,
+                                    rationale: prev[item.sampleId]?.rationale ?? '',
+                                  },
+                                }))
+                              }
+                            >
+                              {labelOptions.map((option) => (
+                                <MenuItem key={`${item.sampleId}-${option}`} value={option}>
+                                  {option}
+                                </MenuItem>
+                              ))}
+                            </TextField>
+                            <TextField
+                              placeholder="Rationale"
+                              fullWidth
+                              size="small"
+                              value={adjudicationDrafts[item.sampleId]?.rationale ?? ''}
+                              onChange={(event) =>
+                                setAdjudicationDrafts((prev) => ({
+                                  ...prev,
+                                  [item.sampleId]: {
+                                    label: prev[item.sampleId]?.label ?? '',
+                                    rationale: event.target.value,
+                                  },
+                                }))
+                              }
+                            />
+                            <Button
+                              variant="contained"
+                              size="small"
+                              startIcon={<Gavel />}
+                              onClick={() => handleAdjudicate(item.sampleId)}
+                            >
+                              Set gold
+                            </Button>
+                          </Stack>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Gold set overview
+              </Typography>
+              {gold.length === 0 ? (
+                <Alert severity="info">No adjudications yet.</Alert>
+              ) : (
+                <Stack spacing={1}>
+                  {gold.map((decision) => (
+                    <Alert
+                      key={decision.sampleId}
+                      severity="success"
+                      icon={<Gavel />}
+                    >
+                      <strong>{decision.sampleId}</strong> → {decision.label} · {decision.adjudicator}
+                    </Alert>
+                  ))}
+                </Stack>
+              )}
+            </CardContent>
+          </Card>
+        </Grid>
+
+        <Grid item xs={12} md={6}>
+          <Card>
+            <CardContent>
+              <Typography variant="h6" gutterBottom>
+                Audit packs
+              </Typography>
+              <Stack spacing={2}>
+                <Stack direction="row" spacing={2}>
+                  <Button variant="contained" startIcon={<DownloadIcon />} onClick={handleExport}>
+                    Export dataset
+                  </Button>
+                  <Button variant="outlined" startIcon={<UploadIcon />} onClick={handleImport}>
+                    Import dataset
+                  </Button>
+                </Stack>
+                <TextField
+                  label="Export preview"
+                  value={exportPreview}
+                  onChange={(event) => setExportPreview(event.target.value)}
+                  multiline
+                  minRows={4}
+                  placeholder="Exports appear here after running an export"
+                />
+                <TextField
+                  label="Import payload"
+                  value={importPayload}
+                  onChange={(event) => setImportPayload(event.target.value)}
+                  multiline
+                  minRows={4}
+                  placeholder="Paste a previously exported dataset payload"
+                />
+              </Stack>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default HFAWorkbench;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -49,6 +49,7 @@ import n8nRouter from './routes/n8n.js';
 import { trustCenterRouter } from './routes/trust-center.js';
 import { dataResidencyRouter } from './routes/data-residency.js';
 import { qualityEvaluationRouter } from './routes/quality-evaluation.js';
+import hfaRouter from './routes/hfa.js';
 import PluginManager from './marketplace/plugin-manager.js';
 import SafetyV2Service from './safety/safety-v2.js';
 import { fipsService } from './federal/fips-compliance.js';
@@ -196,6 +197,7 @@ export const createApp = async () => {
   
   // Quality Evaluation Platform - semantic SLOs and AI model quality assessment
   app.use('/api/quality-evaluation', qualityEvaluationRouter);
+  app.use('/api/hfa', hfaRouter);
   
   // Marketplace GA - signed plugins with capability scoping and revocation
   const pluginManager = new PluginManager();

--- a/server/src/routes/hfa.ts
+++ b/server/src/routes/hfa.ts
@@ -1,0 +1,126 @@
+import { Router } from 'express';
+import {
+  humanFeedbackArbitrationService,
+  HFALabelRecord,
+} from '../services/HumanFeedbackArbitrationService.js';
+
+const router = Router();
+
+router.get('/datasets', (_req, res) => {
+  res.json({ datasets: humanFeedbackArbitrationService.listDatasets() });
+});
+
+router.post('/datasets', (req, res) => {
+  try {
+    const dataset = humanFeedbackArbitrationService.createDataset({
+      name: req.body?.name,
+      description: req.body?.description,
+      labelOptions: req.body?.labelOptions,
+    });
+    res.status(201).json({ dataset });
+  } catch (error) {
+    res.status(400).json({ error: (error as Error).message });
+  }
+});
+
+router.get('/datasets/:datasetId', (req, res) => {
+  try {
+    const dataset = humanFeedbackArbitrationService.getDataset(req.params.datasetId);
+    res.json({
+      dataset: {
+        ...dataset,
+        goldDecisions: Array.from(dataset.goldDecisions.values()),
+        annotatorBaselines: Array.from(dataset.annotatorBaselines.entries()).map(
+          ([annotatorId, distribution]) => ({
+            annotatorId,
+            distribution: Object.fromEntries(distribution.entries()),
+          }),
+        ),
+      },
+      metrics: humanFeedbackArbitrationService.computeMetrics(req.params.datasetId),
+      disagreements: humanFeedbackArbitrationService.getDisagreements(req.params.datasetId),
+    });
+  } catch (error) {
+    res.status(404).json({ error: (error as Error).message });
+  }
+});
+
+router.post('/datasets/:datasetId/labels', (req, res) => {
+  try {
+    const labels: HFALabelRecord[] = req.body?.labels;
+    const metrics = humanFeedbackArbitrationService.ingestLabels(req.params.datasetId, labels);
+    res.status(202).json({ metrics });
+  } catch (error) {
+    res.status(400).json({ error: (error as Error).message });
+  }
+});
+
+router.get('/datasets/:datasetId/metrics', (req, res) => {
+  try {
+    const metrics = humanFeedbackArbitrationService.computeMetrics(req.params.datasetId);
+    res.json({ metrics });
+  } catch (error) {
+    res.status(404).json({ error: (error as Error).message });
+  }
+});
+
+router.get('/datasets/:datasetId/disagreements', (req, res) => {
+  try {
+    const disagreements = humanFeedbackArbitrationService.getDisagreements(req.params.datasetId);
+    res.json({ disagreements });
+  } catch (error) {
+    res.status(404).json({ error: (error as Error).message });
+  }
+});
+
+router.post('/datasets/:datasetId/adjudicate', (req, res) => {
+  try {
+    const result = humanFeedbackArbitrationService.adjudicate(req.params.datasetId, {
+      sampleId: req.body?.sampleId,
+      label: req.body?.label,
+      adjudicator: req.body?.adjudicator,
+      rationale: req.body?.rationale,
+    });
+    res.json(result);
+  } catch (error) {
+    res.status(400).json({ error: (error as Error).message });
+  }
+});
+
+router.get('/datasets/:datasetId/gold', (req, res) => {
+  try {
+    const gold = humanFeedbackArbitrationService.getGold(req.params.datasetId);
+    res.json({ gold });
+  } catch (error) {
+    res.status(404).json({ error: (error as Error).message });
+  }
+});
+
+router.get('/datasets/:datasetId/bias-alerts', (req, res) => {
+  try {
+    const alerts = humanFeedbackArbitrationService.getBiasAlerts(req.params.datasetId);
+    res.json({ alerts });
+  } catch (error) {
+    res.status(404).json({ error: (error as Error).message });
+  }
+});
+
+router.get('/datasets/:datasetId/export', (req, res) => {
+  try {
+    const payload = humanFeedbackArbitrationService.exportDataset(req.params.datasetId);
+    res.json(payload);
+  } catch (error) {
+    res.status(404).json({ error: (error as Error).message });
+  }
+});
+
+router.post('/import', (req, res) => {
+  try {
+    const dataset = humanFeedbackArbitrationService.importDataset(req.body);
+    res.status(201).json({ dataset });
+  } catch (error) {
+    res.status(400).json({ error: (error as Error).message });
+  }
+});
+
+export default router;

--- a/server/src/services/HumanFeedbackArbitrationService.test.ts
+++ b/server/src/services/HumanFeedbackArbitrationService.test.ts
@@ -1,0 +1,80 @@
+import { HumanFeedbackArbitrationService } from './HumanFeedbackArbitrationService';
+
+describe('HumanFeedbackArbitrationService', () => {
+  it('reduces disagreements after adjudication', () => {
+    const service = new HumanFeedbackArbitrationService();
+    const dataset = service.createDataset({ name: 'Case Review' });
+    service.ingestLabels(dataset.id, [
+      { sampleId: 'doc-1', annotatorId: 'ann-a', label: 'approve' },
+      { sampleId: 'doc-1', annotatorId: 'ann-b', label: 'reject' },
+      { sampleId: 'doc-2', annotatorId: 'ann-a', label: 'approve' },
+      { sampleId: 'doc-2', annotatorId: 'ann-b', label: 'approve' },
+    ]);
+
+    const before = service.computeMetrics(dataset.id);
+    expect(before.unresolvedDisagreements).toBe(1);
+
+    const adjudicated = service.adjudicate(dataset.id, {
+      sampleId: 'doc-1',
+      label: 'approve',
+      adjudicator: 'lead-reviewer',
+      rationale: 'Manual override after review',
+    });
+
+    expect(adjudicated.metrics.unresolvedDisagreements).toBe(0);
+    const gold = service.getGold(dataset.id);
+    expect(gold).toHaveLength(1);
+    expect(gold[0].label).toBe('approve');
+  });
+
+  it('raises drift alerts when annotator distribution shifts', () => {
+    const service = new HumanFeedbackArbitrationService();
+    const dataset = service.createDataset({ name: 'Bias Monitoring' });
+
+    service.ingestLabels(
+      dataset.id,
+      Array.from({ length: 5 }, (_, index) => ({
+        sampleId: `seed-${index}`,
+        annotatorId: 'ann-a',
+        label: 'approve',
+      })),
+    );
+
+    service.ingestLabels(
+      dataset.id,
+      Array.from({ length: 10 }, (_, index) => ({
+        sampleId: `shift-${index}`,
+        annotatorId: 'ann-a',
+        label: 'reject',
+      })),
+    );
+
+    const alerts = service.getBiasAlerts(dataset.id).filter((alert) => alert.annotatorId === 'ann-a');
+    expect(alerts.some((alert) => alert.type === 'drift' && !alert.resolved)).toBe(true);
+  });
+
+  it('round-trips dataset exports and imports', () => {
+    const service = new HumanFeedbackArbitrationService();
+    const dataset = service.createDataset({ name: 'Export Suite', labelOptions: ['yes', 'no'] });
+    service.ingestLabels(dataset.id, [
+      { sampleId: 'item-1', annotatorId: 'ann-a', label: 'yes' },
+      { sampleId: 'item-1', annotatorId: 'ann-b', label: 'no' },
+      { sampleId: 'item-2', annotatorId: 'ann-a', label: 'yes' },
+      { sampleId: 'item-2', annotatorId: 'ann-b', label: 'yes' },
+    ]);
+    service.adjudicate(dataset.id, {
+      sampleId: 'item-1',
+      label: 'yes',
+      adjudicator: 'qa-lead',
+    });
+
+    const exported = service.exportDataset(dataset.id);
+    const importer = new HumanFeedbackArbitrationService();
+    importer.importDataset(exported);
+    const importedMetrics = importer.computeMetrics(dataset.id);
+
+    expect(importedMetrics.annotatedSamples).toBe(2);
+    expect(importer.getGold(dataset.id)).toHaveLength(1);
+    expect(importer.getDisagreements(dataset.id).length).toBeGreaterThan(0);
+  });
+});

--- a/server/src/services/HumanFeedbackArbitrationService.ts
+++ b/server/src/services/HumanFeedbackArbitrationService.ts
@@ -1,0 +1,569 @@
+import { randomUUID } from 'crypto';
+
+export interface HFALabelRecord {
+  sampleId: string;
+  annotatorId: string;
+  label: string;
+  timestamp?: string;
+  metadata?: Record<string, any>;
+  seededShift?: boolean;
+}
+
+export interface HFAGoldDecision {
+  sampleId: string;
+  label: string;
+  adjudicator: string;
+  rationale?: string;
+  decidedAt: string;
+}
+
+export interface HFABiasAlert {
+  id: string;
+  datasetId: string;
+  annotatorId: string;
+  type: 'bias' | 'drift' | 'seeded-shift';
+  magnitude: number;
+  triggeredAt: string;
+  details: string;
+  resolved: boolean;
+  resolvedAt?: string;
+}
+
+export interface HFADatasetDefinition {
+  id: string;
+  name: string;
+  description?: string;
+  labelOptions?: string[];
+  createdAt: string;
+  updatedAt: string;
+  labels: HFALabelRecord[];
+  goldDecisions: Map<string, HFAGoldDecision>;
+  biasAlerts: HFABiasAlert[];
+  annotatorBaselines: Map<string, Map<string, number>>;
+}
+
+export interface HFAMetrics {
+  datasetId: string;
+  krippendorffAlpha: number;
+  averageCohenKappa: number | null;
+  pairwiseKappa: Array<{
+    annotators: [string, string];
+    kappa: number;
+    support: number;
+  }>;
+  totalAnnotations: number;
+  annotatedSamples: number;
+  unresolvedDisagreements: number;
+  adjudicatedSamples: number;
+  annotatorThroughput: Array<{
+    annotatorId: string;
+    count: number;
+  }>;
+}
+
+export interface HFADisagreement {
+  sampleId: string;
+  entropy: number;
+  totalAnnotations: number;
+  labelHistogram: Record<string, number>;
+  annotations: HFALabelRecord[];
+}
+
+export interface HFADatasetExport {
+  dataset: Omit<HFADatasetDefinition, 'goldDecisions' | 'annotatorBaselines'> & {
+    goldDecisions: HFAGoldDecision[];
+    annotatorBaselines: Array<{
+      annotatorId: string;
+      distribution: Record<string, number>;
+    }>;
+  };
+  metrics: HFAMetrics;
+  biasAlerts: HFABiasAlert[];
+}
+
+const DRIFT_THRESHOLD = 0.25;
+const BIAS_THRESHOLD = 0.35;
+const MIN_BASELINE_SAMPLES = 5;
+
+export class HumanFeedbackArbitrationService {
+  private datasets: Map<string, HFADatasetDefinition> = new Map();
+
+  listDatasets() {
+    return Array.from(this.datasets.values()).map((dataset) => ({
+      id: dataset.id,
+      name: dataset.name,
+      description: dataset.description,
+      labelOptions: dataset.labelOptions,
+      createdAt: dataset.createdAt,
+      updatedAt: dataset.updatedAt,
+      totalAnnotations: dataset.labels.length,
+      goldDecisions: dataset.goldDecisions.size,
+    }));
+  }
+
+  getDataset(datasetId: string) {
+    const dataset = this.datasets.get(datasetId);
+    if (!dataset) {
+      throw new Error(`Dataset ${datasetId} not found`);
+    }
+    return dataset;
+  }
+
+  createDataset(input: { name: string; description?: string; labelOptions?: string[] }) {
+    if (!input.name?.trim()) {
+      throw new Error('Dataset name is required');
+    }
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    const dataset: HFADatasetDefinition = {
+      id,
+      name: input.name.trim(),
+      description: input.description,
+      labelOptions: input.labelOptions,
+      createdAt: now,
+      updatedAt: now,
+      labels: [],
+      goldDecisions: new Map(),
+      biasAlerts: [],
+      annotatorBaselines: new Map(),
+    };
+    this.datasets.set(id, dataset);
+    return dataset;
+  }
+
+  importDataset(exported: HFADatasetExport) {
+    if (!exported?.dataset?.id) {
+      throw new Error('Invalid export payload');
+    }
+    const dataset: HFADatasetDefinition = {
+      id: exported.dataset.id,
+      name: exported.dataset.name,
+      description: exported.dataset.description,
+      labelOptions: exported.dataset.labelOptions,
+      createdAt: exported.dataset.createdAt,
+      updatedAt: exported.dataset.updatedAt,
+      labels: exported.dataset.labels ?? [],
+      goldDecisions: new Map(
+        (exported.dataset.goldDecisions ?? []).map((decision) => [decision.sampleId, decision]),
+      ),
+      biasAlerts: exported.biasAlerts ?? [],
+      annotatorBaselines: new Map(
+        (exported.dataset.annotatorBaselines ?? []).map((entry) => [entry.annotatorId, new Map(Object.entries(entry.distribution))]),
+      ),
+    };
+    this.datasets.set(dataset.id, dataset);
+    return dataset;
+  }
+
+  ingestLabels(datasetId: string, labels: HFALabelRecord[]) {
+    if (!Array.isArray(labels) || !labels.length) {
+      throw new Error('Labels payload must be a non-empty array');
+    }
+    const dataset = this.getDataset(datasetId);
+    labels.forEach((label) => {
+      if (!label.sampleId || !label.annotatorId || !label.label) {
+        throw new Error('sampleId, annotatorId and label are required for each record');
+      }
+      dataset.labels.push({
+        sampleId: label.sampleId,
+        annotatorId: label.annotatorId,
+        label: label.label,
+        timestamp: label.timestamp ?? new Date().toISOString(),
+        metadata: label.metadata,
+        seededShift: label.seededShift,
+      });
+      this.updateAnnotatorBaselines(dataset, label.annotatorId);
+      this.checkBiasSignals(dataset, label.annotatorId, label.seededShift === true);
+    });
+    dataset.updatedAt = new Date().toISOString();
+    return this.computeMetrics(datasetId);
+  }
+
+  private updateAnnotatorBaselines(dataset: HFADatasetDefinition, annotatorId: string) {
+    const records = dataset.labels.filter((label) => label.annotatorId === annotatorId);
+    if (records.length < MIN_BASELINE_SAMPLES) {
+      return;
+    }
+    if (dataset.annotatorBaselines.has(annotatorId)) {
+      return;
+    }
+    const baseline = this.buildDistribution(records);
+    dataset.annotatorBaselines.set(annotatorId, baseline);
+  }
+
+  private checkBiasSignals(dataset: HFADatasetDefinition, annotatorId: string, forcedShift: boolean) {
+    const records = dataset.labels.filter((label) => label.annotatorId === annotatorId);
+    const distribution = this.buildDistribution(records);
+    const baseline = dataset.annotatorBaselines.get(annotatorId);
+    if (!baseline && !forcedShift) {
+      return;
+    }
+    const baselineDistribution = baseline ?? distribution;
+    const driftMagnitude = this.jensenShannonDivergence(baselineDistribution, distribution);
+    if (forcedShift && driftMagnitude < DRIFT_THRESHOLD) {
+      this.raiseAlert(dataset, annotatorId, 'seeded-shift', 1, 'Seeded drift indicator detected.');
+      return;
+    }
+    if (driftMagnitude >= DRIFT_THRESHOLD) {
+      this.raiseAlert(
+        dataset,
+        annotatorId,
+        'drift',
+        driftMagnitude,
+        `Label distribution drift detected (JSD=${driftMagnitude.toFixed(2)}).`,
+      );
+    } else {
+      this.resolveAlerts(dataset, annotatorId, 'drift');
+    }
+    const overallDistribution = this.buildDistribution(dataset.labels);
+    const biasMagnitude = this.jensenShannonDivergence(overallDistribution, distribution);
+    if (biasMagnitude >= BIAS_THRESHOLD) {
+      this.raiseAlert(
+        dataset,
+        annotatorId,
+        'bias',
+        biasMagnitude,
+        `Annotator distribution deviates from corpus (JSD=${biasMagnitude.toFixed(2)}).`,
+      );
+    } else {
+      this.resolveAlerts(dataset, annotatorId, 'bias');
+    }
+  }
+
+  private raiseAlert(
+    dataset: HFADatasetDefinition,
+    annotatorId: string,
+    type: HFABiasAlert['type'],
+    magnitude: number,
+    details: string,
+  ) {
+    const existing = dataset.biasAlerts.find(
+      (alert) => alert.annotatorId === annotatorId && alert.type === type && !alert.resolved,
+    );
+    if (existing) {
+      existing.magnitude = magnitude;
+      existing.details = details;
+      existing.triggeredAt = new Date().toISOString();
+      return;
+    }
+    dataset.biasAlerts.push({
+      id: randomUUID(),
+      datasetId: dataset.id,
+      annotatorId,
+      type,
+      magnitude,
+      triggeredAt: new Date().toISOString(),
+      details,
+      resolved: false,
+    });
+  }
+
+  private resolveAlerts(dataset: HFADatasetDefinition, annotatorId: string, type: HFABiasAlert['type']) {
+    dataset.biasAlerts
+      .filter((alert) => alert.annotatorId === annotatorId && alert.type === type && !alert.resolved)
+      .forEach((alert) => {
+        alert.resolved = true;
+        alert.resolvedAt = new Date().toISOString();
+      });
+  }
+
+  private buildDistribution(records: HFALabelRecord[]) {
+    const distribution = new Map<string, number>();
+    records.forEach((record) => {
+      distribution.set(record.label, (distribution.get(record.label) ?? 0) + 1);
+    });
+    const total = records.length || 1;
+    distribution.forEach((value, key) => {
+      distribution.set(key, value / total);
+    });
+    return distribution;
+  }
+
+  private jensenShannonDivergence(a: Map<string, number>, b: Map<string, number>) {
+    const labels = new Set([...a.keys(), ...b.keys()]);
+    const avg = new Map<string, number>();
+    labels.forEach((label) => {
+      const pa = a.get(label) ?? 0;
+      const pb = b.get(label) ?? 0;
+      avg.set(label, (pa + pb) / 2);
+    });
+    const kl = (p: Map<string, number>, q: Map<string, number>) => {
+      let sum = 0;
+      labels.forEach((label) => {
+        const pp = p.get(label) ?? 0;
+        const qq = q.get(label) ?? 0;
+        if (pp === 0 || qq === 0) {
+          return;
+        }
+        sum += pp * Math.log2(pp / qq);
+      });
+      return sum;
+    };
+    const divergence = (kl(a, avg) + kl(b, avg)) / 2;
+    return Number.isFinite(divergence) ? divergence : 0;
+  }
+
+  computeMetrics(datasetId: string): HFAMetrics {
+    const dataset = this.getDataset(datasetId);
+    const totalAnnotations = dataset.labels.length;
+    const sampleGroups = this.groupBySample(dataset.labels);
+    const annotatedSamples = sampleGroups.size;
+    const unresolvedDisagreements = Array.from(sampleGroups.entries()).filter(([sampleId, records]) => {
+      const uniqueLabels = new Set(records.map((record) => record.label));
+      return uniqueLabels.size > 1 && !dataset.goldDecisions.has(sampleId);
+    }).length;
+    const adjudicatedSamples = dataset.goldDecisions.size;
+    const annotatorThroughput = this.buildAnnotatorThroughput(dataset.labels);
+    const pairwiseKappa = this.computePairwiseKappa(dataset.labels);
+    const averageCohenKappa =
+      pairwiseKappa.length > 0
+        ? pairwiseKappa.reduce((sum, entry) => sum + entry.kappa, 0) / pairwiseKappa.length
+        : null;
+    return {
+      datasetId,
+      krippendorffAlpha: this.computeKrippendorffAlpha(dataset.labels),
+      averageCohenKappa,
+      pairwiseKappa,
+      totalAnnotations,
+      annotatedSamples,
+      unresolvedDisagreements,
+      adjudicatedSamples,
+      annotatorThroughput,
+    };
+  }
+
+  getDisagreements(datasetId: string): HFADisagreement[] {
+    const dataset = this.getDataset(datasetId);
+    const groups = this.groupBySample(dataset.labels);
+    const disagreements: HFADisagreement[] = [];
+    groups.forEach((records, sampleId) => {
+      const gold = dataset.goldDecisions.get(sampleId);
+      const histogram: Record<string, number> = {};
+      records.forEach((record) => {
+        histogram[record.label] = (histogram[record.label] ?? 0) + 1;
+      });
+      const uniqueLabels = Object.keys(histogram);
+      if (uniqueLabels.length <= 1) {
+        return;
+      }
+      const entropy = this.calculateEntropy(histogram);
+      disagreements.push({
+        sampleId,
+        entropy,
+        totalAnnotations: records.length,
+        labelHistogram: histogram,
+        annotations: records,
+      });
+      if (gold) {
+        // Annotated disagreements should surface gold context as well
+        disagreements[disagreements.length - 1].annotations.push({
+          sampleId,
+          annotatorId: gold.adjudicator,
+          label: gold.label,
+          timestamp: gold.decidedAt,
+          metadata: { rationale: gold.rationale, gold: true },
+        });
+      }
+    });
+    return disagreements.sort((a, b) => b.entropy - a.entropy || b.totalAnnotations - a.totalAnnotations);
+  }
+
+  adjudicate(
+    datasetId: string,
+    payload: { sampleId: string; label: string; adjudicator: string; rationale?: string },
+  ) {
+    const dataset = this.getDataset(datasetId);
+    if (!payload.sampleId || !payload.label || !payload.adjudicator) {
+      throw new Error('sampleId, label, and adjudicator are required for adjudication');
+    }
+    dataset.goldDecisions.set(payload.sampleId, {
+      sampleId: payload.sampleId,
+      label: payload.label,
+      adjudicator: payload.adjudicator,
+      rationale: payload.rationale,
+      decidedAt: new Date().toISOString(),
+    });
+    dataset.updatedAt = new Date().toISOString();
+    return {
+      gold: Array.from(dataset.goldDecisions.values()),
+      metrics: this.computeMetrics(datasetId),
+      disagreements: this.getDisagreements(datasetId),
+    };
+  }
+
+  getGold(datasetId: string) {
+    const dataset = this.getDataset(datasetId);
+    return Array.from(dataset.goldDecisions.values());
+  }
+
+  getBiasAlerts(datasetId: string) {
+    const dataset = this.getDataset(datasetId);
+    return dataset.biasAlerts;
+  }
+
+  exportDataset(datasetId: string): HFADatasetExport {
+    const dataset = this.getDataset(datasetId);
+    const exportPayload: HFADatasetExport = {
+      dataset: {
+        id: dataset.id,
+        name: dataset.name,
+        description: dataset.description,
+        labelOptions: dataset.labelOptions,
+        createdAt: dataset.createdAt,
+        updatedAt: dataset.updatedAt,
+        labels: dataset.labels,
+        goldDecisions: Array.from(dataset.goldDecisions.values()),
+        annotatorBaselines: Array.from(dataset.annotatorBaselines.entries()).map(([annotatorId, distribution]) => ({
+          annotatorId,
+          distribution: Object.fromEntries(distribution.entries()),
+        })),
+        biasAlerts: dataset.biasAlerts,
+      },
+      metrics: this.computeMetrics(datasetId),
+      biasAlerts: dataset.biasAlerts,
+    } as HFADatasetExport;
+    return exportPayload;
+  }
+
+  private buildAnnotatorThroughput(labels: HFALabelRecord[]) {
+    const counts = new Map<string, number>();
+    labels.forEach((label) => {
+      counts.set(label.annotatorId, (counts.get(label.annotatorId) ?? 0) + 1);
+    });
+    return Array.from(counts.entries()).map(([annotatorId, count]) => ({ annotatorId, count }));
+  }
+
+  private computePairwiseKappa(labels: HFALabelRecord[]) {
+    const annotationsByAnnotator = new Map<string, Map<string, string>>();
+    labels.forEach((label) => {
+      if (!annotationsByAnnotator.has(label.annotatorId)) {
+        annotationsByAnnotator.set(label.annotatorId, new Map());
+      }
+      annotationsByAnnotator.get(label.annotatorId)!.set(label.sampleId, label.label);
+    });
+    const annotators = Array.from(annotationsByAnnotator.keys());
+    const results: Array<{ annotators: [string, string]; kappa: number; support: number }> = [];
+    for (let i = 0; i < annotators.length; i += 1) {
+      for (let j = i + 1; j < annotators.length; j += 1) {
+        const a = annotators[i];
+        const b = annotators[j];
+        const matrix = new Map<string, Map<string, number>>();
+        let support = 0;
+        annotationsByAnnotator.get(a)!.forEach((labelA, sampleId) => {
+          const labelB = annotationsByAnnotator.get(b)!.get(sampleId);
+          if (!labelB) {
+            return;
+          }
+          support += 1;
+          if (!matrix.has(labelA)) {
+            matrix.set(labelA, new Map());
+          }
+          matrix.get(labelA)!.set(labelB, (matrix.get(labelA)!.get(labelB) ?? 0) + 1);
+        });
+        if (support === 0) {
+          continue;
+        }
+        const categories = new Set<string>();
+        matrix.forEach((row, rowLabel) => {
+          categories.add(rowLabel);
+          row.forEach((_count, colLabel) => categories.add(colLabel));
+        });
+        const totals = Array.from(categories.values()).reduce(
+          (acc, category) => {
+            const row = matrix.get(category);
+            const rowSum = row ? Array.from(row.values()).reduce((sum, value) => sum + value, 0) : 0;
+            const colSum = Array.from(matrix.values()).reduce((sum, r) => sum + (r.get(category) ?? 0), 0);
+            acc.row.set(category, rowSum);
+            acc.col.set(category, colSum);
+            acc.total += rowSum;
+            acc.agreement += row?.get(category) ?? 0;
+            return acc;
+          },
+          {
+            row: new Map<string, number>(),
+            col: new Map<string, number>(),
+            total: 0,
+            agreement: 0,
+          },
+        );
+        const total = totals.total;
+        const po = total > 0 ? totals.agreement / total : 0;
+        let pe = 0;
+        categories.forEach((category) => {
+          const rowProb = (totals.row.get(category) ?? 0) / total;
+          const colProb = (totals.col.get(category) ?? 0) / total;
+          pe += rowProb * colProb;
+        });
+        const denominator = 1 - pe;
+        const kappa = denominator === 0 ? 0 : (po - pe) / denominator;
+        results.push({ annotators: [a, b], kappa, support });
+      }
+    }
+    return results;
+  }
+
+  private computeKrippendorffAlpha(labels: HFALabelRecord[]) {
+    if (labels.length === 0) {
+      return 1;
+    }
+    const groups = this.groupBySample(labels);
+    const labelFrequencies = new Map<string, number>();
+    let totalAnnotations = 0;
+    groups.forEach((records) => {
+      records.forEach((record) => {
+        labelFrequencies.set(record.label, (labelFrequencies.get(record.label) ?? 0) + 1);
+        totalAnnotations += 1;
+      });
+    });
+    if (totalAnnotations <= 1) {
+      return 1;
+    }
+    let observedDisagreement = 0;
+    groups.forEach((records) => {
+      const n = records.length;
+      if (n <= 1) {
+        return;
+      }
+      const histogram = records.reduce((acc, record) => {
+        acc.set(record.label, (acc.get(record.label) ?? 0) + 1);
+        return acc;
+      }, new Map<string, number>());
+      const sum = Array.from(histogram.values()).reduce((acc, count) => acc + count * (n - count), 0);
+      observedDisagreement += sum / (n - 1);
+    });
+    let expectedDisagreement = 0;
+    labelFrequencies.forEach((count) => {
+      expectedDisagreement += count * (totalAnnotations - count);
+    });
+    expectedDisagreement /= totalAnnotations - 1;
+    if (expectedDisagreement === 0) {
+      return 1;
+    }
+    const alpha = 1 - observedDisagreement / expectedDisagreement;
+    return Number.isFinite(alpha) ? alpha : 0;
+  }
+
+  private groupBySample(labels: HFALabelRecord[]) {
+    const groups = new Map<string, HFALabelRecord[]>();
+    labels.forEach((label) => {
+      if (!groups.has(label.sampleId)) {
+        groups.set(label.sampleId, []);
+      }
+      groups.get(label.sampleId)!.push(label);
+    });
+    return groups;
+  }
+
+  private calculateEntropy(histogram: Record<string, number>) {
+    const total = Object.values(histogram).reduce((sum, value) => sum + value, 0);
+    if (total === 0) {
+      return 0;
+    }
+    return Object.values(histogram).reduce((sum, value) => {
+      const p = value / total;
+      return p > 0 ? sum - p * Math.log2(p) : sum;
+    }, 0);
+  }
+}
+
+export const humanFeedbackArbitrationService = new HumanFeedbackArbitrationService();


### PR DESCRIPTION
## Summary
- add a dedicated human feedback arbitration service that tracks datasets, agreement metrics, bias/drift alerts, and export/import payloads
- expose REST endpoints under `/api/hfa` for label ingestion, adjudication workflows, metrics, disagreements, and audit exports
- build a React HFA workbench experience with dataset management, disagreement triage, drift alerting, and audit pack tooling, plus add navigation wiring
- add unit coverage to ensure adjudication resolves disagreements, seeded drift raises alerts, and exports round-trip cleanly

## Testing
- npm test -- HumanFeedbackArbitrationService *(fails: jest binary missing because workspace protocol dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d767ab98e483339663c83d1e5a8d3e