### PR TITLE
feat: add federated schema registry with policy tags

### DIFF
--- a/src/fsr-pt/SchemaCompatibility.ts
+++ b/src/fsr-pt/SchemaCompatibility.ts
@@ -1,0 +1,138 @@
+import { CompatibilityReport, JsonSchema, PropertyChange } from './types.js';
+
+interface NormalizedProperty {
+  type: string;
+  required: boolean;
+}
+
+interface NormalizedSchema {
+  properties: Map<string, NormalizedProperty>;
+}
+
+function toString(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value) || (value && typeof value === 'object')) {
+    return JSON.stringify(value, null, 2);
+  }
+
+  return String(value);
+}
+
+function normalizeSchema(schema: JsonSchema): NormalizedSchema {
+  const propertiesNode = (schema?.properties ?? {}) as Record<string, JsonSchema>;
+  const requiredList = new Set<string>(Array.isArray(schema?.required) ? (schema.required as string[]) : []);
+
+  const normalized = new Map<string, NormalizedProperty>();
+  for (const key of Object.keys(propertiesNode)) {
+    const propertySchema = propertiesNode[key] as JsonSchema;
+    const propertyType = typeof propertySchema?.type === 'string' ? (propertySchema.type as string) : 'unknown';
+
+    normalized.set(key, {
+      type: propertyType,
+      required: requiredList.has(key),
+    });
+  }
+
+  return { properties: normalized };
+}
+
+export function diffSchemas(previous: JsonSchema | null, next: JsonSchema): PropertyChange[] {
+  const previousSchema = previous ? normalizeSchema(previous) : { properties: new Map() };
+  const nextSchema = normalizeSchema(next);
+
+  const propertyChanges: PropertyChange[] = [];
+  const allPropertyNames = new Set<string>([
+    ...previousSchema.properties.keys(),
+    ...nextSchema.properties.keys(),
+  ]);
+
+  const sortedNames = Array.from(allPropertyNames.values()).sort();
+
+  for (const name of sortedNames) {
+    const before = previousSchema.properties.get(name);
+    const after = nextSchema.properties.get(name);
+
+    if (!before && after) {
+      propertyChanges.push({
+        property: name,
+        current: after.type,
+        changeType: after.required ? 'required-added' : 'added',
+      });
+      continue;
+    }
+
+    if (before && !after) {
+      propertyChanges.push({
+        property: name,
+        previous: before.type,
+        changeType: 'removed',
+      });
+      continue;
+    }
+
+    if (before && after) {
+      if (before.type !== after.type) {
+        propertyChanges.push({
+          property: name,
+          previous: before.type,
+          current: after.type,
+          changeType: 'type-changed',
+        });
+      }
+
+      if (before.required !== after.required) {
+        propertyChanges.push({
+          property: name,
+          previous: toString(before.required),
+          current: toString(after.required),
+          changeType: after.required ? 'required-added' : 'required-removed',
+        });
+      }
+    }
+  }
+
+  return propertyChanges;
+}
+
+export function evaluateCompatibility(previous: JsonSchema | null, next: JsonSchema): CompatibilityReport {
+  const propertyChanges = diffSchemas(previous, next);
+
+  const breakingMessages: string[] = [];
+  const nonBreakingMessages: string[] = [];
+
+  for (const change of propertyChanges) {
+    switch (change.changeType) {
+      case 'removed':
+        breakingMessages.push(`Property \"${change.property}\" was removed.`);
+        break;
+      case 'type-changed':
+        breakingMessages.push(
+          `Property \"${change.property}\" changed type from ${change.previous} to ${change.current}.`,
+        );
+        break;
+      case 'required-added':
+        breakingMessages.push(`Property \"${change.property}\" became required.`);
+        break;
+      case 'added':
+        nonBreakingMessages.push(`Property \"${change.property}\" was added.`);
+        break;
+      case 'required-removed':
+        nonBreakingMessages.push(`Property \"${change.property}\" is no longer required.`);
+        break;
+      default:
+        break;
+    }
+  }
+
+  breakingMessages.sort();
+  nonBreakingMessages.sort();
+
+  return {
+    compatible: breakingMessages.length === 0,
+    breakingChanges: breakingMessages,
+    nonBreakingChanges: nonBreakingMessages,
+  };
+}

