### PR TITLE
feat: introduce categorical privacy validator tooling

### DIFF
--- a/cpv/__init__.py
+++ b/cpv/__init__.py
@@ -1,0 +1,34 @@
+"""Categorical Privacy Validator (CPV).
+
+This package evaluates categorical privacy guarantees on tabular data. It
+currently supports the following privacy models:
+
+* :term:`k-map` anonymity (also known as :math:`(k, P)`-anonymity)
+* :term:`\\ell`-diversity
+* :term:`t`-closeness (with multiple distance metrics)
+
+The public API exposes helpers to build reproducible privacy assessment
+reports, render violation heatmaps, and design remediation plans that rely on
+value generalisation or record suppression.
+"""
+
+from .evaluator import evaluate_privacy, build_population_map
+from .heatmap import generate_violation_heatmap
+from .remediation import plan_remediations
+from .report import (
+    KMappViolation,
+    LDiversityViolation,
+    PrivacyEvaluationReport,
+    TClosenessViolation,
+)
+
+__all__ = [
+    "evaluate_privacy",
+    "build_population_map",
+    "generate_violation_heatmap",
+    "plan_remediations",
+    "KMappViolation",
+    "LDiversityViolation",
+    "TClosenessViolation",
+    "PrivacyEvaluationReport",
+]

