### PR TITLE
Add CompanyOS initiative build playbooks

### DIFF
--- a/project_management/companyos-jira.csv
+++ b/project_management/companyos-jira.csv
@@ -1,0 +1,268 @@
+Summary,Description,Issue Type,Story Points,Components,Labels,Acceptance Criteria
+COS-ID-SCIM-ABAC — OIDC/SCIM + ABAC Enforcement,"Goal: Enforce tenant-scoped ABAC while synchronizing identities through OIDC and SCIM v2.
+
+Scope:
+- Deliver OIDC login for console and API clients with tenant context injection.
+- Build a SCIM v2 role-to-COS role mapper that projects IdP groups into CompanyOS roles and tenants.
+- Apply OPA policy gates on every read/write, attach {tenant, purpose} metadata to requests, and stand up a documented break-glass user rotation.
+
+Implementation Plan:
+1. Draft the tenant/purpose ABAC matrix with Security and encode the rules in OPA rego modules supported by unit fixtures.
+2. Integrate OIDC libraries, configure token refresh + JWKS caching, and add middleware that derives tenant and purpose claims for downstream services.
+3. Stand up the SCIM webhook ingestion worker, map external groups to COS roles, and backfill existing assignments without downtime.
+4. Inject purpose metadata within service adapters, enforce OPA decisions at the edge and service layer, and emit structured audit events.
+5. Provision a break-glass admin account, automate credential rotation, and document escalation and validation steps.
+
+Telemetry & Ops:
+- Emit login success/failure metrics, OPA decision counts, and SCIM sync lag; alert on sustained failures.
+- Create dashboards covering denied decisions, drift detection, and break-glass activity.
+
+Documentation & Enablement:
+- Update console/API authentication guides, publish the break-glass runbook, and brief on-call on the escalation path.
+
+Tests:
+- Unit: ABAC allow/deny vectors across tenant and purpose dimensions.
+- Contract: SCIM webhook event → role visible and enforced via OPA.
+- E2E: login flow → verify access paths with and without declared purpose.
+
+RACI: R—App Eng; A—COS Lead; C—Security; I—SRE
+Estimate: 8 points
+Risks: Role drift; Mitigation: contract tests + drift alarms
+Dependencies: Policy Pack v0 already present",Story,8,CompanyOS,cos;identity;policy,"- SCIM role change takes effect in ≤60s across console and API surfaces.
+- Cross-tenant access attempts are denied with an OPA audit record.
+- Audit logs ship {sub, tenant, purpose, decision} to the SIEM within 2 minutes.
+- Break-glass rotation runbook exercised and signed off by Security." 
+COS-POL-FETCH — Policy Pack Consumer + OPA Hot-Reload,"Goal: Continuously pull and verify policy-pack-v0 while hot-reloading OPA without destabilizing traffic.
+
+Scope:
+- Use clients/cos-policy-fetcher to poll /v1/policy/packs/policy-pack-v0 with Sigstore verification.
+- Support ETag conditional GET with jittered backoff, persisting last-known-good bundles on failure.
+- Trigger sidecar or embedded OPA hot-reload and expose status endpoints.
+
+Implementation Plan:
+1. Implement polling scheduler with exponential backoff, cache busting, and metrics for digest age.
+2. Add SHA256 + Sigstore signature verification and fail closed on mismatch.
+3. Persist policy bundles atomically (write temp → move) and wire last-known-good fallback logic.
+4. Invoke OPA reload hooks (sidecar or embedded) and surface health probes reflecting bundle freshness.
+5. Document operational playbooks for manual rollbacks and failure inspection.
+
+Telemetry & Ops:
+- Emit metrics for fetch latency, bundle digest age, reload successes/failures, and fallback activations.
+- Provide Grafana panels and alerts on stale policy (>15m) and repeated verification failures.
+
+Documentation & Enablement:
+- Update policy loader README, add troubleshooting FAQ, and brief MC integrators on expected headers.
+
+Tests:
+- Contract: digest mismatch results in a hard failure and last-known-good retention.
+- E2E: swap pack → OPA decisions reflect the new policy within 30s.
+- Load: simulate 5xx spike scenario to validate the 0.5% ceiling.
+
+RACI: R—App Eng; A—COS Lead; C—Security; I—MC
+Estimate: 5 points
+Risks: Reload race; Mitigation: atomic bundle swap + canary reload
+Dependencies: Pack route & attestation live (done)",Story,5,CompanyOS,cos;policy-pack,"- On new digest, reload completes in ≤30s with policy version metric updated.
+- No >0.5% 5xx spike observed during induced reload tests.
+- Unsigned or mismatched packs are rejected with alerts to App Eng + Security.
+- Last-known-good bundle continues serving decisions when fetch fails." 
+COS-EVIDENCE-PUB — Publish Evidence (SLO+Cost) to MC,"Goal: Emit canonical release Evidence payloads with SLO and cost telemetry to the MC GraphQL API.
+
+Scope:
+- Implement a resilient client for publishEvidence including Sigstore token handling and retries.
+- Attach SBOM/test hashes, p95/p99/errorRate metrics, and unit cost data sourced from observability pipelines.
+- Correlate releaseId from pod/rollout labels and ensure idempotent submissions.
+
+Implementation Plan:
+1. Define the Evidence payload schema with MC, covering metadata, telemetry, and provenance hashes.
+2. Build a client module with exponential retry, jitter, and idempotency keys keyed on releaseId.
+3. Integrate observability exporters to collect p95/p99/errorRate/unit cost snapshots during rollout.
+4. Gather SBOM + test artifact hashes from CI and embed references in the payload.
+5. Expose operational metrics (success/failure counts) and document manual replay procedures.
+
+Telemetry & Ops:
+- Emit metrics for publish latency, retry counts, and dedupe hits; alert on sustained failure.
+- Provide dashboards for release evidence status across environments.
+
+Documentation & Enablement:
+- Update release engineering guides, annotate rollout checklist, and share example payloads with Finance and MC teams.
+
+Tests:
+- Unit: payload schema validation, redaction checks for sensitive fields, and retry limiter coverage.
+- Contract: GraphQL publishEvidence invocation verified against MC sandbox.
+- E2E: rollout pipeline → evidenceOk==true when metrics under thresholds, including duplicate submission test.
+
+RACI: R—Backend Eng; A—COS Lead; C—MC; I—SRE, Finance
+Estimate: 5 points
+Risks: Token leakage; Mitigation: Secret storage + least privilege + secret rotation
+Dependencies: MC endpoint/token",Story,5,CompanyOS,cos;mc;telemetry,"- Evidence appears in MC within 1 minute of rollout completion with correct releaseId.
+- Duplicate sends are de-duplicated and logged without creating duplicate records.
+- publishEvidence client exposes success/failure metrics and alerting hooks.
+- Finance and MC stakeholders sign off on payload contents and redaction coverage." 
+COS-OTEL-SLO — OTEL Telemetry + SLO Dashboards,"Goal: Provide end-to-end traces, metrics, and logs enriched with {service, tenant, env, purpose} plus opinionated SLO dashboards and alerts.
+
+Scope:
+- Export OTLP data from services, propagate trace IDs into logs, and normalize tenant + purpose labels.
+- Build Grafana dashboards for p95/p99 latency, error budget burn, and unit cost by tenant.
+- Configure multi-window multi-burn-rate alerts for latency, error rate, and budget consumption.
+
+Implementation Plan:
+1. Update service instrumentation libraries to include tenant/purpose attributes and ensure trace-log correlation.
+2. Configure OTLP exporters (metrics, traces, logs) with resilient batching and secure endpoints.
+3. Design SLO definitions with Product + SRE, codify them in Terraform/YAML, and publish to Grafana.
+4. Build per-tenant dashboards with templated variables and document navigation paths.
+5. Create alerting policies for p95 breach, >2% error rate, and 80% burn, routing to on-call with noise controls.
+6. Run synthetic load to validate thresholds and capture runbooks for tuning.
+
+Telemetry & Ops:
+- Add metrics for ingestion lag, dropped spans, and alert firings; hook alerts into incident management.
+- Provide runbooks for tuning thresholds and handling noisy tenants.
+
+Documentation & Enablement:
+- Publish observability handbook updates, record walkthrough of dashboards, and share alert response SOPs.
+
+Tests:
+- Synthetic traffic hitting SLO thresholds to validate alert triggers and dashboard accuracy.
+- Chaos scenarios to ensure telemetry continuity during outages.
+
+RACI: R—SRE; A—SRE Lead; C—App Eng; I—MC
+Estimate: 8 points
+Risks: Noisy alerts; Mitigation: burn-rate rules + staged rollout
+Dependencies: None",Story,8,CompanyOS,cos;slo;observability,"- Synthetic load triggers latency, error, and burn-rate alerts with expected routing.
+- Per-tenant panels render with correct templating and latency/error metrics.
+- Dashboards include unit cost overlays sourced from telemetry exporters.
+- Alert runbooks validated with on-call sign-off." 
+COS-ROLLOUT-GATE — Argo Evidence-Gated Promotion,"Goal: Gate canary promotions at 20%/50% based on MC evidenceOk signals, ensuring automated rollback when quality gates fail.
+
+Scope:
+- Apply an Argo AnalysisTemplate (web or job provider) that queries MC evidenceOk via ConfigMap + Secret token.
+- Ensure release-id labels on pods/deployments and maintain a rollback playbook.
+- Integrate gate status into deployment notifications and audit logs.
+
+Implementation Plan:
+1. Design the AnalysisTemplate with parametrized releaseId and MC endpoint, including success/failure conditions.
+2. Store MC API token in External Secret, mount as Secret, and configure ConfigMap for query payloads.
+3. Update deployment manifests to guarantee release-id labels and propagate to workloads.
+4. Wire Argo Rollouts steps at 20% and 50% with automatic pause + evaluation + promotion/abort logic.
+5. Document rollback playbook covering manual override, token rotation, and evidence troubleshooting.
+6. Add notification hooks (Slack/PagerDuty) for gate outcomes and record events in deployment audit logs.
+
+Telemetry & Ops:
+- Emit metrics for gate evaluations, pass/fail counts, and rollback durations; alert on repeated failures.
+- Create dashboards tracking promotion outcomes per environment.
+
+Documentation & Enablement:
+- Update release engineering runbooks, train on-call on manual override, and share sample MC responses.
+
+Tests:
+- Dry-run analysis with mocked evidenceOk responses to validate gating logic.
+- Failure path halts rollout and triggers rollback automation within SLA.
+- Integration test ensures release-id propagation and notification delivery.
+
+RACI: R—SRE; A—COS Lead; C—MC; I—On-call
+Estimate: 5 points
+Risks: Flaky checks; Mitigation: retry/backoff + manual override guardrails
+Dependencies: COS-EVIDENCE-PUB, MC evidenceOk",Story,5,CompanyOS,cos;argo;rollout,"- Gate blocks when evidenceOk is false and records reason codes in rollout history.
+- Auto-rollback restores prior stable version within 5 minutes end-to-end.
+- Promotion notifications reflect gate results and include rollout + releaseId context.
+- Manual override documented and approved by COS Lead + MC." 
+COS-RET-RTBF — Retention & Right-to-be-Forgotten,"Goal: Enforce data retention tiers and right-to-be-forgotten (RTBF) workflows with auditable controls.
+
+Scope:
+- Tag entities with retention tiers, schedule deletion/anonymization jobs, and enforce purpose limitations.
+- Implement RTBF flow: intake request → authorize → execute → audit with cryptographic receipts.
+- Ensure PITR restores exclude tombstoned data and that RTBF actions propagate to replicas.
+
+Implementation Plan:
+1. Catalogue data assets, assign retention tiers, and codify rules in policy-pack retention.json.
+2. Build scheduler + workers for tier-based deletion/anonymization with dry-run and sampling modes.
+3. Implement RTBF service handling request validation, authorization workflow, execution, and audit log emission.
+4. Add PITR guardrails ensuring tombstoned data is filtered during restore and add verification scripts.
+5. Coordinate with Legal/Security for approval workflows and document manual review steps.
+6. Provide dashboards for retention job success/failure and RTBF throughput.
+
+Telemetry & Ops:
+- Emit metrics for deletion backlog, RTBF duration, and restore validation results; alert on deviations.
+- Archive signed RTBF receipts and integrate with compliance storage.
+
+Documentation & Enablement:
+- Publish retention policy handbook, RTBF runbook, and training materials for support + legal review.
+
+Tests:
+- Unit: retention calculators, anonymization functions, and PITR exclusion logic.
+- E2E: RTBF on sample subject covering approval, execution, audit, and restore validation.
+- Compliance tabletop to validate legal + security checkpoints.
+
+RACI: R—Data Eng; A—COS Lead; C—Legal/Security; I—SRE
+Estimate: 13 points
+Risks: Over-delete; Mitigation: dry-run + sample audit + staged rollout
+Dependencies: Policy Pack retention.json",Story,13,CompanyOS,cos;data-compliance,"- Scheduled job removes or anonymizes data per tier with audit trails stored.
+- RTBF requests complete with signed audit receipts and legal approval records.
+- Restore process demonstrates that deleted PII is not resurrected in PITR tests.
+- Compliance sign-off received from Legal and Security." 
+COS-HELM-HARDEN — Charts, Limits, Secrets,"Goal: Harden Helm charts for production with least privilege, resilience, and externalized secrets.
+
+Scope:
+- Define requests/limits, probes, PDB, securityContext (runAsNonRoot, fsGroup, seccomp) for all workloads.
+- Configure HPA/VPA policies, anti-affinity, External Secrets integration, and image digest pinning.
+- Remove plaintext secrets from charts, relying on external secret managers and sealed secrets where needed.
+
+Implementation Plan:
+1. Inventory all charts, document current gaps, and prioritize remediation order.
+2. Add resource requests/limits, liveness/readiness probes, and PodDisruptionBudgets with environment overrides.
+3. Apply security contexts (runAsNonRoot, fsGroup, seccomp) and enforce restricted Pod Security Standards.
+4. Integrate External Secrets, convert existing plaintext secrets, and add image digest pinning to CI workflows.
+5. Configure HPA/VPA with guarded scaling ranges, anti-affinity rules, and chaos testing hooks.
+6. Run helm lint, kube-bench, and CIS scans; fix findings and document deviations.
+
+Telemetry & Ops:
+- Emit metrics for HPA/VPA activity, pod disruptions, and External Secret sync status.
+- Create dashboards for capacity, disruption budgets, and chaos test outcomes.
+
+Documentation & Enablement:
+- Update deployment playbooks, provide security review summary, and share remediation checklist with Platform.
+
+Tests:
+- kube-bench/gate, pod-security admission tests, and chaos experiments validating error budget impact.
+- CI gating to ensure helm lint + conftest/OPA policies pass.
+
+RACI: R—Platform; A—SRE Lead; C—Security; I—COS
+Estimate: 8 points
+Risks: HPA thrash; Mitigation: disable scale-to-zero off-peak + tuned scaling thresholds
+Dependencies: None",Story,8,CompanyOS,cos;helm;platform,"- helm lint, conftest, and security scans pass with documented exceptions only.
+- CIS compliance checks succeed with approvals from Security.
+- Chaos kill tests stay within agreed error budgets and auto-recovery works.
+- No plaintext secrets remain in charts; External Secrets sync dashboard is green." 
+COS-PACT-E2E — Pact-style Contract + End-to-End Cold-Start,"Goal: Prevent seam drift with Pact contracts and prove both standalone and MC-integrated cold-start paths meet SLOs.
+
+Scope:
+- Author Pact tests covering headers (Content-Type, Digest, ETag) and /attestation payload contracts.
+- Build E2E workflows for standalone mode (local users/policy) and MC-integrated mode (fetch+reload+evidence).
+- Execute k6 load testing validating p95 ≤350ms reads and ≤700ms writes at target RPS.
+
+Implementation Plan:
+1. Define provider/consumer contract scenarios with QA/Eng, encode in Pact files, and set up CI broker publishing.
+2. Implement provider verification in CI gating upstream services and assert header/body invariants.
+3. Automate standalone environment bootstrapping with local policy pack + user seeds and smoke validations.
+4. Automate MC-integrated path: fetch policy pack, hot-reload, emit evidence, and assert readiness checks.
+5. Author k6 scripts with staged ramp, run in CI with thresholds, and publish trend dashboards.
+6. Document troubleshooting guides for contract failures, cold-start issues, and load regressions.
+
+Telemetry & Ops:
+- Track contract test pass/fail history, k6 latency percentiles, and cold-start durations.
+- Provide dashboards plus alerts when thresholds regress.
+
+Documentation & Enablement:
+- Publish contract testing handbook, load testing SOP, and environment bootstrapping guide.
+
+Tests:
+- Pact contract suites executed in CI for every change touching seam APIs.
+- End-to-end standalone + MC-integrated pipelines running nightly.
+- k6 load tests with threshold gates and artifact retention for analysis.
+
+RACI: R—QA/Eng; A—COS Lead; C—MC; I—SRE
+Estimate: 8 points
+Risks: Flaky k6 infrastructure; Mitigation: fixed RPS profile + isolated runners
+Dependencies: COS-POL-FETCH, COS-EVIDENCE-PUB",Story,8,CompanyOS,cos;testing;performance,"- Pact contracts fail on any seam change and block merges until updated + reviewed.
+- Standalone and MC-integrated E2E pipelines pass consecutively for two nights before release.
+- k6 load results meet latency thresholds with trends published to observability dashboards.
+- Runbooks for contract/load failures reviewed and acknowledged by QA/Eng + SRE." 

