### PR TITLE
feat: introduce multicloud egress governor sidecar

### DIFF
--- a/sdk/python/maestro_sdk/mdeg/__init__.py
+++ b/sdk/python/maestro_sdk/mdeg/__init__.py
@@ -1,0 +1,17 @@
+"""Python client bindings for the Multicloud Data Egress Governor (MDEG)."""
+
+from .client import (
+    Destination,
+    ManifestRecord,
+    MdegClient,
+    TransferRequest,
+    TransferResponse,
+)
+
+__all__ = [
+    "Destination",
+    "ManifestRecord",
+    "MdegClient",
+    "TransferRequest",
+    "TransferResponse",
+]

--- a/sdk/python/maestro_sdk/mdeg/client.py
+++ b/sdk/python/maestro_sdk/mdeg/client.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+
+@dataclass
+class Destination:
+    provider: str
+    bucket: str
+    region: str
+
+
+@dataclass
+class TransferRequest:
+    request_id: str
+    destination: Destination
+    data_class: str
+    bytes: int
+    policy_id: str = ""
+
+
+@dataclass
+class ManifestRecord:
+    manifest_id: str
+    request_id: str
+    policy_id: str
+    destination: Destination
+    data_class: str
+    bytes: int
+    cost: float
+    timestamp: str
+    signature: str
+    reconciled: bool
+    provider_bytes: Optional[int] = None
+    provider_cost: Optional[float] = None
+
+
+@dataclass
+class TransferResponse:
+    allowed: bool
+    reason: Optional[str]
+    window_end: Optional[str]
+    manifest: Optional[ManifestRecord]
+
+
+class MdegClient:
+    """Lightweight client for the Multicloud Data Egress Governor HTTP API."""
+
+    def __init__(self, base_url: str, timeout: float = 10.0):
+        self._client = httpx.Client(base_url=base_url, timeout=timeout)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def request_transfer(self, transfer: TransferRequest) -> TransferResponse:
+        payload = {
+            "requestId": transfer.request_id,
+            "policyId": transfer.policy_id,
+            "destination": {
+                "provider": transfer.destination.provider,
+                "bucket": transfer.destination.bucket,
+                "region": transfer.destination.region,
+            },
+            "dataClass": transfer.data_class,
+            "bytes": transfer.bytes,
+        }
+        response = self._client.post("/transfers", json=payload)
+        response.raise_for_status()
+        data = response.json()
+        manifest_data = data.get("manifest")
+        manifest = _parse_manifest(manifest_data) if manifest_data else None
+        return TransferResponse(
+            allowed=data.get("allowed", False),
+            reason=data.get("reason"),
+            window_end=data.get("windowEnd"),
+            manifest=manifest,
+        )
+
+    def get_manifest(self, manifest_id: str) -> ManifestRecord:
+        response = self._client.get(f"/manifests/{manifest_id}")
+        response.raise_for_status()
+        return _parse_manifest(response.json())
+
+    def reconcile_manifest(self, manifest_id: str, provider_bytes: int, provider_cost: float) -> ManifestRecord:
+        payload = {"providerBytes": provider_bytes, "providerCost": provider_cost}
+        response = self._client.post(f"/manifests/{manifest_id}/reconcile", json=payload)
+        response.raise_for_status()
+        return _parse_manifest(response.json())
+
+    def policies(self) -> dict:
+        response = self._client.get("/policies")
+        response.raise_for_status()
+        return response.json()
+
+    def __enter__(self) -> "MdegClient":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore[override]
+        self.close()
+
+
+def _parse_manifest(data: dict) -> ManifestRecord:
+    destination = data.get("destination", {})
+    return ManifestRecord(
+        manifest_id=data["manifestId"],
+        request_id=data["requestId"],
+        policy_id=data["policyId"],
+        destination=Destination(
+            provider=destination.get("provider", ""),
+            bucket=destination.get("bucket", ""),
+            region=destination.get("region", ""),
+        ),
+        data_class=data.get("dataClass", ""),
+        bytes=data.get("bytes", 0),
+        cost=data.get("cost", 0.0),
+        timestamp=data.get("timestamp", ""),
+        signature=data.get("signature", ""),
+        reconciled=data.get("reconciled", False),
+        provider_bytes=data.get("providerBytes"),
+        provider_cost=data.get("providerCost"),
+    )

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,2 +1,3 @@
 export * from './client';
+export * from './mdeg';
 export * from '../sdk/ts/src/generated';

