### PR TITLE
feat: add robust prompt template compiler

### DIFF
--- a/packages/rptc/jest.config.ts
+++ b/packages/rptc/jest.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['<rootDir>/test/**/*.test.ts'],
+  collectCoverageFrom: ['src/**/*.ts'],
+  coverageDirectory: '<rootDir>/coverage',
+  clearMocks: true
+};
+
+export default config;

--- a/packages/rptc/package.json
+++ b/packages/rptc/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@summit/rptc",
+  "version": "0.1.0",
+  "description": "Robust Prompt Template Compiler with typed slots, validation, adapters, and test synthesis.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist",
+    "test": "jest --config jest.config.ts",
+    "lint": "eslint src --ext .ts",
+    "format": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\""
+  },
+  "keywords": [
+    "prompts",
+    "compiler",
+    "llm",
+    "validation"
+  ],
+  "author": "Summit Intelligence Platform",
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/rptc/src/adapters/anthropic.ts
+++ b/packages/rptc/src/adapters/anthropic.ts
@@ -1,0 +1,40 @@
+import type { CompiledPrompt } from '../compiler.js';
+import type { SlotSchemaMap } from '../schema.js';
+import type { LLMAdapter } from './types.js';
+
+export interface AnthropicAdapterOptions {
+  readonly model?: string;
+  readonly systemPrompt?: string;
+}
+
+export class AnthropicAdapter implements LLMAdapter {
+  public readonly name = 'anthropic:messages';
+  private readonly defaultModel: string;
+  private readonly defaultSystemPrompt?: string;
+
+  constructor(options: AnthropicAdapterOptions = {}) {
+    this.defaultModel = options.model ?? 'claude-3-5-sonnet-20241022';
+    this.defaultSystemPrompt = options.systemPrompt;
+  }
+
+  format<TSlots extends SlotSchemaMap>(compiled: CompiledPrompt<TSlots>, options: Record<string, unknown> = {}) {
+    const system = (options.systemPrompt as string | undefined) ?? this.defaultSystemPrompt ?? compiled.description;
+    const model = (options.model as string | undefined) ?? this.defaultModel;
+
+    return {
+      model,
+      system,
+      messages: [
+        {
+          role: 'user',
+          content: [{ type: 'text', text: compiled.rendered }]
+        }
+      ],
+      metadata: {
+        template: compiled.name,
+        slots: compiled.slots,
+        values: compiled.values
+      }
+    };
+  }
+}

--- a/packages/rptc/src/adapters/openai-chat.ts
+++ b/packages/rptc/src/adapters/openai-chat.ts
@@ -1,0 +1,48 @@
+import type { CompiledPrompt } from '../compiler.js';
+import type { SlotSchemaMap } from '../schema.js';
+import type { LLMAdapter } from './types.js';
+
+export interface OpenAIChatAdapterOptions {
+  readonly model?: string;
+  readonly systemPrompt?: string;
+}
+
+export class OpenAIChatAdapter implements LLMAdapter {
+  public readonly name = 'openai:chat-completions';
+  private readonly defaultModel: string;
+  private readonly defaultSystemPrompt?: string;
+
+  constructor(options: OpenAIChatAdapterOptions = {}) {
+    this.defaultModel = options.model ?? 'gpt-4.1-mini';
+    this.defaultSystemPrompt = options.systemPrompt;
+  }
+
+  format<TSlots extends SlotSchemaMap>(compiled: CompiledPrompt<TSlots>, options: Record<string, unknown> = {}) {
+    const overrideModel = typeof options.model === 'string' ? (options.model as string) : undefined;
+    const overrideSystem = typeof options.systemPrompt === 'string' ? (options.systemPrompt as string) : undefined;
+
+    return {
+      model: overrideModel ?? this.defaultModel,
+      messages: buildMessages(compiled, overrideSystem ?? this.defaultSystemPrompt),
+      metadata: {
+        template: compiled.name,
+        slots: Object.keys(compiled.slots),
+        values: compiled.values
+      }
+    };
+  }
+}
+
+function buildMessages<TSlots extends SlotSchemaMap>(
+  compiled: CompiledPrompt<TSlots>,
+  systemPrompt?: string
+): Array<{ role: 'system' | 'user'; content: string }> {
+  const messages: Array<{ role: 'system' | 'user'; content: string }> = [];
+  if (systemPrompt ?? compiled.metadata?.systemPrompt) {
+    messages.push({ role: 'system', content: String(systemPrompt ?? compiled.metadata?.systemPrompt) });
+  } else if (compiled.description) {
+    messages.push({ role: 'system', content: compiled.description });
+  }
+  messages.push({ role: 'user', content: compiled.rendered });
+  return messages;
+}

--- a/packages/rptc/src/adapters/types.ts
+++ b/packages/rptc/src/adapters/types.ts
@@ -1,0 +1,7 @@
+import type { CompiledPrompt } from '../compiler.js';
+import type { SlotSchemaMap } from '../schema.js';
+
+export interface LLMAdapter {
+  readonly name: string;
+  format<TSlots extends SlotSchemaMap>(compiled: CompiledPrompt<TSlots>, options?: Record<string, unknown>): unknown;
+}

--- a/packages/rptc/src/adapters/vertex-ai.ts
+++ b/packages/rptc/src/adapters/vertex-ai.ts
@@ -1,0 +1,34 @@
+import type { CompiledPrompt } from '../compiler.js';
+import type { SlotSchemaMap } from '../schema.js';
+import type { LLMAdapter } from './types.js';
+
+export interface VertexAIAdapterOptions {
+  readonly model?: string;
+}
+
+export class VertexAIAdapter implements LLMAdapter {
+  public readonly name = 'google-vertex:responses';
+  private readonly defaultModel: string;
+
+  constructor(options: VertexAIAdapterOptions = {}) {
+    this.defaultModel = options.model ?? 'gemini-1.5-pro';
+  }
+
+  format<TSlots extends SlotSchemaMap>(compiled: CompiledPrompt<TSlots>, options: Record<string, unknown> = {}) {
+    const model = (options.model as string | undefined) ?? this.defaultModel;
+    return {
+      model,
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: compiled.rendered }]
+        }
+      ],
+      metadata: {
+        template: compiled.name,
+        description: compiled.description,
+        values: compiled.values
+      }
+    };
+  }
+}