--- a/project_management/companyos/COS-EVIDENCE-PUB.md
+++ b/project_management/companyos/COS-EVIDENCE-PUB.md
@@ -1,0 +1,98 @@
+# COS-EVIDENCE-PUB — Publish Evidence (SLO+Cost) to MC
+
+## Goal
+Emit canonical release Evidence payloads enriched with SLO and cost telemetry to the MC GraphQL API, ensuring idempotent retries and stakeholder visibility within one minute of rollout completion.
+
+## Key Outcomes
+- Production-ready `publishEvidence` client with resilient retries, Sigstore token handling, and deduplication.
+- Evidence payload contains SBOM/test artifact hashes, latency/error metrics, and unit cost data correlated to `releaseId`.
+- Dashboards expose evidence submission status; duplicate sends logged and ignored.
+- Finance and MC stakeholders approve payload structure and redaction safeguards.
+
+## Architecture Overview
+| Component | Responsibility |
+| --- | --- |
+| Release Pipeline | Collects rollout metadata, triggers evidence submission job. |
+| Evidence Client | Builds payload, handles retries, signs requests, and ensures idempotency. |
+| Observability Aggregator | Supplies p95/p99 latency, error rates, and cost telemetry snapshots. |
+| Artifact Registry | Provides SBOM and test artifact hashes referenced in payload. |
+| MC GraphQL API | Receives evidence payload and surfaces `evidenceOk` signal. |
+| Metrics & Logging | Tracks submission attempts, successes, dedupe events, and latency. |
+
+### Data Flow
+1. Rollout job reads `releaseId` from pod/deployment labels and collects telemetry snapshots.
+2. Evidence client assembles payload including SBOM/test hashes, metrics, and provenance metadata.
+3. Client signs request using MC-issued token (stored in External Secrets) and executes GraphQL mutation with idempotency key.
+4. On success, MC returns status; client records outcome in metrics and logs.
+5. On failure, client retries with jittered exponential backoff and surfaces alert if thresholds exceeded.
+
+## Implementation Plan
+### Phase 0 — Alignment (Week 1)
+- Finalize payload schema with MC and Finance; document required fields and redaction rules.
+- Provision MC API token, configure secure secret storage, and set up sandbox access for contract tests.
+
+### Phase 1 — Client Development (Week 1)
+- Implement GraphQL client with typed schema, token injection, and idempotency key support.
+- Add payload builders for SBOM/test hash ingestion and telemetry snapshot formatting.
+- Build retry strategy with jitter, capped attempts, and dedupe detection on HTTP 409 responses.
+
+### Phase 2 — Integration (Week 2)
+- Wire client into rollout pipeline (Argo Workflow or CI job) with releaseId discovery.
+- Connect to observability APIs to fetch p95/p99/errorRate/unit cost metrics at rollout checkpoints.
+- Emit Prometheus metrics for submission latency, retries, dedupe counts, and failure rates.
+
+### Phase 3 — Validation & Docs (Week 2)
+- Run contract tests against MC sandbox, capturing golden payload fixtures.
+- Execute end-to-end rollout simulation verifying `evidenceOk==true` when thresholds satisfied.
+- Publish runbooks for manual replay, token rotation, and failure triage.
+
+## Work Breakdown Structure
+| Task | Owner | Duration | Dependencies |
+| --- | --- | --- | --- |
+| Payload schema alignment workshop | Backend Eng + MC + Finance | 2d | None |
+| GraphQL client scaffolding | Backend Eng | 2d | Workshop |
+| Retry + dedupe logic | Backend Eng | 2d | Client scaffold |
+| Telemetry integration | Backend Eng + SRE | 2d | Client scaffold |
+| SBOM/test hash ingestion | Backend Eng | 1d | Artifact registry access |
+| Metrics/dashboard setup | Backend Eng + SRE | 2d | Integration |
+| Runbook creation & training | Backend Eng | 1d | Validation |
+
+## Testing Strategy
+- **Unit**: Payload schema validation, sensitive field redaction, retry limiter behavior.
+- **Contract**: GraphQL mutation tests using MC sandbox to verify response handling and dedupe recognition.
+- **E2E**: Rollout pipeline test ensuring evidence published within 1 minute and duplicates ignored.
+- **Security**: Pen test token handling and ensure secrets never logged.
+
+## Observability & Operations
+- Metrics: `evidence_publish_latency_seconds`, `evidence_publish_retries_total`, `evidence_publish_dedupe_total`, `evidence_publish_failures_total`.
+- Dashboards: Submission success rate by environment, outstanding failures, duplicate suppression trends.
+- Alerts: Failure rate >5% in 10m, publish latency >60s, repeated dedupe hits (indicator of pipeline loops).
+
+## Security & Compliance
+- Store MC API token in External Secrets with rotation cadence (60 days) and audit trail.
+- Mask sensitive data in logs; ensure SBOM/test hashes sanitized for PII.
+- Perform threat modeling for token leakage; limit scope to publishEvidence mutation.
+
+## Documentation & Enablement
+- Update release engineering handbook with evidence submission workflow.
+- Provide sample payloads and troubleshooting guide to Finance and MC stakeholders.
+- Record walkthrough demonstrating metrics dashboards and replay procedure.
+
+## Operational Readiness Checklist
+- [ ] Contract tests pass against MC sandbox with signed fixtures.
+- [ ] Evidence dashboards reviewed and approved by SRE and Finance.
+- [ ] Runbook published, linked in rollout checklist, and acknowledged by on-call.
+- [ ] Secret rotation procedure tested in staging.
+
+## Dependencies
+- MC endpoint and access token provisioned.
+
+## Risks & Mitigations
+- **Token leakage**: Use short-lived tokens, restrict scopes, audit every invocation.
+- **Telemetry lag**: Cache metrics snapshots prior to rollout, retry fetch with fallback values.
+
+## Acceptance Criteria
+- Evidence appears in MC within ≤1 minute of rollout completion with correct releaseId.
+- Duplicate submissions de-duplicated and logged without duplicate records.
+- publishEvidence client exposes success/failure metrics and alerting hooks.
+- Finance and MC stakeholders sign off on payload contents and redaction coverage.