--- a/src/fsr-pt/SchemaRegistry.ts
+++ b/src/fsr-pt/SchemaRegistry.ts
@@ -1,0 +1,149 @@
+import { diffSchemas, evaluateCompatibility } from './SchemaCompatibility.js';
+import { diffPolicyTags } from './TagDiff.js';
+import {
+  CompatibilityReport,
+  JsonSchema,
+  PolicyTags,
+  RegistrationResult,
+  SchemaDiffReport,
+  SchemaHistoryEntry,
+  SchemaMetadata,
+} from './types.js';
+import { generatePythonClient, generateTypescriptClient } from './clientGenerator.js';
+
+function cloneSchema(schema: JsonSchema): JsonSchema {
+  return JSON.parse(JSON.stringify(schema));
+}
+
+export class SchemaRegistry {
+  private store: Map<string, Map<string, SchemaHistoryEntry[]>> = new Map();
+
+  registerSchema(
+    silo: string,
+    name: string,
+    version: string,
+    schema: JsonSchema,
+    policyTags: PolicyTags,
+  ): RegistrationResult {
+    const siloBucket = this.ensureSiloBucket(silo);
+    const history = siloBucket.get(name) ?? [];
+
+    if (history.some((entry) => entry.version === version)) {
+      throw new Error(`Schema ${silo}/${name}@${version} already registered.`);
+    }
+
+    const previous = history.at(-1) ?? null;
+    const compatibility = this.computeCompatibility(previous, schema);
+    const propertyChanges = diffSchemas(previous?.schema ?? null, schema);
+    const tagDiff = diffPolicyTags(previous?.policyTags ?? null, policyTags);
+
+    const metadata: SchemaMetadata = {
+      silo,
+      name,
+      version,
+      policyTags: { ...policyTags },
+      schema: cloneSchema(schema),
+      registeredAt: new Date(),
+    };
+
+    const diff: SchemaDiffReport = {
+      propertyChanges,
+      tagDiff,
+      impactSummary: this.buildImpactSummary(compatibility, tagDiff),
+    };
+
+    history.push(metadata);
+    siloBucket.set(name, history);
+
+    return {
+      metadata,
+      compatibility,
+      diff,
+      isBreakingChange: !compatibility.compatible,
+    };
+  }
+
+  getLatestSchema(silo: string, name: string): SchemaHistoryEntry | null {
+    const history = this.store.get(silo)?.get(name) ?? null;
+    return history && history.length > 0 ? history.at(-1)! : null;
+  }
+
+  getSchemaVersion(silo: string, name: string, version: string): SchemaHistoryEntry | null {
+    const history = this.store.get(silo)?.get(name);
+    if (!history) {
+      return null;
+    }
+
+    return history.find((entry) => entry.version === version) ?? null;
+  }
+
+  listSilos(): string[] {
+    return Array.from(this.store.keys()).sort();
+  }
+
+  listSchemas(silo: string): string[] {
+    const bucket = this.store.get(silo);
+    if (!bucket) {
+      return [];
+    }
+
+    return Array.from(bucket.keys()).sort();
+  }
+
+  generateClientBindings(
+    silo: string,
+    name: string,
+    version?: string,
+  ): { typescript: string; python: string } {
+    const schema = version
+      ? this.getSchemaVersion(silo, name, version)
+      : this.getLatestSchema(silo, name);
+
+    if (!schema) {
+      throw new Error(`Schema ${silo}/${name}${version ? `@${version}` : ''} not found.`);
+    }
+
+    return {
+      typescript: generateTypescriptClient(schema),
+      python: generatePythonClient(schema),
+    };
+  }
+
+  private ensureSiloBucket(silo: string): Map<string, SchemaHistoryEntry[]> {
+    if (!this.store.has(silo)) {
+      this.store.set(silo, new Map());
+    }
+
+    return this.store.get(silo)!;
+  }
+
+  private computeCompatibility(previous: SchemaHistoryEntry | null, schema: JsonSchema): CompatibilityReport {
+    return evaluateCompatibility(previous?.schema ?? null, schema);
+  }
+
+  private buildImpactSummary(
+    compatibility: CompatibilityReport,
+    tagDiff: SchemaDiffReport['tagDiff'],
+  ): string[] {
+    const lines: string[] = [];
+
+    for (const message of compatibility.breakingChanges) {
+      lines.push(`BREAKING: ${message}`);
+    }
+
+    for (const message of compatibility.nonBreakingChanges) {
+      lines.push(`INFO: ${message}`);
+    }
+
+    if (tagDiff.summary) {
+      const tagLines = tagDiff.summary.split('\n').map((entry) => entry.trim());
+      for (const tagLine of tagLines) {
+        if (tagLine.length > 0) {
+          lines.push(`TAG: ${tagLine}`);
+        }
+      }
+    }
+
+    return lines;
+  }
+}