--- a/packages/rptc/src/compiler.ts
+++ b/packages/rptc/src/compiler.ts
@@ -1,0 +1,368 @@
+import { PromptValidationError, type SlotErrorDetail } from './errors.js';
+import {
+  type EnumSlotSchema,
+  type NumberSlotSchema,
+  type SlotSchema,
+  type SlotSchemaMap,
+  type SlotValidationOutcome,
+  type SlotValues,
+  type PartialSlotValues,
+  type SlotValue,
+  type StringSlotSchema,
+  type BooleanSlotSchema
+} from './schema.js';
+import type { GeneratedTestSuite, TestGenerationOptions } from './testing/types.js';
+import { generateTestSuite } from './testing/test-generator.js';
+import type { LLMAdapter } from './adapters/types.js';
+
+const PLACEHOLDER_REGEX = /{{\s*([a-zA-Z0-9_]+)\s*}}/g;
+
+type PlaceholderNames<S extends string> = S extends `${string}{{${infer Slot}}}${infer Rest}`
+  ? TrimPlaceholder<Slot> | PlaceholderNames<Rest>
+  : never;
+
+type TrimPlaceholder<S extends string> = S extends ` ${infer R}`
+  ? TrimPlaceholder<R>
+  : S extends `${infer R} `
+    ? TrimPlaceholder<R>
+    : S;
+
+type MissingSlots<TTemplate extends string, TSlots extends SlotSchemaMap> = Exclude<PlaceholderNames<TTemplate>, keyof TSlots>;
+
+type UnusedSlots<TTemplate extends string, TSlots extends SlotSchemaMap> = Exclude<keyof TSlots, PlaceholderNames<TTemplate>>;
+
+type ValidateTemplate<TTemplate extends string, TSlots extends SlotSchemaMap> = MissingSlots<TTemplate, TSlots> extends never
+  ? UnusedSlots<TTemplate, TSlots> extends never
+    ? TSlots
+    : never
+  : never;
+
+export interface PromptValidationResult<TSlots extends SlotSchemaMap> {
+  readonly valid: boolean;
+  readonly slots: { [K in keyof TSlots]: SlotValidationOutcome<SlotValue<TSlots[K]>> };
+  readonly errors: Array<{ slot: keyof TSlots; details: SlotErrorDetail[] }>;
+  readonly value?: SlotValues<TSlots>;
+}
+
+export interface CompiledPrompt<TSlots extends SlotSchemaMap> {
+  readonly name: string;
+  readonly description?: string;
+  readonly template: string;
+  readonly rendered: string;
+  readonly slots: TSlots;
+  readonly values: SlotValues<TSlots>;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface PromptTemplateConfig<TTemplate extends string, TSlots extends SlotSchemaMap> {
+  readonly name: string;
+  readonly template: TTemplate;
+  readonly slots: TSlots;
+  readonly description?: string;
+  readonly metadata?: Record<string, unknown>;
+}
+
+export interface PromptTemplate<TSlots extends SlotSchemaMap> {
+  readonly name: string;
+  readonly description?: string;
+  readonly template: string;
+  readonly slots: TSlots;
+  readonly metadata?: Record<string, unknown>;
+  validate(values: PartialSlotValues<TSlots>): PromptValidationResult<TSlots>;
+  compile(values: SlotValues<TSlots>): CompiledPrompt<TSlots>;
+  render(values: SlotValues<TSlots>): string;
+  formatFor<TAdapter extends LLMAdapter>(adapter: TAdapter, values: SlotValues<TSlots>, options?: Record<string, unknown>): ReturnType<TAdapter['format']>;
+  generateTestSuite(options?: TestGenerationOptions<TSlots>): GeneratedTestSuite<TSlots>;
+}
+
+interface InternalValidation<TSlots extends SlotSchemaMap> extends PromptValidationResult<TSlots> {
+  readonly value: SlotValues<TSlots>;
+}
+
+export function createPromptTemplate<TTemplate extends string, TSlots extends SlotSchemaMap>(
+  config: PromptTemplateConfig<TTemplate, ValidateTemplate<TTemplate, TSlots>>
+): PromptTemplate<ValidateTemplate<TTemplate, TSlots>> {
+  const validatedSlots = config.slots as ValidateTemplate<TTemplate, TSlots>;
+  const placeholders = collectPlaceholders(config.template);
+
+  if (placeholders.size === 0) {
+    throw new Error(`Prompt template \"${config.name}\" must contain at least one slot placeholder.`);
+  }
+
+  const template: PromptTemplate<ValidateTemplate<TTemplate, TSlots>> = {
+    name: config.name,
+    description: config.description,
+    template: config.template,
+    slots: validatedSlots,
+    metadata: config.metadata,
+    validate(values) {
+      return validateValues(config.name, validatedSlots, placeholders, values);
+    },
+    compile(values) {
+      const validation = validateValues(config.name, validatedSlots, placeholders, values);
+      if (!validation.valid || !validation.value) {
+        const errorMap: Record<string, SlotErrorDetail[]> = {};
+        for (const item of validation.errors) {
+          errorMap[item.slot as string] = item.details;
+        }
+        throw new PromptValidationError(config.name, errorMap);
+      }
+      const rendered = renderTemplate(config.template, validation.value);
+      return {
+        name: config.name,
+        description: config.description,
+        template: config.template,
+        rendered,
+        slots: validatedSlots,
+        values: validation.value,
+        metadata: config.metadata
+      } satisfies CompiledPrompt<ValidateTemplate<TTemplate, TSlots>>;
+    },
+    render(values) {
+      return this.compile(values).rendered;
+    },
+    formatFor(adapter, values, options) {
+      const compiled = this.compile(values);
+      return adapter.format(compiled, options ?? {});
+    },
+    generateTestSuite(options) {
+      return generateTestSuite(this, options);
+    }
+  };
+
+  return template;
+}
+
+function collectPlaceholders(template: string): Set<string> {
+  const matches = template.matchAll(PLACEHOLDER_REGEX);
+  const set = new Set<string>();
+  for (const match of matches) {
+    const placeholder = match[1];
+    if (!placeholder) {
+      continue;
+    }
+    set.add(placeholder.trim());
+  }
+  return set;
+}
+
+function validateValues<TSlots extends SlotSchemaMap>(
+  templateName: string,
+  slots: TSlots,
+  placeholders: Set<string>,
+  values: PartialSlotValues<TSlots>
+): PromptValidationResult<TSlots> | InternalValidation<TSlots> {
+  const slotNames = Object.keys(slots) as Array<keyof TSlots>;
+  const resolved: Partial<SlotValues<TSlots>> = {};
+  const slotOutcomes = {} as { [K in keyof TSlots]: SlotValidationOutcome<SlotValue<TSlots[K]>> };
+  const errors: Array<{ slot: keyof TSlots; details: SlotErrorDetail[] }> = [];
+
+  for (const slotName of slotNames) {
+    const schema = slots[slotName] as SlotSchema;
+    const value = (values as Record<string, unknown>)[slotName as string];
+    const outcome = validateSlot(slotName as string, schema, value);
+    slotOutcomes[slotName] = outcome as SlotValidationOutcome<SlotValue<TSlots[typeof slotName]>>;
+    if (outcome.valid) {
+      resolved[slotName] = outcome.value as SlotValues<TSlots>[typeof slotName];
+    } else {
+      errors.push({ slot: slotName, details: outcome.errors });
+    }
+  }
+
+  for (const placeholder of placeholders) {
+    if (!(placeholder in slots)) {
+      errors.push({
+        slot: placeholder as keyof TSlots,
+        details: [{ code: 'slot.undefined', message: `Placeholder \"${placeholder}\" is not defined in slot schema.` }]
+      });
+    }
+  }
+
+  const extraneous = Object.keys(values ?? {}).filter((key) => !(key in slots));
+  for (const key of extraneous) {
+    errors.push({
+      slot: key as keyof TSlots,
+      details: [{ code: 'slot.unexpected', message: `Value provided for undefined slot \"${key}\".` }]
+    });
+  }
+
+  if (errors.length > 0) {
+    return {
+      valid: false,
+      slots: slotOutcomes,
+      errors
+    } satisfies PromptValidationResult<TSlots>;
+  }
+
+  return {
+    valid: true,
+    slots: slotOutcomes,
+    errors,
+    value: resolved as SlotValues<TSlots>
+  } satisfies InternalValidation<TSlots>;
+}
+
+function validateSlot(slotName: string, schema: SlotSchema, value: unknown): SlotValidationOutcome<unknown> {
+  switch (schema.kind) {
+    case 'string':
+      return validateStringSlot(slotName, schema, value);
+    case 'number':
+      return validateNumberSlot(slotName, schema, value);
+    case 'boolean':
+      return validateBooleanSlot(slotName, schema, value);
+    case 'enum':
+      return validateEnumSlot(slotName, schema as EnumSlotSchema<string>, value);
+    default:
+      return {
+        valid: false,
+        errors: [{ code: 'slot.unsupported', message: `Slot \"${slotName}\" has unsupported kind ${(schema as SlotSchema).kind}.` }]
+      };
+  }
+}
+
+function validateStringSlot(slotName: string, schema: StringSlotSchema, value: unknown): SlotValidationOutcome<string> {
+  if (value === undefined || value === null) {
+    if (schema.defaultValue !== undefined) {
+      return { valid: true, value: schema.defaultValue };
+    }
+    if (schema.optional) {
+      return { valid: true, value: '' };
+    }
+    return { valid: false, errors: [{ code: 'slot.required', message: `Slot \"${slotName}\" is required.` }] };
+  }
+
+  if (typeof value !== 'string') {
+    return {
+      valid: false,
+      errors: [{ code: 'slot.type', message: `Slot \"${slotName}\" must be a string.` }]
+    };
+  }
+
+  const constraints = schema.constraints;
+  const violations: SlotErrorDetail[] = [];
+
+  if (constraints?.minLength !== undefined && value.length < constraints.minLength) {
+    violations.push({
+      code: 'string.minLength',
+      message: `Length must be >= ${constraints.minLength}.`,
+      meta: { provided: value.length }
+    });
+  }
+
+  if (constraints?.maxLength !== undefined && value.length > constraints.maxLength) {
+    violations.push({
+      code: 'string.maxLength',
+      message: `Length must be <= ${constraints.maxLength}.`,
+      meta: { provided: value.length }
+    });
+  }
+
+  if (constraints?.pattern && !constraints.pattern.test(value)) {
+    violations.push({ code: 'string.pattern', message: `Value does not match required pattern ${constraints.pattern}.` });
+  }
+
+  if (violations.length > 0) {
+    return { valid: false, errors: violations };
+  }
+
+  return { valid: true, value };
+}
+
+function validateNumberSlot(slotName: string, schema: NumberSlotSchema, value: unknown): SlotValidationOutcome<number> {
+  if (value === undefined || value === null) {
+    if (schema.defaultValue !== undefined) {
+      return { valid: true, value: schema.defaultValue };
+    }
+    if (schema.optional) {
+      return {
+        valid: false,
+        errors: [{ code: 'slot.required', message: `Slot \"${slotName}\" is optional but requires a defaultValue for numeric slots.` }]
+      };
+    }
+    return { valid: false, errors: [{ code: 'slot.required', message: `Slot \"${slotName}\" is required.` }] };
+  }
+
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return {
+      valid: false,
+      errors: [{ code: 'slot.type', message: `Slot \"${slotName}\" must be a finite number.` }]
+    };
+  }
+
+  const constraints = schema.constraints;
+  const violations: SlotErrorDetail[] = [];
+
+  if (constraints?.min !== undefined && value < constraints.min) {
+    violations.push({ code: 'number.min', message: `Value must be >= ${constraints.min}.`, meta: { provided: value } });
+  }
+
+  if (constraints?.max !== undefined && value > constraints.max) {
+    violations.push({ code: 'number.max', message: `Value must be <= ${constraints.max}.`, meta: { provided: value } });
+  }
+
+  if (violations.length > 0) {
+    return { valid: false, errors: violations };
+  }
+
+  return { valid: true, value };
+}
+
+function validateBooleanSlot(slotName: string, schema: BooleanSlotSchema, value: unknown): SlotValidationOutcome<boolean> {
+  if (value === undefined || value === null) {
+    if (schema.defaultValue !== undefined) {
+      return { valid: true, value: schema.defaultValue };
+    }
+    if (schema.optional) {
+      return {
+        valid: false,
+        errors: [{ code: 'slot.required', message: `Slot \"${slotName}\" is optional but requires a defaultValue for boolean slots.` }]
+      };
+    }
+    return { valid: false, errors: [{ code: 'slot.required', message: `Slot \"${slotName}\" is required.` }] };
+  }
+
+  if (typeof value !== 'boolean') {
+    return { valid: false, errors: [{ code: 'slot.type', message: `Slot \"${slotName}\" must be a boolean.` }] };
+  }
+
+  return { valid: true, value };
+}
+
+function validateEnumSlot(slotName: string, schema: EnumSlotSchema<string>, value: unknown): SlotValidationOutcome<string> {
+  if (value === undefined || value === null) {
+    if (schema.defaultValue !== undefined) {
+      return { valid: true, value: schema.defaultValue };
+    }
+    if (schema.optional) {
+      return {
+        valid: false,
+        errors: [{ code: 'slot.required', message: `Slot \"${slotName}\" is optional but requires a defaultValue for enum slots.` }]
+      };
+    }
+    return { valid: false, errors: [{ code: 'slot.required', message: `Slot \"${slotName}\" is required.` }] };
+  }
+
+  if (typeof value !== 'string') {
+    return { valid: false, errors: [{ code: 'slot.type', message: `Slot \"${slotName}\" must be a string literal.` }] };
+  }
+
+  if (!schema.values.includes(value)) {
+    return {
+      valid: false,
+      errors: [{ code: 'enum.value', message: `Value must be one of: ${schema.values.join(', ')}.` }]
+    };
+  }
+
+  return { valid: true, value };
+}
+
+function renderTemplate<TSlots extends SlotSchemaMap>(template: string, values: SlotValues<TSlots>): string {
+  return template.replace(PLACEHOLDER_REGEX, (_match, group: string) => {
+    const key = group.trim() as keyof TSlots;
+    const value = values[key];
+    if (value === undefined || value === null) {
+      return '';
+    }
+    return typeof value === 'string' ? value : String(value);
+  });
+}