--- a/project_management/companyos/COS-HELM-HARDEN.md
+++ b/project_management/companyos/COS-HELM-HARDEN.md
@@ -1,0 +1,96 @@
+# COS-HELM-HARDEN — Charts, Limits, Secrets
+
+## Goal
+Deliver production-grade Helm charts with resource governance, security hardening, and externalized secrets to support reliable CompanyOS deployments.
+
+## Key Outcomes
+- Helm charts enforce requests/limits, probes, PodDisruptionBudgets, and security contexts.
+- Workloads run as non-root with seccomp profiles, fsGroup, and image digests pinned.
+- Autoscaling (HPA/VPA), anti-affinity, and External Secrets integrated for each service.
+- Compliance validations (helm lint, CIS, pod-security admission) and chaos drills passed.
+
+## Architecture Overview
+| Component | Responsibility |
+| --- | --- |
+| Helm Charts | Templated manifests for services with values-driven configuration.
+| External Secrets | Syncs secrets from secret manager into Kubernetes secrets.
+| Autoscalers (HPA/VPA) | Manage scaling behavior within defined bounds.
+| Security Policies | PodSecurity + seccomp profiles enforced per namespace.
+| Chaos Testing Harness | Validates resilience under pod/node disruptions.
+
+## Implementation Plan
+### Phase 0 — Baseline Assessment (Week 1)
+- Audit existing Helm charts for gaps in security, scaling, and resource settings.
+- Align with SRE/Security on target CIS benchmarks and pod security standards.
+
+### Phase 1 — Resource & Health Hardening (Weeks 1-2)
+- Define CPU/memory requests & limits per workload using performance baselines.
+- Add liveness/readiness/startup probes; configure PodDisruptionBudgets and topology spread.
+- Implement anti-affinity to distribute replicas across zones/nodes.
+
+### Phase 2 — Security Contexts & Secrets (Weeks 2-3)
+- Set `runAsNonRoot`, `runAsUser`, `fsGroup`, `seccompProfile` defaults; disallow privilege escalation.
+- Pin container image digests and enforce registry scanning gates.
+- Integrate External Secrets references replacing inline Kubernetes secrets.
+
+### Phase 3 — Autoscaling & Resilience (Week 3)
+- Configure HPA (CPU/RPS-based) and VPA (recommendation mode) with guardrails.
+- Add PDB-aware chaos experiments (pod kill/node drain) ensuring error budget compliance.
+- Document scaling guidance and fallback procedures.
+
+### Phase 4 — Validation & Compliance (Week 4)
+- Run `helm lint`, CIS benchmark (`kube-bench`), and pod-security admission tests.
+- Execute chaos drill and capture metrics demonstrating error budget adherence.
+- Publish hardening checklist and update platform documentation.
+
+## Work Breakdown Structure
+| Task | Owner | Duration | Dependencies |
+| --- | --- | --- | --- |
+| Chart audit | Platform Eng | 3d | None |
+| Resource tuning | Platform Eng + SRE | 4d | Chart audit |
+| Probes & PDBs | Platform Eng | 3d | Resource tuning |
+| Security contexts | Platform Eng + Security | 4d | Probes |
+| External Secrets integration | Platform Eng | 3d | Security contexts |
+| Autoscaling config | Platform Eng + SRE | 4d | Secrets integration |
+| Chaos testing | Platform Eng + SRE | 3d | Autoscaling |
+| Compliance checks & docs | Platform Eng | 3d | Chaos testing |
+
+## Testing Strategy
+- **Static**: `helm lint`, schema validation, image digest enforcement tests.
+- **Security**: PodSecurity admission tests, CIS benchmark runs, vulnerability scan enforcement.
+- **Resilience**: Chaos experiments (pod kill, node drain) verifying error budgets maintained.
+- **Performance**: Load tests to confirm resource requests/limits sustain target throughput.
+
+## Observability & Operations
+- Metrics: `autoscaler_recommendations`, `pod_disruption_budget_violations`, `chaos_test_failures_total`.
+- Dashboards: Resource utilization vs limits, autoscaler actions, chaos outcomes.
+- Alerts: HPA thrash detection, External Secrets sync failures, pod security violations.
+
+## Security & Compliance
+- Enforce image signature verification (Cosign) with admission controller.
+- Rotate External Secrets credentials and audit access logs.
+- Document compliance evidence for security review.
+
+## Documentation & Enablement
+- Update platform deployment guide with new Helm values and defaults.
+- Provide cookbook for scaling adjustments and chaos drill procedures.
+- Train App Eng teams on adopting hardened chart patterns.
+
+## Operational Readiness Checklist
+- [ ] Helm charts pass linting and schema validation.
+- [ ] CIS and pod-security checks produce compliant reports stored in evidence repository.
+- [ ] Chaos drill completed with error budget impact ≤ defined threshold.
+- [ ] Documentation updated and reviewed by Security & SRE leads.
+
+## Dependencies
+- None beyond cluster tooling; External Secrets controller available.
+
+## Risks & Mitigations
+- **HPA thrash**: Implement scaling stabilization windows and disable scale-to-zero off-peak.
+- **Misconfigured limits**: Run performance profiling before production rollout.
+
+## Acceptance Criteria
+- helm lint runs clean with zero warnings.
+- CIS and pod-security admission checks pass for all workloads.
+- Chaos kill tests stay within error budget and validate rollback paths.
+- No plaintext secrets remain in chart values; all use External Secrets references.