--- a/cpv/evaluator.py
+++ b/cpv/evaluator.py
@@ -1,0 +1,180 @@
+"""Privacy metric calculations for categorical data."""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+from .report import (
+    KMappViolation,
+    LDiversityViolation,
+    PrivacyEvaluationReport,
+    TClosenessViolation,
+    QuasiIdentifier,
+)
+
+
+Row = Mapping[str, Any]
+
+
+def _normalise_rows(rows: Iterable[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    return [dict(row) for row in rows]
+
+
+def build_population_map(rows: Iterable[Row], qi_columns: Sequence[str]) -> Dict[QuasiIdentifier, int]:
+    """Build a frequency map over quasi identifier combinations."""
+
+    population_counts: Dict[QuasiIdentifier, int] = Counter()
+    for row in rows:
+        key = tuple(row[column] for column in qi_columns)
+        population_counts[key] += 1
+    return dict(population_counts)
+
+
+def _group_by_qi(rows: Iterable[Row], qi_columns: Sequence[str]) -> Dict[QuasiIdentifier, List[Dict[str, Any]]]:
+    grouped: Dict[QuasiIdentifier, List[Dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        key = tuple(row[column] for column in qi_columns)
+        grouped[key].append(dict(row))
+    return grouped
+
+
+def _distribution(values: Iterable[Any]) -> Dict[Any, float]:
+    total = 0
+    counts: Dict[Any, int] = Counter()
+    for value in values:
+        counts[value] += 1
+        total += 1
+    if total == 0:
+        return {}
+    return {value: count / float(total) for value, count in counts.items()}
+
+
+def _total_variation_distance(p: Mapping[Any, float], q: Mapping[Any, float]) -> float:
+    support = set(p) | set(q)
+    distance = 0.0
+    for value in support:
+        distance += abs(p.get(value, 0.0) - q.get(value, 0.0))
+    return 0.5 * distance
+
+
+def _hellinger_distance(p: Mapping[Any, float], q: Mapping[Any, float]) -> float:
+    from math import sqrt
+
+    support = set(p) | set(q)
+    accum = 0.0
+    for value in support:
+        accum += (sqrt(p.get(value, 0.0)) - sqrt(q.get(value, 0.0))) ** 2
+    return (accum / 2.0) ** 0.5
+
+
+_DISTANCE_METRICS = {
+    "total_variation": _total_variation_distance,
+    "hellinger": _hellinger_distance,
+}
+
+
+def evaluate_privacy(
+    rows: Iterable[Row],
+    *,
+    quasi_identifier_columns: Sequence[str],
+    sensitive_columns: Sequence[str],
+    k_map_threshold: int | None = None,
+    population_map: Mapping[QuasiIdentifier, int] | None = None,
+    l_diversity_threshold: int | None = None,
+    t_closeness_threshold: float | None = None,
+    t_closeness_metrics: Sequence[str] | None = None,
+) -> PrivacyEvaluationReport:
+    """Evaluate privacy guarantees and return a structured report."""
+
+    records = _normalise_rows(rows)
+    grouped = _group_by_qi(records, quasi_identifier_columns)
+    population_map = (
+        dict(population_map)
+        if population_map is not None
+        else build_population_map(records, quasi_identifier_columns)
+    )
+
+    k_map_violations: List[KMappViolation] = []
+    if k_map_threshold is not None and k_map_threshold > 0:
+        for key, sample_rows in grouped.items():
+            population_count = population_map.get(key, len(sample_rows))
+            if population_count < k_map_threshold:
+                violation = KMappViolation(
+                    quasi_identifier=key,
+                    sample_count=len(sample_rows),
+                    population_count=population_count,
+                    risk=1.0 / max(population_count, 1),
+                )
+                k_map_violations.append(violation)
+        k_map_violations.sort(key=lambda violation: violation.quasi_identifier)
+
+    l_diversity_violations: List[LDiversityViolation] = []
+    if l_diversity_threshold is not None and l_diversity_threshold > 0:
+        for key, sample_rows in grouped.items():
+            for sensitive in sensitive_columns:
+                values = {row.get(sensitive) for row in sample_rows}
+                if len(values) < l_diversity_threshold:
+                    violation = LDiversityViolation(
+                        quasi_identifier=key,
+                        sensitive_attribute=sensitive,
+                        distinct_sensitive_values=len(values),
+                    )
+                    l_diversity_violations.append(violation)
+        l_diversity_violations.sort(
+            key=lambda violation: (violation.quasi_identifier, violation.sensitive_attribute)
+        )
+
+    t_closeness_violations: List[TClosenessViolation] = []
+    if (
+        t_closeness_threshold is not None
+        and t_closeness_threshold > 0
+        and sensitive_columns
+    ):
+        metrics = list(t_closeness_metrics or _DISTANCE_METRICS.keys())
+        global_distributions = {
+            column: _distribution(row[column] for row in records)
+            for column in sensitive_columns
+        }
+        for key, sample_rows in grouped.items():
+            for sensitive in sensitive_columns:
+                class_distribution = _distribution(row[sensitive] for row in sample_rows)
+                global_distribution = global_distributions[sensitive]
+                for metric in metrics:
+                    distance_fn = _DISTANCE_METRICS.get(metric)
+                    if distance_fn is None:
+                        raise ValueError(f"Unsupported distance metric: {metric}")
+                    distance = distance_fn(class_distribution, global_distribution)
+                    if distance > t_closeness_threshold:
+                        violation = TClosenessViolation(
+                            quasi_identifier=key,
+                            sensitive_attribute=sensitive,
+                            metric=metric,
+                            distance=distance,
+                        )
+                        t_closeness_violations.append(violation)
+        t_closeness_violations.sort(
+            key=lambda violation: (
+                violation.quasi_identifier,
+                violation.sensitive_attribute,
+                violation.metric,
+            )
+        )
+
+    return PrivacyEvaluationReport(
+        quasi_identifier_columns=list(quasi_identifier_columns),
+        sensitive_columns=list(sensitive_columns),
+        k_map_threshold=k_map_threshold,
+        l_diversity_threshold=l_diversity_threshold,
+        t_closeness_threshold=t_closeness_threshold,
+        t_closeness_metrics=list(t_closeness_metrics or _DISTANCE_METRICS.keys()),
+        k_map_violations=k_map_violations,
+        l_diversity_violations=l_diversity_violations,
+        t_closeness_violations=t_closeness_violations,
+    )
+
+
+__all__ = [
+    "evaluate_privacy",
+    "build_population_map",
+]

--- a/cpv/heatmap.py
+++ b/cpv/heatmap.py
@@ -1,0 +1,90 @@
+"""Heatmap rendering utilities for privacy violation reports."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .report import PrivacyEvaluationReport
+
+
+def _colour_for_intensity(intensity: float) -> str:
+    intensity = max(0.0, min(1.0, intensity))
+    red = int(255 * intensity)
+    green = int(255 * (1.0 - intensity / 2.0))
+    blue = int(255 * (1.0 - intensity))
+    return f"#{red:02x}{green:02x}{blue:02x}"
+
+
+def _svg_rect(x: float, y: float, width: float, height: float, fill: str) -> str:
+    return f'<rect x="{x}" y="{y}" width="{width}" height="{height}" fill="{fill}" />'
+
+
+def _svg_text(x: float, y: float, text: str, *, anchor: str = "middle") -> str:
+    escaped = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return (
+        f'<text x="{x}" y="{y}" text-anchor="{anchor}" '
+        f'font-family="Inter, Arial" font-size="12">{escaped}</text>'
+    )
+
+
+def generate_violation_heatmap(
+    report: PrivacyEvaluationReport,
+    metric: str,
+    output_path: str | Path,
+    *,
+    seed: int | None = None,
+) -> Path:
+    """Generate an SVG heatmap visualising violations for ``metric``.
+
+    The function returns the path to the rendered SVG file. Heatmaps are stable
+    across runs; a ``seed`` parameter is accepted for API compatibility with
+    callers that expect deterministic pseudo-random behaviour.
+    """
+
+    _ = seed  # No random elements are currently required.
+
+    row_labels, column_labels, matrix = report.heatmap_matrix(metric)
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not row_labels:
+        svg = [
+            "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"320\" height=\"80\">",
+            _svg_text(160, 40, "No violations detected", anchor="middle"),
+            "</svg>",
+        ]
+        output_path.write_text("\n".join(svg), encoding="utf-8")
+        return output_path
+
+    cell_size = 40
+    label_height = 30
+    left_margin = 160
+    top_margin = 20
+
+    width = left_margin + cell_size * len(column_labels) + 20
+    height = top_margin + label_height + cell_size * len(row_labels) + 20
+
+    svg = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}">',
+        _svg_text(left_margin + (cell_size * len(column_labels)) / 2, 15, f"Violations: {metric}"),
+    ]
+
+    for idx, column in enumerate(column_labels):
+        x = left_margin + idx * cell_size + cell_size / 2
+        svg.append(_svg_text(x, top_margin + label_height - 8, column))
+
+    for row_idx, label in enumerate(row_labels):
+        y = top_margin + label_height + row_idx * cell_size + cell_size / 2
+        svg.append(_svg_text(left_margin - 10, y + 4, label, anchor="end"))
+        for col_idx, intensity in enumerate(matrix[row_idx]):
+            x = left_margin + col_idx * cell_size
+            y_rect = top_margin + label_height + row_idx * cell_size
+            colour = _colour_for_intensity(intensity)
+            svg.append(_svg_rect(x, y_rect, cell_size, cell_size, colour))
+
+    svg.append("</svg>")
+    output_path.write_text("\n".join(svg), encoding="utf-8")
+    return output_path
+
+
+__all__ = ["generate_violation_heatmap"]

--- a/cpv/remediation.py
+++ b/cpv/remediation.py
@@ -1,0 +1,143 @@
+"""Remediation planning for privacy violations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+from .report import (
+    KMappViolation,
+    LDiversityViolation,
+    PrivacyEvaluationReport,
+    TClosenessViolation,
+)
+
+
+Row = Mapping[str, Any]
+
+
+@dataclass
+class RemediationStep:
+    action: str  # "generalize" or "suppress"
+    quasi_identifier: Tuple[Any, ...]
+    columns: Sequence[str]
+    value: Any | None = None
+
+
+@dataclass
+class RemediationPlan:
+    steps: List[RemediationStep] = field(default_factory=list)
+    generalization_value: Any = "ANY"
+
+    def apply(self, rows: Iterable[Row]) -> List[Dict[str, Any]]:
+        """Apply the remediation plan to a tabular dataset."""
+
+        processed = [dict(row) for row in rows]
+        suppressed_indices: set[int] = set()
+        for step in self.steps:
+            if step.action == "generalize":
+                for row in processed:
+                    if tuple(row[column] for column in step.columns) == step.quasi_identifier:
+                        for column in step.columns:
+                            row[column] = step.value if step.value is not None else self.generalization_value
+            elif step.action == "suppress":
+                for idx, row in enumerate(processed):
+                    if tuple(row[column] for column in step.columns) == step.quasi_identifier:
+                        suppressed_indices.add(idx)
+        if suppressed_indices:
+            return [row for idx, row in enumerate(processed) if idx not in suppressed_indices]
+        return processed
+
+
+def _deduplicate_steps(steps: List[RemediationStep]) -> List[RemediationStep]:
+    seen = set()
+    unique: List[RemediationStep] = []
+    for step in steps:
+        fingerprint = (step.action, step.quasi_identifier, tuple(step.columns), step.value)
+        if fingerprint in seen:
+            continue
+        seen.add(fingerprint)
+        unique.append(step)
+    return unique
+
+
+def _plan_for_k_map(
+    violations: Sequence[KMappViolation],
+    qi_columns: Sequence[str],
+    generalization_value: Any,
+) -> List[RemediationStep]:
+    steps: List[RemediationStep] = []
+    for violation in violations:
+        steps.append(
+            RemediationStep(
+                action="generalize",
+                quasi_identifier=violation.quasi_identifier,
+                columns=list(qi_columns),
+                value=generalization_value,
+            )
+        )
+    return steps
+
+
+def _plan_for_l_diversity(
+    violations: Sequence[LDiversityViolation],
+    qi_columns: Sequence[str],
+    generalization_value: Any,
+) -> List[RemediationStep]:
+    steps: List[RemediationStep] = []
+    for violation in violations:
+        steps.append(
+            RemediationStep(
+                action="generalize",
+                quasi_identifier=violation.quasi_identifier,
+                columns=list(qi_columns),
+                value=generalization_value,
+            )
+        )
+    return steps
+
+
+def _plan_for_t_closeness(
+    violations: Sequence[TClosenessViolation],
+    qi_columns: Sequence[str],
+    generalization_value: Any,
+) -> List[RemediationStep]:
+    steps: List[RemediationStep] = []
+    for violation in violations:
+        steps.append(
+            RemediationStep(
+                action="generalize",
+                quasi_identifier=violation.quasi_identifier,
+                columns=list(qi_columns),
+                value=generalization_value,
+            )
+        )
+    return steps
+
+
+def plan_remediations(
+    report: PrivacyEvaluationReport,
+    rows: Iterable[Row],
+    *,
+    generalization_value: Any = "ANY",
+) -> RemediationPlan:
+    """Create a remediation plan for the detected privacy violations."""
+
+    _ = rows
+    if not report.any_violations():
+        return RemediationPlan(steps=[], generalization_value=generalization_value)
+
+    qi_columns = list(report.quasi_identifier_columns)
+    steps: List[RemediationStep] = []
+
+    steps.extend(_plan_for_k_map(report.k_map_violations, qi_columns, generalization_value))
+    steps.extend(_plan_for_l_diversity(report.l_diversity_violations, qi_columns, generalization_value))
+    steps.extend(
+        _plan_for_t_closeness(report.t_closeness_violations, qi_columns, generalization_value)
+    )
+
+    steps = _deduplicate_steps(steps)
+    return RemediationPlan(steps=steps, generalization_value=generalization_value)
+
+
+__all__ = ["plan_remediations", "RemediationPlan", "RemediationStep"]

--- a/cpv/report.py
+++ b/cpv/report.py
@@ -1,0 +1,152 @@
+"""Data structures that capture privacy evaluation results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+import json
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+
+QuasiIdentifier = Tuple[Any, ...]
+
+
+@dataclass(frozen=True)
+class KMappViolation:
+    """Represents a violation of the k-map anonymity requirement."""
+
+    quasi_identifier: QuasiIdentifier
+    sample_count: int
+    population_count: int
+    risk: float
+
+    def severity(self, k_threshold: int) -> float:
+        """Return a normalised severity score in ``[0, 1]``."""
+
+        if k_threshold <= 0:
+            return 0.0
+        gap = max(0, k_threshold - self.population_count)
+        return min(1.0, gap / float(k_threshold))
+
+
+@dataclass(frozen=True)
+class LDiversityViolation:
+    """Represents a violation of the ``l``-diversity requirement."""
+
+    quasi_identifier: QuasiIdentifier
+    sensitive_attribute: str
+    distinct_sensitive_values: int
+
+    def severity(self, l_threshold: int) -> float:
+        if l_threshold <= 0:
+            return 0.0
+        gap = max(0, l_threshold - self.distinct_sensitive_values)
+        return min(1.0, gap / float(l_threshold))
+
+
+@dataclass(frozen=True)
+class TClosenessViolation:
+    """Represents a violation of the ``t``-closeness requirement."""
+
+    quasi_identifier: QuasiIdentifier
+    sensitive_attribute: str
+    metric: str
+    distance: float
+
+    def severity(self, t_threshold: float) -> float:
+        if t_threshold <= 0:
+            return 0.0
+        excess = max(0.0, self.distance - t_threshold)
+        return min(1.0, excess / t_threshold)
+
+
+@dataclass
+class PrivacyEvaluationReport:
+    """Container for privacy guarantees and detected violations."""
+
+    quasi_identifier_columns: Sequence[str]
+    sensitive_columns: Sequence[str]
+    k_map_threshold: int | None
+    l_diversity_threshold: int | None
+    t_closeness_threshold: float | None
+    t_closeness_metrics: Sequence[str] = field(default_factory=tuple)
+    k_map_violations: List[KMappViolation] = field(default_factory=list)
+    l_diversity_violations: List[LDiversityViolation] = field(default_factory=list)
+    t_closeness_violations: List[TClosenessViolation] = field(default_factory=list)
+
+    def any_violations(self) -> bool:
+        return bool(
+            self.k_map_violations
+            or self.l_diversity_violations
+            or self.t_closeness_violations
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        def _dataclass_list(items: Iterable[Any]) -> List[Dict[str, Any]]:
+            return [asdict(item) for item in items]
+
+        return {
+            "quasi_identifier_columns": list(self.quasi_identifier_columns),
+            "sensitive_columns": list(self.sensitive_columns),
+            "k_map_threshold": self.k_map_threshold,
+            "l_diversity_threshold": self.l_diversity_threshold,
+            "t_closeness_threshold": self.t_closeness_threshold,
+            "t_closeness_metrics": list(self.t_closeness_metrics),
+            "k_map_violations": _dataclass_list(self.k_map_violations),
+            "l_diversity_violations": _dataclass_list(self.l_diversity_violations),
+            "t_closeness_violations": _dataclass_list(self.t_closeness_violations),
+        }
+
+    def to_bytes(self, seed: int | None = None) -> bytes:
+        """Serialise the report to bytes deterministically."""
+
+        # ``seed`` is accepted for API compatibility; we do not rely on
+        # randomness, yet the explicit parameter makes determinism contractual.
+        _ = seed
+        canonical = json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+        return canonical.encode("utf-8")
+
+    # --- Heatmap helpers -------------------------------------------------
+    def _violation_rows(self, metric: str) -> List[Tuple[str, float]]:
+        rows: List[Tuple[str, float]] = []
+        if self.k_map_threshold and self.k_map_threshold > 0:
+            for violation in self.k_map_violations:
+                label = " | ".join(map(str, violation.quasi_identifier))
+                rows.append((label, violation.severity(self.k_map_threshold)))
+        if self.l_diversity_threshold and self.l_diversity_threshold > 0:
+            for violation in self.l_diversity_violations:
+                label = (
+                    " | ".join(map(str, violation.quasi_identifier))
+                    + f" → {violation.sensitive_attribute}"
+                )
+                rows.append((label, violation.severity(self.l_diversity_threshold)))
+        if self.t_closeness_threshold and self.t_closeness_threshold > 0:
+            for violation in self.t_closeness_violations:
+                if violation.metric != metric:
+                    continue
+                label = (
+                    " | ".join(map(str, violation.quasi_identifier))
+                    + f" → {violation.sensitive_attribute}"
+                    + f" ({violation.metric})"
+                )
+                rows.append((label, violation.severity(self.t_closeness_threshold)))
+        return rows
+
+    def heatmap_matrix(self, metric: str) -> Tuple[List[str], List[str], List[List[float]]]:
+        """Return (row_labels, column_labels, matrix) for heatmap rendering."""
+
+        rows = self._violation_rows(metric)
+        if not rows:
+            return ([], list(self.quasi_identifier_columns), [])
+
+        rows.sort(key=lambda item: item[0])
+        matrix = [[score for _ in self.quasi_identifier_columns] for _, score in rows]
+        row_labels = [label for label, _ in rows]
+        return (row_labels, list(self.quasi_identifier_columns), matrix)
+
+
+__all__ = [
+    "KMappViolation",
+    "LDiversityViolation",
+    "PrivacyEvaluationReport",
+    "TClosenessViolation",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Test-wide configuration for Python modules."""
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/fixtures/cpv/injected_privacy_violations.json
+++ b/tests/fixtures/cpv/injected_privacy_violations.json
@@ -1,0 +1,11 @@
+[
+  {"zip": "12345", "age": 34, "disease": "flu"},
+  {"zip": "12345", "age": 34, "disease": "flu"},
+  {"zip": "12345", "age": 34, "disease": "flu"},
+  {"zip": "54321", "age": 52, "disease": "cancer"},
+  {"zip": "54321", "age": 52, "disease": "flu"},
+  {"zip": "54321", "age": 52, "disease": "cancer"},
+  {"zip": "11111", "age": 28, "disease": "flu"},
+  {"zip": "11111", "age": 28, "disease": "flu"},
+  {"zip": "11111", "age": 28, "disease": "flu"}
+]

--- a/tests/unit/cpv/test_cpv.py
+++ b/tests/unit/cpv/test_cpv.py
@@ -1,0 +1,91 @@
+import hashlib
+import json
+from pathlib import Path
+
+from cpv import (
+    build_population_map,
+    evaluate_privacy,
+    generate_violation_heatmap,
+    plan_remediations,
+)
+
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "fixtures" / "cpv"
+DATASET = json.loads((FIXTURE_DIR / "injected_privacy_violations.json").read_text())
+QI_COLUMNS = ["zip", "age"]
+SENSITIVE_COLUMNS = ["disease"]
+K_THRESHOLD = 4
+L_THRESHOLD = 2
+T_THRESHOLD = 0.2
+METRICS = ("total_variation", "hellinger")
+
+
+def _evaluate(rows):
+    return evaluate_privacy(
+        rows,
+        quasi_identifier_columns=QI_COLUMNS,
+        sensitive_columns=SENSITIVE_COLUMNS,
+        k_map_threshold=K_THRESHOLD,
+        population_map=build_population_map(rows, QI_COLUMNS),
+        l_diversity_threshold=L_THRESHOLD,
+        t_closeness_threshold=T_THRESHOLD,
+        t_closeness_metrics=METRICS,
+    )
+
+
+def test_detects_injected_privacy_violations():
+    report = _evaluate(DATASET)
+
+    assert len(report.k_map_violations) == 3
+    violating_keys = {violation.quasi_identifier for violation in report.k_map_violations}
+    assert {("12345", 34), ("54321", 52), ("11111", 28)} == violating_keys
+
+    ldiv_keys = {
+        (violation.quasi_identifier, violation.sensitive_attribute)
+        for violation in report.l_diversity_violations
+    }
+    assert {
+        (("12345", 34), "disease"),
+        (("11111", 28), "disease"),
+    } == ldiv_keys
+
+    assert report.t_closeness_violations, "t-closeness violations should be detected"
+    for violation in report.t_closeness_violations:
+        assert violation.metric in METRICS
+        assert violation.distance > T_THRESHOLD
+
+
+def test_remediation_plan_restores_targets():
+    report = _evaluate(DATASET)
+    plan = plan_remediations(report, DATASET, generalization_value="*")
+    remediated = plan.apply(DATASET)
+
+    remediated_report = evaluate_privacy(
+        remediated,
+        quasi_identifier_columns=QI_COLUMNS,
+        sensitive_columns=SENSITIVE_COLUMNS,
+        k_map_threshold=K_THRESHOLD,
+        population_map=build_population_map(remediated, QI_COLUMNS),
+        l_diversity_threshold=L_THRESHOLD,
+        t_closeness_threshold=T_THRESHOLD,
+        t_closeness_metrics=METRICS,
+    )
+    assert not remediated_report.any_violations()
+
+
+def test_reports_and_heatmaps_are_deterministic(tmp_path: Path):
+    report = _evaluate(DATASET)
+
+    first = report.to_bytes(seed=123)
+    second = report.to_bytes(seed=123)
+    assert first == second
+
+    heatmap_path_1 = tmp_path / "heatmap1.svg"
+    heatmap_path_2 = tmp_path / "heatmap2.svg"
+    generate_violation_heatmap(report, "total_variation", heatmap_path_1, seed=42)
+    generate_violation_heatmap(report, "total_variation", heatmap_path_2, seed=42)
+
+    digest_1 = hashlib.sha256(heatmap_path_1.read_bytes()).hexdigest()
+    digest_2 = hashlib.sha256(heatmap_path_2.read_bytes()).hexdigest()
+    assert digest_1 == digest_2
+    assert heatmap_path_1.read_text() == heatmap_path_2.read_text()


### PR DESCRIPTION
## Summary
- add a cpv package to compute k-map, l-diversity, and t-closeness privacy metrics with structured reports
- implement deterministic SVG heatmap generation and remediation planning utilities for categorical datasets
- cover the new package with fixtures and pytest-based validation of detection, remediation, and reproducibility

## Testing
- pytest tests/unit/cpv/test_cpv.py

------
https://chatgpt.com/codex/tasks/task_e_68d7679a76888333a2dc60522f41f80c