--- a/packages/rptc/src/errors.ts
+++ b/packages/rptc/src/errors.ts
@@ -1,0 +1,34 @@
+export interface SlotErrorDetail {
+  readonly code: string;
+  readonly message: string;
+  readonly meta?: Record<string, unknown>;
+}
+
+export class SlotValidationError extends Error {
+  public readonly slot: string;
+  public readonly details: SlotErrorDetail[];
+
+  constructor(slot: string, details: SlotErrorDetail[]) {
+    const message = details.map((detail) => `${detail.code}: ${detail.message}`).join('; ');
+    super(`Slot \"${slot}\" validation failed: ${message}`);
+    this.name = 'SlotValidationError';
+    this.slot = slot;
+    this.details = details;
+  }
+}
+
+export class PromptValidationError extends Error {
+  public readonly templateName: string;
+  public readonly slotErrors: Record<string, SlotErrorDetail[]>;
+
+  constructor(templateName: string, slotErrors: Record<string, SlotErrorDetail[]>) {
+    const segments = Object.entries(slotErrors).map(([slot, errors]) => {
+      const joined = errors.map((error) => `${error.code}: ${error.message}`).join('; ');
+      return `${slot} -> ${joined}`;
+    });
+    super(`Prompt template \"${templateName}\" validation failed: ${segments.join(' | ')}`);
+    this.name = 'PromptValidationError';
+    this.templateName = templateName;
+    this.slotErrors = slotErrors;
+  }
+}