--- a/src/fsr-pt/TagDiff.ts
+++ b/src/fsr-pt/TagDiff.ts
@@ -1,0 +1,89 @@
+import { PolicyTags, TagChange, TagDiffReport } from './types.js';
+
+const SENSITIVITY_ORDER = ['public', 'internal', 'confidential', 'restricted', 'secret', 'top-secret'];
+const RETENTION_ORDER = ['transient', 'short-term', 'standard', 'extended', 'indefinite'];
+
+function classifyDirection(order: string[], previous: string, current: string): 'higher' | 'lower' | 'unknown' {
+  const previousIndex = order.indexOf(previous.toLowerCase());
+  const currentIndex = order.indexOf(current.toLowerCase());
+
+  if (previousIndex === -1 || currentIndex === -1) {
+    return 'unknown';
+  }
+
+  if (currentIndex === previousIndex) {
+    return 'unknown';
+  }
+
+  return currentIndex > previousIndex ? 'higher' : 'lower';
+}
+
+function impactForTag(tag: keyof PolicyTags, previous: string, current: string): string {
+  if (!previous || previous === 'n/a') {
+    return `Initial ${tag} set to ${current}.`;
+  }
+
+  switch (tag) {
+    case 'sensitivity': {
+      const direction = classifyDirection(SENSITIVITY_ORDER, previous, current);
+      if (direction === 'higher') {
+        return 'Escalate data handling and access controls.';
+      }
+      if (direction === 'lower') {
+        return 'Data sensitivity reduced; review if controls can be relaxed safely.';
+      }
+      return 'Sensitivity level adjusted; communicate handling requirements.';
+    }
+    case 'residency':
+      return 'Update deployment and storage to honor residency obligations.';
+    case 'retentionClass': {
+      const direction = classifyDirection(RETENTION_ORDER, previous, current);
+      if (direction === 'higher') {
+        return 'Retention window extended; confirm archival and deletion workflows.';
+      }
+      if (direction === 'lower') {
+        return 'Retention shortened; ensure accelerated purge routines.';
+      }
+      return 'Retention policy changed; notify compliance stakeholders.';
+    }
+    default:
+      return 'Policy tag updated; assess governance implications.';
+  }
+}
+
+export function diffPolicyTags(previous: PolicyTags | null, current: PolicyTags): TagDiffReport {
+  const orderedTags: (keyof PolicyTags)[] = ['sensitivity', 'residency', 'retentionClass'];
+  const changes: TagChange[] = [];
+
+  for (const tag of orderedTags) {
+    const previousValue = previous ? previous[tag] : 'n/a';
+    const currentValue = current[tag];
+
+    if (!previous || previousValue !== currentValue) {
+      changes.push({
+        tag,
+        previous: previousValue,
+        current: currentValue,
+        impact: impactForTag(tag, previousValue, currentValue),
+      });
+    }
+  }
+
+  const hasChanges = changes.length > 0;
+
+  let summary: string;
+  if (!previous) {
+    const summaryParts = orderedTags.map((tag) => `${tag}: ${current[tag]}`);
+    summary = `Initial policy tags established (${summaryParts.join(', ')}).`;
+  } else if (!hasChanges) {
+    const summaryParts = orderedTags.map((tag) => `${tag}=${current[tag]}`);
+    summary = `Policy tags unchanged (${summaryParts.join(', ')}).`;
+  } else {
+    const lines = changes.map(
+      (change) => `- ${change.tag}: ${change.previous} -> ${change.current} (Impact: ${change.impact})`,
+    );
+    summary = `Policy tag updates detected:\n${lines.join('\n')}`;
+  }
+
+  return { hasChanges, changes, summary };
+}

