### PR TITLE
feat: add knowledge cutoff router library

### DIFF
--- a/src/kcr/__tests__/router.test.ts
+++ b/src/kcr/__tests__/router.test.ts
@@ -1,0 +1,154 @@
+import { KnowledgeCutoffRouter } from '../router';
+import { RoutingSimulator } from '../simulator';
+import { RoutingConfig, SimulationQuery, RoutingError } from '../types';
+
+const config: RoutingConfig = {
+  defaultJurisdiction: 'US',
+  sources: [
+    {
+      id: 'snapshot-global-2021',
+      type: 'snapshot',
+      knowledgeCutoff: new Date('2021-09-30T00:00:00Z'),
+      validFrom: new Date('2020-01-01T00:00:00Z'),
+      jurisdictions: ['*'],
+      freshnessRisk: 'low',
+    },
+    {
+      id: 'model-us-2023',
+      type: 'model',
+      knowledgeCutoff: new Date('2023-11-30T00:00:00Z'),
+      validFrom: new Date('2023-01-01T00:00:00Z'),
+      jurisdictions: ['US'],
+      freshnessRisk: 'medium',
+    },
+    {
+      id: 'snapshot-us-2024-safe',
+      type: 'snapshot',
+      knowledgeCutoff: new Date('2024-05-15T00:00:00Z'),
+      validFrom: new Date('2023-08-01T00:00:00Z'),
+      jurisdictions: ['US'],
+      freshnessRisk: 'low',
+    },
+    {
+      id: 'model-us-2024-fast',
+      type: 'model',
+      knowledgeCutoff: new Date('2024-06-01T00:00:00Z'),
+      validFrom: new Date('2024-01-01T00:00:00Z'),
+      jurisdictions: ['US'],
+      freshnessRisk: 'high',
+    },
+    {
+      id: 'model-us-2024-future',
+      type: 'model',
+      knowledgeCutoff: new Date('2024-09-01T00:00:00Z'),
+      validFrom: new Date('2024-07-01T00:00:00Z'),
+      jurisdictions: ['US'],
+      freshnessRisk: 'medium',
+    },
+    {
+      id: 'snapshot-eu-2024',
+      type: 'snapshot',
+      knowledgeCutoff: new Date('2024-01-10T00:00:00Z'),
+      validFrom: new Date('2023-06-01T00:00:00Z'),
+      jurisdictions: ['EU'],
+      freshnessRisk: 'low',
+    },
+  ],
+};
+
+describe('KnowledgeCutoffRouter', () => {
+  const router = new KnowledgeCutoffRouter(config);
+
+  it('routes labeled queries to their expected sources', () => {
+    const simulator = new RoutingSimulator(router);
+    const queries: SimulationQuery[] = [
+      {
+        id: 'q1',
+        requestedDate: new Date('2024-03-01T00:00:00Z'),
+        jurisdiction: 'US',
+        expectedSourceId: 'model-us-2023',
+      },
+      {
+        id: 'q2',
+        requestedDate: new Date('2024-06-15T00:00:00Z'),
+        jurisdiction: 'US',
+        expectedSourceId: 'snapshot-us-2024-safe',
+      },
+      {
+        id: 'q3',
+        requestedDate: new Date('2024-06-15T00:00:00Z'),
+        jurisdiction: 'US',
+        riskTolerance: 'high',
+        expectedSourceId: 'model-us-2024-fast',
+      },
+      {
+        id: 'q4',
+        requestedDate: new Date('2024-02-01T00:00:00Z'),
+        jurisdiction: 'EU',
+        expectedSourceId: 'snapshot-eu-2024',
+      },
+      {
+        id: 'q5',
+        requestedDate: new Date('2021-11-01T00:00:00Z'),
+        jurisdiction: 'US',
+        expectedSourceId: 'snapshot-global-2021',
+      },
+    ];
+
+    const summary = simulator.run(queries);
+
+    expect(summary.correct).toBe(5);
+    expect(summary.incorrect).toBe(0);
+    expect(summary.total).toBe(5);
+  });
+
+  it('prevents leakage from post-cutoff sources by falling back to older knowledge', () => {
+    const decision = router.route({
+      requestedDate: new Date('2024-06-15T00:00:00Z'),
+      jurisdiction: 'US',
+    });
+
+    expect(decision.source.id).toBe('snapshot-us-2024-safe');
+    expect(decision.source.knowledgeCutoff.getTime()).toBeLessThanOrEqual(
+      new Date('2024-06-15T00:00:00Z').getTime(),
+    );
+    expect(decision.source.id).not.toBe('model-us-2024-future');
+  });
+
+  it('rejects routing when no jurisdiction matches and no default is provided', () => {
+    const isolated = new KnowledgeCutoffRouter({ sources: config.sources });
+
+    expect(() =>
+      isolated.route({
+        requestedDate: new Date('2024-03-01T00:00:00Z'),
+        jurisdiction: 'APAC',
+      }),
+    ).toThrow(RoutingError);
+  });
+});
+
+describe('RoutingSimulator', () => {
+  it('produces deterministic outcomes for the same inputs', () => {
+    const router = new KnowledgeCutoffRouter(config);
+    const simulator = new RoutingSimulator(router);
+    const queries: SimulationQuery[] = [
+      {
+        id: 'q-risk-medium',
+        requestedDate: new Date('2024-06-15T00:00:00Z'),
+        jurisdiction: 'US',
+      },
+      {
+        id: 'q-risk-high',
+        requestedDate: new Date('2024-06-15T00:00:00Z'),
+        jurisdiction: 'US',
+        riskTolerance: 'high',
+      },
+    ];
+
+    const firstRun = simulator.run(queries);
+    const secondRun = simulator.run(queries);
+
+    expect(firstRun).toEqual(secondRun);
+    expect(JSON.stringify(firstRun)).toBe(JSON.stringify(secondRun));
+  });
+});