--- a/project_management/companyos/COS-ID-SCIM-ABAC.md
+++ b/project_management/companyos/COS-ID-SCIM-ABAC.md
@@ -1,0 +1,113 @@
+# COS-ID-SCIM-ABAC — OIDC/SCIM + ABAC Enforcement
+
+## Goal
+Enforce tenant-scoped attribute-based access control (ABAC) while synchronizing identity data via OIDC and SCIM v2, ensuring purpose-based access decisions with comprehensive auditing and a secure break-glass process.
+
+## Key Outcomes
+- Unified login for console and API with tenant and purpose attributes propagated end-to-end.
+- Deterministic SCIM role-to-CompanyOS role mapping that updates within 60 seconds.
+- OPA-backed allow/deny decisions for all data plane operations, producing structured audit trails.
+- Documented break-glass account lifecycle with rotation and validation automation.
+
+## Architecture Overview
+| Component | Responsibility |
+| --- | --- |
+| Identity Provider (IdP) | Issues OIDC tokens and SCIM events; source of truth for groups. |
+| Auth Gateway | Performs OIDC flows, derives tenant/purpose claims, attaches metadata to requests. |
+| SCIM Worker | Consumes SCIM webhooks, maps IdP groups to COS roles/tenants, persists assignments. |
+| OPA Policy Engine | Evaluates ABAC rules authored in Rego and enforced at gateway and services. |
+| Audit Service | Collects `{sub, tenant, purpose, decision}` events and forwards to SIEM. |
+| Break-Glass Vault | Stores emergency credentials, rotation metadata, and access logs. |
+
+### Sequence Diagram (Textual)
+1. User authenticates via OIDC; Auth Gateway exchanges code for tokens and validates signatures.
+2. Gateway enriches request context with tenant + purpose attributes (from token claims or lookup) and queries OPA for decision.
+3. OPA evaluates ABAC policy pack (referencing tenant/purpose matrices) and returns allow/deny.
+4. Downstream services enforce decision; audit event emitted with full context.
+5. SCIM webhook posts role updates → SCIM Worker validates Sigstore signature, updates mapping store, notifies OPA bundle generator.
+
+## Implementation Plan
+### Phase 0 — Foundations (Week 1)
+- Finalize ABAC matrix with Security; model tenants, purposes, and resource actions.
+- Set up dedicated secrets for OIDC client credentials and SCIM signing keys using External Secrets.
+
+### Phase 1 — OIDC Integration (Weeks 1-2)
+- Implement PKCE/OAuth flows for console and API, including JWKS rotation and cache invalidation.
+- Extend session middleware to attach tenant + purpose attributes; fallback to directory lookup when absent.
+- Add login success/failure metrics and alerts for authentication anomalies.
+
+### Phase 2 — SCIM Synchronization (Weeks 2-3)
+- Build SCIM ingestion worker with replay protection, Sigstore validation, and exponential backoff retries.
+- Create group-to-role mapping store (PostgreSQL table) with change tracking for auditability.
+- Implement contract tests using MC sandbox data to ensure role projections align with expectations.
+
+### Phase 3 — ABAC Enforcement (Weeks 3-4)
+- Author Rego policies representing tenant/purpose rules; include regression fixtures and golden tests.
+- Embed OPA evaluation in gateway and service middleware; fail closed on policy evaluation errors.
+- Emit structured audit logs and forward to SIEM with dashboards for denied decisions.
+
+### Phase 4 — Break-Glass & Rollout (Week 4)
+- Provision break-glass user in vault; automate rotation via scheduled job and record validations.
+- Conduct dry-run incident exercising runbook and capture sign-offs from Security & SRE.
+- Stage rollout by environment with canary tenant to monitor for regressions.
+
+## Work Breakdown Structure
+| Task | Owner | Duration | Dependencies |
+| --- | --- | --- | --- |
+| ABAC policy modeling workshop | App Eng + Security | 2d | None |
+| OIDC middleware implementation | App Eng | 4d | Workshop |
+| SCIM worker scaffolding | App Eng | 3d | Secrets provisioned |
+| Rego policy authoring & tests | App Eng | 5d | Worker scaffolding |
+| Audit pipeline integration | App Eng + SRE | 2d | Rego decisions |
+| Break-glass runbook & automation | App Eng + Security | 3d | Audit pipeline |
+
+## Data Model Changes
+- New `tenant_roles` table keyed by `{identity_id, tenant_id}` with role + purpose attributes.
+- Extend audit log schema to include `purpose` and `decision_source` fields.
+
+## Testing Strategy
+### Unit Tests
+- Rego unit tests covering allow/deny vectors for each tenant and purpose combination.
+- SCIM payload parser and mapper tests verifying idempotency and validation failures.
+
+### Integration / Contract Tests
+- SCIM webhook contract tests using recorded fixtures to ensure updates visible in <60s.
+- OIDC token exchange tests verifying JWKS rotation and claim derivation.
+
+### End-to-End Tests
+- Synthetic login flows validating access with/without purpose set; verify denied paths produce audit records.
+- Chaos test toggling policy bundle to ensure fail-closed behavior.
+
+## Observability & Operations
+- Metrics: `auth_login_success`, `auth_login_failure`, `scim_sync_latency`, `opa_denied_total`.
+- Dashboards: Tenant-level access denials, SCIM lag, break-glass usage.
+- Alerts: High denied rate (>5% in 5m), SCIM lag >60s, break-glass credential age >14d.
+
+## Security & Compliance
+- Secrets stored in External Secrets; rotate OIDC client secret quarterly.
+- Maintain SCIM signing key fingerprint list with rotation procedure.
+- Ensure audit logs comply with retention policy and are access-controlled.
+
+## Documentation & Enablement
+- Update authentication guide with OIDC flows, purpose selection UI, and troubleshooting steps.
+- Publish break-glass rotation runbook and review with on-call.
+- Provide ABAC policy overview to stakeholders.
+
+## Operational Readiness Checklist
+- [ ] Security sign-off on ABAC matrix and Rego policies.
+- [ ] SRE validation of monitoring dashboards and alerts.
+- [ ] Break-glass drill completed with recorded evidence.
+- [ ] Runbook links added to on-call handbook.
+
+## Dependencies
+- Policy Pack v0 available in COS policy repository.
+
+## Risks & Mitigations
+- **Role drift**: Automated contract tests and nightly reconciliation job.
+- **Token misuse**: Enforce short-lived tokens and refresh with proof-of-possession (DPoP) where feasible.
+
+## Acceptance Criteria
+- SCIM role changes propagate to COS within ≤60 seconds for console and API.
+- Cross-tenant access attempts are denied with OPA audit records containing `{sub, tenant, purpose, decision}`.
+- Audit logs shipped to SIEM within 2 minutes, accessible in dashboards.
+- Break-glass rotation runbook executed and signed by Security.