--- a/sdk/typescript/src/mdeg.ts
+++ b/sdk/typescript/src/mdeg.ts
@@ -1,0 +1,83 @@
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+export interface Destination {
+  provider: string;
+  bucket: string;
+  region: string;
+}
+
+export interface TransferRequest {
+  requestId: string;
+  policyId?: string;
+  destination: Destination;
+  dataClass: string;
+  bytes: number;
+}
+
+export interface ManifestRecord {
+  manifestId: string;
+  requestId: string;
+  policyId: string;
+  destination: Destination;
+  dataClass: string;
+  bytes: number;
+  cost: number;
+  timestamp: string;
+  signature: string;
+  reconciled: boolean;
+  providerBytes?: number;
+  providerCost?: number;
+}
+
+export interface TransferResponse {
+  allowed: boolean;
+  reason?: string;
+  windowEnd?: string;
+  manifest?: ManifestRecord;
+}
+
+export interface ReconcileRequest {
+  providerBytes: number;
+  providerCost: number;
+}
+
+export class MdegClient {
+  private readonly http: AxiosInstance;
+
+  constructor(baseURL: string, config?: AxiosRequestConfig) {
+    this.http = axios.create({ baseURL, ...config });
+  }
+
+  async requestTransfer(request: TransferRequest): Promise<TransferResponse> {
+    const response = await this.http.post<TransferResponse>('/transfers', {
+      requestId: request.requestId,
+      policyId: request.policyId ?? '',
+      destination: request.destination,
+      dataClass: request.dataClass,
+      bytes: request.bytes,
+    });
+    return response.data;
+  }
+
+  async getManifest(manifestId: string): Promise<ManifestRecord> {
+    const response = await this.http.get<ManifestRecord>(`/manifests/${manifestId}`);
+    return response.data;
+  }
+
+  async reconcileManifest(manifestId: string, reconcile: ReconcileRequest): Promise<ManifestRecord> {
+    const response = await this.http.post<ManifestRecord>(
+      `/manifests/${manifestId}/reconcile`,
+      reconcile,
+    );
+    return response.data;
+  }
+
+  async policies(): Promise<Record<string, unknown>> {
+    const response = await this.http.get<Record<string, unknown>>('/policies');
+    return response.data;
+  }
+}
+
+export const createMdegClient = (baseURL: string, config?: AxiosRequestConfig): MdegClient => {
+  return new MdegClient(baseURL, config);
+};

--- a/services/mdeg/README.md
+++ b/services/mdeg/README.md
@@ -1,0 +1,55 @@
+# Multicloud Data Egress Governor (MDEG)
+
+MDEG is a Go sidecar that enforces multicloud object storage egress policies. The
+service applies deterministic policy decisions, hard data volume and cost caps,
+and per-policy rate limiting before any transfer is permitted. Approved transfers
+emit signed manifests that can be reconciled against provider accounting data.
+
+## Features
+
+- **Policy Scoping** – Match requests by data class and destination (AWS, GCP, Azure).
+- **Deterministic Enforcement** – Byte, cost, and rate ceilings block violations synchronously.
+- **Signed Manifests** – Each approved transfer is recorded with an HMAC-SHA256 signature.
+- **Provider Reconciliation** – Manifests can be reconciled against provider byte/cost reports.
+- **SDKs** – Lightweight TypeScript and Python clients wrap the HTTP API.
+
+## Running the Sidecar
+
+```bash
+cd services/mdeg
+cp config.example.yaml config.yaml
+MDEG_CONFIG=config.yaml go run ./cmd/mdeg
+```
+
+Configuration is supplied via YAML (see `config.example.yaml`). Key values:
+
+- `providers`: Per-cloud egress pricing metadata.
+- `policies`: Policy definitions containing allowed destinations, classes, and caps.
+- `signingKey`: Secret used to sign manifests.
+
+## HTTP API
+
+| Method & Path | Description |
+| --- | --- |
+| `POST /transfers` | Request approval for a transfer. Returns signed manifest on success. |
+| `GET /manifests/{id}` | Retrieve a previously issued manifest. |
+| `POST /manifests/{id}/reconcile` | Submit provider totals (bytes, cost) to reconcile against the manifest. |
+| `GET /policies` | Diagnostic snapshot of accounting windows and usage. |
+| `GET /healthz` | Health probe. |
+
+## Tests
+
+Run the policy tests with:
+
+```bash
+cd services/mdeg
+go test ./...
+```
+
+## Clients
+
+- TypeScript client: `sdk/typescript/src/mdeg.ts`
+- Python client: `sdk/python/maestro_sdk/mdeg/client.py`
+
+Both provide simple wrappers for requesting transfers, retrieving manifests, and
+posting reconciliation results.

--- a/services/mdeg/cmd/mdeg/main.go
+++ b/services/mdeg/cmd/mdeg/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/summit/mdeg/internal/config"
+	"github.com/summit/mdeg/internal/manifest"
+	"github.com/summit/mdeg/internal/policy"
+	"github.com/summit/mdeg/internal/provider"
+	"github.com/summit/mdeg/internal/server"
+)
+
+func main() {
+	configPath := os.Getenv("MDEG_CONFIG")
+	if configPath == "" {
+		configPath = "config.yaml"
+	}
+
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		log.Fatalf("failed to load config: %v", err)
+	}
+
+	calculator := provider.NewPricingTable(cfg.Providers)
+	engine, err := policy.NewEngine(cfg, calculator)
+	if err != nil {
+		log.Fatalf("failed to build policy engine: %v", err)
+	}
+
+	signer, err := manifest.NewSigner(cfg.SigningKey)
+	if err != nil {
+		log.Fatalf("failed to build signer: %v", err)
+	}
+
+	store := manifest.NewStore()
+	srv := server.New(engine, signer, store, log.Default())
+
+	addr := cfg.ListenAddr
+	if addr == "" {
+		addr = ":8080"
+	}
+
+	if err := srv.ListenAndServe(addr); err != nil {
+		log.Fatalf("server exited: %v", err)
+	}
+}

