### PR TITLE
feat: add qawe quorum approval engine

### DIFF
--- a/services/qawe/README.md
+++ b/services/qawe/README.md
@@ -1,0 +1,62 @@
+
+# Quorum Approval Workflow Engine (QAWE)
+
+QAWE is an Ed25519-signed quorum workflow service written in Go with a companion
+React dashboard. It allows policy-defined voter groups to approve workflow gates
+with explicit quorum requirements, stage expirations, delegation rules, and
+parallel/conditional stage topologies.
+
+## Features
+
+- **Policy-aware quorums**: Each gate references a role whose principals are
+  specified in the workflow definition. Delegation keys can be registered per
+  principal and enforced per-gate.
+- **Deterministic expiry handling**: Gates define per-activation expiry windows;
+  approvals after the deadline are rejected and the workflow instance becomes
+  `expired`.
+- **Parallel and conditional stages**: Stages may fan out in parallel (all gates
+  must complete) or route conditionally based on instance context.
+- **Cryptographic evidence**: Every satisfied gate produces a server-signed
+  approval bundle that can be verified offline with the exposed server public
+  key.
+
+## Running the service
+
+```bash
+cd services/qawe
+# compile & run on :8080
+go run ./cmd/qawe
+```
+
+Environment variables:
+
+- `QAWE_SERVER_PRIVATE_KEY` (optional): base64-encoded Ed25519 private key.
+  When omitted, the server generates an ephemeral key pair on startup.
+
+## HTTP API
+
+| Method | Path                                | Description |
+| ------ | ----------------------------------- | ----------- |
+| POST   | `/api/workflows`                    | Register a workflow definition (policy included). |
+| POST   | `/api/instances`                    | Start a workflow instance with context. |
+| GET    | `/api/instances/{id}`               | Retrieve instance state. |
+| POST   | `/api/instances/{id}/approvals`     | Submit a signed approval payload. |
+| GET    | `/api/info`                         | Return server public key for bundle verification. |
+
+Approval payloads must be signed using the canonical message format:
+
+```
+{instanceID}|{stageID}|{gateID}|{actorID}|{delegatedFrom}|{signedAtUnixNanos}
+```
+
+## React Console
+
+The UI lives in `ui/qawe` and can be started with:
+
+```bash
+cd ui/qawe
+npm install
+npm run dev
+```
+
+By default it proxies API requests to `http://localhost:8080`.

--- a/services/qawe/cmd/qawe/main.go
+++ b/services/qawe/cmd/qawe/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"qawe/internal/engine"
+	"qawe/internal/server"
+)
+
+func main() {
+	addr := flag.String("addr", ":8080", "listen address")
+	flag.Parse()
+
+	priv, pub, err := loadServerKey()
+	if err != nil {
+		log.Fatalf("load signing key: %v", err)
+	}
+
+	eng := engine.NewEngine(nil, priv, pub)
+	api := server.New(eng, pub)
+	log.Printf("QAWE listening on %s (server public key %s)", *addr, base64.StdEncoding.EncodeToString(pub))
+	if err := http.ListenAndServe(*addr, api.Handler()); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}
+
+func loadServerKey() (ed25519.PrivateKey, ed25519.PublicKey, error) {
+	encoded := os.Getenv("QAWE_SERVER_PRIVATE_KEY")
+	if encoded == "" {
+		pub, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
+		return priv, pub, nil
+	}
+	data, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode private key: %w", err)
+	}
+	if len(data) != ed25519.PrivateKeySize {
+		return nil, nil, fmt.Errorf("invalid private key length %d", len(data))
+	}
+	priv := ed25519.PrivateKey(data)
+	pub := priv.Public().(ed25519.PublicKey)
+	return priv, pub, nil
+}

--- a/services/qawe/go.mod
+++ b/services/qawe/go.mod
@@ -1,0 +1,5 @@
+module qawe
+
+go 1.21
+
+require github.com/google/uuid v1.5.0