--- a/project_management/companyos/COS-OTEL-SLO.md
+++ b/project_management/companyos/COS-OTEL-SLO.md
@@ -1,0 +1,95 @@
+# COS-OTEL-SLO — OTEL Telemetry + SLO Dashboards
+
+## Goal
+Deliver end-to-end OpenTelemetry-based traces, metrics, and logs enriched with `{service, tenant, env, purpose}` attributes, along with curated SLO dashboards and alerts for latency, error budgets, and unit cost.
+
+## Key Outcomes
+- Unified instrumentation library exporting OTLP data with tenant/purpose attributes.
+- Grafana dashboards for p95/p99 latency, error budget burn, and unit cost by tenant.
+- Multi-window, multi-burn-rate alerts firing on latency breaches, error rates >2%, and 80% budget consumption.
+- Runbooks and observability handbook updates enabling on-call to triage quickly.
+
+## Architecture Overview
+| Component | Responsibility |
+| --- | --- |
+| Instrumented Services | Emit traces, metrics, and logs with enriched attributes.
+| OTEL Collector | Receives OTLP data, batches/export to backend (e.g., Tempo, Prometheus, Loki).
+| Observability Backend | Stores traces, metrics, logs; feeds Grafana dashboards.
+| SLO Config Repo | Houses SLO definitions (YAML/Terraform) tracked in Git.
+| Alert Routing | Integrates with PagerDuty/Slack for incident notification.
+
+### Data Flow
+1. Service instrumentation captures request context and attaches `{tenant, purpose}` attributes.
+2. OTEL Collector batches data, applies tail sampling for high-cardinality traces, and exports to backend.
+3. SLO definitions compiled into backend (Prometheus + Cortex) to compute burn rates and error budgets.
+4. Grafana dashboards visualize per-tenant metrics; alerts trigger via Alertmanager with burn-rate logic.
+
+## Implementation Plan
+### Phase 0 — Discovery (Week 1)
+- Audit existing instrumentation coverage; identify gaps per service.
+- Align on SLO targets with Product, App Eng, and Finance (latency, error, cost).
+
+### Phase 1 — Instrumentation Upgrades (Weeks 1-2)
+- Update shared OTEL library to include tenant/purpose attributes; propagate trace IDs into logs.
+- Configure collectors for high-availability deployment, batching, and retries.
+- Add unit tests ensuring attribute propagation and log correlation.
+
+### Phase 2 — SLO Definition & Infrastructure (Week 2)
+- Author SLO YAML/Terraform modules capturing latency, error rate, and cost metrics.
+- Deploy SLO dashboards and alert rules to staging; validate calculations with sample data.
+- Implement burn-rate alerting (1h/6h windows) with 80% budget threshold notifications.
+
+### Phase 3 — Synthetic Validation & Runbooks (Week 3)
+- Build synthetic load jobs that drive metrics near thresholds to test alert behavior.
+- Document runbooks covering alert interpretation, mitigations, and escalation.
+- Conduct on-call training session reviewing dashboards and alerts.
+
+## Work Breakdown Structure
+| Task | Owner | Duration | Dependencies |
+| --- | --- | --- | --- |
+| Instrumentation audit | SRE + App Eng | 2d | None |
+| Library attribute enhancements | App Eng | 3d | Audit |
+| Collector configuration | SRE | 2d | Library enhancements |
+| SLO YAML authoring | SRE | 3d | Targets aligned |
+| Dashboard creation | SRE | 3d | SLO YAML |
+| Alert routing integration | SRE | 2d | Dashboard creation |
+| Synthetic load + runbooks | SRE + App Eng | 3d | Alerts configured |
+
+## Testing Strategy
+- **Unit**: Attribute propagation tests, log correlation tests, metric export verification.
+- **Integration**: Collector pipeline tests ensuring telemetry continuity during restart/failure.
+- **Synthetic**: Load tests hitting thresholds to validate alert firing and auto-resolve behavior.
+- **Chaos**: Drop collector pod to confirm failover and data continuity.
+
+## Observability & Operations
+- Metrics: `otel_exporter_queue_length`, `otel_span_dropped_total`, `slo_error_budget_remaining`, `slo_burn_rate`.
+- Dashboards: Global + per-tenant panels for latency, error rate, cost overlays.
+- Alerts: p95 latency breach, error rate >2%, 80% budget consumed in 6h window.
+
+## Security & Compliance
+- Ensure telemetry pipelines encrypted in transit (mTLS between services and collector).
+- Apply tenant data access controls to dashboards (folder permissions, multi-tenant safe variables).
+
+## Documentation & Enablement
+- Update observability handbook with instrumentation guidelines and attribute taxonomy.
+- Record video walkthrough of dashboards and alert triage.
+- Provide cheat sheet for on-call to quickly identify tenant-specific issues.
+
+## Operational Readiness Checklist
+- [ ] Synthetic load triggers each alert and demonstrates proper routing.
+- [ ] Dashboards reviewed and signed off by Product, SRE, and Finance.
+- [ ] Runbooks linked within alert annotations.
+- [ ] Observability configs stored in Git with peer review completed.
+
+## Dependencies
+- None (runs independently but consumes outputs from telemetry stack).
+
+## Risks & Mitigations
+- **Noisy alerts**: Use multi-window burn rates and staged rollout to tune thresholds.
+- **High cardinality**: Apply attribute cardinality controls and sampling strategies.
+
+## Acceptance Criteria
+- Synthetic load triggers latency, error, and burn-rate alerts with correct routing.
+- Per-tenant dashboards render accurately with templated variables.
+- Dashboards include unit cost overlays derived from telemetry exporters.
+- Alert runbooks validated with on-call sign-off.