--- a/services/mdeg/config.example.yaml
+++ b/services/mdeg/config.example.yaml
@@ -1,0 +1,29 @@
+listenAddr: ":8080"
+signingKey: "change-me"
+providers:
+  aws:
+    name: "AWS S3"
+    pricePerGiB: 0.09
+  gcp:
+    name: "GCP Storage"
+    pricePerGiB: 0.085
+  azure:
+    name: "Azure Blob"
+    pricePerGiB: 0.087
+policies:
+  - id: "restricted-us"
+    description: "Restricted data to US buckets"
+    dataClasses: ["restricted", "confidential"]
+    destinations:
+      - provider: "aws"
+        bucket: "corp-restricted"
+        region: "us-east-1"
+      - provider: "azure"
+        bucket: "corp-restricted"
+        region: "eastus"
+    maxBytes: 107374182400 # 100 GiB
+    maxCost: 500
+    rateLimit:
+      bytesPerSecond: 5242880 # 5 MiB/s
+      burstBytes: 10485760
+    windowSeconds: 86400

--- a/services/mdeg/go.mod
+++ b/services/mdeg/go.mod
@@ -1,0 +1,8 @@
+module github.com/summit/mdeg
+
+go 1.21
+
+require (
+	github.com/google/uuid v1.6.0
+	gopkg.in/yaml.v3 v3.0.1
+)

--- a/services/mdeg/go.sum
+++ b/services/mdeg/go.sum
@@ -1,0 +1,6 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/services/mdeg/internal/config/config.go
+++ b/services/mdeg/internal/config/config.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config captures the runtime parameters for the MDEG sidecar.
+type Config struct {
+	ListenAddr string                    `yaml:"listenAddr"`
+	SigningKey string                    `yaml:"signingKey"`
+	Providers  map[string]ProviderConfig `yaml:"providers"`
+	Policies   []PolicyConfig            `yaml:"policies"`
+}
+
+// ProviderConfig sets the billing metadata for a storage provider.
+type ProviderConfig struct {
+	Name        string  `yaml:"name"`
+	PricePerGiB float64 `yaml:"pricePerGiB"`
+}
+
+// PolicyConfig describes a single egress governance policy.
+type PolicyConfig struct {
+	ID            string            `yaml:"id"`
+	Description   string            `yaml:"description"`
+	DataClasses   []string          `yaml:"dataClasses"`
+	Destinations  []DestinationRule `yaml:"destinations"`
+	MaxBytes      int64             `yaml:"maxBytes"`
+	MaxCost       float64           `yaml:"maxCost"`
+	RateLimit     RateLimitConfig   `yaml:"rateLimit"`
+	WindowSeconds int64             `yaml:"windowSeconds"`
+	Tags          map[string]string `yaml:"tags"`
+}
+
+// DestinationRule restricts which external targets can receive data.
+type DestinationRule struct {
+	Provider string `yaml:"provider"`
+	Bucket   string `yaml:"bucket"`
+	Region   string `yaml:"region"`
+}
+
+// RateLimitConfig represents the throughput ceiling for a policy.
+type RateLimitConfig struct {
+	BytesPerSecond int64 `yaml:"bytesPerSecond"`
+	BurstBytes     int64 `yaml:"burstBytes"`
+}
+
+// DefaultWindow returns the default accounting window for a policy.
+func (p PolicyConfig) DefaultWindow() time.Duration {
+	if p.WindowSeconds <= 0 {
+		return 24 * time.Hour
+	}
+	return time.Duration(p.WindowSeconds) * time.Second
+}
+
+// Load reads a YAML configuration file from disk.
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	if cfg.SigningKey == "" {
+		return nil, fmt.Errorf("signingKey must be provided")
+	}
+
+	if len(cfg.Policies) == 0 {
+		return nil, fmt.Errorf("at least one policy must be defined")
+	}
+
+	return &cfg, nil
+}