--- a/src/kcr/index.ts
+++ b/src/kcr/index.ts
@@ -1,0 +1,3 @@
+export * from './router';
+export * from './simulator';
+export * from './types';

--- a/src/kcr/router.ts
+++ b/src/kcr/router.ts
@@ -1,0 +1,137 @@
+import {
+  FreshnessRisk,
+  KnowledgeSource,
+  RouteDecision,
+  RoutingConfig,
+  RoutingError,
+  RoutingQuery,
+} from './types';
+
+const riskRank: Record<FreshnessRisk, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+};
+
+const wildcardJurisdiction = '*';
+
+const toTime = (value: Date | undefined): number | undefined =>
+  value?.getTime();
+
+const cloneSource = (source: KnowledgeSource): KnowledgeSource => ({
+  ...source,
+  knowledgeCutoff: new Date(source.knowledgeCutoff),
+  validFrom: source.validFrom ? new Date(source.validFrom) : undefined,
+  jurisdictions: [...source.jurisdictions],
+  metadata: source.metadata ? { ...source.metadata } : undefined,
+});
+
+export class KnowledgeCutoffRouter {
+  private readonly sources: KnowledgeSource[];
+
+  constructor(private readonly config: RoutingConfig) {
+    if (!config.sources?.length) {
+      throw new RoutingError('KnowledgeCutoffRouter requires at least one source');
+    }
+
+    this.sources = config.sources
+      .map((source) => ({
+        ...cloneSource(source),
+        jurisdictions: source.jurisdictions.length
+          ? source.jurisdictions.map((j) => j.toUpperCase())
+          : [wildcardJurisdiction],
+      }))
+      .sort((a, b) => {
+        const cutoff = toTime(b.knowledgeCutoff)! - toTime(a.knowledgeCutoff)!;
+        if (cutoff !== 0) {
+          return cutoff;
+        }
+        const risk = riskRank[a.freshnessRisk] - riskRank[b.freshnessRisk];
+        if (risk !== 0) {
+          return risk;
+        }
+        if (a.type !== b.type) {
+          return a.type === 'snapshot' ? -1 : 1;
+        }
+        return a.id.localeCompare(b.id);
+      });
+  }
+
+  route(query: RoutingQuery): RouteDecision {
+    if (!query.requestedDate) {
+      throw new RoutingError('Routing query missing requestedDate');
+    }
+
+    const jurisdiction = this.resolveJurisdiction(query);
+    const tolerance = query.riskTolerance ?? 'medium';
+    const reasons: string[] = [];
+
+    const candidates = this.sources.filter((source) => {
+      if (!this.matchesJurisdiction(source, jurisdiction)) {
+        return false;
+      }
+
+      const cutoffTime = toTime(source.knowledgeCutoff)!;
+      const queryTime = toTime(query.requestedDate)!;
+      if (cutoffTime > queryTime) {
+        return false;
+      }
+
+      const validFrom = toTime(source.validFrom);
+      if (typeof validFrom === 'number' && validFrom > queryTime) {
+        return false;
+      }
+
+      return riskRank[source.freshnessRisk] <= riskRank[tolerance];
+    });
+
+    if (!candidates.length) {
+      throw new RoutingError('No compatible knowledge source found', {
+        jurisdiction,
+        requestedDate: query.requestedDate.toISOString(),
+        riskTolerance: tolerance,
+      });
+    }
+
+    const best = [...candidates].sort((a, b) => {
+      const cutoff = toTime(b.knowledgeCutoff)! - toTime(a.knowledgeCutoff)!;
+      if (cutoff !== 0) {
+        return cutoff;
+      }
+      const risk = riskRank[a.freshnessRisk] - riskRank[b.freshnessRisk];
+      if (risk !== 0) {
+        return risk;
+      }
+      if (a.type !== b.type) {
+        return a.type === 'snapshot' ? -1 : 1;
+      }
+      return a.id.localeCompare(b.id);
+    })[0];
+
+    reasons.push(
+      `selected highest allowable cutoff (${best.knowledgeCutoff.toISOString()}) for ${jurisdiction}`,
+    );
+
+    reasons.push(`freshness risk ${best.freshnessRisk} within tolerance ${tolerance}`);
+
+    return {
+      source: cloneSource(best),
+      reasons,
+    };
+  }
+
+  private resolveJurisdiction(query: RoutingQuery): string {
+    const jurisdiction = query.jurisdiction ?? this.config.defaultJurisdiction;
+    if (!jurisdiction) {
+      throw new RoutingError('Routing query missing jurisdiction and no default provided');
+    }
+    return jurisdiction.toUpperCase();
+  }
+
+  private matchesJurisdiction(source: KnowledgeSource, jurisdiction: string): boolean {
+    return (
+      source.jurisdictions.includes(wildcardJurisdiction) ||
+      source.jurisdictions.includes(jurisdiction)
+    );
+  }
+}