--- a/src/fsr-pt/clientGenerator.ts
+++ b/src/fsr-pt/clientGenerator.ts
@@ -1,0 +1,235 @@
+import { JsonSchema, SchemaHistoryEntry } from './types.js';
+
+interface PropertyDescriptor {
+  name: string;
+  type: string;
+  required: boolean;
+}
+
+function toPascalCase(value: string): string {
+  const core = value
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+  const candidate = core.length > 0 ? core : 'Schema';
+  return /^[A-Za-z]/.test(candidate) ? candidate : `Schema${candidate}`;
+}
+
+function toCamelCase(value: string): string {
+  const pascal = toPascalCase(value);
+  const lowered = pascal.charAt(0).toLowerCase() + pascal.slice(1);
+  return /^[A-Za-z]/.test(lowered) ? lowered : `schema${pascal}`;
+}
+
+function versionIdentifier(version: string): string {
+  return version.replace(/[^a-zA-Z0-9]/g, '_');
+}
+
+function getPropertyDescriptors(schema: JsonSchema): PropertyDescriptor[] {
+  const properties = (schema?.properties ?? {}) as Record<string, JsonSchema>;
+  const required = new Set<string>(Array.isArray(schema?.required) ? (schema.required as string[]) : []);
+
+  return Object.keys(properties)
+    .sort()
+    .map((key) => {
+      const descriptor = properties[key] as JsonSchema;
+      const type = typeof descriptor?.type === 'string' ? (descriptor.type as string) : 'unknown';
+      return {
+        name: key,
+        type,
+        required: required.has(key),
+      };
+    });
+}
+
+function tsPropertyName(name: string): string {
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+    return name;
+  }
+
+  return `'${name.replace(/'/g, "\\'")}'`;
+}
+
+function tsTypeFor(jsonType: string): string {
+  switch (jsonType) {
+    case 'string':
+      return 'string';
+    case 'number':
+    case 'integer':
+      return 'number';
+    case 'boolean':
+      return 'boolean';
+    case 'array':
+      return 'unknown[]';
+    case 'object':
+      return 'Record<string, unknown>';
+    default:
+      return 'unknown';
+  }
+}
+
+function pythonFieldName(name: string): { fieldName: string; alias?: string } {
+  const sanitized = name
+    .replace(/[^0-9A-Za-z_]/g, '_')
+    .replace(/^[^A-Za-z_]+/, (match) => `field_${match}`);
+
+  if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(sanitized)) {
+    if (sanitized === name) {
+      return { fieldName: sanitized };
+    }
+    return { fieldName: sanitized, alias: name };
+  }
+
+  return { fieldName: `field_${sanitized}`, alias: name };
+}
+
+function pythonTypeFor(jsonType: string, optional: boolean): string {
+  const baseType = (() => {
+    switch (jsonType) {
+      case 'string':
+        return 'str';
+      case 'number':
+        return 'float';
+      case 'integer':
+        return 'int';
+      case 'boolean':
+        return 'bool';
+      case 'array':
+        return 'List[Any]';
+      case 'object':
+        return 'Dict[str, Any]';
+      default:
+        return 'Any';
+    }
+  })();
+
+  return optional ? `Optional[${baseType}]` : baseType;
+}
+
+function toTypescriptLiteral(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+function toPythonLiteral(value: unknown, indent = 0): string {
+  if (value === null) {
+    return 'None';
+  }
+
+  if (typeof value === 'string') {
+    return `'${value.replace(/'/g, "\\'")}'`;
+  }
+
+  if (typeof value === 'number' || typeof value === 'bigint') {
+    return String(value);
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 'True' : 'False';
+  }
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) {
+      return '[]';
+    }
+    const nextIndent = indent + 2;
+    const joined = value
+      .map((item) => `${' '.repeat(nextIndent)}${toPythonLiteral(item, nextIndent)}`)
+      .join(',\n');
+    return `[\n${joined}\n${' '.repeat(indent)}]`;
+  }
+
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) => a.localeCompare(b));
+    if (entries.length === 0) {
+      return '{}';
+    }
+    const nextIndent = indent + 2;
+    const body = entries
+      .map(
+        ([key, val]) =>
+          `${' '.repeat(nextIndent)}'${key.replace(/'/g, "\\'")}': ${toPythonLiteral(val, nextIndent)}`,
+      )
+      .join(',\n');
+    return `{\n${body}\n${' '.repeat(indent)}}`;
+  }
+
+  return 'None';
+}
+
+export function generateTypescriptClient(entry: SchemaHistoryEntry): string {
+  const descriptors = getPropertyDescriptors(entry.schema);
+  const interfaceName = `${toPascalCase(entry.name)}V${versionIdentifier(entry.version)}`;
+  const metadataConst = `${toCamelCase(entry.name)}${versionIdentifier(entry.version)}Metadata`;
+  const metadata = {
+    silo: entry.silo,
+    name: entry.name,
+    version: entry.version,
+    policyTags: entry.policyTags,
+    schema: entry.schema,
+    registeredAt: entry.registeredAt.toISOString(),
+  };
+
+  const interfaceBody =
+    descriptors.length === 0
+      ? '  [key: string]: unknown;'
+      : descriptors
+          .map((descriptor) =>
+            `  ${tsPropertyName(descriptor.name)}${descriptor.required ? '' : '?'}: ${tsTypeFor(descriptor.type)};`,
+          )
+          .join('\n');
+
+  const docSummary = `Schema for ${entry.name} (v${entry.version}) in silo ${entry.silo}.`;
+  const tagSummary = `Policy tags: sensitivity=${entry.policyTags.sensitivity}, residency=${entry.policyTags.residency}, retentionClass=${entry.policyTags.retentionClass}.`;
+
+  return `/* Auto-generated by fsr-pt */\n` +
+    `/**\n * ${docSummary}\n * ${tagSummary}\n */\n` +
+    `export interface ${interfaceName} {\n${interfaceBody}\n}\n\n` +
+    `export const ${metadataConst} = ${toTypescriptLiteral(metadata)} as const;\n\n` +
+    `export function get${interfaceName}PolicyTags() {\n  return ${metadataConst}.policyTags;\n}\n`;
+}
+
+export function generatePythonClient(entry: SchemaHistoryEntry): string {
+  const descriptors = getPropertyDescriptors(entry.schema);
+  const className = `${toPascalCase(entry.name)}V${versionIdentifier(entry.version)}`;
+  const metadata = {
+    'silo': entry.silo,
+    'name': entry.name,
+    'version': entry.version,
+    'policyTags': entry.policyTags,
+    'schema': entry.schema,
+    'registeredAt': entry.registeredAt.toISOString(),
+  };
+
+  const fields = descriptors.length
+    ? descriptors
+        .map((descriptor) => {
+          const { fieldName, alias } = pythonFieldName(descriptor.name);
+          const pythonType = pythonTypeFor(descriptor.type, !descriptor.required);
+          const comment = alias ? `  # original: ${descriptor.name}` : '';
+          const defaultValue = descriptor.required ? '' : ' = None';
+          return `    ${fieldName}: ${pythonType}${defaultValue}${comment}`;
+        })
+        .join('\n')
+    : '    data: Optional[Dict[str, Any]] = None';
+
+  const imports = [
+    'from __future__ import annotations',
+    'from dataclasses import dataclass',
+    'from typing import Any, Dict, List, Optional',
+  ].join('\n');
+
+  const metadataLiteral = toPythonLiteral(metadata);
+
+  return `# Auto-generated by fsr-pt\n${imports}\n\nPOLICY_TAGS: Dict[str, str] = ${toPythonLiteral(entry.policyTags)}\nSCHEMA_DEFINITION: Dict[str, Any] = ${toPythonLiteral(entry.schema)}\n\n` +
+    `@dataclass\nclass ${className}:\n${fields}\n\n` +
+    `def get_${toSnakeCase(className)}_metadata() -> Dict[str, Any]:\n` +
+    `    return ${metadataLiteral}\n`;
+}
+
+function toSnakeCase(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/[^A-Za-z0-9]+/g, '_')
+    .toLowerCase();
+}