--- a/services/qawe/go.sum
+++ b/services/qawe/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/services/qawe/internal/bundle/bundle.go
+++ b/services/qawe/internal/bundle/bundle.go
@@ -1,0 +1,93 @@
+package bundle
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// ApprovalRecord is a single signed approval entry.
+type ApprovalRecord struct {
+	PrincipalID   string    `json:"principalId"`
+	ActorID       string    `json:"actorId"`
+	DelegatedFrom string    `json:"delegatedFrom,omitempty"`
+	Payload       string    `json:"payload"`
+	Signature     string    `json:"signature"`
+	SignedAt      time.Time `json:"signedAt"`
+}
+
+// ApprovalBundle aggregates multiple approvals and is signed by the server so
+// that it can be verified offline.
+type ApprovalBundle struct {
+	InstanceID      string           `json:"instanceId"`
+	WorkflowID      string           `json:"workflowId"`
+	StageID         string           `json:"stageId"`
+	GateID          string           `json:"gateId"`
+	Quorum          int              `json:"quorum"`
+	Approvals       []ApprovalRecord `json:"approvals"`
+	IssuedAt        time.Time        `json:"issuedAt"`
+	ServerSignature string           `json:"serverSignature"`
+	ServerPublicKey string           `json:"serverPublicKey"`
+}
+
+// New creates a bundle and signs it using the provided server key pair.
+func New(instanceID, workflowID, stageID, gateID string, quorum int, approvals []ApprovalRecord, issuedAt time.Time, priv ed25519.PrivateKey, pub ed25519.PublicKey) (ApprovalBundle, error) {
+	bundle := ApprovalBundle{
+		InstanceID:      instanceID,
+		WorkflowID:      workflowID,
+		StageID:         stageID,
+		GateID:          gateID,
+		Quorum:          quorum,
+		Approvals:       approvals,
+		IssuedAt:        issuedAt.UTC(),
+		ServerPublicKey: base64.StdEncoding.EncodeToString(pub),
+	}
+	payload, err := bundle.payload()
+	if err != nil {
+		return ApprovalBundle{}, err
+	}
+	signature := ed25519.Sign(priv, payload)
+	bundle.ServerSignature = base64.StdEncoding.EncodeToString(signature)
+	return bundle, nil
+}
+
+func (b ApprovalBundle) payload() ([]byte, error) {
+	body := map[string]any{
+		"instanceId": b.InstanceID,
+		"workflowId": b.WorkflowID,
+		"stageId":    b.StageID,
+		"gateId":     b.GateID,
+		"quorum":     b.Quorum,
+		"approvals":  b.Approvals,
+		"issuedAt":   b.IssuedAt.UTC().Format(time.RFC3339Nano),
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	sum := sha256.Sum256(raw)
+	return sum[:], nil
+}
+
+// VerifyServerSignature ensures the bundle signature matches the provided
+// public key.
+func VerifyServerSignature(b ApprovalBundle, pub ed25519.PublicKey) error {
+	if len(pub) == 0 {
+		return errors.New("server public key is required")
+	}
+	payload, err := b.payload()
+	if err != nil {
+		return err
+	}
+	sigBytes, err := base64.StdEncoding.DecodeString(b.ServerSignature)
+	if err != nil {
+		return err
+	}
+	if !ed25519.Verify(pub, payload, sigBytes) {
+		return errors.New("bundle signature verification failed")
+	}
+	return nil
+}

--- a/services/qawe/internal/engine/engine.go
+++ b/services/qawe/internal/engine/engine.go
@@ -1,0 +1,532 @@
+package engine
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"qawe/internal/bundle"
+	"qawe/internal/policy"
+)
+
+// StageKind defines the execution behavior for a workflow stage.
+type StageKind string
+
+const (
+	StageKindSequential  StageKind = "sequential"
+	StageKindParallel    StageKind = "parallel"
+	StageKindConditional StageKind = "conditional"
+)
+
+// GateDefinition describes a quorum gate that must be satisfied.
+type GateDefinition struct {
+	ID             string `json:"id"`
+	Role           string `json:"role"`
+	Quorum         int    `json:"quorum"`
+	ExpirySeconds  int64  `json:"expirySeconds"`
+	AllowDelegates bool   `json:"allowDelegates"`
+}
+
+// Condition is a simple equality expression evaluated against workflow context.
+type Condition struct {
+	Field  string `json:"field"`
+	Equals string `json:"equals"`
+}
+
+// BranchDefinition routes execution to the provided stages when the condition matches the workflow context.
+type BranchDefinition struct {
+	Condition Condition `json:"condition"`
+	Next      []string  `json:"next"`
+}
+
+// StageDefinition describes a unit of work inside a workflow.
+type StageDefinition struct {
+	ID       string             `json:"id"`
+	Kind     StageKind          `json:"kind"`
+	Gates    []GateDefinition   `json:"gates,omitempty"`
+	Branches []BranchDefinition `json:"branches,omitempty"`
+	Next     []string           `json:"next,omitempty"`
+}
+
+// WorkflowDefinition contains the complete structure for an approval workflow.
+type WorkflowDefinition struct {
+	ID     string            `json:"id"`
+	Name   string            `json:"name"`
+	Start  string            `json:"start"`
+	Stages []StageDefinition `json:"stages"`
+	Policy policy.Policy     `json:"policy"`
+}
+
+// StartInstanceRequest is the payload for creating a workflow instance.
+type StartInstanceRequest struct {
+	WorkflowID string            `json:"workflowId"`
+	Context    map[string]string `json:"context"`
+}
+
+// SubmitApprovalRequest captures an approval for a given gate.
+type SubmitApprovalRequest struct {
+	StageID       string    `json:"stageId"`
+	GateID        string    `json:"gateId"`
+	ActorID       string    `json:"actorId"`
+	DelegatedFrom string    `json:"delegatedFrom,omitempty"`
+	Signature     string    `json:"signature"`
+	SignedAt      time.Time `json:"signedAt"`
+}
+
+// InstanceStatus tracks lifecycle state for a workflow instance.
+type InstanceStatus string
+
+const (
+	InstanceStatusPending   InstanceStatus = "pending"
+	InstanceStatusActive    InstanceStatus = "active"
+	InstanceStatusCompleted InstanceStatus = "completed"
+	InstanceStatusExpired   InstanceStatus = "expired"
+)
+
+// StageStatus represents the final state for a stage.
+type StageStatus string
+
+const (
+	StageStatusCompleted StageStatus = "completed"
+	StageStatusExpired   StageStatus = "expired"
+)
+
+type workflow struct {
+	definition *WorkflowDefinition
+	stages     map[string]*StageDefinition
+}
+
+type stageRuntime struct {
+	Definition *StageDefinition        `json:"definition"`
+	Gates      map[string]*gateRuntime `json:"gates"`
+	ActiveGate string                  `json:"activeGate,omitempty"`
+	StartedAt  time.Time               `json:"startedAt"`
+}
+
+type gateRuntime struct {
+	Definition         GateDefinition          `json:"definition"`
+	Approvals          []bundle.ApprovalRecord `json:"approvals"`
+	PrincipalApprovals map[string]struct{}     `json:"principalApprovals"`
+	Satisfied          bool                    `json:"satisfied"`
+	ExpiresAt          time.Time               `json:"expiresAt"`
+	Bundle             *bundle.ApprovalBundle  `json:"bundle,omitempty"`
+	Index              int                     `json:"index"`
+}
+
+// StageResult captures the terminal details for a stage.
+type StageResult struct {
+	StageID     string      `json:"stageId"`
+	Status      StageStatus `json:"status"`
+	CompletedAt time.Time   `json:"completedAt"`
+}
+
+// WorkflowInstance tracks runtime state.
+type WorkflowInstance struct {
+	ID              string                   `json:"id"`
+	WorkflowID      string                   `json:"workflowId"`
+	Context         map[string]string        `json:"context"`
+	Status          InstanceStatus           `json:"status"`
+	ActiveStages    map[string]*stageRuntime `json:"activeStages"`
+	CompletedStages map[string]StageResult   `json:"completedStages"`
+	ApprovalBundles []bundle.ApprovalBundle  `json:"approvalBundles"`
+	CreatedAt       time.Time                `json:"createdAt"`
+	UpdatedAt       time.Time                `json:"updatedAt"`
+}
+
+// Engine executes workflows and enforces quorum policies.
+type Engine struct {
+	mu         sync.RWMutex
+	workflows  map[string]*workflow
+	instances  map[string]*WorkflowInstance
+	now        func() time.Time
+	serverPriv ed25519.PrivateKey
+	serverPub  ed25519.PublicKey
+}
+
+// NewEngine builds a new workflow engine.
+func NewEngine(now func() time.Time, priv ed25519.PrivateKey, pub ed25519.PublicKey) *Engine {
+	if now == nil {
+		now = time.Now
+	}
+	return &Engine{
+		workflows:  make(map[string]*workflow),
+		instances:  make(map[string]*WorkflowInstance),
+		now:        now,
+		serverPriv: priv,
+		serverPub:  pub,
+	}
+}
+
+// CreateWorkflow registers a new workflow definition.
+func (e *Engine) CreateWorkflow(def WorkflowDefinition) (*WorkflowDefinition, error) {
+	if def.Start == "" {
+		return nil, errors.New("workflow start stage is required")
+	}
+	if len(def.Stages) == 0 {
+		return nil, errors.New("workflow must define at least one stage")
+	}
+	if err := def.Policy.Validate(); err != nil {
+		return nil, err
+	}
+	stageMap := make(map[string]*StageDefinition)
+	for i := range def.Stages {
+		stage := &def.Stages[i]
+		if stage.ID == "" {
+			return nil, fmt.Errorf("stage at index %d is missing an id", i)
+		}
+		if _, exists := stageMap[stage.ID]; exists {
+			return nil, fmt.Errorf("duplicate stage id %s", stage.ID)
+		}
+		switch stage.Kind {
+		case StageKindSequential, StageKindParallel, StageKindConditional:
+		default:
+			return nil, fmt.Errorf("stage %s has unsupported kind %s", stage.ID, stage.Kind)
+		}
+		for j, gate := range stage.Gates {
+			if gate.ID == "" {
+				return nil, fmt.Errorf("stage %s gate %d missing id", stage.ID, j)
+			}
+			if gate.Quorum <= 0 {
+				return nil, fmt.Errorf("gate %s quorum must be >0", gate.ID)
+			}
+			if gate.Role == "" {
+				return nil, fmt.Errorf("gate %s missing role", gate.ID)
+			}
+		}
+		stageMap[stage.ID] = stage
+	}
+	if _, ok := stageMap[def.Start]; !ok {
+		return nil, fmt.Errorf("start stage %s does not exist", def.Start)
+	}
+	if def.ID == "" {
+		def.ID = uuid.NewString()
+	}
+	wf := &workflow{definition: &def, stages: stageMap}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.workflows[def.ID] = wf
+	return wf.definition, nil
+}
+
+// StartInstance creates a new instance from the workflow definition.
+func (e *Engine) StartInstance(req StartInstanceRequest) (*WorkflowInstance, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	wf, ok := e.workflows[req.WorkflowID]
+	if !ok {
+		return nil, errors.New("workflow not found")
+	}
+	instance := &WorkflowInstance{
+		ID:              uuid.NewString(),
+		WorkflowID:      req.WorkflowID,
+		Context:         make(map[string]string),
+		Status:          InstanceStatusPending,
+		ActiveStages:    make(map[string]*stageRuntime),
+		CompletedStages: make(map[string]StageResult),
+		CreatedAt:       e.now(),
+		UpdatedAt:       e.now(),
+	}
+	for k, v := range req.Context {
+		instance.Context[k] = v
+	}
+	if err := e.activateStage(instance, wf, wf.definition.Start); err != nil {
+		return nil, err
+	}
+	if instance.Status != InstanceStatusCompleted && len(instance.ActiveStages) == 0 {
+		instance.Status = InstanceStatusCompleted
+	} else {
+		instance.Status = InstanceStatusActive
+	}
+	e.instances[instance.ID] = instance
+	return instance, nil
+}
+
+// GetInstance retrieves the workflow instance by ID.
+func (e *Engine) GetInstance(id string) (*WorkflowInstance, error) {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	inst, ok := e.instances[id]
+	if !ok {
+		return nil, errors.New("instance not found")
+	}
+	return cloneInstance(inst), nil
+}
+
+// SubmitApproval records an approval for the specified gate.
+func (e *Engine) SubmitApproval(instanceID string, req SubmitApprovalRequest) (*bundle.ApprovalBundle, error) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	inst, ok := e.instances[instanceID]
+	if !ok {
+		return nil, errors.New("instance not found")
+	}
+	if inst.Status == InstanceStatusCompleted {
+		return nil, errors.New("instance already completed")
+	}
+	if inst.Status == InstanceStatusExpired {
+		return nil, errors.New("instance expired")
+	}
+	wf := e.workflows[inst.WorkflowID]
+	stageRuntime, ok := inst.ActiveStages[req.StageID]
+	if !ok {
+		return nil, errors.New("stage is not active")
+	}
+	gateRuntime, ok := stageRuntime.Gates[req.GateID]
+	if !ok {
+		return nil, errors.New("gate not found")
+	}
+	if gateRuntime.Satisfied {
+		return nil, errors.New("gate already satisfied")
+	}
+	if stageRuntime.Definition.Kind == StageKindSequential && stageRuntime.ActiveGate != gateRuntime.Definition.ID {
+		return nil, errors.New("gate not currently active in sequential stage")
+	}
+	now := e.now()
+	if !gateRuntime.ExpiresAt.IsZero() && now.After(gateRuntime.ExpiresAt) {
+		inst.Status = InstanceStatusExpired
+		inst.UpdatedAt = now
+		e.markStageExpired(inst, req.StageID)
+		return nil, errors.New("gate expired")
+	}
+	principal, actorKey, pubKey, err := wf.definition.Policy.ResolveActor(gateRuntime.Definition.Role, req.ActorID, req.DelegatedFrom)
+	if err != nil {
+		return nil, err
+	}
+	if req.DelegatedFrom != "" {
+		if !gateRuntime.Definition.AllowDelegates {
+			return nil, errors.New("delegation is not allowed for this gate")
+		}
+		if principal.ID != req.DelegatedFrom {
+			return nil, errors.New("delegatedFrom does not match a principal")
+		}
+	} else if actorKey != principal.ID {
+		return nil, errors.New("delegation must specify delegatedFrom")
+	}
+	message := canonicalApprovalMessage(instanceID, req.StageID, req.GateID, req.ActorID, req.DelegatedFrom, req.SignedAt)
+	sigBytes, err := base64.StdEncoding.DecodeString(req.Signature)
+	if err != nil {
+		return nil, err
+	}
+	if !ed25519.Verify(pubKey, []byte(message), sigBytes) {
+		return nil, errors.New("approval signature verification failed")
+	}
+	if gateRuntime.PrincipalApprovals == nil {
+		gateRuntime.PrincipalApprovals = make(map[string]struct{})
+	}
+	if _, exists := gateRuntime.PrincipalApprovals[principal.ID]; exists {
+		return nil, errors.New("principal already satisfied the quorum")
+	}
+	record := bundle.ApprovalRecord{
+		PrincipalID:   principal.ID,
+		ActorID:       actorKey,
+		DelegatedFrom: req.DelegatedFrom,
+		Payload:       message,
+		Signature:     req.Signature,
+		SignedAt:      req.SignedAt.UTC(),
+	}
+	gateRuntime.Approvals = append(gateRuntime.Approvals, record)
+	gateRuntime.PrincipalApprovals[principal.ID] = struct{}{}
+	inst.UpdatedAt = now
+	var bundleResult *bundle.ApprovalBundle
+	if len(gateRuntime.PrincipalApprovals) >= gateRuntime.Definition.Quorum {
+		approvalBundle, err := bundle.New(inst.ID, inst.WorkflowID, req.StageID, req.GateID, gateRuntime.Definition.Quorum, gateRuntime.Approvals, now, e.serverPriv, e.serverPub)
+		if err != nil {
+			return nil, err
+		}
+		gateRuntime.Satisfied = true
+		gateRuntime.Bundle = &approvalBundle
+		inst.ApprovalBundles = append(inst.ApprovalBundles, approvalBundle)
+		bundleResult = gateRuntime.Bundle
+		e.advanceStage(inst, wf, req.StageID)
+	}
+	return bundleResult, nil
+}
+
+func (e *Engine) advanceStage(inst *WorkflowInstance, wf *workflow, stageID string) {
+	stageRuntime, ok := inst.ActiveStages[stageID]
+	if !ok {
+		return
+	}
+	stageDef := stageRuntime.Definition
+	switch stageDef.Kind {
+	case StageKindSequential:
+		nextGate := ""
+		for _, gate := range stageDef.Gates {
+			state := stageRuntime.Gates[gate.ID]
+			if !state.Satisfied {
+				nextGate = gate.ID
+				break
+			}
+		}
+		if nextGate != "" {
+			stageRuntime.ActiveGate = nextGate
+			return
+		}
+		delete(inst.ActiveStages, stageID)
+		e.markStageCompleted(inst, wf, stageID)
+	case StageKindParallel:
+		for _, state := range stageRuntime.Gates {
+			if !state.Satisfied {
+				return
+			}
+		}
+		delete(inst.ActiveStages, stageID)
+		e.markStageCompleted(inst, wf, stageID)
+	}
+}
+
+func (e *Engine) markStageCompleted(inst *WorkflowInstance, wf *workflow, stageID string) {
+	stageDef := wf.stages[stageID]
+	inst.CompletedStages[stageID] = StageResult{
+		StageID:     stageID,
+		Status:      StageStatusCompleted,
+		CompletedAt: e.now(),
+	}
+	for _, next := range stageDef.Next {
+		_ = e.activateStage(inst, wf, next)
+	}
+	if len(inst.ActiveStages) == 0 && inst.Status != InstanceStatusExpired {
+		inst.Status = InstanceStatusCompleted
+		inst.UpdatedAt = e.now()
+	}
+}
+
+func (e *Engine) markStageExpired(inst *WorkflowInstance, stageID string) {
+	delete(inst.ActiveStages, stageID)
+	inst.CompletedStages[stageID] = StageResult{
+		StageID:     stageID,
+		Status:      StageStatusExpired,
+		CompletedAt: e.now(),
+	}
+	inst.UpdatedAt = e.now()
+}
+
+func (e *Engine) activateStage(inst *WorkflowInstance, wf *workflow, stageID string) error {
+	if stageID == "" {
+		return nil
+	}
+	if _, done := inst.CompletedStages[stageID]; done {
+		return nil
+	}
+	if _, active := inst.ActiveStages[stageID]; active {
+		return nil
+	}
+	stageDef, ok := wf.stages[stageID]
+	if !ok {
+		return fmt.Errorf("stage %s not found", stageID)
+	}
+	runtime := &stageRuntime{
+		Definition: stageDef,
+		Gates:      make(map[string]*gateRuntime),
+		StartedAt:  e.now(),
+	}
+	switch stageDef.Kind {
+	case StageKindConditional:
+		matched := false
+		for _, branch := range stageDef.Branches {
+			if inst.Context[branch.Condition.Field] == branch.Condition.Equals {
+				matched = true
+				inst.CompletedStages[stageID] = StageResult{
+					StageID:     stageID,
+					Status:      StageStatusCompleted,
+					CompletedAt: e.now(),
+				}
+				for _, next := range branch.Next {
+					_ = e.activateStage(inst, wf, next)
+				}
+				break
+			}
+		}
+		if !matched {
+			if len(stageDef.Next) == 0 {
+				return fmt.Errorf("no matching branch for conditional stage %s", stageID)
+			}
+			inst.CompletedStages[stageID] = StageResult{
+				StageID:     stageID,
+				Status:      StageStatusCompleted,
+				CompletedAt: e.now(),
+			}
+			for _, next := range stageDef.Next {
+				_ = e.activateStage(inst, wf, next)
+			}
+		}
+		if len(inst.ActiveStages) == 0 && inst.Status != InstanceStatusExpired {
+			inst.Status = InstanceStatusCompleted
+		}
+		return nil
+	default:
+		for idx, gate := range stageDef.Gates {
+			var expiresAt time.Time
+			if gate.ExpirySeconds > 0 {
+				expiresAt = runtime.StartedAt.Add(time.Duration(gate.ExpirySeconds) * time.Second)
+			}
+			runtime.Gates[gate.ID] = &gateRuntime{
+				Definition:         gate,
+				PrincipalApprovals: make(map[string]struct{}),
+				Index:              idx,
+				ExpiresAt:          expiresAt,
+			}
+		}
+		if stageDef.Kind == StageKindSequential && len(stageDef.Gates) > 0 {
+			runtime.ActiveGate = stageDef.Gates[0].ID
+		}
+		inst.ActiveStages[stageID] = runtime
+		if len(stageDef.Gates) == 0 {
+			delete(inst.ActiveStages, stageID)
+			inst.CompletedStages[stageID] = StageResult{
+				StageID:     stageID,
+				Status:      StageStatusCompleted,
+				CompletedAt: e.now(),
+			}
+			for _, next := range stageDef.Next {
+				_ = e.activateStage(inst, wf, next)
+			}
+			if len(inst.ActiveStages) == 0 && inst.Status != InstanceStatusExpired {
+				inst.Status = InstanceStatusCompleted
+			}
+		}
+	}
+	return nil
+}
+
+func canonicalApprovalMessage(instanceID, stageID, gateID, actorID, delegatedFrom string, signedAt time.Time) string {
+	return fmt.Sprintf("%s|%s|%s|%s|%s|%d", instanceID, stageID, gateID, actorID, delegatedFrom, signedAt.UTC().UnixNano())
+}
+
+func cloneInstance(src *WorkflowInstance) *WorkflowInstance {
+	copy := *src
+	copy.Context = make(map[string]string)
+	for k, v := range src.Context {
+		copy.Context[k] = v
+	}
+	copy.ActiveStages = make(map[string]*stageRuntime)
+	for id, stage := range src.ActiveStages {
+		stageCopy := *stage
+		stageCopy.Gates = make(map[string]*gateRuntime)
+		for gid, gate := range stage.Gates {
+			gateCopy := *gate
+			if gate.Bundle != nil {
+				bundleCopy := *gate.Bundle
+				gateCopy.Bundle = &bundleCopy
+			}
+			gateCopy.PrincipalApprovals = make(map[string]struct{})
+			for k := range gate.PrincipalApprovals {
+				gateCopy.PrincipalApprovals[k] = struct{}{}
+			}
+			gateCopy.Approvals = append([]bundle.ApprovalRecord(nil), gate.Approvals...)
+			stageCopy.Gates[gid] = &gateCopy
+		}
+		copy.ActiveStages[id] = &stageCopy
+	}
+	copy.CompletedStages = make(map[string]StageResult)
+	for k, v := range src.CompletedStages {
+		copy.CompletedStages[k] = v
+	}
+	copy.ApprovalBundles = append([]bundle.ApprovalBundle(nil), src.ApprovalBundles...)
+	return &copy
+}