--- a/src/kcr/simulator.ts
+++ b/src/kcr/simulator.ts
@@ -1,0 +1,71 @@
+import { KnowledgeCutoffRouter } from './router';
+import {
+  SimulationQuery,
+  SimulationResult,
+  SimulationSummary,
+  RoutingError,
+} from './types';
+
+export class RoutingSimulator {
+  constructor(private readonly router: KnowledgeCutoffRouter) {}
+
+  run(queries: SimulationQuery[]): SimulationSummary {
+    const results: SimulationResult[] = queries.map((query) => {
+      try {
+        const decision = this.router.route(query);
+        const correct =
+          typeof query.expectedSourceId === 'string'
+            ? decision.source.id === query.expectedSourceId
+            : undefined;
+        const mismatchReason =
+          typeof correct === 'boolean' && !correct
+            ? `expected ${query.expectedSourceId} but received ${decision.source.id}`
+            : undefined;
+
+        return {
+          query,
+          decision,
+          correct,
+          mismatchReason,
+        };
+      } catch (error) {
+        if (error instanceof RoutingError) {
+          return {
+            query,
+            decision: {
+              source: {
+                id: 'unroutable',
+                type: 'snapshot',
+                knowledgeCutoff: query.requestedDate,
+                jurisdictions: [],
+                freshnessRisk: 'high',
+              },
+              reasons: [error.message],
+            },
+            correct: false,
+            mismatchReason: error.message,
+          };
+        }
+        throw error;
+      }
+    });
+
+    const totals = results.reduce(
+      (acc, result) => {
+        acc.total += 1;
+        if (result.correct === true) {
+          acc.correct += 1;
+        } else if (result.correct === false) {
+          acc.incorrect += 1;
+        }
+        return acc;
+      },
+      { total: 0, correct: 0, incorrect: 0 },
+    );
+
+    return {
+      results,
+      ...totals,
+    };
+  }
+}