--- a/src/fsr-pt/index.ts
+++ b/src/fsr-pt/index.ts
@@ -1,0 +1,5 @@
+export * from './SchemaRegistry.js';
+export * from './types.js';
+export { diffPolicyTags } from './TagDiff.js';
+export { evaluateCompatibility, diffSchemas } from './SchemaCompatibility.js';
+export { generatePythonClient, generateTypescriptClient } from './clientGenerator.js';

--- a/src/fsr-pt/types.ts
+++ b/src/fsr-pt/types.ts
@@ -1,0 +1,57 @@
+export type JsonSchema = Record<string, unknown>;
+
+export interface PolicyTags {
+  sensitivity: string;
+  residency: string;
+  retentionClass: string;
+}
+
+export interface SchemaMetadata {
+  silo: string;
+  name: string;
+  version: string;
+  policyTags: PolicyTags;
+  schema: JsonSchema;
+  registeredAt: Date;
+}
+
+export interface PropertyChange {
+  property: string;
+  previous?: string;
+  current?: string;
+  changeType: 'added' | 'removed' | 'type-changed' | 'required-added' | 'required-removed';
+}
+
+export interface CompatibilityReport {
+  compatible: boolean;
+  breakingChanges: string[];
+  nonBreakingChanges: string[];
+}
+
+export interface TagChange {
+  tag: keyof PolicyTags;
+  previous: string;
+  current: string;
+  impact: string;
+}
+
+export interface TagDiffReport {
+  hasChanges: boolean;
+  changes: TagChange[];
+  summary: string;
+}
+
+export interface SchemaDiffReport {
+  propertyChanges: PropertyChange[];
+  tagDiff: TagDiffReport;
+  impactSummary: string[];
+}
+
+export interface RegistrationResult {
+  metadata: SchemaMetadata;
+  compatibility: CompatibilityReport;
+  diff: SchemaDiffReport;
+  isBreakingChange: boolean;
+}
+
+export interface SchemaHistoryEntry extends SchemaMetadata {}