--- a/packages/rptc/src/format/ci-formatter.ts
+++ b/packages/rptc/src/format/ci-formatter.ts
@@ -1,0 +1,35 @@
+import type { PromptTemplate, PromptValidationResult } from '../compiler.js';
+import type { SlotSchemaMap } from '../schema.js';
+import type { GeneratedTestResults } from '../testing/types.js';
+
+export function formatValidationResultForCI<TSlots extends SlotSchemaMap>(
+  template: PromptTemplate<TSlots>,
+  result: PromptValidationResult<TSlots>
+): string {
+  const header = `[RPTC] Validation ${result.valid ? 'PASSED' : 'FAILED'} :: template=${template.name}`;
+  if (result.valid) {
+    return `${header} :: slots=${Object.keys(template.slots).length}`;
+  }
+  const lines = result.errors
+    .map((error) => {
+      const details = error.details.map((detail) => `${detail.code} (${detail.message})`).join(', ');
+      return `  - slot=${String(error.slot)} :: ${details}`;
+    })
+    .join('\n');
+  return `${header}\n${lines}`;
+}
+
+export function formatTestRunForCI<TSlots extends SlotSchemaMap>(
+  suiteName: string,
+  results: GeneratedTestResults<TSlots>
+): string {
+  const status = results.passed ? 'PASSED' : 'FAILED';
+  const lines = results.results
+    .filter((result) => !result.passed)
+    .map((result) => {
+      const message = result.error?.message ?? 'Unknown failure';
+      return `  - case=\"${result.testCase.description}\" slot=${String(result.testCase.slot)} :: ${message}`;
+    })
+    .join('\n');
+  return lines.length > 0 ? `[RPTC] TestSuite ${status} :: ${suiteName}\n${lines}` : `[RPTC] TestSuite ${status} :: ${suiteName}`;
+}

--- a/packages/rptc/src/index.ts
+++ b/packages/rptc/src/index.ts
@@ -1,0 +1,35 @@
+export {
+  createPromptTemplate,
+  type CompiledPrompt,
+  type PromptTemplate,
+  type PromptTemplateConfig,
+  type PromptValidationResult
+} from './compiler.js';
+
+export {
+  stringSlot,
+  numberSlot,
+  booleanSlot,
+  enumSlot,
+  type SlotSchema,
+  type SlotSchemaMap,
+  type SlotValues,
+  type PartialSlotValues
+} from './schema.js';
+
+export { formatValidationResultForCI, formatTestRunForCI } from './format/ci-formatter.js';
+
+export {
+  generateTestSuite,
+  type GeneratedTestSuite,
+  type GeneratedTestCase,
+  type GeneratedTestResults,
+  type TestGenerationOptions,
+  type TestHarness
+} from './testing/test-generator.js';
+
+export type { LLMAdapter } from './adapters/types.js';
+export { OpenAIChatAdapter } from './adapters/openai-chat.js';
+export { AnthropicAdapter } from './adapters/anthropic.js';
+export { VertexAIAdapter } from './adapters/vertex-ai.js';
+export { PromptValidationError, SlotValidationError } from './errors.js';