--- a/project_management/companyos/COS-PACT-E2E.md
+++ b/project_management/companyos/COS-PACT-E2E.md
@@ -1,0 +1,96 @@
+# COS-PACT-E2E — Pact-style Contract + End-to-End Cold-Start
+
+## Goal
+Prevent seam drift between CompanyOS components by introducing Pact-style consumer/provider contracts and dual-mode end-to-end tests that validate both standalone (local policy) and integrated (MC-connected) operations, including performance load tests.
+
+## Key Outcomes
+- Pact contracts covering critical headers and `/attestation` endpoint semantics.
+- Cold-start E2E workflow validating standalone mode (local users/policy) and MC-integrated mode (policy fetch, evidence publish).
+- k6 load test ensuring p95 ≤350ms reads and ≤700ms writes at target RPS.
+- CI gating on contract, E2E, and load test thresholds with flaky test mitigations.
+
+## Architecture Overview
+| Component | Responsibility |
+| --- | --- |
+| Pact Consumer Tests | Define expectations for CompanyOS API clients (headers, responses).
+| Pact Provider Verification | Validates server responses against consumer contracts.
+| E2E Harness | Spins up environment with/without MC integrations for smoke tests.
+| k6 Load Suite | Exercises read/write paths to validate latency SLOs.
+| CI Pipeline | Orchestrates contract, E2E, and load tests; enforces thresholds.
+
+## Implementation Plan
+### Phase 0 — Contract Scoping (Week 1)
+- Identify APIs requiring contracts (login, `/attestation`, evidence publish callbacks).
+- Collaborate with MC to confirm header expectations and digest/ETag semantics.
+
+### Phase 1 — Pact Implementation (Weeks 1-2)
+- Implement Pact consumer tests capturing request/response headers, payloads, and error cases.
+- Build provider verification pipeline integrated with server test harness; ensure contract fixtures stored in repo.
+- Add contract verification to CI with failure triage notifications.
+
+### Phase 2 — E2E Dual-Mode Harness (Weeks 2-3)
+- Create infrastructure-as-code (Terraform/k8s manifests) for standalone mode (local policy, users) and integrated mode (MC + policy fetcher).
+- Automate environment bootstrap scripts to switch between modes and run smoke scenarios.
+- Validate policy fetch, OPA reload, and evidence publish flows end-to-end.
+
+### Phase 3 — Load Testing & CI Gating (Week 3)
+- Author k6 scripts simulating target RPS mix; collect metrics for p95 latency and error rates.
+- Integrate k6 execution into CI with threshold gating and artifact uploads (charts, raw metrics).
+- Implement retry/backoff wrappers for known flaky steps with telemetry.
+
+### Phase 4 — Documentation & Rollout (Week 4)
+- Document contract update process, versioning strategy, and release checklist.
+- Publish runbooks for running E2E harness locally and in CI.
+- Train QA/Engineering teams on interpreting k6 reports and debugging failures.
+
+## Work Breakdown Structure
+| Task | Owner | Duration | Dependencies |
+| --- | --- | --- | --- |
+| API contract scoping | QA/Eng + MC | 2d | None |
+| Pact consumer tests | QA/Eng | 3d | Scoping |
+| Provider verification | QA/Eng | 3d | Consumer tests |
+| CI integration for Pact | QA/Eng | 2d | Provider verification |
+| E2E harness standalone mode | QA/Eng | 4d | Pact CI |
+| E2E harness integrated mode | QA/Eng + App Eng | 4d | Standalone harness |
+| k6 script development | QA/Eng | 3d | Harness integrated |
+| CI gating & docs | QA/Eng | 3d | Load tests |
+
+## Testing Strategy
+- **Contract**: Pact consumer/provider tests fail on any seam change.
+- **E2E**: Standalone mode verifying local policy fallback; integrated mode verifying policy fetch, reload, evidence publish.
+- **Load**: k6 thresholds gating builds; collect CPU/memory metrics for regression tracking.
+- **Resilience**: Inject network faults between COS and MC to ensure graceful degradation (standalone fallback).
+
+## Observability & Operations
+- Metrics: `contract_test_failures_total`, `e2e_suite_duration_seconds`, `k6_threshold_breaches_total`.
+- Dashboards: CI trend lines for contract stability, E2E duration, load test latencies.
+- Alerts: CI failure notifications routed to QA/Engineering on contract/load regression.
+
+## Security & Compliance
+- Ensure Pact fixtures scrub sensitive data; store in version control with review.
+- Restrict MC credentials used in integrated mode to limited scope and ephemeral lifetime.
+
+## Documentation & Enablement
+- Add contract testing section to QA handbook describing update approvals.
+- Provide step-by-step guide for running E2E modes locally.
+- Share k6 report interpretation cheat sheet with Engineering teams.
+
+## Operational Readiness Checklist
+- [ ] Pact contracts reviewed and versioned with MC stakeholders.
+- [ ] E2E harness executed successfully in both modes with artifacts archived.
+- [ ] k6 load test passes thresholds and publishes report to CI artifacts.
+- [ ] Runbooks and documentation reviewed by QA lead.
+
+## Dependencies
+- COS-POL-FETCH and COS-EVIDENCE-PUB implemented to enable integrated mode.
+- MC sandbox credentials available for contract and E2E tests.
+
+## Risks & Mitigations
+- **Flaky k6 infra**: Use fixed RPS profiles, warm-up periods, and isolate environment resources.
+- **Contract churn**: Establish versioning strategy and change approval workflow with MC.
+
+## Acceptance Criteria
+- Pact tests fail on any seam change; builds blocked until updated.
+- E2E suite passes for standalone and integrated modes.
+- k6 load tests meet latency thresholds (≤350ms reads, ≤700ms writes) at target RPS.
+- CI pipeline gates merges on contract/E2E/load test results.

--- a/project_management/companyos/COS-POL-FETCH.md
+++ b/project_management/companyos/COS-POL-FETCH.md
@@ -1,0 +1,96 @@
+# COS-POL-FETCH — Policy Pack Consumer + OPA Hot-Reload
+
+## Goal
+Continuously pull and verify the `policy-pack-v0` bundle, validate integrity with SHA256 + Sigstore, and hot-reload OPA without causing customer-impacting errors.
+
+## Key Outcomes
+- Deterministic polling loop with conditional requests and resilient backoff.
+- Verified policy bundles stored atomically and rolled back to last-known-good on failures.
+- OPA reload events complete within 30 seconds and are observable via health endpoints.
+- Operational playbooks covering troubleshooting, manual rollbacks, and alert response.
+
+## Architecture Overview
+| Component | Responsibility |
+| --- | --- |
+| Policy Fetcher Service | Polls `/v1/policy/packs/policy-pack-v0`, handles verification, writes bundles. |
+| Sigstore Verifier | Validates signatures against trusted roots and transparency log. |
+| Bundle Store | Persistent volume or config map storing active and last-known-good bundles. |
+| OPA Sidecar/Embedded | Consumes bundles and exposes decision APIs + health metrics. |
+| Metrics Exporter | Publishes fetch latency, digest age, and reload success metrics. |
+
+### Fetch Flow
+1. Scheduler triggers fetch; sends conditional GET with cached ETag.
+2. Response verified (status 200/304). If new digest, compute SHA256 and verify Sigstore signature.
+3. Write bundle to temp location, fsync, then atomically move to `active` path while preserving previous version under `lkg/`.
+4. Notify OPA via control API or filesystem watch; wait for confirmation.
+5. Emit metrics and logs; on failure revert to previous bundle and raise alerts.
+
+## Implementation Plan
+### Phase 0 — Setup (Week 1)
+- Import `clients/cos-policy-fetcher` and configure base environment variables (poll interval, endpoints, trust roots).
+- Define configuration CRD (if Kubernetes) or environment config file for bundle locations.
+
+### Phase 1 — Polling & Verification (Week 1)
+- Implement conditional GET with `If-None-Match` and jittered interval to avoid thundering herd.
+- Add SHA256 checksum verification, Sigstore bundle validation, and failure telemetry.
+- Build fallback logic retaining last-known-good bundle and raising structured alerts on mismatch.
+
+### Phase 2 — Storage & Hot Reload (Week 2)
+- Implement atomic write flow (temp → fsync → rename) with cleanup of stale temporary files.
+- Integrate with OPA reload API (sidecar: HTTP POST; embedded: library call) and await success acknowledgment.
+- Expose `/healthz` endpoint reporting bundle version, digest age, and last reload timestamp.
+
+### Phase 3 — Observability & Docs (Week 2)
+- Wire Prometheus metrics (`bundle_digest_age_seconds`, `bundle_reload_failures_total`).
+- Create Grafana dashboards and alert rules (stale bundle >15m, reload failure rate >3 in 10m, 5xx spike >0.5%).
+- Produce troubleshooting guide and runbook for manual rollback.
+
+## Work Breakdown Structure
+| Task | Owner | Duration | Dependencies |
+| --- | --- | --- | --- |
+| Configure fetcher library and environment | App Eng | 2d | Setup |
+| Implement conditional GET + jitter | App Eng | 1d | Library configured |
+| Add signature verification | App Eng | 2d | Conditional GET |
+| Atomic storage + fallback | App Eng | 2d | Verification |
+| OPA reload integration | App Eng | 2d | Storage |
+| Metrics & dashboards | App Eng + SRE | 2d | Reload integration |
+| Runbook authoring | App Eng | 1d | Metrics |
+
+## Testing Strategy
+- **Unit**: Signature verification, conditional GET caching behavior, atomic write logic.
+- **Contract**: Simulate digest mismatch to ensure fetcher fails closed and retains last-known-good.
+- **E2E**: Swap policy pack in staging; verify OPA decisions change within 30s without >0.5% error spike.
+- **Load**: Inject network latency/failure scenarios to ensure backoff and fallback operate correctly.
+
+## Observability & Operations
+- Metrics: `policy_fetch_duration_seconds`, `policy_digest_age_seconds`, `policy_reload_success_total`, `policy_reload_failure_total`.
+- Alerts: Stale bundle >15m, consecutive reload failures (>=3), HTTP 5xx error rate >0.5% during reload windows.
+- Dashboard panels: Current digest, last reload, fallback activations, Sigstore validation status.
+
+## Security & Compliance
+- Trust root and Sigstore key material stored via External Secrets with rotation schedule.
+- Fetcher uses mTLS to connect to policy endpoint; audit fetch requests with correlation IDs.
+
+## Documentation & Enablement
+- Update policy loader README with configuration examples and failure handling matrix.
+- Provide FAQ for common errors (ETag mismatch, signature expiration, OPA reload failures).
+- Conduct knowledge transfer session with MC and SRE teams.
+
+## Operational Readiness Checklist
+- [ ] Staging dry run demonstrating automatic rollback to last-known-good.
+- [ ] Alerts integrated with on-call rotations.
+- [ ] Runbook reviewed and approved by Security.
+- [ ] Health endpoint registered with platform monitoring.
+
+## Dependencies
+- Policy pack endpoint and attestation pipeline already live.
+
+## Risks & Mitigations
+- **Reload race conditions**: Use file locks and sequential reload queue to prevent overlapping updates.
+- **Policy regression**: Stage canary reload; monitor decision metrics before promoting.
+
+## Acceptance Criteria
+- New digest triggers reload within ≤30 seconds and updates policy version metric.
+- No sustained >0.5% 5xx spike during controlled reload tests.
+- Unsigned or mismatched packs rejected with alerts to App Engineering and Security.
+- Last-known-good bundle remains active when fetch fails.

