### PR TITLE
feat: add consent-compliant messaging orchestrator service

### DIFF
--- a/client/src/App.router.jsx
+++ b/client/src/App.router.jsx
@@ -77,6 +77,7 @@ import ClaimsViewer from './features/conductor/ClaimsViewer';
 import RetractionQueue from './features/conductor/RetractionQueue';
 import CostAdvisor from './features/conductor/CostAdvisor';
 import RunSearch from './features/conductor/RunSearch';
+import CCMOSandboxPage from './pages/CCMOSandbox.tsx';
 
 // Navigation items
 const navigationItems = [
@@ -105,6 +106,7 @@ const navigationItems = [
     ? [{ path: '/workflows', label: 'Workflows', icon: <Engineering /> }]
     : []),
   { path: '/docs/openapi', label: 'API Docs', icon: <Description />, external: true },
+  { path: '/ccmo/sandbox', label: 'CCMO Sandbox', icon: <Description /> },
   { path: '/mcp/registry', label: 'MCP Registry', icon: <Engineering /> },
   { path: '/threats', label: 'Threat Assessment', icon: <Assessment /> },
   { path: '/access-intel', label: 'Access Intel', icon: <Security /> },
@@ -650,6 +652,7 @@ function MainLayout() {
             <Route path="/pipelines" element={<VisualPipelines />} />
             <Route path="/executors" element={<ExecutorsPage />} />
             <Route path="/observability" element={<ObservabilityPanel />} />
+            <Route path="/ccmo/sandbox" element={<CCMOSandboxPage />} />
               <Route path="/admin/studio" element={<AdminStudio />} />
           {import.meta.env.VITE_FEATURE_WORK === 'true' && (
             <Route path="/work" element={<WorkBoard />} />

--- a/client/src/features/ccmo/CCMOSandbox.tsx
+++ b/client/src/features/ccmo/CCMOSandbox.tsx
@@ -1,0 +1,250 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  Box,
+  Button,
+  Checkbox,
+  FormControl,
+  FormControlLabel,
+  InputLabel,
+  MenuItem,
+  Paper,
+  Select,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+
+interface NotificationResponse {
+  status: string;
+  message: string;
+  body?: string;
+}
+
+interface AppealEntry {
+  subjectId: string;
+  topic: string;
+  purpose: string;
+  channel: string;
+  reason: string;
+  timestamp: number;
+}
+
+const defaultData = {
+  subject: 'Consent Update',
+  name: 'Jordan',
+  body: 'Your control center is ready.',
+};
+
+const channelOptions = [
+  { label: 'Email', value: 'email' },
+  { label: 'Push', value: 'push' },
+  { label: 'In-App', value: 'in-app' },
+];
+
+const locales = ['en-US', 'es'];
+
+const CCMOSandbox: React.FC = () => {
+  const [baseUrl, setBaseUrl] = useState('http://localhost:8080');
+  const [subjectId, setSubjectId] = useState('user-1');
+  const [topic, setTopic] = useState('product');
+  const [purpose, setPurpose] = useState('onboarding');
+  const [channel, setChannel] = useState('email');
+  const [locale, setLocale] = useState('en-US');
+  const [template, setTemplate] = useState('welcome');
+  const [darkMode, setDarkMode] = useState(false);
+  const [allowed, setAllowed] = useState(true);
+  const [response, setResponse] = useState<NotificationResponse | null>(null);
+  const [appeals, setAppeals] = useState<AppealEntry[]>([]);
+  const [payloadBody, setPayloadBody] = useState(JSON.stringify(defaultData, null, 2));
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const request = useCallback(
+    async (path: string, init: RequestInit) => {
+      const response = await fetch(`${baseUrl}${path}`, {
+        headers: { 'Content-Type': 'application/json' },
+        ...init,
+      });
+      if (!response.ok) {
+        const details = await response.text();
+        throw new Error(`${response.status} ${details}`);
+      }
+      return response;
+    },
+    [baseUrl],
+  );
+
+  const refreshAppeals = useCallback(async () => {
+    try {
+      const res = await request('/appeals', { method: 'GET' });
+      const items = (await res.json()) as AppealEntry[];
+      setAppeals(items);
+    } catch (err) {
+      console.error('Unable to load appeals', err);
+    }
+  }, [request]);
+
+  useEffect(() => {
+    void refreshAppeals();
+  }, [refreshAppeals]);
+
+  const handleSetConsent = async () => {
+    setError(null);
+    try {
+      await request('/consents', {
+        method: 'POST',
+        body: JSON.stringify({
+          subjectId,
+          topic,
+          purpose,
+          allowed,
+          locales: [locale],
+        }),
+      });
+      await refreshAppeals();
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  const handleSend = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await request('/notifications/send', {
+        method: 'POST',
+        body: JSON.stringify({
+          subjectId,
+          topic,
+          purpose,
+          channel,
+          locale,
+          darkMode,
+          template,
+          data: JSON.parse(payloadBody || '{}'),
+        }),
+      });
+      const body = (await res.json()) as NotificationResponse;
+      setResponse(body);
+      await refreshAppeals();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ p: 4 }}>
+      <Typography variant="h4" gutterBottom>
+        Consent-Compliant Messaging Orchestrator Sandbox
+      </Typography>
+      <Typography variant="body1" color="text.secondary" sx={{ mb: 3 }}>
+        Quickly experiment with consent configuration, locale-aware templating, and delivery enforcement policies.
+      </Typography>
+      <Paper sx={{ p: 3, mb: 3 }} elevation={1}>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2}>
+          <TextField label="Service URL" fullWidth value={baseUrl} onChange={(event) => setBaseUrl(event.target.value)} />
+          <FormControlLabel
+            control={<Checkbox checked={darkMode} onChange={(event) => setDarkMode(event.target.checked)} />}
+            label="Dark mode variant"
+          />
+        </Stack>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ mt: 2 }}>
+          <TextField label="Subject" fullWidth value={subjectId} onChange={(event) => setSubjectId(event.target.value)} />
+          <TextField label="Topic" fullWidth value={topic} onChange={(event) => setTopic(event.target.value)} />
+          <TextField label="Purpose" fullWidth value={purpose} onChange={(event) => setPurpose(event.target.value)} />
+        </Stack>
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ mt: 2 }}>
+          <FormControl fullWidth>
+            <InputLabel id="channel-label">Channel</InputLabel>
+            <Select labelId="channel-label" label="Channel" value={channel} onChange={(event) => setChannel(event.target.value)}>
+              {channelOptions.map((option) => (
+                <MenuItem key={option.value} value={option.value}>
+                  {option.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl fullWidth>
+            <InputLabel id="locale-label">Locale</InputLabel>
+            <Select labelId="locale-label" label="Locale" value={locale} onChange={(event) => setLocale(event.target.value)}>
+              {locales.map((value) => (
+                <MenuItem key={value} value={value}>
+                  {value}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <TextField label="Template" fullWidth value={template} onChange={(event) => setTemplate(event.target.value)} />
+        </Stack>
+        <TextField
+          label="Template Data"
+          value={payloadBody}
+          onChange={(event) => setPayloadBody(event.target.value)}
+          multiline
+          minRows={4}
+          fullWidth
+          sx={{ mt: 2 }}
+        />
+        <FormControlLabel
+          sx={{ mt: 2 }}
+          control={<Checkbox checked={allowed} onChange={(event) => setAllowed(event.target.checked)} />}
+          label="Consent granted for this locale"
+        />
+        <Stack direction={{ xs: 'column', md: 'row' }} spacing={2} sx={{ mt: 2 }}>
+          <Button variant="contained" onClick={handleSetConsent} disabled={isLoading}>
+            Save Consent
+          </Button>
+          <Button variant="outlined" onClick={handleSend} disabled={isLoading}>
+            {isLoading ? 'Sending…' : 'Send Notification'}
+          </Button>
+        </Stack>
+        {error && (
+          <Typography sx={{ mt: 2 }} color="error">
+            {error}
+          </Typography>
+        )}
+        {response && (
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="subtitle1">Delivery Result</Typography>
+            <Typography>Status: {response.status}</Typography>
+            <Typography>Message: {response.message}</Typography>
+            {response.body && (
+              <Paper sx={{ p: 2, mt: 1, backgroundColor: 'grey.100' }}>
+                <pre style={{ margin: 0 }}>{response.body}</pre>
+              </Paper>
+            )}
+          </Box>
+        )}
+      </Paper>
+      <Paper sx={{ p: 3 }} elevation={1}>
+        <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+          <Typography variant="h6">Appeals Log</Typography>
+          <Button variant="text" onClick={refreshAppeals}>
+            Refresh
+          </Button>
+        </Stack>
+        {appeals.length === 0 ? (
+          <Typography color="text.secondary">No appeals recorded yet.</Typography>
+        ) : (
+          <Stack spacing={1}>
+            {appeals.map((appeal) => (
+              <Paper key={`${appeal.subjectId}-${appeal.timestamp}`} sx={{ p: 2 }} variant="outlined">
+                <Typography variant="subtitle2">
+                  {appeal.subjectId} – {appeal.topic}/{appeal.purpose}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Channel: {appeal.channel} · Reason: {appeal.reason} · Recorded at:{' '}
+                  {new Date(appeal.timestamp * 1000).toLocaleString()}
+                </Typography>
+              </Paper>
+            ))}
+          </Stack>
+        )}
+      </Paper>
+    </Box>
+  );
+};
+
+export default CCMOSandbox;

--- a/client/src/pages/CCMOSandbox.tsx
+++ b/client/src/pages/CCMOSandbox.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import CCMOSandbox from '../features/ccmo/CCMOSandbox';
+
+const CCMOSandboxPage: React.FC = () => {
+  return <CCMOSandbox />;
+};
+
+export default CCMOSandboxPage;

--- a/sdk/python/maestro_sdk/__init__.py
+++ b/sdk/python/maestro_sdk/__init__.py
@@ -1,0 +1,11 @@
+"""Convenience exports for the Maestro SDK packages."""
+
+from .client import MaestroClient  # noqa: F401
+from .ccmo import CCMOClient, ConsentPayload, NotificationPayload  # noqa: F401
+
+__all__ = [
+    'MaestroClient',
+    'CCMOClient',
+    'ConsentPayload',
+    'NotificationPayload',
+]

--- a/sdk/python/maestro_sdk/ccmo.py
+++ b/sdk/python/maestro_sdk/ccmo.py
@@ -1,0 +1,81 @@
+"""Client for interacting with the Consent-Compliant Messaging Orchestrator (CCMO)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+
+@dataclass
+class ConsentPayload:
+    subject_id: str
+    topic: str
+    purpose: str
+    allowed: bool
+    locales: Optional[List[str]] = None
+
+
+@dataclass
+class NotificationPayload:
+    subject_id: str
+    topic: str
+    purpose: str
+    channel: str
+    locale: str
+    template: str
+    dark_mode: bool = False
+    data: Optional[Dict[str, Any]] = None
+
+
+class CCMOClient:
+    """Synchronous wrapper around the CCMO HTTP API."""
+
+    def __init__(self, base_url: str, *, timeout: float = 10.0) -> None:
+        self._client = httpx.Client(base_url=base_url.rstrip('/'), timeout=timeout)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def set_consent(self, payload: ConsentPayload) -> None:
+        locales = payload.locales or []
+        response = self._client.post(
+            '/consents',
+            json={
+                'subjectId': payload.subject_id,
+                'topic': payload.topic,
+                'purpose': payload.purpose,
+                'allowed': payload.allowed,
+                'locales': locales,
+            },
+        )
+        response.raise_for_status()
+
+    def send_notification(self, payload: NotificationPayload) -> Dict[str, Any]:
+        response = self._client.post(
+            '/notifications/send',
+            json={
+                'subjectId': payload.subject_id,
+                'topic': payload.topic,
+                'purpose': payload.purpose,
+                'channel': payload.channel,
+                'locale': payload.locale,
+                'template': payload.template,
+                'darkMode': payload.dark_mode,
+                'data': payload.data or {},
+            },
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def get_appeals(self) -> List[Dict[str, Any]]:
+        response = self._client.get('/appeals')
+        response.raise_for_status()
+        return response.json()
+
+    def __enter__(self) -> "CCMOClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()

--- a/sdk/typescript/src/ccmoClient.ts
+++ b/sdk/typescript/src/ccmoClient.ts
@@ -1,0 +1,79 @@
+export type NotificationChannel = 'email' | 'push' | 'in-app';
+
+export interface ConsentPayload {
+  subjectId: string;
+  topic: string;
+  purpose: string;
+  allowed: boolean;
+  locales?: string[];
+}
+
+export interface NotificationPayload {
+  subjectId: string;
+  topic: string;
+  purpose: string;
+  channel: NotificationChannel;
+  locale: string;
+  darkMode?: boolean;
+  template: string;
+  data?: Record<string, unknown>;
+}
+
+export interface NotificationResponse {
+  status: string;
+  message: string;
+  body?: string;
+}
+
+export interface AppealEntry {
+  subjectId: string;
+  topic: string;
+  purpose: string;
+  channel: string;
+  reason: string;
+  timestamp: number;
+}
+
+export class CCMOClient {
+  constructor(private readonly baseUrl: string) {}
+
+  async setConsent(payload: ConsentPayload): Promise<void> {
+    await this.request('/consents', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async sendNotification(payload: NotificationPayload): Promise<NotificationResponse> {
+    const response = await this.request('/notifications/send', {
+      method: 'POST',
+      body: JSON.stringify({
+        ...payload,
+        darkMode: payload.darkMode ?? false,
+      }),
+    });
+    return (await response.json()) as NotificationResponse;
+  }
+
+  async getAppeals(): Promise<AppealEntry[]> {
+    const response = await this.request('/appeals', {
+      method: 'GET',
+    });
+    return (await response.json()) as AppealEntry[];
+  }
+
+  private async request(path: string, init: RequestInit): Promise<Response> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(init.headers || {}),
+      },
+      ...init,
+    });
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(`CCMO request failed: ${response.status} ${message}`);
+    }
+    return response;
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,2 +1,3 @@
 export * from './client';
+export * from './ccmoClient';
 export * from '../sdk/ts/src/generated';

--- a/services/ccmo/cmd/ccmo/main.go
+++ b/services/ccmo/cmd/ccmo/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/summit/ccmo/internal/ccmo"
+)
+
+func main() {
+	service, err := ccmo.NewService(ccmo.RealClock{})
+	if err != nil {
+		log.Fatalf("unable to start CCMO service: %v", err)
+	}
+	server := ccmo.NewServer(service)
+
+	mux := http.NewServeMux()
+	server.Routes(mux)
+
+	addr := ":8080"
+	if fromEnv := os.Getenv("CCMO_ADDR"); fromEnv != "" {
+		addr = fromEnv
+	}
+
+	log.Printf("CCMO listening on %s", addr)
+	log.Fatal(http.ListenAndServe(addr, mux))
+}

--- a/services/ccmo/go.mod
+++ b/services/ccmo/go.mod
@@ -1,0 +1,4 @@
+module github.com/summit/ccmo
+
+go 1.21
+

--- a/services/ccmo/internal/ccmo/appeals.go
+++ b/services/ccmo/internal/ccmo/appeals.go
@@ -1,0 +1,50 @@
+package ccmo
+
+import "sync"
+
+// AppealReason defines why a notification was blocked.
+type AppealReason string
+
+const (
+	// AppealReasonConsent indicates a missing consent.
+	AppealReasonConsent AppealReason = "consent-block"
+	// AppealReasonFrequency indicates frequency capping.
+	AppealReasonFrequency AppealReason = "frequency-cap"
+)
+
+// AppealEntry captures a blocked delivery attempt.
+type AppealEntry struct {
+	SubjectID string       `json:"subjectId"`
+	Topic     string       `json:"topic"`
+	Purpose   string       `json:"purpose"`
+	Channel   string       `json:"channel"`
+	Reason    AppealReason `json:"reason"`
+	Timestamp int64        `json:"timestamp"`
+}
+
+// AppealsLog stores blocked delivery attempts for audit/appeals.
+type AppealsLog struct {
+	mu      sync.RWMutex
+	entries []AppealEntry
+}
+
+// NewAppealsLog constructs an AppealsLog.
+func NewAppealsLog() *AppealsLog {
+	return &AppealsLog{entries: make([]AppealEntry, 0)}
+}
+
+// Record adds an appeal entry.
+func (l *AppealsLog) Record(entry AppealEntry) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append([]AppealEntry{entry}, l.entries...)
+}
+
+// List returns a copy of all appeal entries.
+func (l *AppealsLog) List() []AppealEntry {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	out := make([]AppealEntry, len(l.entries))
+	copy(out, l.entries)
+	return out
+}

--- a/services/ccmo/internal/ccmo/clock.go
+++ b/services/ccmo/internal/ccmo/clock.go
@@ -1,0 +1,16 @@
+package ccmo
+
+import "time"
+
+// Clock abstracts time retrieval for deterministic testing.
+type Clock interface {
+	Now() time.Time
+}
+
+// RealClock implements Clock using the system time.
+type RealClock struct{}
+
+// Now returns the current time.
+func (RealClock) Now() time.Time {
+	return time.Now()
+}

--- a/services/ccmo/internal/ccmo/consent.go
+++ b/services/ccmo/internal/ccmo/consent.go
@@ -1,0 +1,51 @@
+package ccmo
+
+import "sync"
+
+// ConsentRecord models an individual's permission for a topic/purpose pair.
+type ConsentRecord struct {
+	Allowed bool            `json:"allowed"`
+	Locales map[string]bool `json:"locales"`
+}
+
+// ConsentStore maintains granular consent preferences.
+type ConsentStore struct {
+	mu       sync.RWMutex
+	subjects map[string]map[string]map[string]ConsentRecord // subject -> topic -> purpose
+}
+
+// NewConsentStore constructs an empty ConsentStore.
+func NewConsentStore() *ConsentStore {
+	return &ConsentStore{subjects: make(map[string]map[string]map[string]ConsentRecord)}
+}
+
+// SetConsent records the consent preference for a subject/topic/purpose.
+func (s *ConsentStore) SetConsent(subjectID, topic, purpose string, record ConsentRecord) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.subjects[subjectID]; !ok {
+		s.subjects[subjectID] = make(map[string]map[string]ConsentRecord)
+	}
+	if _, ok := s.subjects[subjectID][topic]; !ok {
+		s.subjects[subjectID][topic] = make(map[string]ConsentRecord)
+	}
+	s.subjects[subjectID][topic][purpose] = record
+}
+
+// GetConsent retrieves the consent record for a subject/topic/purpose pair.
+func (s *ConsentStore) GetConsent(subjectID, topic, purpose string) (ConsentRecord, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	topics, ok := s.subjects[subjectID]
+	if !ok {
+		return ConsentRecord{}, false
+	}
+	purposes, ok := topics[topic]
+	if !ok {
+		return ConsentRecord{}, false
+	}
+	record, ok := purposes[purpose]
+	return record, ok
+}

--- a/services/ccmo/internal/ccmo/frequency.go
+++ b/services/ccmo/internal/ccmo/frequency.go
@@ -1,0 +1,51 @@
+package ccmo
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// FrequencyCap defines the allowed volume per duration for a channel.
+type FrequencyCap struct {
+	MaxMessages int           `json:"maxMessages"`
+	Period      time.Duration `json:"-"`
+}
+
+// MarshalJSON customises JSON encoding so Period is expressed in seconds.
+func (f FrequencyCap) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(`{"maxMessages":%d,"periodSeconds":%d}`, f.MaxMessages, int64(f.Period/time.Second))), nil
+}
+
+// FrequencyTracker tracks send events for enforcing caps.
+type FrequencyTracker struct {
+	mu      sync.Mutex
+	history map[string][]time.Time
+}
+
+// NewFrequencyTracker constructs an empty FrequencyTracker.
+func NewFrequencyTracker() *FrequencyTracker {
+	return &FrequencyTracker{history: make(map[string][]time.Time)}
+}
+
+// Allow returns true if the request can proceed under the provided cap.
+func (t *FrequencyTracker) Allow(key string, cap FrequencyCap, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	entries := t.history[key]
+	cutoff := now.Add(-cap.Period)
+	filtered := entries[:0]
+	for _, ts := range entries {
+		if ts.After(cutoff) {
+			filtered = append(filtered, ts)
+		}
+	}
+	if len(filtered) >= cap.MaxMessages {
+		t.history[key] = filtered
+		return false
+	}
+	filtered = append(filtered, now)
+	t.history[key] = filtered
+	return true
+}

--- a/services/ccmo/internal/ccmo/http.go
+++ b/services/ccmo/internal/ccmo/http.go
@@ -1,0 +1,90 @@
+package ccmo
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Server exposes CCMO functionality over HTTP.
+type Server struct {
+	service *Service
+}
+
+// NewServer constructs the HTTP server wrapper.
+func NewServer(service *Service) *Server {
+	return &Server{service: service}
+}
+
+// Routes wires handlers onto the provided mux.
+func (s *Server) Routes(mux *http.ServeMux) {
+	mux.HandleFunc("/healthz", s.health)
+	mux.HandleFunc("/consents", s.handleConsents)
+	mux.HandleFunc("/notifications/send", s.handleSend)
+	mux.HandleFunc("/appeals", s.handleAppeals)
+}
+
+func (s *Server) health(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("ok"))
+}
+
+func (s *Server) handleConsents(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var payload struct {
+			SubjectID string   `json:"subjectId"`
+			Topic     string   `json:"topic"`
+			Purpose   string   `json:"purpose"`
+			Allowed   bool     `json:"allowed"`
+			Locales   []string `json:"locales"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		locales := make(map[string]bool)
+		for _, locale := range payload.Locales {
+			locales[normaliseLocale(locale)] = true
+		}
+		s.service.SetConsent(payload.SubjectID, payload.Topic, payload.Purpose, ConsentRecord{Allowed: payload.Allowed, Locales: locales})
+		w.WriteHeader(http.StatusCreated)
+		return
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleSend(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var payload NotificationRequest
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	payload.Locale = normaliseLocale(payload.Locale)
+	resp, err := s.service.Send(payload)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	status := http.StatusOK
+	if resp.Status == "blocked" {
+		status = http.StatusAccepted
+	}
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (s *Server) handleAppeals(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	entries := s.service.Appeals()
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(entries)
+}

--- a/services/ccmo/internal/ccmo/service.go
+++ b/services/ccmo/internal/ccmo/service.go
@@ -1,0 +1,170 @@
+package ccmo
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// NotificationChannel enumerates supported outbound destinations.
+type NotificationChannel string
+
+const (
+	ChannelEmail NotificationChannel = "email"
+	ChannelPush  NotificationChannel = "push"
+	ChannelInApp NotificationChannel = "in-app"
+)
+
+// NotificationRequest represents a delivery attempt.
+type NotificationRequest struct {
+	SubjectID string              `json:"subjectId"`
+	Topic     string              `json:"topic"`
+	Purpose   string              `json:"purpose"`
+	Channel   NotificationChannel `json:"channel"`
+	Locale    string              `json:"locale"`
+	DarkMode  bool                `json:"darkMode"`
+	Template  string              `json:"template"`
+	Data      map[string]any      `json:"data"`
+}
+
+// NotificationResponse conveys the result of a send attempt.
+type NotificationResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	Body    string `json:"body,omitempty"`
+}
+
+// Service bundles CCMO domain logic.
+type Service struct {
+	consents      *ConsentStore
+	templates     *TemplateRenderer
+	frequency     *FrequencyTracker
+	frequencyCaps map[NotificationChannel]FrequencyCap
+	appeals       *AppealsLog
+	clock         Clock
+}
+
+// NewService constructs a Service with defaults.
+func NewService(clock Clock) (*Service, error) {
+	if clock == nil {
+		clock = RealClock{}
+	}
+	renderer, err := NewTemplateRenderer()
+	if err != nil {
+		return nil, err
+	}
+	return &Service{
+		consents:      NewConsentStore(),
+		templates:     renderer,
+		frequency:     NewFrequencyTracker(),
+		frequencyCaps: defaultFrequencyCaps(),
+		appeals:       NewAppealsLog(),
+		clock:         clock,
+	}, nil
+}
+
+func defaultFrequencyCaps() map[NotificationChannel]FrequencyCap {
+	return map[NotificationChannel]FrequencyCap{
+		ChannelEmail: {MaxMessages: 3, Period: time.Hour},
+		ChannelPush:  {MaxMessages: 5, Period: 30 * time.Minute},
+		ChannelInApp: {MaxMessages: 8, Period: time.Hour},
+	}
+}
+
+// SetFrequencyCap overrides the default cap for a channel.
+func (s *Service) SetFrequencyCap(channel NotificationChannel, cap FrequencyCap) {
+	s.frequencyCaps[channel] = cap
+}
+
+// SetConsent is a convenience wrapper for ConsentStore.SetConsent.
+func (s *Service) SetConsent(subjectID, topic, purpose string, record ConsentRecord) {
+	s.consents.SetConsent(subjectID, topic, purpose, record)
+}
+
+// Appeals returns the recorded appeals log.
+func (s *Service) Appeals() []AppealEntry {
+	return s.appeals.List()
+}
+
+// Send orchestrates consent, frequency, and templating checks before sending.
+func (s *Service) Send(req NotificationRequest) (NotificationResponse, error) {
+	if err := s.validateRequest(req); err != nil {
+		return NotificationResponse{}, err
+	}
+	key := TemplateKey{
+		Name:    req.Template,
+		Channel: string(req.Channel),
+		Locale:  normaliseLocale(req.Locale),
+		Dark:    req.DarkMode,
+	}
+
+	consentRecord, ok := s.consents.GetConsent(req.SubjectID, req.Topic, req.Purpose)
+	if !ok || !consentRecord.Allowed {
+		s.recordAppeal(req, AppealReasonConsent)
+		return NotificationResponse{Status: "blocked", Message: "consent not granted"}, nil
+	}
+	if len(consentRecord.Locales) > 0 {
+		if !consentRecord.Locales[key.Locale] {
+			s.recordAppeal(req, AppealReasonConsent)
+			return NotificationResponse{Status: "blocked", Message: "locale not consented"}, nil
+		}
+	}
+
+	cap, ok := s.frequencyCaps[req.Channel]
+	if ok {
+		freqKey := fmt.Sprintf("%s|%s|%s|%s", req.SubjectID, req.Topic, req.Purpose, req.Channel)
+		if !s.frequency.Allow(freqKey, cap, s.clock.Now()) {
+			s.recordAppeal(req, AppealReasonFrequency)
+			return NotificationResponse{Status: "blocked", Message: "frequency cap exceeded"}, nil
+		}
+	}
+
+	if req.Data == nil {
+		req.Data = map[string]any{}
+	}
+	rendered, err := s.templates.Render(key, req.Data)
+	if err != nil {
+		return NotificationResponse{}, err
+	}
+	return NotificationResponse{Status: "sent", Message: "notification delivered", Body: rendered}, nil
+}
+
+func (s *Service) recordAppeal(req NotificationRequest, reason AppealReason) {
+	s.appeals.Record(AppealEntry{
+		SubjectID: req.SubjectID,
+		Topic:     req.Topic,
+		Purpose:   req.Purpose,
+		Channel:   string(req.Channel),
+		Reason:    reason,
+		Timestamp: s.clock.Now().Unix(),
+	})
+}
+
+func (s *Service) validateRequest(req NotificationRequest) error {
+	if req.SubjectID == "" {
+		return errors.New("subjectId is required")
+	}
+	if req.Topic == "" {
+		return errors.New("topic is required")
+	}
+	if req.Purpose == "" {
+		return errors.New("purpose is required")
+	}
+	if req.Template == "" {
+		return errors.New("template is required")
+	}
+	switch req.Channel {
+	case ChannelEmail, ChannelPush, ChannelInApp:
+	default:
+		return fmt.Errorf("unsupported channel %s", req.Channel)
+	}
+	if req.Locale == "" {
+		return errors.New("locale is required")
+	}
+	return nil
+}
+
+func normaliseLocale(locale string) string {
+	return strings.ReplaceAll(strings.ToLower(locale), "-", "_")
+}

--- a/services/ccmo/internal/ccmo/service_test.go
+++ b/services/ccmo/internal/ccmo/service_test.go
@@ -1,0 +1,100 @@
+package ccmo
+
+import (
+	"testing"
+	"time"
+)
+
+type stubClock struct {
+	now time.Time
+}
+
+func (s *stubClock) Now() time.Time {
+	return s.now
+}
+
+func TestSendBlocksWithoutConsent(t *testing.T) {
+	clock := &stubClock{now: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)}
+	service, err := NewService(clock)
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	req := NotificationRequest{
+		SubjectID: "user-1",
+		Topic:     "product",
+		Purpose:   "onboarding",
+		Channel:   ChannelEmail,
+		Locale:    "en-US",
+		DarkMode:  false,
+		Template:  "welcome",
+		Data: map[string]any{
+			"subject": "Welcome",
+			"name":    "Casey",
+			"body":    "Here's how to get started.",
+		},
+	}
+
+	resp, err := service.Send(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != "blocked" {
+		t.Fatalf("expected blocked status, got %s", resp.Status)
+	}
+	appeals := service.Appeals()
+	if len(appeals) != 1 {
+		t.Fatalf("expected 1 appeal entry, got %d", len(appeals))
+	}
+	if appeals[0].Reason != AppealReasonConsent {
+		t.Fatalf("expected consent appeal, got %s", appeals[0].Reason)
+	}
+}
+
+func TestFrequencyCapEnforced(t *testing.T) {
+	clock := &stubClock{now: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)}
+	service, err := NewService(clock)
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+	service.SetConsent("user-1", "product", "onboarding", ConsentRecord{Allowed: true})
+	service.SetFrequencyCap(ChannelEmail, FrequencyCap{MaxMessages: 1, Period: time.Hour})
+
+	req := NotificationRequest{
+		SubjectID: "user-1",
+		Topic:     "product",
+		Purpose:   "onboarding",
+		Channel:   ChannelEmail,
+		Locale:    "en-US",
+		DarkMode:  false,
+		Template:  "welcome",
+		Data: map[string]any{
+			"subject": "Welcome",
+			"name":    "Casey",
+			"body":    "Here's how to get started.",
+		},
+	}
+
+	resp, err := service.Send(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != "sent" {
+		t.Fatalf("expected sent status, got %s", resp.Status)
+	}
+
+	resp, err = service.Send(req)
+	if err != nil {
+		t.Fatalf("unexpected error on second attempt: %v", err)
+	}
+	if resp.Status != "blocked" {
+		t.Fatalf("expected blocked status, got %s", resp.Status)
+	}
+	appeals := service.Appeals()
+	if len(appeals) != 1 {
+		t.Fatalf("expected 1 appeal entry, got %d", len(appeals))
+	}
+	if appeals[0].Reason != AppealReasonFrequency {
+		t.Fatalf("expected frequency appeal, got %s", appeals[0].Reason)
+	}
+}

--- a/services/ccmo/internal/ccmo/templates.go
+++ b/services/ccmo/internal/ccmo/templates.go
@@ -1,0 +1,81 @@
+package ccmo
+
+import (
+	"embed"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"text/template"
+)
+
+//go:embed templates/*.tmpl
+var templatesFS embed.FS
+
+// TemplateKey identifies a specific localized rendering variant.
+type TemplateKey struct {
+	Name    string
+	Channel string
+	Locale  string
+	Dark    bool
+}
+
+// TemplateRenderer loads and renders localized templates.
+type TemplateRenderer struct {
+	mu        sync.RWMutex
+	templates map[TemplateKey]*template.Template
+}
+
+// NewTemplateRenderer parses all embedded templates.
+func NewTemplateRenderer() (*TemplateRenderer, error) {
+	entries, err := templatesFS.ReadDir("templates")
+	if err != nil {
+		return nil, err
+	}
+	parsed := make(map[TemplateKey]*template.Template)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".tmpl") {
+			continue
+		}
+		base := strings.TrimSuffix(name, ".tmpl")
+		parts := strings.Split(base, "_")
+		if len(parts) < 4 {
+			return nil, fmt.Errorf("template %s does not follow <channel>_<name>_<locale>_<mode>.tmpl format", name)
+		}
+		channel := parts[0]
+		tplName := parts[1]
+		mode := parts[len(parts)-1]
+		locale := strings.Join(parts[2:len(parts)-1], "_")
+		isDark := mode == "dark"
+		content, err := templatesFS.ReadFile(filepath.ToSlash(filepath.Join("templates", name)))
+		if err != nil {
+			return nil, err
+		}
+		tpl, err := template.New(name).Parse(string(content))
+		if err != nil {
+			return nil, err
+		}
+		key := TemplateKey{Name: tplName, Channel: channel, Locale: locale, Dark: isDark}
+		parsed[key] = tpl
+	}
+	return &TemplateRenderer{templates: parsed}, nil
+}
+
+// Render produces the final content for a template variant.
+func (r *TemplateRenderer) Render(key TemplateKey, data map[string]any) (string, error) {
+	r.mu.RLock()
+	tpl, ok := r.templates[key]
+	r.mu.RUnlock()
+	if !ok {
+		return "", fmt.Errorf("template not found for %s/%s/%s (dark=%t)", key.Channel, key.Name, key.Locale, key.Dark)
+	}
+	var builder strings.Builder
+	if err := tpl.Execute(&builder, data); err != nil {
+		return "", err
+	}
+	return builder.String(), nil
+}

--- a/services/ccmo/internal/ccmo/templates/email_welcome_en_us_dark.tmpl
+++ b/services/ccmo/internal/ccmo/templates/email_welcome_en_us_dark.tmpl
@@ -1,0 +1,4 @@
+Subject: {{.subject}}
+Hey {{.name}},
+Thanks for switching to the night-friendly experience.
+{{.body}}

--- a/services/ccmo/internal/ccmo/templates/email_welcome_en_us_light.tmpl
+++ b/services/ccmo/internal/ccmo/templates/email_welcome_en_us_light.tmpl
@@ -1,0 +1,4 @@
+Subject: {{.subject}}
+Hello {{.name}},
+We noticed you're enjoying our updates in light mode.
+{{.body}}

--- a/services/ccmo/internal/ccmo/templates/email_welcome_es_dark.tmpl
+++ b/services/ccmo/internal/ccmo/templates/email_welcome_es_dark.tmpl
@@ -1,0 +1,4 @@
+Asunto: {{.subject}}
+Hola {{.name}},
+Gracias por elegir nuestra experiencia nocturna.
+{{.body}}

--- a/services/ccmo/internal/ccmo/templates/email_welcome_es_light.tmpl
+++ b/services/ccmo/internal/ccmo/templates/email_welcome_es_light.tmpl
@@ -1,0 +1,4 @@
+Asunto: {{.subject}}
+Hola {{.name}},
+Estamos encantados de compartir novedades en modo claro contigo.
+{{.body}}

--- a/services/ccmo/internal/ccmo/templates/in-app_welcome_en_light.tmpl
+++ b/services/ccmo/internal/ccmo/templates/in-app_welcome_en_light.tmpl
@@ -1,0 +1,3 @@
+### {{.subject}}
+Welcome back, {{.name}}!
+{{.body}}

--- a/services/ccmo/internal/ccmo/templates/push_welcome_en_light.tmpl
+++ b/services/ccmo/internal/ccmo/templates/push_welcome_en_light.tmpl
@@ -1,0 +1,1 @@
+{{.subject}} — Hi {{.name}}, check the latest update: {{.body}}

--- a/services/ccmo/internal/ccmo/templates/testdata/email_welcome_en_us_light.txt
+++ b/services/ccmo/internal/ccmo/templates/testdata/email_welcome_en_us_light.txt
@@ -1,0 +1,4 @@
+Subject: Consent Update
+Hello Jordan,
+We noticed you're enjoying our updates in light mode.
+Your control center is ready.

--- a/services/ccmo/internal/ccmo/templates/testdata/email_welcome_es_dark.txt
+++ b/services/ccmo/internal/ccmo/templates/testdata/email_welcome_es_dark.txt
@@ -1,0 +1,4 @@
+Asunto: Consent Update
+Hola Jordan,
+Gracias por elegir nuestra experiencia nocturna.
+Your control center is ready.

--- a/services/ccmo/internal/ccmo/templates_test.go
+++ b/services/ccmo/internal/ccmo/templates_test.go
@@ -1,0 +1,51 @@
+package ccmo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTemplateSnapshots(t *testing.T) {
+	renderer, err := NewTemplateRenderer()
+	if err != nil {
+		t.Fatalf("failed to init renderer: %v", err)
+	}
+	scenarios := []struct {
+		name string
+		key  TemplateKey
+	}{
+		{
+			name: "email_welcome_en_us_light",
+			key:  TemplateKey{Name: "welcome", Channel: string(ChannelEmail), Locale: "en_us", Dark: false},
+		},
+		{
+			name: "email_welcome_es_dark",
+			key:  TemplateKey{Name: "welcome", Channel: string(ChannelEmail), Locale: "es", Dark: true},
+		},
+	}
+
+	data := map[string]any{
+		"subject": "Consent Update",
+		"name":    "Jordan",
+		"body":    "Your control center is ready.",
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.name, func(t *testing.T) {
+			actual, err := renderer.Render(scenario.key, data)
+			if err != nil {
+				t.Fatalf("render failed: %v", err)
+			}
+			snapshotPath := filepath.Join("templates", "testdata", scenario.name+".txt")
+			expectedBytes, err := os.ReadFile(snapshotPath)
+			if err != nil {
+				t.Fatalf("failed to read snapshot: %v", err)
+			}
+			expected := string(expectedBytes)
+			if actual != expected {
+				t.Fatalf("snapshot mismatch\nexpected:\n%s\nactual:\n%s", expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- implement a Go-based Consent-Compliant Messaging Orchestrator with consent validation, frequency caps, dark-mode/locale templating, and an appeals log exposed via HTTP
- add TypeScript and Python SDK clients for interacting with the CCMO API
- create a CCMO sandbox page in the client app for exercising consent, delivery, and appeals flows

## Testing
- go test ./... (from services/ccmo)


------
https://chatgpt.com/codex/tasks/task_e_68d76efd0e048333a7dedf8d58f4f00d