--- a/packages/rptc/src/schema.ts
+++ b/packages/rptc/src/schema.ts
@@ -1,0 +1,90 @@
+import type { SlotErrorDetail } from './errors.js';
+
+export type SlotKind = 'string' | 'number' | 'enum' | 'boolean';
+
+export interface BaseSlotSchema<T> {
+  readonly kind: SlotKind;
+  readonly description?: string;
+  readonly optional?: boolean;
+  readonly defaultValue?: T;
+  readonly example?: T;
+  readonly counterExamples?: readonly unknown[];
+}
+
+export interface StringConstraints {
+  readonly minLength?: number;
+  readonly maxLength?: number;
+  readonly pattern?: RegExp;
+}
+
+export interface NumberConstraints {
+  readonly min?: number;
+  readonly max?: number;
+}
+
+export interface StringSlotSchema extends BaseSlotSchema<string> {
+  readonly kind: 'string';
+  readonly constraints?: StringConstraints;
+}
+
+export interface NumberSlotSchema extends BaseSlotSchema<number> {
+  readonly kind: 'number';
+  readonly constraints?: NumberConstraints;
+}
+
+export interface BooleanSlotSchema extends BaseSlotSchema<boolean> {
+  readonly kind: 'boolean';
+}
+
+export interface EnumSlotSchema<T extends string> extends BaseSlotSchema<T> {
+  readonly kind: 'enum';
+  readonly values: readonly T[];
+}
+
+export type SlotSchema = StringSlotSchema | NumberSlotSchema | BooleanSlotSchema | EnumSlotSchema<string>;
+
+export type SlotSchemaMap = Record<string, SlotSchema>;
+
+export type SlotValue<S extends SlotSchema> = S extends StringSlotSchema
+  ? string
+  : S extends NumberSlotSchema
+    ? number
+    : S extends BooleanSlotSchema
+      ? boolean
+      : S extends EnumSlotSchema<infer T>
+        ? T
+        : never;
+
+export type SlotValues<TSlots extends SlotSchemaMap> = {
+  [K in keyof TSlots]: SlotValue<TSlots[K]>;
+};
+
+export type PartialSlotValues<TSlots extends SlotSchemaMap> = Partial<SlotValues<TSlots>>;
+
+export interface SlotValidationSuccess<T> {
+  readonly valid: true;
+  readonly value: T;
+}
+
+export interface SlotValidationFailure {
+  readonly valid: false;
+  readonly errors: SlotErrorDetail[];
+}
+
+export type SlotValidationOutcome<T> = SlotValidationSuccess<T> | SlotValidationFailure;
+
+export function stringSlot(options: Omit<StringSlotSchema, 'kind'> = {}): StringSlotSchema {
+  return { kind: 'string', ...options };
+}
+
+export function numberSlot(options: Omit<NumberSlotSchema, 'kind'> = {}): NumberSlotSchema {
+  return { kind: 'number', ...options };
+}
+
+export function booleanSlot(options: Omit<BooleanSlotSchema, 'kind'> = {}): BooleanSlotSchema {
+  return { kind: 'boolean', ...options };
+}
+
+export function enumSlot<T extends string>(values: readonly T[], options: Omit<EnumSlotSchema<T>, 'kind' | 'values'> = {}): EnumSlotSchema<T> {
+  return { kind: 'enum', values, ...options };
+}