--- a/test/fsr-pt/schemaRegistry.test.ts
+++ b/test/fsr-pt/schemaRegistry.test.ts
@@ -1,0 +1,116 @@
+import { SchemaRegistry, diffPolicyTags } from '../../src/fsr-pt/index.js';
+import type { JsonSchema, PolicyTags } from '../../src/fsr-pt/types.js';
+
+describe('Federated Schema Registry with Policy Tags', () => {
+  const baseSchema: JsonSchema = {
+    type: 'object',
+    properties: {
+      id: { type: 'string' },
+      status: { type: 'string' },
+    },
+    required: ['id'],
+  };
+
+  const baseTags: PolicyTags = {
+    sensitivity: 'internal',
+    residency: 'us-central',
+    retentionClass: 'standard',
+  };
+
+  it('registers schemas and computes compatibility with deterministic flags', () => {
+    const registry = new SchemaRegistry();
+
+    const first = registry.registerSchema('alpha', 'orders', '1.0.0', baseSchema, baseTags);
+    expect(first.compatibility.compatible).toBe(true);
+    expect(first.diff.tagDiff.summary).toContain('Initial policy tags established');
+
+    const relaxedSchema: JsonSchema = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        status: { type: 'string' },
+        note: { type: 'string' },
+      },
+      required: ['id'],
+    };
+
+    const relaxedTags: PolicyTags = {
+      ...baseTags,
+      retentionClass: 'extended',
+    };
+
+    const second = registry.registerSchema('alpha', 'orders', '1.1.0', relaxedSchema, relaxedTags);
+    expect(second.compatibility.compatible).toBe(true);
+    expect(second.compatibility.nonBreakingChanges).toEqual(['Property "note" was added.']);
+    expect(second.diff.tagDiff.summary).toContain('Policy tag updates detected');
+    expect(second.diff.impactSummary).toEqual([
+      'INFO: Property "note" was added.',
+      'TAG: Policy tag updates detected:',
+      'TAG: - retentionClass: standard -> extended (Impact: Retention window extended; confirm archival and deletion workflows.)',
+    ]);
+
+    const breakingSchema: JsonSchema = {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+      },
+      required: ['id'],
+    };
+
+    const hardenedTags: PolicyTags = {
+      sensitivity: 'confidential',
+      residency: 'us-central',
+      retentionClass: 'extended',
+    };
+
+    const third = registry.registerSchema('alpha', 'orders', '2.0.0', breakingSchema, hardenedTags);
+    expect(third.isBreakingChange).toBe(true);
+    expect(third.compatibility.breakingChanges).toEqual(['Property "note" was removed.', 'Property "status" was removed.']);
+    expect(third.diff.tagDiff.summary).toContain('Policy tag updates detected');
+    expect(third.diff.impactSummary[0]).toBe('BREAKING: Property "note" was removed.');
+    expect(third.diff.impactSummary[1]).toBe('BREAKING: Property "status" was removed.');
+  });
+
+  it('produces clear tag diff impact summaries', () => {
+    const previous: PolicyTags = {
+      sensitivity: 'internal',
+      residency: 'eu-west',
+      retentionClass: 'standard',
+    };
+
+    const current: PolicyTags = {
+      sensitivity: 'restricted',
+      residency: 'eu-west',
+      retentionClass: 'indefinite',
+    };
+
+    const diff = diffPolicyTags(previous, current);
+    expect(diff.hasChanges).toBe(true);
+    expect(diff.summary).toContain('Policy tag updates detected');
+    expect(diff.changes).toEqual([
+      {
+        tag: 'sensitivity',
+        previous: 'internal',
+        current: 'restricted',
+        impact: 'Escalate data handling and access controls.',
+      },
+      {
+        tag: 'retentionClass',
+        previous: 'standard',
+        current: 'indefinite',
+        impact: 'Retention window extended; confirm archival and deletion workflows.',
+      },
+    ]);
+  });
+
+  it('generates client bindings with embedded policy metadata', () => {
+    const registry = new SchemaRegistry();
+    registry.registerSchema('silo-x', 'profile', '1.0.0', baseSchema, baseTags);
+    const bindings = registry.generateClientBindings('silo-x', 'profile', '1.0.0');
+
+    expect(bindings.typescript).toContain('Policy tags: sensitivity=');
+    expect(bindings.typescript).toContain('getProfileV1_0_0PolicyTags');
+    expect(bindings.python).toContain('POLICY_TAGS');
+    expect(bindings.python).toContain('policyTags');
+  });
+});


### PR DESCRIPTION
## Summary
- add a federated schema registry module that stores schema history with policy tags per silo
- implement compatibility analysis, tag-aware diffs, and TypeScript/Python client generation with embedded metadata
- cover registry workflows with targeted jest specifications for compatibility, tag summaries, and codegen output

## Testing
- pnpm exec jest --runInBand test/fsr-pt/schemaRegistry.test.ts *(fails: workspace dependencies are not installed and pnpm install aborts due to an invalid package name in apps/intelgraph-api)*

------
https://chatgpt.com/codex/tasks/task_e_68d767db2c648333b0cb49c08c0e3c87