--- a/project_management/companyos/COS-RET-RTBF.md
+++ b/project_management/companyos/COS-RET-RTBF.md
@@ -1,0 +1,104 @@
+# COS-RET-RTBF — Retention & Right-to-be-Forgotten
+
+## Goal
+Enforce data retention tiers and implement a Right-to-be-Forgotten (RTBF) workflow with auditability, ensuring deleted/anonymized data is excluded from restores and access paths respect purpose limitations.
+
+## Key Outcomes
+- Tiered retention tagging across entities with scheduled deletion/anonymization jobs.
+- RTBF request workflow covering intake, authorization, execution, and signed audit records.
+- Purpose enforcement integrated with policy pack to prevent unauthorized resurrection of deleted PII.
+- Point-in-time restore verification ensuring tombstoned data remains excluded.
+
+## Architecture Overview
+| Component | Responsibility |
+| --- | --- |
+| Data Catalog | Stores entity metadata including retention tier and purpose tags.
+| Retention Scheduler | Orchestrates deletion/anonymization jobs per tier.
+| RTBF Service | Handles intake, approval, execution, and audit trail generation.
+| Policy Engine | Ensures requests include `{tenant, purpose}` metadata and respect retention policies.
+| PITR Validation Job | Confirms restores do not reintroduce deleted PII.
+| Audit Ledger | Records RTBF actions with signatures and approvals.
+
+### Workflow Overview
+1. Entities tagged with retention tier and purpose upon creation.
+2. Scheduler runs daily/weekly jobs to delete/anonymize data past retention deadlines.
+3. RTBF request initiated; authorization checks ensure legitimacy; execution anonymizes/deletes records across data stores.
+4. Audit ledger captures actions, approvals, and cryptographic signatures.
+5. PITR validation job restores snapshot to sandbox to confirm deleted data absent.
+
+## Implementation Plan
+### Phase 0 — Policy Alignment (Week 1)
+- Review retention.json from policy pack; map to data entities and storage systems.
+- Align with Legal/Security on RTBF SLAs and audit requirements.
+
+### Phase 1 — Data Tagging & Catalog (Weeks 1-2)
+- Update schemas to include `retention_tier` and `purpose` fields; backfill existing data.
+- Build catalog views/dashboards for retention coverage and upcoming expirations.
+
+### Phase 2 — Scheduler & Execution (Weeks 2-4)
+- Implement retention scheduler (Airflow/Temporal) with tier-specific cadence.
+- Develop anonymization/deletion routines per datastore (PostgreSQL, object storage, search indices).
+- Integrate purpose enforcement to ensure jobs run under appropriate service identities.
+
+### Phase 3 — RTBF Workflow (Weeks 3-5)
+- Build RTBF service with intake API, approval workflow, and execution engine.
+- Generate signed audit records (Sigstore) and store in append-only ledger.
+- Provide customer communication templates and status tracking.
+
+### Phase 4 — Validation & Restore Checks (Weeks 5-6)
+- Implement PITR validation job that restores backups to sandbox and verifies deleted PII absent.
+- Run dry-run RTBF on sample subjects; capture metrics and audit evidence.
+- Publish runbooks and training materials for support teams.
+
+## Work Breakdown Structure
+| Task | Owner | Duration | Dependencies |
+| --- | --- | --- | --- |
+| Retention policy mapping | Data Eng + Legal | 3d | None |
+| Schema updates & backfill | Data Eng | 5d | Policy mapping |
+| Scheduler implementation | Data Eng | 5d | Schema updates |
+| Datastore routines | Data Eng | 6d | Scheduler |
+| RTBF service build | Data Eng + Security | 7d | Routines |
+| Audit ledger integration | Data Eng | 3d | RTBF service |
+| PITR validation job | Data Eng + SRE | 4d | Audit ledger |
+| Runbooks & training | Data Eng | 3d | Validation |
+
+## Testing Strategy
+- **Unit**: Retention calculators, anonymization functions, purpose checks.
+- **Integration**: Scheduler-to-datastore integration tests ensuring transactions succeed/fail safely.
+- **E2E**: RTBF request from intake → execution → audit signature verification.
+- **Restore Validation**: Automated PITR job ensuring deleted data absent; fail pipeline if detected.
+
+## Observability & Operations
+- Metrics: `retention_jobs_run_total`, `rtbf_requests_total`, `rtbf_completion_seconds`, `pitr_validation_failures_total`.
+- Dashboards: Upcoming retention actions, RTBF status by tenant, audit ledger health.
+- Alerts: RTBF backlog > SLA, PITR validation failure, retention job errors.
+
+## Security & Compliance
+- Enforce least privilege for RTBF execution accounts; require MFA for approvals.
+- Store audit ledger in tamper-evident storage with cryptographic signatures.
+- Ensure redaction/anonymization routines handle derived datasets (caches, analytics).
+
+## Documentation & Enablement
+- Publish RTBF runbook for support/legal teams with contact tree.
+- Create customer-facing FAQ summarizing retention tiers and RTBF process.
+- Train SRE on PITR validation steps and rollback safeguards.
+
+## Operational Readiness Checklist
+- [ ] Retention scheduler runs dry-run reporting without destructive actions.
+- [ ] RTBF demo completed with signed audit record reviewed by Legal.
+- [ ] PITR validation job executed successfully on staging backup.
+- [ ] Runbooks and customer comms reviewed by Legal/Security.
+
+## Dependencies
+- Policy Pack `retention.json` available via COS policy fetcher.
+- Underlying datastores support selective deletion/anonymization APIs.
+
+## Risks & Mitigations
+- **Over-deletion**: Dry-run mode with sampling audits before activation.
+- **Data resurrection**: Enforce purpose checks and PITR validation before promoting backups.
+
+## Acceptance Criteria
+- Retention jobs remove/anonymize data per tier schedule without violating SLAs.
+- RTBF requests complete with signed audit records and stakeholder approvals.
+- PITR restores do not resurrect deleted PII; validation job reports success.
+- Purpose enforcement prevents access to deleted data across services.