--- a/packages/rptc/src/testing/test-generator.ts
+++ b/packages/rptc/src/testing/test-generator.ts
@@ -1,0 +1,364 @@
+import type { PromptTemplate } from '../compiler.js';
+import {
+  type EnumSlotSchema,
+  type NumberSlotSchema,
+  type SlotSchema,
+  type SlotSchemaMap,
+  type SlotValues,
+  type PartialSlotValues,
+  type StringSlotSchema
+} from '../schema.js';
+import {
+  type GeneratedCaseResult,
+  type GeneratedTestCase,
+  type GeneratedTestResults,
+  type GeneratedTestSuite,
+  type TestGenerationOptions,
+  type TestHarness
+} from './types.js';
+
+export type {
+  GeneratedTestSuite,
+  GeneratedTestCase,
+  GeneratedTestResults,
+  GeneratedCaseResult,
+  TestGenerationOptions,
+  TestHarness
+} from './types.js';
+
+export function generateTestSuite<TSlots extends SlotSchemaMap>(
+  template: PromptTemplate<TSlots>,
+  options: TestGenerationOptions<TSlots> = {}
+): GeneratedTestSuite<TSlots> {
+  const baseValues = buildBaseValues(template, options);
+  const cases: GeneratedTestCase<TSlots>[] = [
+    {
+      description: 'renders successfully with canonical valid values',
+      slot: 'template',
+      values: baseValues,
+      expectValid: true
+    }
+  ];
+
+  for (const [slotName, schema] of Object.entries(template.slots) as Array<[
+    keyof TSlots,
+    SlotSchema
+  ]>) {
+    const slotCases = buildSlotCases(slotName, schema, options);
+    cases.push(...slotCases);
+  }
+
+  const suiteName = options.suiteName ?? `${template.name} validation suite`;
+
+  return {
+    name: suiteName,
+    baseValues,
+    cases,
+    run(targetTemplate?: PromptTemplate<TSlots>) {
+      const target = targetTemplate ?? template;
+      const results = cases.map((testCase) => executeTestCase(target, baseValues, testCase));
+      return {
+        passed: results.every((result) => result.passed),
+        results
+      } satisfies GeneratedTestResults<TSlots>;
+    },
+    register(harness?: TestHarness) {
+      const effectiveHarness = harness ?? detectHarness();
+      if (!effectiveHarness) {
+        throw new Error('No test harness detected. Provide a harness with describe/it/expect.');
+      }
+      effectiveHarness.describe(suiteName, () => {
+        for (const testCase of cases) {
+          effectiveHarness.it(testCase.description, () => {
+            const result = executeTestCase(template, baseValues, testCase);
+            if (testCase.expectValid) {
+              effectiveHarness.expect(result.passed).toBe(true);
+            } else {
+              effectiveHarness.expect(result.passed).toBe(true);
+            }
+            if (!result.passed && result.error) {
+              throw result.error;
+            }
+          });
+        }
+      });
+    }
+  } satisfies GeneratedTestSuite<TSlots>;
+}
+
+function buildBaseValues<TSlots extends SlotSchemaMap>(
+  template: PromptTemplate<TSlots>,
+  options: TestGenerationOptions<TSlots>
+): SlotValues<TSlots> {
+  const base: Partial<SlotValues<TSlots>> = { ...(options.validExample ?? {}) };
+
+  for (const [slotName, schema] of Object.entries(template.slots) as Array<[
+    keyof TSlots,
+    SlotSchema
+  ]>) {
+    if (base[slotName] !== undefined) {
+      continue;
+    }
+    const value = deriveValidValue(slotName as string, schema);
+    if (value === undefined) {
+      throw new Error(`Unable to derive valid example for slot ${String(slotName)}. Provide a validExample override.`);
+    }
+    base[slotName] = value as SlotValues<TSlots>[typeof slotName];
+  }
+
+  return base as SlotValues<TSlots>;
+}
+
+function deriveValidValue(slotName: string, schema: SlotSchema): unknown {
+  if ('example' in schema && schema.example !== undefined) {
+    return schema.example;
+  }
+  if ('defaultValue' in schema && schema.defaultValue !== undefined) {
+    return schema.defaultValue;
+  }
+
+  switch (schema.kind) {
+    case 'string':
+      return deriveStringValue(slotName, schema);
+    case 'number':
+      return deriveNumberValue(schema);
+    case 'boolean':
+      return true;
+    case 'enum':
+      return (schema as EnumSlotSchema<string>).values[0];
+    default:
+      return undefined;
+  }
+}
+
+function deriveStringValue(slotName: string, schema: StringSlotSchema): string {
+  const min = schema.constraints?.minLength ?? 1;
+  const base = schema.constraints?.pattern?.source.includes('email') ? 'user@example.com' : `${slotName}-value`;
+  let candidate = base.repeat(Math.max(1, Math.ceil(min / base.length)));
+  if (candidate.length < min) {
+    candidate = candidate.padEnd(min, 'x');
+  }
+  if (schema.constraints?.maxLength && candidate.length > schema.constraints.maxLength) {
+    candidate = candidate.slice(0, schema.constraints.maxLength);
+  }
+  if (schema.constraints?.pattern && !schema.constraints.pattern.test(candidate)) {
+    candidate = ensurePatternCompliance(schema.constraints.pattern, min, schema.constraints?.maxLength);
+  }
+  return candidate;
+}
+
+function ensurePatternCompliance(pattern: RegExp, minLength?: number, maxLength?: number): string {
+  const safe = 'valid';
+  let candidate = safe;
+  if (minLength && candidate.length < minLength) {
+    candidate = candidate.padEnd(minLength, 'd');
+  }
+  if (maxLength && candidate.length > maxLength) {
+    candidate = candidate.slice(0, maxLength);
+  }
+  if (pattern.test(candidate)) {
+    return candidate;
+  }
+  return pattern.flags.includes('i') ? candidate.toUpperCase() : `${candidate}x`;
+}
+
+function deriveNumberValue(schema: NumberSlotSchema): number {
+  if (schema.constraints?.min !== undefined) {
+    return schema.constraints.min;
+  }
+  if (schema.constraints?.max !== undefined) {
+    return schema.constraints.max;
+  }
+  return 1;
+}
+
+function buildSlotCases<TSlots extends SlotSchemaMap>(
+  slotName: keyof TSlots,
+  schema: SlotSchema,
+  options: TestGenerationOptions<TSlots>
+): GeneratedTestCase<TSlots>[] {
+  const cases: GeneratedTestCase<TSlots>[] = [];
+
+  if (!schema.optional && schema.defaultValue === undefined) {
+    cases.push({
+      description: `fails when slot ${String(slotName)} is missing`,
+      slot: slotName,
+      values: { [slotName]: undefined } as PartialSlotValues<TSlots>,
+      expectValid: false
+    });
+  }
+
+  const counterExamples = collectCounterExamples(slotName, schema, options);
+  for (const value of counterExamples) {
+    cases.push({
+      description: `rejects counterexample for slot ${String(slotName)}`,
+      slot: slotName,
+      values: { [slotName]: value } as PartialSlotValues<TSlots>,
+      expectValid: false
+    });
+  }
+
+  switch (schema.kind) {
+    case 'string':
+      cases.push(...buildStringCases(slotName, schema as StringSlotSchema));
+      break;
+    case 'number':
+      cases.push(...buildNumberCases(slotName, schema as NumberSlotSchema));
+      break;
+    case 'enum':
+      cases.push(buildEnumCase(slotName, schema as EnumSlotSchema<string>));
+      break;
+    case 'boolean':
+      cases.push(buildBooleanCase(slotName));
+      break;
+  }
+
+  return cases;
+}
+
+function buildStringCases<TSlots extends SlotSchemaMap>(
+  slotName: keyof TSlots,
+  schema: StringSlotSchema
+): GeneratedTestCase<TSlots>[] {
+  const cases: GeneratedTestCase<TSlots>[] = [];
+  const min = schema.constraints?.minLength;
+  const max = schema.constraints?.maxLength;
+
+  if (min !== undefined && min > 0) {
+    cases.push({
+      description: `enforces minLength on ${String(slotName)}`,
+      slot: slotName,
+      values: { [slotName]: 'x'.repeat(Math.max(0, min - 1)) } as PartialSlotValues<TSlots>,
+      expectValid: false
+    });
+  }
+
+  if (max !== undefined) {
+    cases.push({
+      description: `enforces maxLength on ${String(slotName)}`,
+      slot: slotName,
+      values: { [slotName]: 'y'.repeat(max + 1) } as PartialSlotValues<TSlots>,
+      expectValid: false
+    });
+  }
+
+  if (schema.constraints?.pattern) {
+    cases.push({
+      description: `enforces pattern on ${String(slotName)}`,
+      slot: slotName,
+      values: { [slotName]: '__invalid__' } as PartialSlotValues<TSlots>,
+      expectValid: false
+    });
+  }
+
+  return cases;
+}
+
+function buildNumberCases<TSlots extends SlotSchemaMap>(
+  slotName: keyof TSlots,
+  schema: NumberSlotSchema
+): GeneratedTestCase<TSlots>[] {
+  const cases: GeneratedTestCase<TSlots>[] = [];
+  const min = schema.constraints?.min;
+  const max = schema.constraints?.max;
+
+  if (min !== undefined) {
+    cases.push({
+      description: `enforces minimum on ${String(slotName)}`,
+      slot: slotName,
+      values: { [slotName]: min - 1 } as PartialSlotValues<TSlots>,
+      expectValid: false
+    });
+  }
+
+  if (max !== undefined) {
+    cases.push({
+      description: `enforces maximum on ${String(slotName)}`,
+      slot: slotName,
+      values: { [slotName]: max + 1 } as PartialSlotValues<TSlots>,
+      expectValid: false
+    });
+  }
+
+  return cases;
+}
+
+function buildEnumCase<TSlots extends SlotSchemaMap>(
+  slotName: keyof TSlots,
+  schema: EnumSlotSchema<string>
+): GeneratedTestCase<TSlots> {
+  return {
+    description: `rejects value outside enum for ${String(slotName)}`,
+    slot: slotName,
+    values: { [slotName]: '__invalid__' } as PartialSlotValues<TSlots>,
+    expectValid: false
+  };
+}
+
+function buildBooleanCase<TSlots extends SlotSchemaMap>(slotName: keyof TSlots): GeneratedTestCase<TSlots> {
+  return {
+    description: `rejects non-boolean values for ${String(slotName)}`,
+    slot: slotName,
+    values: { [slotName]: 'truthy' } as PartialSlotValues<TSlots>,
+    expectValid: false
+  };
+}
+
+function collectCounterExamples<TSlots extends SlotSchemaMap>(
+  slotName: keyof TSlots,
+  schema: SlotSchema,
+  options: TestGenerationOptions<TSlots>
+): readonly unknown[] {
+  const schemaExamples = schema.counterExamples ?? [];
+  const optionExamples = (options.counterExamples?.[slotName] ?? []) as readonly unknown[];
+  return [...schemaExamples, ...optionExamples];
+}
+
+function executeTestCase<TSlots extends SlotSchemaMap>(
+  template: PromptTemplate<TSlots>,
+  baseValues: SlotValues<TSlots>,
+  testCase: GeneratedTestCase<TSlots>
+): GeneratedCaseResult<TSlots> {
+  const mergedValues = { ...baseValues, ...testCase.values } as SlotValues<TSlots>;
+  try {
+    const result = template.validate(mergedValues);
+    if (testCase.expectValid && !result.valid) {
+      return { testCase, passed: false, error: new Error(`Expected valid but got errors for slot ${String(testCase.slot)}.`) };
+    }
+    if (!testCase.expectValid && result.valid) {
+      return { testCase, passed: false, error: new Error(`Expected validation failure for slot ${String(testCase.slot)}.`) };
+    }
+    if (testCase.expectValid) {
+      template.render(mergedValues);
+      return { testCase, passed: true };
+    }
+    let threw = false;
+    try {
+      template.render(mergedValues);
+    } catch (error) {
+      threw = true;
+    }
+    if (!threw) {
+      return {
+        testCase,
+        passed: false,
+        error: new Error(`Expected render to throw for invalid slot ${String(testCase.slot)}.`)
+      };
+    }
+    return { testCase, passed: true };
+  } catch (error) {
+    return { testCase, passed: false, error: error as Error };
+  }
+}
+
+function detectHarness(): TestHarness | undefined {
+  const globalRef = globalThis as unknown as Partial<TestHarness> & { describe?: unknown; it?: unknown; expect?: unknown };
+  if (typeof globalRef.describe === 'function' && typeof globalRef.it === 'function' && typeof globalRef.expect === 'function') {
+    return {
+      describe: globalRef.describe.bind(globalRef),
+      it: globalRef.it.bind(globalRef),
+      expect: globalRef.expect as TestHarness['expect']
+    } satisfies TestHarness;
+  }
+  return undefined;
+}