--- a/src/kcr/types.ts
+++ b/src/kcr/types.ts
@@ -1,0 +1,56 @@
+export type FreshnessRisk = 'low' | 'medium' | 'high';
+
+export type KnowledgeSourceType = 'model' | 'snapshot';
+
+export interface KnowledgeSource {
+  id: string;
+  type: KnowledgeSourceType;
+  knowledgeCutoff: Date;
+  validFrom?: Date;
+  jurisdictions: string[];
+  freshnessRisk: FreshnessRisk;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RoutingConfig {
+  sources: KnowledgeSource[];
+  defaultJurisdiction?: string;
+}
+
+export interface RoutingQuery {
+  id?: string;
+  requestedDate: Date;
+  jurisdiction?: string;
+  riskTolerance?: FreshnessRisk;
+}
+
+export interface RouteDecision {
+  source: KnowledgeSource;
+  reasons: string[];
+}
+
+export interface SimulationQuery extends RoutingQuery {
+  label?: string;
+  expectedSourceId?: string;
+}
+
+export interface SimulationResult {
+  query: SimulationQuery;
+  decision: RouteDecision;
+  correct?: boolean;
+  mismatchReason?: string;
+}
+
+export interface SimulationSummary {
+  results: SimulationResult[];
+  total: number;
+  correct: number;
+  incorrect: number;
+}
+
+export class RoutingError extends Error {
+  constructor(message: string, public readonly context?: Record<string, unknown>) {
+    super(message);
+    this.name = 'RoutingError';
+  }
+}

--- a/tests/kcr-simulator.ts
+++ b/tests/kcr-simulator.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { KnowledgeCutoffRouter, RoutingSimulator, SimulationQuery } from '../src/kcr/index';
+import { RoutingConfig } from '../src/kcr/types';
+
+const config: RoutingConfig = {
+  defaultJurisdiction: 'US',
+  sources: [
+    {
+      id: 'snapshot-global-2021',
+      type: 'snapshot',
+      knowledgeCutoff: new Date('2021-09-30T00:00:00Z'),
+      validFrom: new Date('2020-01-01T00:00:00Z'),
+      jurisdictions: ['*'],
+      freshnessRisk: 'low',
+    },
+    {
+      id: 'model-us-2023',
+      type: 'model',
+      knowledgeCutoff: new Date('2023-11-30T00:00:00Z'),
+      validFrom: new Date('2023-01-01T00:00:00Z'),
+      jurisdictions: ['US'],
+      freshnessRisk: 'medium',
+    },
+    {
+      id: 'snapshot-us-2024-safe',
+      type: 'snapshot',
+      knowledgeCutoff: new Date('2024-05-15T00:00:00Z'),
+      validFrom: new Date('2023-08-01T00:00:00Z'),
+      jurisdictions: ['US'],
+      freshnessRisk: 'low',
+    },
+    {
+      id: 'model-us-2024-fast',
+      type: 'model',
+      knowledgeCutoff: new Date('2024-06-01T00:00:00Z'),
+      validFrom: new Date('2024-01-01T00:00:00Z'),
+      jurisdictions: ['US'],
+      freshnessRisk: 'high',
+    },
+    {
+      id: 'model-us-2024-future',
+      type: 'model',
+      knowledgeCutoff: new Date('2024-09-01T00:00:00Z'),
+      validFrom: new Date('2024-07-01T00:00:00Z'),
+      jurisdictions: ['US'],
+      freshnessRisk: 'medium',
+    },
+    {
+      id: 'snapshot-eu-2024',
+      type: 'snapshot',
+      knowledgeCutoff: new Date('2024-01-10T00:00:00Z'),
+      validFrom: new Date('2023-06-01T00:00:00Z'),
+      jurisdictions: ['EU'],
+      freshnessRisk: 'low',
+    },
+  ],
+};
+
+const router = new KnowledgeCutoffRouter(config);
+const simulator = new RoutingSimulator(router);
+
+const labeledQueries: SimulationQuery[] = [
+  {
+    id: 'q1',
+    requestedDate: new Date('2024-03-01T00:00:00Z'),
+    jurisdiction: 'US',
+    expectedSourceId: 'model-us-2023',
+  },
+  {
+    id: 'q2',
+    requestedDate: new Date('2024-06-15T00:00:00Z'),
+    jurisdiction: 'US',
+    expectedSourceId: 'snapshot-us-2024-safe',
+  },
+  {
+    id: 'q3',
+    requestedDate: new Date('2024-06-15T00:00:00Z'),
+    jurisdiction: 'US',
+    riskTolerance: 'high',
+    expectedSourceId: 'model-us-2024-fast',
+  },
+  {
+    id: 'q4',
+    requestedDate: new Date('2024-02-01T00:00:00Z'),
+    jurisdiction: 'EU',
+    expectedSourceId: 'snapshot-eu-2024',
+  },
+  {
+    id: 'q5',
+    requestedDate: new Date('2021-11-01T00:00:00Z'),
+    jurisdiction: 'US',
+    expectedSourceId: 'snapshot-global-2021',
+  },
+];
+
+const summary = simulator.run(labeledQueries);
+
+assert.equal(summary.correct, 5, 'all labeled queries should match expected sources');
+assert.equal(summary.incorrect, 0, 'no mismatches expected');
+assert.equal(summary.total, labeledQueries.length, 'total count should match input size');
+
+const fallbackDecision = router.route({
+  requestedDate: new Date('2024-06-15T00:00:00Z'),
+  jurisdiction: 'US',
+});
+
+assert.equal(
+  fallbackDecision.source.id,
+  'snapshot-us-2024-safe',
+  'router should fall back to the freshest permissible snapshot when risk tolerance is medium',
+);
+assert.ok(
+  fallbackDecision.source.knowledgeCutoff.getTime() <=
+    new Date('2024-06-15T00:00:00Z').getTime(),
+  'router must never select knowledge after the requested date',
+);
+
+const deterministicFirst = simulator.run(labeledQueries);
+const deterministicSecond = simulator.run(labeledQueries);
+
+assert.deepEqual(
+  deterministicFirst,
+  deterministicSecond,
+  'simulator should be deterministic for identical inputs',
+);
+
+console.log('KCR simulator tests passed');


### PR DESCRIPTION
## Summary
- add a reusable KnowledgeCutoffRouter that filters sources by jurisdiction, cutoff date, and freshness risk
- provide a deterministic RoutingSimulator plus typed exports for integrating KCR in other modules
- cover the router with labeled query tests and a deterministic simulation harness

## Testing
- npx --yes tsx@4.7.1 tests/kcr-simulator.ts

------
https://chatgpt.com/codex/tasks/task_e_68d769198a208333900d8adb3c7e7b8b