--- a/services/qawe/internal/engine/engine_test.go
+++ b/services/qawe/internal/engine/engine_test.go
@@ -1,0 +1,317 @@
+package engine
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"qawe/internal/bundle"
+	"qawe/internal/policy"
+)
+
+func TestSequentialQuorumAndBundle(t *testing.T) {
+	now := time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)
+	current := now
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate server key: %v", err)
+	}
+	eng := NewEngine(func() time.Time { return current }, priv, pub)
+
+	legal, legalPrivs := buildRole(t, "legal", 3)
+	workflow := WorkflowDefinition{
+		Name:  "Test",
+		Start: "stage-legal",
+		Policy: policy.Policy{
+			Roles: map[string]*policy.Role{
+				"legal": legal,
+			},
+		},
+		Stages: []StageDefinition{
+			{
+				ID:   "stage-legal",
+				Kind: StageKindSequential,
+				Gates: []GateDefinition{
+					{ID: "g-legal", Role: "legal", Quorum: 2, ExpirySeconds: 120, AllowDelegates: false},
+				},
+			},
+		},
+	}
+	created, err := eng.CreateWorkflow(workflow)
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	inst, err := eng.StartInstance(StartInstanceRequest{WorkflowID: created.ID})
+	if err != nil {
+		t.Fatalf("start instance: %v", err)
+	}
+
+	signedAt := current
+	sig1 := signApproval(t, legalPrivs[0], inst.ID, "stage-legal", "g-legal", legal.Principals[0].ID, "", signedAt)
+	bundleRes, err := eng.SubmitApproval(inst.ID, SubmitApprovalRequest{
+		StageID:   "stage-legal",
+		GateID:    "g-legal",
+		ActorID:   legal.Principals[0].ID,
+		Signature: sig1,
+		SignedAt:  signedAt,
+	})
+	if err != nil {
+		t.Fatalf("submit first approval: %v", err)
+	}
+	if bundleRes != nil {
+		t.Fatalf("expected quorum not reached yet")
+	}
+
+	sig2 := signApproval(t, legalPrivs[1], inst.ID, "stage-legal", "g-legal", legal.Principals[1].ID, "", signedAt)
+	bundleRes, err = eng.SubmitApproval(inst.ID, SubmitApprovalRequest{
+		StageID:   "stage-legal",
+		GateID:    "g-legal",
+		ActorID:   legal.Principals[1].ID,
+		Signature: sig2,
+		SignedAt:  signedAt,
+	})
+	if err != nil {
+		t.Fatalf("submit second approval: %v", err)
+	}
+	if bundleRes == nil {
+		t.Fatalf("expected quorum bundle")
+	}
+	if err := bundle.VerifyServerSignature(*bundleRes, pub); err != nil {
+		t.Fatalf("verify bundle: %v", err)
+	}
+	verifyApprovalSignatures(t, bundleRes.Approvals, legal.Principals, legalPrivs)
+
+	snapshot, err := eng.GetInstance(inst.ID)
+	if err != nil {
+		t.Fatalf("get instance: %v", err)
+	}
+	if snapshot.Status != InstanceStatusCompleted {
+		t.Fatalf("expected completed instance, got %s", snapshot.Status)
+	}
+	if len(snapshot.ApprovalBundles) != 1 {
+		t.Fatalf("expected 1 approval bundle, got %d", len(snapshot.ApprovalBundles))
+	}
+
+	if _, err := eng.SubmitApproval(inst.ID, SubmitApprovalRequest{
+		StageID:   "stage-legal",
+		GateID:    "g-legal",
+		ActorID:   legal.Principals[2].ID,
+		Signature: sig2,
+		SignedAt:  signedAt,
+	}); err == nil {
+		t.Fatalf("expected error when approving completed gate")
+	}
+}
+
+func TestDelegationParallelAndConditional(t *testing.T) {
+	now := time.Date(2024, 2, 1, 9, 0, 0, 0, time.UTC)
+	current := now
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate server key: %v", err)
+	}
+	eng := NewEngine(func() time.Time { return current }, priv, pub)
+
+	legalRole, legalPrivs := buildRole(t, "legal", 1)
+	securityRole, _ := buildRole(t, "security", 1)
+	delegatePub, delegatePriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("delegate key: %v", err)
+	}
+	securityRole.Principals[0].Delegates = []*policy.Delegate{{
+		ID:        "sec-delegate",
+		Display:   "Security Delegate",
+		PublicKey: base64.StdEncoding.EncodeToString(delegatePub),
+	}}
+
+	workflow := WorkflowDefinition{
+		Name:  "Parallel",
+		Start: "router",
+		Policy: policy.Policy{
+			Roles: map[string]*policy.Role{
+				"legal":    legalRole,
+				"security": securityRole,
+			},
+		},
+		Stages: []StageDefinition{
+			{
+				ID:   "router",
+				Kind: StageKindConditional,
+				Branches: []BranchDefinition{
+					{Condition: Condition{Field: "risk", Equals: "high"}, Next: []string{"parallel"}},
+				},
+				Next: []string{"low"},
+			},
+			{
+				ID:   "parallel",
+				Kind: StageKindParallel,
+				Gates: []GateDefinition{
+					{ID: "g-legal", Role: "legal", Quorum: 1, ExpirySeconds: 60},
+					{ID: "g-security", Role: "security", Quorum: 1, ExpirySeconds: 60, AllowDelegates: true},
+				},
+				Next: []string{"final"},
+			},
+			{
+				ID:    "low",
+				Kind:  StageKindSequential,
+				Gates: []GateDefinition{{ID: "g-low", Role: "legal", Quorum: 1, ExpirySeconds: 60}},
+				Next:  []string{"final"},
+			},
+			{
+				ID:    "final",
+				Kind:  StageKindSequential,
+				Gates: []GateDefinition{{ID: "g-final", Role: "legal", Quorum: 1, ExpirySeconds: 60}},
+			},
+		},
+	}
+	created, err := eng.CreateWorkflow(workflow)
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+
+	inst, err := eng.StartInstance(StartInstanceRequest{WorkflowID: created.ID, Context: map[string]string{"risk": "high"}})
+	if err != nil {
+		t.Fatalf("start instance: %v", err)
+	}
+
+	signedAt := current
+	sigLegal := signApproval(t, legalPrivs[0], inst.ID, "parallel", "g-legal", legalRole.Principals[0].ID, "", signedAt)
+	if _, err := eng.SubmitApproval(inst.ID, SubmitApprovalRequest{
+		StageID:   "parallel",
+		GateID:    "g-legal",
+		ActorID:   legalRole.Principals[0].ID,
+		Signature: sigLegal,
+		SignedAt:  signedAt,
+	}); err != nil {
+		t.Fatalf("legal approval: %v", err)
+	}
+
+	sigDelegate := signApproval(t, delegatePriv, inst.ID, "parallel", "g-security", "sec-delegate", securityRole.Principals[0].ID, signedAt)
+	bundleRes, err := eng.SubmitApproval(inst.ID, SubmitApprovalRequest{
+		StageID:       "parallel",
+		GateID:        "g-security",
+		ActorID:       "sec-delegate",
+		DelegatedFrom: securityRole.Principals[0].ID,
+		Signature:     sigDelegate,
+		SignedAt:      signedAt,
+	})
+	if err != nil {
+		t.Fatalf("delegate approval: %v", err)
+	}
+	if bundleRes == nil {
+		t.Fatalf("expected bundle for security gate")
+	}
+
+	sigFinal := signApproval(t, legalPrivs[0], inst.ID, "final", "g-final", legalRole.Principals[0].ID, "", signedAt)
+	finalBundle, err := eng.SubmitApproval(inst.ID, SubmitApprovalRequest{
+		StageID:   "final",
+		GateID:    "g-final",
+		ActorID:   legalRole.Principals[0].ID,
+		Signature: sigFinal,
+		SignedAt:  signedAt,
+	})
+	if err != nil {
+		t.Fatalf("final approval: %v", err)
+	}
+	if finalBundle == nil {
+		t.Fatalf("final gate should complete with bundle")
+	}
+}
+
+func TestExpiryDeterministicFailure(t *testing.T) {
+	now := time.Date(2024, 3, 1, 8, 0, 0, 0, time.UTC)
+	current := now
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("server key: %v", err)
+	}
+	eng := NewEngine(func() time.Time { return current }, priv, pub)
+
+	legalRole, legalPrivs := buildRole(t, "legal", 1)
+	workflow := WorkflowDefinition{
+		Name:   "Expiry",
+		Start:  "stage",
+		Policy: policy.Policy{Roles: map[string]*policy.Role{"legal": legalRole}},
+		Stages: []StageDefinition{{
+			ID:    "stage",
+			Kind:  StageKindSequential,
+			Gates: []GateDefinition{{ID: "gate", Role: "legal", Quorum: 1, ExpirySeconds: 1}},
+		}},
+	}
+	created, err := eng.CreateWorkflow(workflow)
+	if err != nil {
+		t.Fatalf("create workflow: %v", err)
+	}
+	inst, err := eng.StartInstance(StartInstanceRequest{WorkflowID: created.ID})
+	if err != nil {
+		t.Fatalf("start instance: %v", err)
+	}
+
+	current = current.Add(2 * time.Second)
+	sig := signApproval(t, legalPrivs[0], inst.ID, "stage", "gate", legalRole.Principals[0].ID, "", current)
+	if _, err := eng.SubmitApproval(inst.ID, SubmitApprovalRequest{
+		StageID:   "stage",
+		GateID:    "gate",
+		ActorID:   legalRole.Principals[0].ID,
+		Signature: sig,
+		SignedAt:  current,
+	}); err == nil {
+		t.Fatalf("expected error due to expiry")
+	}
+	snapshot, err := eng.GetInstance(inst.ID)
+	if err != nil {
+		t.Fatalf("get instance: %v", err)
+	}
+	if snapshot.Status != InstanceStatusExpired {
+		t.Fatalf("expected expired status, got %s", snapshot.Status)
+	}
+}
+
+func signApproval(t *testing.T, priv ed25519.PrivateKey, instanceID, stageID, gateID, actorID, delegatedFrom string, signedAt time.Time) string {
+	t.Helper()
+	message := canonicalApprovalMessage(instanceID, stageID, gateID, actorID, delegatedFrom, signedAt)
+	sig := ed25519.Sign(priv, []byte(message))
+	return base64.StdEncoding.EncodeToString(sig)
+}
+
+func buildRole(t *testing.T, id string, count int) (*policy.Role, []ed25519.PrivateKey) {
+	t.Helper()
+	principals := make([]*policy.Principal, 0, count)
+	privs := make([]ed25519.PrivateKey, 0, count)
+	for i := 0; i < count; i++ {
+		pub, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatalf("generate key: %v", err)
+		}
+		principals = append(principals, &policy.Principal{
+			ID:        id + "-" + string(rune('a'+i)),
+			Display:   "Principal " + string(rune('A'+i)),
+			PublicKey: base64.StdEncoding.EncodeToString(pub),
+		})
+		privs = append(privs, priv)
+	}
+	return &policy.Role{ID: id, Name: id, Principals: principals}, privs
+}
+
+func verifyApprovalSignatures(t *testing.T, approvals []bundle.ApprovalRecord, principals []*policy.Principal, privs []ed25519.PrivateKey) {
+	t.Helper()
+	keyMap := make(map[string]ed25519.PublicKey)
+	for i, principal := range principals {
+		keyMap[principal.ID] = privs[i].Public().(ed25519.PublicKey)
+	}
+	for _, approval := range approvals {
+		pub, ok := keyMap[approval.ActorID]
+		if !ok {
+			t.Fatalf("missing public key for %s", approval.ActorID)
+		}
+		sigBytes, err := base64.StdEncoding.DecodeString(approval.Signature)
+		if err != nil {
+			t.Fatalf("decode signature: %v", err)
+		}
+		if !ed25519.Verify(pub, []byte(approval.Payload), sigBytes) {
+			t.Fatalf("invalid signature for %s", approval.ActorID)
+		}
+	}
+}