--- a/packages/rptc/src/testing/types.ts
+++ b/packages/rptc/src/testing/types.ts
@@ -1,0 +1,51 @@
+import type { PromptTemplate, PromptValidationResult } from '../compiler.js';
+import type { SlotSchemaMap, SlotValues, PartialSlotValues } from '../schema.js';
+
+export interface GeneratedTestCase<TSlots extends SlotSchemaMap> {
+  readonly description: string;
+  readonly slot: keyof TSlots | 'template';
+  readonly values: PartialSlotValues<TSlots>;
+  readonly expectValid: boolean;
+}
+
+export interface GeneratedTestSuite<TSlots extends SlotSchemaMap> {
+  readonly name: string;
+  readonly cases: readonly GeneratedTestCase<TSlots>[];
+  readonly baseValues: SlotValues<TSlots>;
+  run(template?: PromptTemplate<TSlots>): GeneratedTestResults<TSlots>;
+  register(harness?: TestHarness): void;
+}
+
+export interface GeneratedTestResults<TSlots extends SlotSchemaMap> {
+  readonly passed: boolean;
+  readonly results: ReadonlyArray<GeneratedCaseResult<TSlots>>;
+}
+
+export interface GeneratedCaseResult<TSlots extends SlotSchemaMap> {
+  readonly testCase: GeneratedTestCase<TSlots>;
+  readonly passed: boolean;
+  readonly error?: Error;
+}
+
+export interface TestHarness {
+  describe(name: string, fn: () => void): void;
+  it(name: string, fn: () => void): void;
+  expect: (value: unknown) => {
+    toThrow(error?: unknown): void;
+    not: { toThrow(): void };
+    toBe(value: unknown): void;
+    toEqual(value: unknown): void;
+  };
+}
+
+export interface TestGenerationOptions<TSlots extends SlotSchemaMap> {
+  readonly suiteName?: string;
+  readonly validExample?: SlotValues<TSlots>;
+  readonly counterExamples?: Partial<Record<keyof TSlots, readonly unknown[]>>;
+}
+
+export interface ValidationProbe<TSlots extends SlotSchemaMap> {
+  template: PromptTemplate<TSlots>;
+  values: PartialSlotValues<TSlots>;
+  validation: PromptValidationResult<TSlots>;
+}