--- a/project_management/companyos/COS-ROLLOUT-GATE.md
+++ b/project_management/companyos/COS-ROLLOUT-GATE.md
@@ -1,0 +1,96 @@
+# COS-ROLLOUT-GATE — Argo Evidence-Gated Promotion
+
+## Goal
+Gate canary promotions at 20% and 50% rollout stages using MC `evidenceOk` signals, providing automated rollback and rich observability when quality gates fail.
+
+## Key Outcomes
+- AnalysisTemplate leveraging MC evidence API via ConfigMap + Secret token.
+- Release workloads labeled with `release-id` and traced through audit logs and notifications.
+- Automated rollback completing within <5 minutes when `evidenceOk=false`.
+- Notification hooks (Slack/PagerDuty) reporting gate outcomes with context.
+
+## Architecture Overview
+| Component | Responsibility |
+| --- | --- |
+| Argo Rollouts Controller | Manages canary steps and invokes AnalysisTemplates. |
+| AnalysisTemplate Job | Queries MC `evidenceOk` via ConfigMap/Secret and returns pass/fail.
+| MC Evidence API | Provides current evidence status per `releaseId`.
+| Notification Service | Publishes gate outcomes to Slack/PagerDuty and audit logs.
+| Rollback Playbook | Defines manual override and fallback procedures.
+
+### Promotion Flow
+1. Deployment reaches 20% stage; AnalysisTemplate executes job hitting MC API with `releaseId`.
+2. Job validates response signature, updates status ConfigMap, and reports pass/fail to Rollouts.
+3. On pass, rollout proceeds to next step; on fail, rollout aborts and rollback automation restores stable version.
+4. Notifications emitted with context (releaseId, failure reason); audit event recorded.
+5. Repeat at 50% gate before full promotion.
+
+## Implementation Plan
+### Phase 0 — Preparation (Week 1)
+- Confirm dependency on COS-EVIDENCE-PUB and ensure evidence signals reliable in staging.
+- Provision MC API token via External Secrets and create ConfigMap template for AnalysisTemplate parameters.
+
+### Phase 1 — Template & Integration (Week 1)
+- Author AnalysisTemplate (webhook/job provider) that authenticates to MC and evaluates `evidenceOk`.
+- Update rollout manifests to include `release-id` labels propagated from CI/CD pipelines.
+- Add audit annotations capturing evaluation results for compliance.
+
+### Phase 2 — Automation & Observability (Week 2)
+- Configure rollback automation (Argo Rollouts rollback or Helm rollback) triggered on failure.
+- Build metrics for gate pass/fail counts, evaluation latency, and rollback duration.
+- Integrate Slack/PagerDuty notifications with failure context and runbook links.
+
+### Phase 3 — Validation & Docs (Week 2)
+- Run dry-run analysis with mocked responses to validate gating logic.
+- Execute failure scenario causing automatic rollback; measure recovery <5 minutes.
+- Publish rollback playbook and update deployment runbooks with new gating behavior.
+
+## Work Breakdown Structure
+| Task | Owner | Duration | Dependencies |
+| --- | --- | --- | --- |
+| Configure MC token secret | SRE | 1d | COS-EVIDENCE-PUB live |
+| Author AnalysisTemplate | SRE | 2d | Secret configured |
+| Update rollout manifests | SRE + App Eng | 2d | Template authored |
+| Notification integration | SRE | 2d | Template authored |
+| Metrics & dashboards | SRE | 2d | Notification integration |
+| Rollback playbook | SRE + On-call | 2d | Validation |
+
+## Testing Strategy
+- **Dry Run**: Mock `evidenceOk=true/false` responses; ensure proper gating decisions.
+- **Failure Path**: Force `evidenceOk=false` to confirm rollback occurs <5 minutes and notifications sent.
+- **Integration**: Validate release-id labels propagate from CI → deployment → AnalysisTemplate.
+- **Resilience**: Simulate MC API latency/timeouts to ensure retries and safe fail behavior.
+
+## Observability & Operations
+- Metrics: `rollout_gate_pass_total`, `rollout_gate_fail_total`, `rollout_gate_duration_seconds`, `rollout_gate_rollback_duration_seconds`.
+- Dashboards: Gate status over time, failure reasons, rollback durations per environment.
+- Alerts: Consecutive gate failures (>=3), rollback duration >5m, MC API latency >2s.
+
+## Security & Compliance
+- Store MC token in External Secrets with namespace restrictions; rotate every 60 days.
+- Log gate evaluations with trace IDs for compliance audits.
+
+## Documentation & Enablement
+- Update deployment runbooks with gating behavior, manual override steps, and contact tree.
+- Provide training session for on-call and release managers on interpreting gate failures.
+- Share sample MC response payloads for troubleshooting.
+
+## Operational Readiness Checklist
+- [ ] Dry-run gating scenario executed with positive/negative outcomes.
+- [ ] Automatic rollback tested and measured <5 minutes.
+- [ ] Notifications verified in Slack/PagerDuty with correct context.
+- [ ] Playbook published and linked in deployment checklist.
+
+## Dependencies
+- COS-EVIDENCE-PUB delivering timely `evidenceOk` signals.
+- MC evidence API accessible from deployment environment.
+
+## Risks & Mitigations
+- **Flaky checks**: Implement retry/backoff and allow manual override with audit logging.
+- **API latency**: Use timeout + circuit breaker; default to fail-safe (pause) if MC unreachable.
+
+## Acceptance Criteria
+- Gate blocks promotion when `evidenceOk=false` and records failure reasons.
+- Auto-rollback restores previous stable version within <5 minutes.
+- Notifications emitted for both pass and fail outcomes with release context.
+- Rollback playbook validated with on-call sign-off.

--- a/project_management/companyos/README.md
+++ b/project_management/companyos/README.md
@@ -1,0 +1,26 @@
+# CompanyOS Initiative Build Plans
+
+This directory captures the full execution playbooks for the eight parallel CompanyOS tickets. Each dossier expands the Jira-ready definitions into end-to-end delivery guidance covering architecture, work breakdown, validation, and operational readiness requirements.
+
+## Files
+
+| Ticket | Title | Primary Owner | Story Points |
+| --- | --- | --- | --- |
+| COS-ID-SCIM-ABAC | OIDC/SCIM + ABAC Enforcement | App Engineering | 8 |
+| COS-POL-FETCH | Policy Pack Consumer + OPA Hot-Reload | App Engineering | 5 |
+| COS-EVIDENCE-PUB | Publish Evidence (SLO+Cost) to MC | Backend Engineering | 5 |
+| COS-OTEL-SLO | OTEL Telemetry + SLO Dashboards | Site Reliability Engineering | 8 |
+| COS-ROLLOUT-GATE | Argo Evidence-Gated Promotion | Site Reliability Engineering | 5 |
+| COS-RET-RTBF | Retention & Right-to-be-Forgotten | Data Engineering | 13 |
+| COS-HELM-HARDEN | Charts, Limits, Secrets | Platform Engineering | 8 |
+| COS-PACT-E2E | Pact-style Contract + E2E Cold-Start | QA & Engineering | 8 |
+
+Each individual markdown file documents:
+
+- **Architecture overview** illustrating service interactions, data flows, and policy touch points.
+- **Detailed implementation plan** broken into phases with explicit task owners and sequencing.
+- **Validation matrix** mapping unit, integration, and end-to-end tests to acceptance criteria.
+- **Observability, security, and documentation deliverables** required before rollout.
+- **Operational readiness checklist** with go/no-go gates, rollback plans, and training artifacts.
+
+Use these build plans as the authoritative reference when executing the sprint or producing downstream artifacts such as SOPs, playbooks, and runbooks.


### PR DESCRIPTION
## Summary
- add a CompanyOS playbook directory with detailed build plans for the eight Jira initiatives
- document architecture, phased implementation, testing, and readiness checklists for each ticket

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d761c50fc48333ac1088ff0142f585