--- a/services/mdeg/internal/manifest/manifest.go
+++ b/services/mdeg/internal/manifest/manifest.go
@@ -1,0 +1,74 @@
+package manifest
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/summit/mdeg/internal/policy"
+)
+
+// Record captures the signed details of an approved transfer.
+type Record struct {
+	ManifestID    string             `json:"manifestId"`
+	RequestID     string             `json:"requestId"`
+	PolicyID      string             `json:"policyId"`
+	Destination   policy.Destination `json:"destination"`
+	DataClass     string             `json:"dataClass"`
+	Bytes         int64              `json:"bytes"`
+	Cost          float64            `json:"cost"`
+	Timestamp     time.Time          `json:"timestamp"`
+	Signature     string             `json:"signature"`
+	Reconciled    bool               `json:"reconciled"`
+	ProviderBytes int64              `json:"providerBytes,omitempty"`
+	ProviderCost  float64            `json:"providerCost,omitempty"`
+}
+
+// Signer produces deterministic signatures for manifest payloads.
+type Signer struct {
+	key []byte
+}
+
+// NewSigner builds a signer using the provided secret key.
+func NewSigner(secret string) (*Signer, error) {
+	if secret == "" {
+		return nil, fmt.Errorf("signing key must be provided")
+	}
+	return &Signer{key: []byte(secret)}, nil
+}
+
+// Sign calculates the HMAC-SHA256 signature for the record payload.
+func (s *Signer) Sign(record *Record) (string, error) {
+	payload := map[string]any{
+		"manifestId":  record.ManifestID,
+		"requestId":   record.RequestID,
+		"policyId":    record.PolicyID,
+		"dataClass":   record.DataClass,
+		"bytes":       record.Bytes,
+		"cost":        record.Cost,
+		"destination": record.Destination,
+		"timestamp":   record.Timestamp.UnixNano(),
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal manifest payload: %w", err)
+	}
+
+	h := hmac.New(sha256.New, s.key)
+	if _, err := h.Write(raw); err != nil {
+		return "", fmt.Errorf("sign manifest: %w", err)
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// Verify recomputes the signature and ensures it matches the manifest.
+func (s *Signer) Verify(record *Record) (bool, error) {
+	expected, err := s.Sign(record)
+	if err != nil {
+		return false, err
+	}
+	return hmac.Equal([]byte(expected), []byte(record.Signature)), nil
+}

--- a/services/mdeg/internal/manifest/manifest_test.go
+++ b/services/mdeg/internal/manifest/manifest_test.go
@@ -1,0 +1,68 @@
+package manifest
+
+import (
+	"testing"
+	"time"
+
+	"github.com/summit/mdeg/internal/policy"
+)
+
+func TestSignerRoundTrip(t *testing.T) {
+	signer, err := NewSigner("secret")
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+
+	record := &Record{
+		ManifestID:  "man-1",
+		RequestID:   "req-1",
+		PolicyID:    "policy-1",
+		Destination: policy.Destination{Provider: "aws", Bucket: "bucket", Region: "us-east-1"},
+		DataClass:   "restricted",
+		Bytes:       512,
+		Cost:        1.23,
+		Timestamp:   time.Now().UTC(),
+	}
+
+	signature, err := signer.Sign(record)
+	if err != nil {
+		t.Fatalf("failed to sign: %v", err)
+	}
+	record.Signature = signature
+
+	ok, err := signer.Verify(record)
+	if err != nil {
+		t.Fatalf("verify error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected signature to verify")
+	}
+}
+
+func TestStoreReconcile(t *testing.T) {
+	store := NewStore()
+	record := &Record{
+		ManifestID:  "man-2",
+		RequestID:   "req-2",
+		PolicyID:    "policy-1",
+		Destination: policy.Destination{Provider: "aws", Bucket: "bucket", Region: "us-east-1"},
+		DataClass:   "restricted",
+		Bytes:       1024,
+		Cost:        2.0,
+		Timestamp:   time.Now().UTC(),
+		Signature:   "abc",
+	}
+	store.Save(record)
+
+	if _, err := store.Reconcile("man-2", 100, 2.0); err == nil {
+		t.Fatalf("expected byte mismatch error")
+	}
+
+	reconciled, err := store.Reconcile("man-2", 1024, 2.0)
+	if err != nil {
+		t.Fatalf("expected reconciliation to succeed: %v", err)
+	}
+	if !reconciled.Reconciled {
+		t.Fatalf("expected manifest to be marked reconciled")
+	}
+}

--- a/services/mdeg/internal/manifest/store.go
+++ b/services/mdeg/internal/manifest/store.go
@@ -1,0 +1,72 @@
+package manifest
+
+import (
+	"fmt"
+	"math"
+	"sync"
+)
+
+// Store keeps manifests in-memory for quick retrieval and reconciliation.
+type Store struct {
+	mu        sync.RWMutex
+	manifests map[string]*Record
+}
+
+// NewStore creates an empty manifest store.
+func NewStore() *Store {
+	return &Store{manifests: make(map[string]*Record)}
+}
+
+// Save persists a manifest in the store.
+func (s *Store) Save(record *Record) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.manifests[record.ManifestID] = record
+}
+
+// Get retrieves a manifest by identifier.
+func (s *Store) Get(id string) (*Record, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	record, ok := s.manifests[id]
+	return record, ok
+}
+
+// Reconcile compares the manifest details with provider reported figures.
+func (s *Store) Reconcile(id string, providerBytes int64, providerCost float64) (*Record, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	record, ok := s.manifests[id]
+	if !ok {
+		return nil, fmt.Errorf("manifest %s not found", id)
+	}
+
+	if record.Reconciled {
+		return record, nil
+	}
+
+	if record.Bytes != providerBytes {
+		return nil, fmt.Errorf("byte mismatch: manifest=%d provider=%d", record.Bytes, providerBytes)
+	}
+
+	if math.Abs(record.Cost-providerCost) > 0.01 {
+		return nil, fmt.Errorf("cost mismatch: manifest=%.4f provider=%.4f", record.Cost, providerCost)
+	}
+
+	record.Reconciled = true
+	record.ProviderBytes = providerBytes
+	record.ProviderCost = providerCost
+	return record, nil
+}
+
+// All returns a snapshot of stored manifests.
+func (s *Store) All() []*Record {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	records := make([]*Record, 0, len(s.manifests))
+	for _, record := range s.manifests {
+		records = append(records, record)
+	}
+	return records
+}

--- a/services/mdeg/internal/policy/enforcer.go
+++ b/services/mdeg/internal/policy/enforcer.go
@@ -1,0 +1,77 @@
+package policy
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/summit/mdeg/internal/config"
+	"github.com/summit/mdeg/internal/provider"
+)
+
+// Engine manages loaded policies and enforces them for transfer requests.
+type Engine struct {
+	policies map[string]*Policy
+	mu       sync.RWMutex
+}
+
+// NewEngine constructs an Engine from the provided configuration.
+func NewEngine(cfg *config.Config, calc provider.CostCalculator) (*Engine, error) {
+	policies := make(map[string]*Policy)
+	for _, policyCfg := range cfg.Policies {
+		policy, err := NewPolicy(policyCfg, calc)
+		if err != nil {
+			return nil, err
+		}
+		policies[policyCfg.ID] = policy
+	}
+	return &Engine{policies: policies}, nil
+}
+
+// Evaluate applies the appropriate policy to the transfer request.
+func (e *Engine) Evaluate(req TransferRequest) (EvaluationOutcome, error) {
+	policy, err := e.findPolicy(req)
+	if err != nil {
+		return EvaluationOutcome{Allowed: false}, err
+	}
+	outcome, evalErr := policy.Evaluate(req)
+	return outcome, evalErr
+}
+
+func (e *Engine) findPolicy(req TransferRequest) (*Policy, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	if req.PolicyID != "" {
+		if policy, ok := e.policies[req.PolicyID]; ok {
+			if policy.Matches(req) {
+				return policy, nil
+			}
+			return nil, fmt.Errorf("policy %s does not permit this transfer", req.PolicyID)
+		}
+		return nil, fmt.Errorf("unknown policy %s", req.PolicyID)
+	}
+
+	for _, policy := range e.policies {
+		if policy.Matches(req) {
+			return policy, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no policy matched the transfer request")
+}
+
+// Snapshot exposes a copy of the loaded policies for diagnostics.
+func (e *Engine) Snapshot() map[string]map[string]any {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	snapshot := make(map[string]map[string]any)
+	for id, policy := range e.policies {
+		bytesUsed, costUsed, windowStart := policy.Snapshot()
+		snapshot[id] = map[string]any{
+			"bytesUsed":   bytesUsed,
+			"costUsed":    costUsed,
+			"windowStart": windowStart,
+		}
+	}
+	return snapshot
+}

--- a/services/mdeg/internal/policy/policy.go
+++ b/services/mdeg/internal/policy/policy.go
@@ -1,0 +1,153 @@
+package policy
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/summit/mdeg/internal/config"
+	"github.com/summit/mdeg/internal/provider"
+)
+
+// Destination identifies a remote object storage target.
+type Destination struct {
+	Provider string `json:"provider"`
+	Bucket   string `json:"bucket"`
+	Region   string `json:"region"`
+}
+
+// TransferRequest is submitted by co-located services to request egress.
+type TransferRequest struct {
+	RequestID   string      `json:"requestId"`
+	PolicyID    string      `json:"policyId"`
+	Destination Destination `json:"destination"`
+	DataClass   string      `json:"dataClass"`
+	Bytes       int64       `json:"bytes"`
+}
+
+// EvaluationOutcome indicates the policy decision.
+type EvaluationOutcome struct {
+	Allowed    bool
+	PolicyID   string
+	Cost       float64
+	Reason     string
+	WindowEnds time.Time
+}
+
+// Policy encapsulates runtime metadata for enforcing a rule.
+type Policy struct {
+	cfg         config.PolicyConfig
+	limiter     *TokenBucket
+	mu          sync.Mutex
+	windowStart time.Time
+	bytesUsed   int64
+	costUsed    float64
+	calculator  provider.CostCalculator
+}
+
+// NewPolicy constructs an enforceable policy from configuration.
+func NewPolicy(cfg config.PolicyConfig, calc provider.CostCalculator) (*Policy, error) {
+	if cfg.ID == "" {
+		return nil, errors.New("policy id is required")
+	}
+	if len(cfg.DataClasses) == 0 {
+		return nil, fmt.Errorf("policy %s requires at least one data class", cfg.ID)
+	}
+	if len(cfg.Destinations) == 0 {
+		return nil, fmt.Errorf("policy %s requires at least one destination", cfg.ID)
+	}
+
+	limiter := NewTokenBucket(cfg.RateLimit.BytesPerSecond, cfg.RateLimit.BurstBytes)
+
+	return &Policy{
+		cfg:         cfg,
+		limiter:     limiter,
+		windowStart: time.Now(),
+		calculator:  calc,
+	}, nil
+}
+
+// Matches verifies that the transfer attributes fall under the policy scope.
+func (p *Policy) Matches(req TransferRequest) bool {
+	if !containsInsensitive(p.cfg.DataClasses, req.DataClass) {
+		return false
+	}
+
+	for _, dest := range p.cfg.Destinations {
+		if strings.EqualFold(dest.Provider, req.Destination.Provider) &&
+			(dest.Bucket == "" || strings.EqualFold(dest.Bucket, req.Destination.Bucket)) &&
+			(dest.Region == "" || strings.EqualFold(dest.Region, req.Destination.Region)) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsInsensitive(values []string, candidate string) bool {
+	for _, value := range values {
+		if strings.EqualFold(value, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+// Evaluate enforces rate, volume, and cost thresholds for the policy.
+func (p *Policy) Evaluate(req TransferRequest) (EvaluationOutcome, error) {
+	if req.Bytes <= 0 {
+		return EvaluationOutcome{Allowed: false}, fmt.Errorf("bytes must be positive")
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.maybeResetWindow()
+
+	if !p.limiter.Allow(req.Bytes) {
+		return EvaluationOutcome{Allowed: false, PolicyID: p.cfg.ID, Reason: "rate limit exceeded", WindowEnds: p.windowStart.Add(p.cfg.DefaultWindow())}, nil
+	}
+
+	projectedBytes := p.bytesUsed + req.Bytes
+	if p.cfg.MaxBytes > 0 && projectedBytes > p.cfg.MaxBytes {
+		return EvaluationOutcome{Allowed: false, PolicyID: p.cfg.ID, Reason: "byte cap exceeded", WindowEnds: p.windowStart.Add(p.cfg.DefaultWindow())}, nil
+	}
+
+	cost, err := p.calculator.Cost(req.Destination.Provider, req.Bytes)
+	if err != nil {
+		return EvaluationOutcome{Allowed: false, PolicyID: p.cfg.ID, Reason: err.Error()}, nil
+	}
+
+	projectedCost := p.costUsed + cost
+	if p.cfg.MaxCost > 0 && projectedCost > p.cfg.MaxCost {
+		return EvaluationOutcome{Allowed: false, PolicyID: p.cfg.ID, Reason: "cost cap exceeded", WindowEnds: p.windowStart.Add(p.cfg.DefaultWindow())}, nil
+	}
+
+	p.bytesUsed = projectedBytes
+	p.costUsed = projectedCost
+
+	return EvaluationOutcome{
+		Allowed:    true,
+		PolicyID:   p.cfg.ID,
+		Cost:       cost,
+		WindowEnds: p.windowStart.Add(p.cfg.DefaultWindow()),
+	}, nil
+}
+
+func (p *Policy) maybeResetWindow() {
+	window := p.cfg.DefaultWindow()
+	if time.Since(p.windowStart) >= window {
+		p.windowStart = time.Now()
+		p.bytesUsed = 0
+		p.costUsed = 0
+		p.limiter.Reset()
+	}
+}
+
+// Snapshot exposes current accounting numbers for diagnostics.
+func (p *Policy) Snapshot() (bytesUsed int64, costUsed float64, windowStart time.Time) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.bytesUsed, p.costUsed, p.windowStart
+}

--- a/services/mdeg/internal/policy/policy_test.go
+++ b/services/mdeg/internal/policy/policy_test.go
@@ -1,0 +1,159 @@
+package policy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/summit/mdeg/internal/config"
+	"github.com/summit/mdeg/internal/provider"
+)
+
+func testCalculator() provider.CostCalculator {
+	return provider.NewPricingTable(map[string]config.ProviderConfig{
+		"aws": {
+			Name:        "AWS",
+			PricePerGiB: 0.1,
+		},
+	})
+}
+
+func basePolicyConfig() config.PolicyConfig {
+	return config.PolicyConfig{
+		ID:          "policy-1",
+		DataClasses: []string{"restricted"},
+		Destinations: []config.DestinationRule{
+			{Provider: "aws", Bucket: "allowed", Region: "us-east-1"},
+		},
+		MaxBytes: 1024,
+		MaxCost:  10,
+		RateLimit: config.RateLimitConfig{
+			BytesPerSecond: 256,
+			BurstBytes:     256,
+		},
+		WindowSeconds: 3600,
+	}
+}
+
+func TestPolicyAllowsWithinLimits(t *testing.T) {
+	policy, err := NewPolicy(basePolicyConfig(), testCalculator())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	req := TransferRequest{
+		RequestID: "req-1",
+		Destination: Destination{
+			Provider: "aws",
+			Bucket:   "allowed",
+			Region:   "us-east-1",
+		},
+		DataClass: "restricted",
+		Bytes:     128,
+	}
+
+	outcome, err := policy.Evaluate(req)
+	if err != nil {
+		t.Fatalf("evaluate failed: %v", err)
+	}
+	if !outcome.Allowed {
+		t.Fatalf("expected allowed, got %+v", outcome)
+	}
+	if outcome.Cost <= 0 {
+		t.Fatalf("expected cost to be positive")
+	}
+}
+
+func TestPolicyBlocksByteCap(t *testing.T) {
+	policy, err := NewPolicy(basePolicyConfig(), testCalculator())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	req := TransferRequest{
+		RequestID: "req-2",
+		Destination: Destination{
+			Provider: "aws",
+			Bucket:   "allowed",
+			Region:   "us-east-1",
+		},
+		DataClass: "restricted",
+		Bytes:     2048,
+	}
+
+	outcome, err := policy.Evaluate(req)
+	if err != nil {
+		t.Fatalf("evaluate returned error: %v", err)
+	}
+	if outcome.Allowed {
+		t.Fatalf("expected rejection when byte cap exceeded")
+	}
+}
+
+func TestPolicyRateLimiter(t *testing.T) {
+	cfg := basePolicyConfig()
+	cfg.RateLimit.BytesPerSecond = 128
+	cfg.RateLimit.BurstBytes = 128
+
+	policy, err := NewPolicy(cfg, testCalculator())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	req := TransferRequest{
+		RequestID:   "req-3",
+		Destination: Destination{Provider: "aws", Bucket: "allowed", Region: "us-east-1"},
+		DataClass:   "restricted",
+		Bytes:       128,
+	}
+
+	outcome, err := policy.Evaluate(req)
+	if err != nil {
+		t.Fatalf("initial evaluate returned error: %v", err)
+	}
+	if !outcome.Allowed {
+		t.Fatalf("expected initial request to be allowed")
+	}
+
+	outcome, err = policy.Evaluate(req)
+	if err != nil {
+		t.Fatalf("second evaluate returned error: %v", err)
+	}
+	if outcome.Allowed {
+		t.Fatalf("expected rate limiter to reject second burst request")
+	}
+
+	time.Sleep(2 * time.Second)
+
+	outcome, err = policy.Evaluate(req)
+	if err != nil {
+		t.Fatalf("evaluate after wait returned error: %v", err)
+	}
+	if !outcome.Allowed {
+		t.Fatalf("expected allowance after limiter refill")
+	}
+}
+
+func TestPolicyBlocksCostCap(t *testing.T) {
+	cfg := basePolicyConfig()
+	cfg.MaxCost = 0.0000001
+
+	policy, err := NewPolicy(cfg, testCalculator())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	req := TransferRequest{
+		RequestID:   "req-4",
+		Destination: Destination{Provider: "aws", Bucket: "allowed", Region: "us-east-1"},
+		DataClass:   "restricted",
+		Bytes:       1024,
+	}
+
+	outcome, err := policy.Evaluate(req)
+	if err != nil {
+		t.Fatalf("evaluate returned error: %v", err)
+	}
+	if outcome.Allowed {
+		t.Fatalf("expected cost cap rejection")
+	}
+}

--- a/services/mdeg/internal/policy/ratelimiter.go
+++ b/services/mdeg/internal/policy/ratelimiter.go
@@ -1,0 +1,62 @@
+package policy
+
+import (
+	"sync"
+	"time"
+)
+
+// TokenBucket implements a byte-based token bucket limiter.
+type TokenBucket struct {
+	capacity int64
+	rate     int64
+	mu       sync.Mutex
+	tokens   float64
+	last     time.Time
+}
+
+// NewTokenBucket creates a limiter with the desired throughput.
+func NewTokenBucket(bytesPerSecond, burstBytes int64) *TokenBucket {
+	if bytesPerSecond <= 0 {
+		bytesPerSecond = 1
+	}
+	if burstBytes <= 0 {
+		burstBytes = bytesPerSecond
+	}
+	return &TokenBucket{
+		capacity: burstBytes,
+		rate:     bytesPerSecond,
+		tokens:   float64(burstBytes),
+		last:     time.Now(),
+	}
+}
+
+// Allow consumes tokens if available for the requested bytes.
+func (t *TokenBucket) Allow(bytes int64) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	now := time.Now()
+	elapsed := now.Sub(t.last).Seconds()
+	if elapsed > 0 {
+		t.tokens += float64(t.rate) * elapsed
+		if t.tokens > float64(t.capacity) {
+			t.tokens = float64(t.capacity)
+		}
+		t.last = now
+	}
+
+	if float64(bytes) > t.tokens {
+		return false
+	}
+
+	t.tokens -= float64(bytes)
+	return true
+}
+
+// Reset restores the limiter to its full capacity.
+func (t *TokenBucket) Reset() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.tokens = float64(t.capacity)
+	t.last = time.Now()
+}

--- a/services/mdeg/internal/provider/cost.go
+++ b/services/mdeg/internal/provider/cost.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/summit/mdeg/internal/config"
+)
+
+// CostCalculator computes cost estimates for object storage egress.
+type CostCalculator interface {
+	Cost(provider string, bytes int64) (float64, error)
+}
+
+// PricingTable implements CostCalculator using static metadata.
+type PricingTable struct {
+	pricing map[string]config.ProviderConfig
+}
+
+// NewPricingTable constructs a calculator from provider configuration.
+func NewPricingTable(providers map[string]config.ProviderConfig) *PricingTable {
+	normalized := make(map[string]config.ProviderConfig)
+	for key, value := range providers {
+		normalized[strings.ToLower(key)] = value
+	}
+	return &PricingTable{pricing: normalized}
+}
+
+// Cost returns the estimated spend in USD for the transfer.
+func (p *PricingTable) Cost(provider string, bytes int64) (float64, error) {
+	if bytes < 0 {
+		return 0, fmt.Errorf("bytes must be non-negative")
+	}
+
+	cfg, ok := p.pricing[strings.ToLower(provider)]
+	if !ok {
+		return 0, fmt.Errorf("unsupported provider %s", provider)
+	}
+
+	gib := float64(bytes) / (1024 * 1024 * 1024)
+	return cfg.PricePerGiB * gib, nil
+}

--- a/services/mdeg/internal/server/handlers.go
+++ b/services/mdeg/internal/server/handlers.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/summit/mdeg/internal/manifest"
+	"github.com/summit/mdeg/internal/policy"
+)
+
+type errorResponse struct {
+	Error   string `json:"error"`
+	Details string `json:"details,omitempty"`
+}
+
+type transferResponse struct {
+	Allowed  bool             `json:"allowed"`
+	Manifest *manifest.Record `json:"manifest,omitempty"`
+	Reason   string           `json:"reason,omitempty"`
+	Window   time.Time        `json:"windowEnd"`
+}
+
+type reconcileRequest struct {
+	ProviderBytes int64   `json:"providerBytes"`
+	ProviderCost  float64 `json:"providerCost"`
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) handlePolicies(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+	writeJSON(w, http.StatusOK, s.engine.Snapshot())
+}
+
+func (s *Server) handleTransfer(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "method not allowed"})
+		return
+	}
+
+	var req policy.TransferRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid request", Details: err.Error()})
+		return
+	}
+
+	outcome, err := s.engine.Evaluate(req)
+	if err != nil {
+		writeJSON(w, http.StatusForbidden, transferResponse{Allowed: false, Reason: err.Error(), Window: outcome.WindowEnds})
+		return
+	}
+
+	if !outcome.Allowed {
+		writeJSON(w, http.StatusForbidden, transferResponse{Allowed: false, Reason: outcome.Reason, Window: outcome.WindowEnds})
+		return
+	}
+
+	manifestRecord := &manifest.Record{
+		ManifestID:  uuid.NewString(),
+		RequestID:   req.RequestID,
+		PolicyID:    outcome.PolicyID,
+		Destination: req.Destination,
+		DataClass:   req.DataClass,
+		Bytes:       req.Bytes,
+		Cost:        outcome.Cost,
+		Timestamp:   time.Now().UTC(),
+	}
+	signature, err := s.signer.Sign(manifestRecord)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, errorResponse{Error: "signing failed", Details: err.Error()})
+		return
+	}
+	manifestRecord.Signature = signature
+	s.store.Save(manifestRecord)
+
+	writeJSON(w, http.StatusCreated, transferResponse{Allowed: true, Manifest: manifestRecord, Window: outcome.WindowEnds})
+}
+
+func (s *Server) handleManifest(w http.ResponseWriter, r *http.Request) {
+	parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/manifests/"), "/")
+	if len(parts) == 0 || parts[0] == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{Error: "manifest id required"})
+		return
+	}
+	id := parts[0]
+
+	switch {
+	case r.Method == http.MethodGet && len(parts) == 1:
+		record, ok := s.store.Get(id)
+		if !ok {
+			writeJSON(w, http.StatusNotFound, errorResponse{Error: "manifest not found"})
+			return
+		}
+		writeJSON(w, http.StatusOK, record)
+		return
+	case r.Method == http.MethodPost && len(parts) == 2 && parts[1] == "reconcile":
+		var req reconcileRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, errorResponse{Error: "invalid request", Details: err.Error()})
+			return
+		}
+		record, err := s.store.Reconcile(id, req.ProviderBytes, req.ProviderCost)
+		if err != nil {
+			writeJSON(w, http.StatusConflict, errorResponse{Error: "reconciliation failed", Details: err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, record)
+		return
+	default:
+		writeJSON(w, http.StatusMethodNotAllowed, errorResponse{Error: "unsupported operation"})
+		return
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}

--- a/services/mdeg/internal/server/server.go
+++ b/services/mdeg/internal/server/server.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/summit/mdeg/internal/manifest"
+	"github.com/summit/mdeg/internal/policy"
+)
+
+// Server exposes the HTTP API for the MDEG sidecar.
+type Server struct {
+	engine *policy.Engine
+	signer *manifest.Signer
+	store  *manifest.Store
+	logger *log.Logger
+}
+
+// New constructs a server with its dependencies wired in.
+func New(engine *policy.Engine, signer *manifest.Signer, store *manifest.Store, logger *log.Logger) *Server {
+	if logger == nil {
+		logger = log.New(log.Writer(), "mdeg", log.LstdFlags)
+	}
+	return &Server{
+		engine: engine,
+		signer: signer,
+		store:  store,
+		logger: logger,
+	}
+}
+
+// Handler returns the configured HTTP handler.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", s.handleHealth)
+	mux.HandleFunc("/transfers", s.handleTransfer)
+	mux.HandleFunc("/manifests/", s.handleManifest)
+	mux.HandleFunc("/policies", s.handlePolicies)
+	return mux
+}
+
+// ListenAndServe starts the HTTP server.
+func (s *Server) ListenAndServe(addr string) error {
+	s.logger.Printf("listening on %s", addr)
+	return http.ListenAndServe(addr, s.Handler())
+}


### PR DESCRIPTION
## Summary
- add a Go-based Multicloud Data Egress Governor sidecar with policy evaluation, rate limiting, and signed manifest storage
- expose HTTP endpoints plus reconciliation support and document configuration and usage
- ship TypeScript and Python SDK clients for requesting transfers and reconciling manifests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d767a385248333ad3483a6313d26d3