--- a/packages/rptc/test/compiler.test.ts
+++ b/packages/rptc/test/compiler.test.ts
@@ -1,0 +1,100 @@
+import {
+  AnthropicAdapter,
+  OpenAIChatAdapter,
+  VertexAIAdapter,
+  createPromptTemplate,
+  enumSlot,
+  formatTestRunForCI,
+  formatValidationResultForCI,
+  generateTestSuite,
+  numberSlot,
+  stringSlot,
+  booleanSlot
+} from '../src/index.js';
+import { PromptValidationError } from '../src/errors.js';
+
+describe('RPTC prompt compiler', () => {
+  const prompt = createPromptTemplate({
+    name: 'release-brief',
+    description: 'Summarize capability updates for analyst briefings.',
+    template:
+      'Create a {{format}} update for {{audience}} about {{topic}} with {{count}} highlights. Include summary? {{includeSummary}}',
+    slots: {
+      audience: stringSlot({
+        constraints: { minLength: 3, maxLength: 40 },
+        example: 'intelligence leads'
+      }),
+      topic: stringSlot({
+        constraints: { minLength: 5, pattern: /^[A-Za-z\s]+$/ },
+        example: 'Network defense readiness',
+        counterExamples: ['###']
+      }),
+      count: numberSlot({ constraints: { min: 1, max: 5 }, example: 3 }),
+      includeSummary: booleanSlot({ defaultValue: true }),
+      format: enumSlot(['bulleted', 'narrative'] as const, { defaultValue: 'bulleted' })
+    }
+  });
+
+  const validValues = {
+    audience: 'field officers',
+    topic: 'Advanced network hardening',
+    count: 3,
+    includeSummary: false,
+    format: 'narrative' as const
+  };
+
+  it('renders prompts when validation passes', () => {
+    const output = prompt.render(validValues);
+    expect(output).toContain('field officers');
+    expect(output).toContain('Advanced network hardening');
+    expect(output).toContain('3 highlights');
+  });
+
+  it('exposes compiled adapters for multiple providers', () => {
+    const openai = new OpenAIChatAdapter({ model: 'gpt-test', systemPrompt: 'You are a release agent.' });
+    const anthropic = new AnthropicAdapter({ model: 'claude-test' });
+    const vertex = new VertexAIAdapter({ model: 'gemini-test' });
+
+    const compiled = prompt.compile(validValues);
+
+    const openaiPayload = openai.format(compiled);
+    expect(openaiPayload).toMatchObject({ model: 'gpt-test' });
+    expect(Array.isArray((openaiPayload as any).messages)).toBe(true);
+
+    const anthropicPayload = anthropic.format(compiled);
+    expect(anthropicPayload).toMatchObject({ model: 'claude-test' });
+    expect((anthropicPayload as any).messages[0].content[0].text).toContain('Advanced network hardening');
+
+    const vertexPayload = vertex.format(compiled);
+    expect(vertexPayload).toMatchObject({ model: 'gemini-test' });
+    expect((vertexPayload as any).contents[0].parts[0].text).toContain('field officers');
+  });
+
+  it('fails validation with descriptive errors', () => {
+    const validation = prompt.validate({ ...validValues, topic: 'bad' });
+    expect(validation.valid).toBe(false);
+    expect(validation.errors[0].details[0].code).toBe('string.minLength');
+
+    expect(() => prompt.render({ ...validValues, topic: 'bad' })).toThrow(PromptValidationError);
+  });
+
+  it('rejects extraneous slot data', () => {
+    const validation = prompt.validate({ ...validValues, unknown: 'nope' } as any);
+    expect(validation.valid).toBe(false);
+    expect(validation.errors.some((error) => error.details[0].code === 'slot.unexpected')).toBe(true);
+  });
+
+  it('produces CI-friendly summaries', () => {
+    const validation = prompt.validate({ ...validValues, topic: 'bad' });
+    const summary = formatValidationResultForCI(prompt, validation);
+    expect(summary).toContain('FAILED');
+    expect(summary).toContain('string.minLength');
+
+    const suite = generateTestSuite(prompt, { validExample: validValues });
+    expect(suite.cases.some((testCase) => testCase.description.includes('counterexample'))).toBe(true);
+    const run = suite.run();
+    expect(run.passed).toBe(true);
+    const suiteSummary = formatTestRunForCI(suite.name, run);
+    expect(suiteSummary).toContain('PASSED');
+  });
+});

--- a/packages/rptc/test/test-generator.test.ts
+++ b/packages/rptc/test/test-generator.test.ts
@@ -1,0 +1,102 @@
+import {
+  PromptTemplate,
+  type PromptValidationResult,
+  booleanSlot,
+  createPromptTemplate,
+  enumSlot,
+  generateTestSuite,
+  numberSlot,
+  stringSlot,
+  type SlotValues,
+  type TestHarness
+} from '../src/index.js';
+
+function buildTemplate() {
+  return createPromptTemplate({
+    name: 'policy-brief',
+    description: 'Generate policy briefs with strict slot validation.',
+    template: 'Policy for {{audience}} on {{topic}} with {{count}} actions. Mode={{mode}} Include summary={{includeSummary}}',
+    slots: {
+      audience: stringSlot({ constraints: { minLength: 4, maxLength: 32 }, example: 'mission planners' }),
+      topic: stringSlot({ constraints: { minLength: 6, pattern: /^[A-Za-z\s]+$/ }, example: 'Resilience drills' }),
+      count: numberSlot({ constraints: { min: 2, max: 4 }, example: 2 }),
+      mode: enumSlot(['strategic', 'tactical'] as const, { defaultValue: 'strategic' }),
+      includeSummary: booleanSlot({ defaultValue: true })
+    }
+  });
+}
+
+describe('generated test suites', () => {
+  const template = buildTemplate();
+  const suite = generateTestSuite(template, {
+    validExample: {
+      audience: 'intel chiefs',
+      topic: 'Resilience drills',
+      count: 3,
+      mode: 'strategic',
+      includeSummary: true
+    }
+  });
+
+  it('passes when template enforces constraints', () => {
+    const results = suite.run();
+    expect(results.passed).toBe(true);
+  });
+
+  it('catches seeded regressions', () => {
+    const broken: PromptTemplate<typeof template.slots> = {
+      ...template,
+      validate(values) {
+        const slots = Object.fromEntries(
+          Object.keys(template.slots).map((slot) => [slot, { valid: true, value: (values as Record<string, unknown>)[slot] }])
+        ) as PromptValidationResult<typeof template.slots>['slots'];
+        return {
+          valid: true,
+          slots,
+          errors: [],
+          value: values as SlotValues<typeof template.slots>
+        } satisfies PromptValidationResult<typeof template.slots>;
+      },
+      compile(values) {
+        return {
+          name: template.name,
+          description: template.description,
+          template: template.template,
+          rendered: template.template.replace(/{{\s*([a-zA-Z0-9_]+)\s*}}/g, (_, key: string) => {
+            const resolved = (values as Record<string, unknown>)[key];
+            return resolved === undefined || resolved === null ? '' : String(resolved);
+          }),
+          slots: template.slots,
+          values: values as SlotValues<typeof template.slots>,
+          metadata: template.metadata
+        };
+      },
+      render(values) {
+        return this.compile(values as SlotValues<typeof template.slots>).rendered;
+      }
+    };
+
+    const results = suite.run(broken);
+    expect(results.passed).toBe(false);
+    expect(results.results.some((result) => !result.passed)).toBe(true);
+  });
+
+  it('registers tests against a harness', () => {
+    const calls: string[] = [];
+    const harness: TestHarness = {
+      describe(name, fn) {
+        calls.push(`describe:${name}`);
+        fn();
+      },
+      it(name, fn) {
+        calls.push(`it:${name}`);
+        fn();
+      },
+      expect
+    };
+
+    suite.register(harness);
+    expect(calls.some((entry) => entry.startsWith('describe:'))).toBe(true);
+    expect(calls.some((entry) => entry.startsWith('it:'))).toBe(true);
+  });
+});

--- a/packages/rptc/tsconfig.build.json
+++ b/packages/rptc/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["test"]
+}

--- a/packages/rptc/tsconfig.json
+++ b/packages/rptc/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "composite": true,
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- add the @summit/rptc workspace package with typed slot schemas, validation pipeline, and compile-time placeholder checks
- expose adapters for OpenAI, Anthropic, and Vertex AI alongside CI-friendly validation/test formatters
- generate constraint-driven regression suites with Jest specs covering invalid value detection and harness registration

## Testing
- `pnpm install --ignore-scripts` *(fails: pnpm not available in container)*
- `pnpm --filter @summit/rptc test` *(not run: pnpm not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d76787ca988333817b7e8752eaed81