--- a/services/qawe/internal/policy/policy.go
+++ b/services/qawe/internal/policy/policy.go
@@ -1,0 +1,125 @@
+package policy
+
+import (
+	"encoding/base64"
+	"errors"
+)
+
+// Policy defines the set of roles and eligible voters that can participate in
+// workflow approvals.
+type Policy struct {
+	Roles map[string]*Role `json:"roles"`
+}
+
+// Role describes a named collection of principals who can vote on a gate.
+type Role struct {
+	ID         string       `json:"id"`
+	Name       string       `json:"name"`
+	Principals []*Principal `json:"principals"`
+}
+
+// Principal is a primary voter that may optionally delegate authority to
+// alternate actors.
+type Principal struct {
+	ID        string      `json:"id"`
+	Display   string      `json:"display"`
+	PublicKey string      `json:"publicKey"`
+	Delegates []*Delegate `json:"delegates,omitempty"`
+}
+
+// Delegate is an alternate voter acting on behalf of a principal.
+type Delegate struct {
+	ID        string `json:"id"`
+	Display   string `json:"display"`
+	PublicKey string `json:"publicKey"`
+}
+
+// ResolveActor validates that the provided actor is permitted to cast a vote
+// for the given role. It returns the canonical principal that the vote counts
+// towards, the actor that is signing, and the actor's public key.
+func (p *Policy) ResolveActor(roleID, actorID, delegatedFrom string) (*Principal, string, []byte, error) {
+	if p == nil {
+		return nil, "", nil, errors.New("policy not configured")
+	}
+	role, ok := p.Roles[roleID]
+	if !ok {
+		return nil, "", nil, errors.New("role not found")
+	}
+	for _, principal := range role.Principals {
+		if delegatedFrom != "" && principal.ID != delegatedFrom {
+			continue
+		}
+		if principal.ID == actorID {
+			pub, err := decodeKey(principal.PublicKey)
+			return principal, principal.ID, pub, err
+		}
+		for _, delegate := range principal.Delegates {
+			if delegate.ID != actorID {
+				continue
+			}
+			pub, err := decodeKey(delegate.PublicKey)
+			return principal, delegate.ID, pub, err
+		}
+	}
+	return nil, "", nil, errors.New("actor not authorized for role")
+}
+
+func decodeKey(key string) ([]byte, error) {
+	if key == "" {
+		return nil, errors.New("missing public key")
+	}
+	bytes, err := base64.StdEncoding.DecodeString(key)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
+
+// PrincipalByID fetches a principal by ID.
+func (r *Role) PrincipalByID(id string) *Principal {
+	for _, principal := range r.Principals {
+		if principal.ID == id {
+			return principal
+		}
+	}
+	return nil
+}
+
+// DelegateKey returns the public key for the named delegate if it exists.
+func (p *Principal) DelegateKey(delegateID string) (string, bool) {
+	for _, delegate := range p.Delegates {
+		if delegate.ID == delegateID {
+			return delegate.PublicKey, true
+		}
+	}
+	return "", false
+}
+
+// Validate ensures the policy definition is internally consistent.
+func (p *Policy) Validate() error {
+	if p == nil {
+		return errors.New("policy is nil")
+	}
+	if len(p.Roles) == 0 {
+		return errors.New("policy must define at least one role")
+	}
+	for id, role := range p.Roles {
+		if role == nil {
+			return errors.New("role " + id + " is nil")
+		}
+		if len(role.Principals) == 0 {
+			return errors.New("role " + id + " has no principals")
+		}
+		for _, principal := range role.Principals {
+			if _, err := decodeKey(principal.PublicKey); err != nil {
+				return err
+			}
+			for _, delegate := range principal.Delegates {
+				if _, err := decodeKey(delegate.PublicKey); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/services/qawe/internal/server/server.go
+++ b/services/qawe/internal/server/server.go
@@ -1,0 +1,145 @@
+package server
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"qawe/internal/engine"
+)
+
+// API wires HTTP endpoints to the workflow engine.
+type API struct {
+	Engine *engine.Engine
+	pubKey ed25519.PublicKey
+}
+
+// New creates an API handler.
+func New(e *engine.Engine, pub ed25519.PublicKey) *API {
+	return &API{Engine: e, pubKey: pub}
+}
+
+// Handler exposes the API routes.
+func (a *API) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/info", a.handleInfo)
+	mux.HandleFunc("/api/workflows", a.handleWorkflows)
+	mux.HandleFunc("/api/instances", a.handleInstances)
+	mux.HandleFunc("/api/instances/", a.handleInstanceByID)
+	return withJSONHeaders(mux)
+}
+
+func (a *API) handleInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, errors.New("method not allowed"))
+		return
+	}
+	response := map[string]string{
+		"serverPublicKey": base64.StdEncoding.EncodeToString(a.pubKey),
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (a *API) handleWorkflows(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, errors.New("method not allowed"))
+		return
+	}
+	var def engine.WorkflowDefinition
+	if err := json.NewDecoder(r.Body).Decode(&def); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	created, err := a.Engine.CreateWorkflow(def)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, created)
+}
+
+func (a *API) handleInstances(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeError(w, http.StatusMethodNotAllowed, errors.New("method not allowed"))
+		return
+	}
+	var req engine.StartInstanceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	instance, err := a.Engine.StartInstance(req)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, instance)
+}
+
+func (a *API) handleInstanceByID(w http.ResponseWriter, r *http.Request) {
+	segments := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/instances/"), "/")
+	if len(segments) == 0 || segments[0] == "" {
+		writeError(w, http.StatusNotFound, errors.New("missing instance id"))
+		return
+	}
+	instanceID := segments[0]
+	if len(segments) == 1 {
+		switch r.Method {
+		case http.MethodGet:
+			instance, err := a.Engine.GetInstance(instanceID)
+			if err != nil {
+				writeError(w, http.StatusNotFound, err)
+				return
+			}
+			writeJSON(w, http.StatusOK, instance)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, errors.New("method not allowed"))
+		}
+		return
+	}
+	if len(segments) == 2 && segments[1] == "approvals" {
+		if r.Method != http.MethodPost {
+			writeError(w, http.StatusMethodNotAllowed, errors.New("method not allowed"))
+			return
+		}
+		var req engine.SubmitApprovalRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		bundle, err := a.Engine.SubmitApproval(instanceID, req)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err)
+			return
+		}
+		if bundle == nil {
+			writeJSON(w, http.StatusAccepted, map[string]string{"status": "recorded"})
+			return
+		}
+		writeJSON(w, http.StatusCreated, bundle)
+		return
+	}
+	writeError(w, http.StatusNotFound, errors.New("unknown path"))
+}
+
+func withJSONHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		next.ServeHTTP(w, r)
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeError(w http.ResponseWriter, status int, err error) {
+	type errorResponse struct {
+		Error string `json:"error"`
+	}
+	writeJSON(w, status, errorResponse{Error: err.Error()})
+}

--- a/ui/qawe/index.html
+++ b/ui/qawe/index.html
@@ -1,0 +1,13 @@
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>QAWE Console</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/ui/qawe/package.json
+++ b/ui/qawe/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "qawe-ui",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@noble/ed25519": "^2.1.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "typescript": "^5.4.5",
+    "vite": "^5.0.10",
+    "@vitejs/plugin-react": "^4.2.1"
+  }
+}

--- a/ui/qawe/src/App.tsx
+++ b/ui/qawe/src/App.tsx
@@ -1,0 +1,430 @@
+
+import { useEffect, useMemo, useState } from 'react';
+import { sign } from '@noble/ed25519';
+import type { ApprovalBundle, WorkflowDefinition, WorkflowInstance } from './types';
+import { ApprovalRequest, createWorkflow, fetchServerInfo, loadInstance, startInstance, submitApproval } from './api';
+
+const encoder = new TextEncoder();
+
+function collectActiveGates(inst: WorkflowInstance | null): { stageId: string; gateId: string }[] {
+  if (!inst) return [];
+  const pairs: { stageId: string; gateId: string }[] = [];
+  Object.entries(inst.activeStages).forEach(([stageId, stage]) => {
+    Object.entries(stage.gates).forEach(([gateId, gate]) => {
+      if (!gate.satisfied) {
+        if (stage.definition.kind !== 'sequential' || stage.activeGate === gateId) {
+          pairs.push({ stageId, gateId });
+        }
+      }
+    });
+  });
+  return pairs;
+}
+
+const sampleWorkflow = `{
+  "name": "QAWE Sample Workflow",
+  "start": "intake",
+  "stages": [
+    {
+      "id": "intake",
+      "kind": "conditional",
+      "branches": [
+        { "condition": { "field": "risk", "equals": "high" }, "next": ["parallel-review"] }
+      ],
+      "next": ["fast-track"]
+    },
+    {
+      "id": "parallel-review",
+      "kind": "parallel",
+      "gates": [
+        { "id": "legal", "role": "legal", "quorum": 2, "expirySeconds": 3600 },
+        { "id": "security", "role": "security", "quorum": 1, "expirySeconds": 3600, "allowDelegates": true }
+      ],
+      "next": ["data-owner"]
+    },
+    {
+      "id": "fast-track",
+      "kind": "sequential",
+      "gates": [
+        { "id": "legal-fast", "role": "legal", "quorum": 1, "expirySeconds": 1800 }
+      ],
+      "next": ["data-owner"]
+    },
+    {
+      "id": "data-owner",
+      "kind": "sequential",
+      "gates": [
+        { "id": "owner", "role": "data-owner", "quorum": 1, "expirySeconds": 7200 }
+      ]
+    }
+  ],
+  "policy": {
+    "roles": {
+      "legal": {
+        "id": "legal",
+        "name": "Legal Quorum",
+        "principals": []
+      },
+      "security": {
+        "id": "security",
+        "name": "Security",
+        "principals": []
+      },
+      "data-owner": {
+        "id": "data-owner",
+        "name": "Data Owner",
+        "principals": []
+      }
+    }
+  }
+}`;
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = '';
+  bytes.forEach((b) => {
+    binary += String.fromCharCode(b);
+  });
+  return btoa(binary);
+}
+
+function decodePrivateKey(base64Key: string): Uint8Array {
+  const sanitized = base64Key.trim();
+  if (!sanitized) {
+    throw new Error('A base64-encoded Ed25519 private key is required.');
+  }
+  const binary = atob(sanitized);
+  const buffer = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    buffer[i] = binary.charCodeAt(i);
+  }
+  if (buffer.length === 32) {
+    return buffer;
+  }
+  if (buffer.length === 64) {
+    return buffer.slice(0, 32);
+  }
+  throw new Error('Private key must decode to 32 or 64 bytes.');
+}
+
+function canonicalMessage(instanceId: string, stageId: string, gateId: string, actorId: string, delegatedFrom: string, nanos: bigint): string {
+  return `${instanceId}|${stageId}|${gateId}|${actorId}|${delegatedFrom}|${nanos}`;
+}
+
+interface StatusMessage {
+  tone: 'success' | 'error';
+  message: string;
+}
+
+const emptyApproval = {
+  stageId: '',
+  gateId: '',
+  actorId: '',
+  delegatedFrom: '',
+  privateKey: ''
+};
+
+const emptyContext = `{
+  "risk": "high"
+}`;
+
+function App() {
+  const [serverKey, setServerKey] = useState<string>('');
+  const [workflowInput, setWorkflowInput] = useState<string>(sampleWorkflow);
+  const [contextInput, setContextInput] = useState<string>(emptyContext);
+  const [currentWorkflow, setCurrentWorkflow] = useState<WorkflowDefinition | null>(null);
+  const [workflowIdInput, setWorkflowIdInput] = useState<string>('');
+  const [instanceIdInput, setInstanceIdInput] = useState<string>('');
+  const [instance, setInstance] = useState<WorkflowInstance | null>(null);
+  const [approvalForm, setApprovalForm] = useState({ ...emptyApproval });
+  const [status, setStatus] = useState<StatusMessage | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    fetchServerInfo()
+      .then((info) => setServerKey(info.serverPublicKey))
+      .catch((err) => setStatus({ tone: 'error', message: `Failed to load server info: ${err.message}` }));
+  }, []);
+
+  const activeGates = useMemo(() => collectActiveGates(instance), [instance]);
+
+  const handleCreateWorkflow = async () => {
+    setStatus(null);
+    try {
+      const parsed = JSON.parse(workflowInput) as WorkflowDefinition;
+      setLoading(true);
+      const created = await createWorkflow(parsed);
+      setCurrentWorkflow(created);
+      setWorkflowIdInput(created.id ?? '');
+      setStatus({ tone: 'success', message: `Workflow created with id ${created.id}` });
+    } catch (err) {
+      setStatus({ tone: 'error', message: `Unable to create workflow: ${(err as Error).message}` });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleStartInstance = async () => {
+    if (!workflowIdInput) {
+      setStatus({ tone: 'error', message: 'Workflow ID is required to start an instance.' });
+      return;
+    }
+    setStatus(null);
+    try {
+      const context = contextInput ? (JSON.parse(contextInput) as Record<string, string>) : {};
+      setLoading(true);
+      const created = await startInstance(workflowIdInput, context);
+      setInstance(created);
+      setInstanceIdInput(created.id);
+      setStatus({ tone: 'success', message: `Instance ${created.id} started.` });
+      const gates = collectActiveGates(created);
+      if (gates[0]) {
+        setApprovalForm((prev) => ({ ...prev, stageId: gates[0].stageId, gateId: gates[0].gateId }));
+      }
+    } catch (err) {
+      setStatus({ tone: 'error', message: `Unable to start instance: ${(err as Error).message}` });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleLoadInstance = async (id: string) => {
+    if (!id) {
+      setStatus({ tone: 'error', message: 'Instance ID is required to load state.' });
+      return;
+    }
+    setStatus(null);
+    try {
+      setLoading(true);
+      const loaded = await loadInstance(id);
+      setInstance(loaded);
+      const gates = collectActiveGates(loaded);
+      if (gates[0]) {
+        setApprovalForm((prev) => ({ ...prev, stageId: gates[0].stageId, gateId: gates[0].gateId }));
+      }
+      setStatus({ tone: 'success', message: `Instance ${loaded.id} state refreshed.` });
+    } catch (err) {
+      setStatus({ tone: 'error', message: `Unable to load instance: ${(err as Error).message}` });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleApprovalSubmit = async () => {
+    if (!instance) {
+      setStatus({ tone: 'error', message: 'Load an instance before submitting approvals.' });
+      return;
+    }
+    const { stageId, gateId, actorId, delegatedFrom, privateKey } = approvalForm;
+    if (!stageId || !gateId || !actorId || !privateKey) {
+      setStatus({ tone: 'error', message: 'Stage, gate, actor, and private key are required.' });
+      return;
+    }
+    setStatus(null);
+    try {
+      const seed = decodePrivateKey(privateKey);
+      const issuedAt = new Date();
+      const nanos = BigInt(issuedAt.getTime()) * 1_000_000n;
+      const message = canonicalMessage(instance.id, stageId, gateId, actorId, delegatedFrom ?? '', nanos);
+      const signature = await sign(encoder.encode(message), seed);
+      const payload: ApprovalRequest = {
+        stageId,
+        gateId,
+        actorId,
+        delegatedFrom: delegatedFrom ? delegatedFrom : undefined,
+        signature: toBase64(signature),
+        signedAt: issuedAt.toISOString()
+      };
+      setLoading(true);
+      const response = await submitApproval(instance.id, payload);
+      let info = 'Approval recorded.';
+      if ((response as ApprovalBundle).gateId) {
+        info = `Gate ${stageId}/${gateId} reached quorum.`;
+      }
+      const updated = await loadInstance(instance.id);
+      setInstance(updated);
+      setStatus({ tone: 'success', message: info });
+    } catch (err) {
+      setStatus({ tone: 'error', message: `Approval failed: ${(err as Error).message}` });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderBundles = (bundles: ApprovalBundle[]) => {
+    if (bundles.length === 0) {
+      return <p>No approval bundles issued yet.</p>;
+    }
+    return (
+      <div className="form-grid">
+        {bundles.map((bundle) => (
+          <section key={`${bundle.stageId}-${bundle.gateId}-${bundle.issuedAt}`}>
+            <h3>
+              Bundle for stage <strong>{bundle.stageId}</strong> / gate <strong>{bundle.gateId}</strong>
+            </h3>
+            <p className="badge">Quorum {bundle.quorum}</p>
+            <p>Issued: {new Date(bundle.issuedAt).toLocaleString()}</p>
+            <pre>{JSON.stringify(bundle, null, 2)}</pre>
+          </section>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="container">
+      <h1>Quorum Approval Workflow Engine</h1>
+      <p>
+        Server public key: <code>{serverKey || 'loading...'}</code>
+      </p>
+
+      {status && (
+        <section style={{ border: status.tone === 'success' ? '1px solid #22c55e' : '1px solid #f87171' }}>
+          <strong>{status.tone === 'success' ? 'Success' : 'Error'}:</strong> {status.message}
+        </section>
+      )}
+
+      <section>
+        <h2>1. Define Workflow</h2>
+        <p>Paste a workflow definition including policy participants. Create operations to persist and receive the workflow id.</p>
+        <textarea
+          rows={16}
+          value={workflowInput}
+          onChange={(event) => setWorkflowInput(event.target.value)}
+        />
+        <div className="flex-row" style={{ marginTop: '1rem' }}>
+          <button onClick={handleCreateWorkflow} disabled={loading}>
+            Create / Update Workflow
+          </button>
+          <div>
+            <label htmlFor="workflow-id">Workflow ID</label>
+            <input
+              id="workflow-id"
+              value={workflowIdInput}
+              onChange={(event) => setWorkflowIdInput(event.target.value)}
+              placeholder="workflow identifier"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2>2. Start or Load Instance</h2>
+        <div className="form-grid">
+          <div>
+            <label htmlFor="context-json">Context JSON</label>
+            <textarea
+              id="context-json"
+              rows={6}
+              value={contextInput}
+              onChange={(event) => setContextInput(event.target.value)}
+            />
+            <button style={{ marginTop: '0.75rem' }} onClick={handleStartInstance} disabled={loading}>
+              Start Instance
+            </button>
+          </div>
+          <div>
+            <label htmlFor="instance-id">Instance ID</label>
+            <input
+              id="instance-id"
+              value={instanceIdInput}
+              onChange={(event) => setInstanceIdInput(event.target.value)}
+              placeholder="instance identifier"
+            />
+            <button style={{ marginTop: '0.75rem' }} onClick={() => handleLoadInstance(instanceIdInput)} disabled={loading}>
+              Load Instance
+            </button>
+          </div>
+        </div>
+        {instance && (
+          <div style={{ marginTop: '1rem' }}>
+            <h3>Instance Snapshot</h3>
+            <p>
+              Status: <strong>{instance.status}</strong> | Created {new Date(instance.createdAt).toLocaleString()} | Updated{' '}
+              {new Date(instance.updatedAt).toLocaleString()}
+            </p>
+            <details>
+              <summary>View raw instance payload</summary>
+              <pre>{JSON.stringify(instance, null, 2)}</pre>
+            </details>
+          </div>
+        )}
+      </section>
+
+      <section>
+        <h2>3. Submit Approval</h2>
+        <div className="form-grid">
+          <div className="flex-row">
+            <div>
+              <label htmlFor="stage-id">Stage ID</label>
+              <input
+                id="stage-id"
+                value={approvalForm.stageId}
+                onChange={(event) => setApprovalForm((prev) => ({ ...prev, stageId: event.target.value }))}
+                placeholder="stage-identifier"
+                list="active-stages"
+              />
+            </div>
+            <div>
+              <label htmlFor="gate-id">Gate ID</label>
+              <input
+                id="gate-id"
+                value={approvalForm.gateId}
+                onChange={(event) => setApprovalForm((prev) => ({ ...prev, gateId: event.target.value }))}
+                placeholder="gate-identifier"
+                list="active-gates"
+              />
+            </div>
+          </div>
+          <div className="flex-row">
+            <div>
+              <label htmlFor="actor-id">Actor ID</label>
+              <input
+                id="actor-id"
+                value={approvalForm.actorId}
+                onChange={(event) => setApprovalForm((prev) => ({ ...prev, actorId: event.target.value }))}
+              />
+            </div>
+            <div>
+              <label htmlFor="delegated-from">Delegated From</label>
+              <input
+                id="delegated-from"
+                value={approvalForm.delegatedFrom}
+                onChange={(event) => setApprovalForm((prev) => ({ ...prev, delegatedFrom: event.target.value }))}
+                placeholder="optional principal id"
+              />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="private-key">Signer Private Key (base64)</label>
+            <textarea
+              id="private-key"
+              rows={4}
+              value={approvalForm.privateKey}
+              onChange={(event) => setApprovalForm((prev) => ({ ...prev, privateKey: event.target.value }))}
+            />
+          </div>
+          <button onClick={handleApprovalSubmit} disabled={loading || !instance}>
+            Submit Approval
+          </button>
+        </div>
+        <datalist id="active-stages">
+          {activeGates.map((pair) => (
+            <option key={`stage-${pair.stageId}`} value={pair.stageId} />
+          ))}
+        </datalist>
+        <datalist id="active-gates">
+          {activeGates.map((pair) => (
+            <option key={`gate-${pair.stageId}-${pair.gateId}`} value={pair.gateId} />
+          ))}
+        </datalist>
+      </section>
+
+      <section>
+        <h2>4. Approval Bundles</h2>
+        {instance ? renderBundles(instance.approvalBundles) : <p>Load an instance to view signed bundles.</p>}
+      </section>
+    </div>
+  );
+}
+
+export default App;

--- a/ui/qawe/src/api.ts
+++ b/ui/qawe/src/api.ts
@@ -1,0 +1,56 @@
+
+import { ApprovalBundle, ServerInfo, WorkflowDefinition, WorkflowInstance } from './types';
+
+export interface ApprovalRequest {
+  stageId: string;
+  gateId: string;
+  actorId: string;
+  delegatedFrom?: string;
+  signature: string;
+  signedAt: string;
+}
+
+async function handleResponse<T>(res: Response): Promise<T> {
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || res.statusText);
+  }
+  return (await res.json()) as T;
+}
+
+export async function fetchServerInfo(): Promise<ServerInfo> {
+  const res = await fetch('/api/info');
+  return handleResponse<ServerInfo>(res);
+}
+
+export async function createWorkflow(def: WorkflowDefinition): Promise<WorkflowDefinition> {
+  const res = await fetch('/api/workflows', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(def)
+  });
+  return handleResponse<WorkflowDefinition>(res);
+}
+
+export async function startInstance(workflowId: string, context: Record<string, string>): Promise<WorkflowInstance> {
+  const res = await fetch('/api/instances', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ workflowId, context })
+  });
+  return handleResponse<WorkflowInstance>(res);
+}
+
+export async function loadInstance(instanceId: string): Promise<WorkflowInstance> {
+  const res = await fetch(`/api/instances/${instanceId}`);
+  return handleResponse<WorkflowInstance>(res);
+}
+
+export async function submitApproval(instanceId: string, approval: ApprovalRequest): Promise<ApprovalBundle | { status: string }> {
+  const res = await fetch(`/api/instances/${instanceId}/approvals`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(approval)
+  });
+  return handleResponse<ApprovalBundle | { status: string }>(res);
+}

--- a/ui/qawe/src/main.tsx
+++ b/ui/qawe/src/main.tsx
@@ -1,0 +1,11 @@
+
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ui/qawe/src/styles.css
+++ b/ui/qawe/src/styles.css
@@ -1,0 +1,89 @@
+
+:root {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+}
+
+h1, h2, h3 {
+  color: #0f172a;
+}
+
+a {
+  color: #2563eb;
+}
+
+button {
+  cursor: pointer;
+  background-color: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+}
+
+button:disabled {
+  background-color: #94a3b8;
+  cursor: not-allowed;
+}
+
+input, textarea, select {
+  font: inherit;
+  padding: 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #cbd5f5;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+section {
+  background: #fff;
+  border-radius: 8px;
+  padding: 1.5rem;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+  margin-bottom: 1.5rem;
+}
+
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.flex-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.flex-row > * {
+  flex: 1 1 240px;
+}
+
+pre {
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 1rem;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+
+.badge {
+  background: #dbeafe;
+  color: #1d4ed8;
+  padding: 0.2rem 0.5rem;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}

--- a/ui/qawe/src/types.ts
+++ b/ui/qawe/src/types.ts
@@ -1,0 +1,117 @@
+
+export type StageKind = 'sequential' | 'parallel' | 'conditional';
+
+export interface GateDefinition {
+  id: string;
+  role: string;
+  quorum: number;
+  expirySeconds: number;
+  allowDelegates?: boolean;
+}
+
+export interface BranchDefinition {
+  condition: {
+    field: string;
+    equals: string;
+  };
+  next: string[];
+}
+
+export interface StageDefinition {
+  id: string;
+  kind: StageKind;
+  gates?: GateDefinition[];
+  branches?: BranchDefinition[];
+  next?: string[];
+}
+
+export interface Delegate {
+  id: string;
+  display: string;
+  publicKey: string;
+}
+
+export interface Principal {
+  id: string;
+  display: string;
+  publicKey: string;
+  delegates?: Delegate[];
+}
+
+export interface RolePolicy {
+  id: string;
+  name: string;
+  principals: Principal[];
+}
+
+export interface Policy {
+  roles: Record<string, RolePolicy>;
+}
+
+export interface WorkflowDefinition {
+  id?: string;
+  name: string;
+  start: string;
+  stages: StageDefinition[];
+  policy: Policy;
+}
+
+export interface ApprovalRecord {
+  principalId: string;
+  actorId: string;
+  delegatedFrom?: string;
+  payload: string;
+  signature: string;
+  signedAt: string;
+}
+
+export interface ApprovalBundle {
+  instanceId: string;
+  workflowId: string;
+  stageId: string;
+  gateId: string;
+  quorum: number;
+  approvals: ApprovalRecord[];
+  issuedAt: string;
+  serverSignature: string;
+  serverPublicKey: string;
+}
+
+export type InstanceStatus = 'pending' | 'active' | 'completed' | 'expired';
+
+export interface GateRuntime {
+  definition: GateDefinition;
+  approvals: ApprovalRecord[];
+  satisfied: boolean;
+  expiresAt?: string;
+  bundle?: ApprovalBundle;
+}
+
+export interface StageRuntime {
+  definition: StageDefinition;
+  gates: Record<string, GateRuntime>;
+  activeGate?: string;
+  startedAt: string;
+}
+
+export interface StageResult {
+  stageId: string;
+  status: 'completed' | 'expired';
+  completedAt: string;
+}
+
+export interface WorkflowInstance {
+  id: string;
+  workflowId: string;
+  context: Record<string, string>;
+  status: InstanceStatus;
+  activeStages: Record<string, StageRuntime>;
+  completedStages: Record<string, StageResult>;
+  approvalBundles: ApprovalBundle[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ServerInfo {
+  serverPublicKey: string;
+}

--- a/ui/qawe/tsconfig.json
+++ b/ui/qawe/tsconfig.json
@@ -1,0 +1,19 @@
+
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/ui/qawe/tsconfig.node.json
+++ b/ui/qawe/tsconfig.node.json
@@ -1,0 +1,10 @@
+
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/ui/qawe/vite.config.ts
+++ b/ui/qawe/vite.config.ts
@@ -1,0 +1,16 @@
+
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true
+      }
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- implement the QAWE Go engine with policy-backed quorum checks, bundle signing, expiry handling, and regression tests
- expose REST endpoints and a CLI entrypoint for running the workflow service
- scaffold a React console that can author workflows, manage instances, and sign approvals client-side

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d7683846e883338f3f0d12194e5001