### PR TITLE
Add DSAR fulfillment engine with proofs and reviewer UI

### DIFF
--- a/apps/intelgraph-api/package.json
+++ b/apps/intelgraph-api/package.json
@@ -1,5 +1,5 @@
 {
-  "name": " @companyos/intelgraph-api",
+  "name": "@companyos/intelgraph-api",
   "version": "0.1.0",
   "private": true,
   "type": "module",
@@ -24,11 +24,11 @@
     "jwks-rsa": "^3.1.0"
   },
   "devDependencies": {
-    " @types/express": "^4.17.21",
-    " @types/node": "^20.12.12",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.12",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.5.4",
     "eslint": "^9.9.0",
-    " @types/jsonwebtoken": "^9.0.6"
+    "@types/jsonwebtoken": "^9.0.6"
   }
 }

--- a/client/src/features/compliance/DsarReviewer.tsx
+++ b/client/src/features/compliance/DsarReviewer.tsx
@@ -1,0 +1,193 @@
+import { useMemo, useState } from 'react';
+
+type Operation = 'export' | 'rectify' | 'delete';
+
+type ProofSummary = {
+  connector: string;
+  hash: string;
+  type: 'rectification' | 'deletion';
+};
+
+type RequestStatus = 'pending' | 'in-progress' | 'completed' | 'failed';
+
+export interface DsarReviewRecord {
+  id: string;
+  subjectId: string;
+  tenantId: string;
+  operation: Operation;
+  status: RequestStatus;
+  submittedAt: string;
+  replayAvailable: boolean;
+  exportLocation?: string;
+  proofs?: ProofSummary[];
+}
+
+export interface DsarReviewerProps {
+  requests: DsarReviewRecord[];
+  onReplay?: (requestId: string) => Promise<void> | void;
+  onInspect?: (request: DsarReviewRecord) => void;
+}
+
+const statusLabel: Record<RequestStatus, string> = {
+  pending: 'Pending approval',
+  'in-progress': 'Processing',
+  completed: 'Completed',
+  failed: 'Failed',
+};
+
+const OperationBadge = ({ operation }: { operation: Operation }) => {
+  const color = operation === 'export' ? '#2563eb' : operation === 'rectify' ? '#047857' : '#dc2626';
+  return (
+    <span
+      style={{
+        background: `${color}14`,
+        border: `1px solid ${color}33`,
+        color,
+        borderRadius: '999px',
+        padding: '2px 10px',
+        fontSize: 12,
+        fontWeight: 600,
+        textTransform: 'uppercase',
+      }}
+    >
+      {operation}
+    </span>
+  );
+};
+
+const ProofList = ({ proofs }: { proofs: ProofSummary[] }) => {
+  if (!proofs.length) {
+    return <p style={{ margin: 0, fontStyle: 'italic' }}>No proofs attached.</p>;
+  }
+  return (
+    <ul style={{ margin: '8px 0 0', paddingLeft: 16 }}>
+      {proofs.map((proof) => (
+        <li key={`${proof.type}-${proof.connector}-${proof.hash}`} style={{ marginBottom: 4 }}>
+          <strong>{proof.connector}</strong> — {proof.type} proof <code>{proof.hash.slice(0, 8)}…</code>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export const DsarReviewer = ({ requests, onReplay, onInspect }: DsarReviewerProps) => {
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const sortedRequests = useMemo(
+    () =>
+      [...requests].sort((a, b) =>
+        new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime(),
+      ),
+    [requests],
+  );
+
+  const activeRequest = useMemo(
+    () => sortedRequests.find((request) => request.id === activeId) ?? null,
+    [sortedRequests, activeId],
+  );
+
+  return (
+    <div style={{ display: 'flex', gap: 24, alignItems: 'flex-start' }}>
+      <div style={{ flex: '1 1 50%' }}>
+        <h2 style={{ marginTop: 0 }}>DSAR Review Queue</h2>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr>
+              <th style={{ textAlign: 'left', padding: '8px 12px' }}>Subject</th>
+              <th style={{ textAlign: 'left', padding: '8px 12px' }}>Tenant</th>
+              <th style={{ textAlign: 'left', padding: '8px 12px' }}>Operation</th>
+              <th style={{ textAlign: 'left', padding: '8px 12px' }}>Status</th>
+              <th style={{ textAlign: 'left', padding: '8px 12px' }}>Submitted</th>
+              <th style={{ textAlign: 'left', padding: '8px 12px' }}>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sortedRequests.map((request) => {
+              const isActive = activeId === request.id;
+              return (
+                <tr
+                  key={request.id}
+                  style={{
+                    background: isActive ? '#eff6ff' : 'transparent',
+                    cursor: 'pointer',
+                    borderBottom: '1px solid #e2e8f0',
+                  }}
+                  onClick={() => {
+                    setActiveId(request.id);
+                    onInspect?.(request);
+                  }}
+                >
+                  <td style={{ padding: '8px 12px' }}>{request.subjectId}</td>
+                  <td style={{ padding: '8px 12px' }}>{request.tenantId}</td>
+                  <td style={{ padding: '8px 12px' }}>
+                    <OperationBadge operation={request.operation} />
+                  </td>
+                  <td style={{ padding: '8px 12px' }}>{statusLabel[request.status]}</td>
+                  <td style={{ padding: '8px 12px' }}>
+                    {new Date(request.submittedAt).toLocaleString()}
+                  </td>
+                  <td style={{ padding: '8px 12px' }}>
+                    {request.replayAvailable && (
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          onReplay?.(request.id);
+                        }}
+                        style={{
+                          background: '#111827',
+                          color: '#fff',
+                          border: 'none',
+                          borderRadius: 4,
+                          padding: '6px 12px',
+                          cursor: 'pointer',
+                        }}
+                        aria-label={`Replay DSAR request ${request.id}`}
+                      >
+                        Replay
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <aside style={{ flex: '1 1 50%', borderLeft: '1px solid #e5e7eb', paddingLeft: 24 }}>
+        <h3 style={{ marginTop: 0 }}>Request details</h3>
+        {activeRequest ? (
+          <div>
+            <p style={{ margin: '4px 0' }}>
+              <strong>Request ID:</strong> {activeRequest.id}
+            </p>
+            <p style={{ margin: '4px 0' }}>
+              <strong>Subject:</strong> {activeRequest.subjectId}
+            </p>
+            <p style={{ margin: '4px 0' }}>
+              <strong>Tenant:</strong> {activeRequest.tenantId}
+            </p>
+            <p style={{ margin: '4px 0' }}>
+              <strong>Status:</strong> {statusLabel[activeRequest.status]}
+            </p>
+            {activeRequest.exportLocation && (
+              <p style={{ margin: '4px 0' }}>
+                <strong>Export pack:</strong> <code>{activeRequest.exportLocation}</code>
+              </p>
+            )}
+            {activeRequest.proofs && activeRequest.proofs.length > 0 && (
+              <div style={{ marginTop: 16 }}>
+                <h4 style={{ margin: '0 0 8px' }}>Proofs</h4>
+                <ProofList proofs={activeRequest.proofs} />
+              </div>
+            )}
+          </div>
+        ) : (
+          <p style={{ fontStyle: 'italic' }}>Select a request to inspect its fulfillment artifacts.</p>
+        )}
+      </aside>
+    </div>
+  );
+};
+
+export default DsarReviewer;

--- a/client/src/features/compliance/__tests__/DsarReviewer.test.tsx
+++ b/client/src/features/compliance/__tests__/DsarReviewer.test.tsx
@@ -1,0 +1,51 @@
+import { jest } from '@jest/globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { DsarReviewer, type DsarReviewRecord } from '../DsarReviewer';
+
+describe('DsarReviewer', () => {
+  const baseRequests: DsarReviewRecord[] = [
+    {
+      id: 'req-1',
+      subjectId: 'sub-1',
+      tenantId: 'tenant-1',
+      operation: 'export',
+      status: 'completed',
+      submittedAt: '2025-09-01T00:00:00.000Z',
+      replayAvailable: true,
+      exportLocation: 's3://bucket/req-1.json',
+    },
+    {
+      id: 'req-2',
+      subjectId: 'sub-2',
+      tenantId: 'tenant-2',
+      operation: 'delete',
+      status: 'pending',
+      submittedAt: '2025-09-02T12:00:00.000Z',
+      replayAvailable: false,
+      proofs: [
+        { connector: 'postgres', type: 'deletion', hash: 'abc12345' },
+      ],
+    },
+  ];
+
+  it('renders requests and surfaces replay actions', () => {
+    const onReplay = jest.fn();
+    render(<DsarReviewer requests={baseRequests} onReplay={onReplay} />);
+
+    expect(screen.getByText('DSAR Review Queue')).toBeInTheDocument();
+    expect(screen.getByText('sub-1')).toBeInTheDocument();
+    expect(screen.getByText('sub-2')).toBeInTheDocument();
+
+    const replayButton = screen.getByRole('button', { name: /Replay DSAR request req-1/i });
+    fireEvent.click(replayButton);
+    expect(onReplay).toHaveBeenCalledWith('req-1');
+  });
+
+  it('shows request details when selected', () => {
+    render(<DsarReviewer requests={baseRequests} />);
+
+    fireEvent.click(screen.getByText('sub-2'));
+    expect(screen.getByText(/Request ID:/)).toHaveTextContent('req-2');
+    expect(screen.getByText(/Proofs/)).toBeInTheDocument();
+  });
+});

--- a/server/src/privacy/dsar/connectors.ts
+++ b/server/src/privacy/dsar/connectors.ts
@@ -1,0 +1,186 @@
+import type {
+  ConnectorSnapshot,
+  DSARConnector,
+  ExportStorage,
+  KafkaEventLog,
+} from './types';
+
+export interface PostgresRow {
+  table: string;
+  subjectId: string;
+  tenantId: string;
+  data: Record<string, unknown>;
+}
+
+const clone = <T>(value: T): T => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+};
+
+const cloneRows = (rows: PostgresRow[]): PostgresRow[] => rows.map((row) => ({ ...row, data: clone(row.data) }));
+
+export class InMemoryPostgresConnector implements DSARConnector<PostgresRow[]> {
+  public readonly name = 'postgres';
+  private rows: PostgresRow[];
+  public readonly calls = { collect: 0, rectify: 0, delete: 0 };
+
+  constructor(rows: PostgresRow[]) {
+    this.rows = cloneRows(rows);
+  }
+
+  private subjects(): string[] {
+    return Array.from(new Set(this.rows.map((row) => row.subjectId))).sort();
+  }
+
+  private orderedRows(): PostgresRow[] {
+    return cloneRows(
+      this.rows
+        .slice()
+        .sort((a, b) => `${a.subjectId}:${a.table}`.localeCompare(`${b.subjectId}:${b.table}`)),
+    );
+  }
+
+  async collect(subjectId: string, tenantId: string): Promise<PostgresRow[]> {
+    this.calls.collect += 1;
+    return this.orderedRows().filter((row) => row.subjectId === subjectId && row.tenantId === tenantId);
+  }
+
+  async rectify(
+    subjectId: string,
+    tenantId: string,
+    patch: Record<string, unknown>,
+  ): Promise<void> {
+    this.calls.rectify += 1;
+    Object.entries(patch).forEach(([table, value]) => {
+      const target = this.rows.find(
+        (row) => row.subjectId === subjectId && row.tenantId === tenantId && row.table === table,
+      );
+      if (target) {
+        target.data = { ...target.data, ...(value as Record<string, unknown>) };
+      } else {
+        this.rows.push({
+          table,
+          tenantId,
+          subjectId,
+          data: clone(value as Record<string, unknown>),
+        });
+      }
+    });
+  }
+
+  async delete(subjectId: string, tenantId: string): Promise<void> {
+    this.calls.delete += 1;
+    this.rows = this.rows.filter((row) => !(row.subjectId === subjectId && row.tenantId === tenantId));
+  }
+
+  async snapshot(): Promise<ConnectorSnapshot<PostgresRow[]>> {
+    return {
+      data: this.orderedRows(),
+      subjectIds: this.subjects(),
+    };
+  }
+
+  getRows(subjectId: string, tenantId: string): PostgresRow[] {
+    return cloneRows(this.rows.filter((row) => row.subjectId === subjectId && row.tenantId === tenantId));
+  }
+}
+
+export interface ElasticsearchDocument {
+  id: string;
+  subjectId: string;
+  tenantId: string;
+  index: string;
+  body: Record<string, unknown>;
+}
+
+const cloneDocuments = (documents: ElasticsearchDocument[]): ElasticsearchDocument[] =>
+  documents.map((doc) => ({ ...doc, body: clone(doc.body) }));
+
+export class InMemoryElasticsearchConnector implements DSARConnector<ElasticsearchDocument[]> {
+  public readonly name = 'elasticsearch';
+  private documents: ElasticsearchDocument[];
+  public readonly calls = { collect: 0, rectify: 0, delete: 0 };
+
+  constructor(documents: ElasticsearchDocument[]) {
+    this.documents = cloneDocuments(documents);
+  }
+
+  private subjects(): string[] {
+    return Array.from(new Set(this.documents.map((doc) => doc.subjectId))).sort();
+  }
+
+  private orderedDocuments(): ElasticsearchDocument[] {
+    return cloneDocuments(
+      this.documents
+        .slice()
+        .sort((a, b) => `${a.subjectId}:${a.index}:${a.id}`.localeCompare(`${b.subjectId}:${b.index}:${b.id}`)),
+    );
+  }
+
+  async collect(subjectId: string, tenantId: string): Promise<ElasticsearchDocument[]> {
+    this.calls.collect += 1;
+    return this.orderedDocuments().filter((doc) => doc.subjectId === subjectId && doc.tenantId === tenantId);
+  }
+
+  async rectify(
+    subjectId: string,
+    tenantId: string,
+    patch: Record<string, unknown>,
+  ): Promise<void> {
+    this.calls.rectify += 1;
+    Object.entries(patch).forEach(([index, value]) => {
+      this.documents
+        .filter((doc) => doc.subjectId === subjectId && doc.tenantId === tenantId && doc.index === index)
+        .forEach((doc) => {
+          doc.body = { ...doc.body, ...(value as Record<string, unknown>) };
+        });
+    });
+  }
+
+  async delete(subjectId: string, tenantId: string): Promise<void> {
+    this.calls.delete += 1;
+    this.documents = this.documents.filter(
+      (doc) => !(doc.subjectId === subjectId && doc.tenantId === tenantId),
+    );
+  }
+
+  async snapshot(): Promise<ConnectorSnapshot<ElasticsearchDocument[]>> {
+    return {
+      data: this.orderedDocuments(),
+      subjectIds: this.subjects(),
+    };
+  }
+
+  getDocuments(subjectId: string, tenantId: string): ElasticsearchDocument[] {
+    return cloneDocuments(this.documents.filter((doc) => doc.subjectId === subjectId && doc.tenantId === tenantId));
+  }
+}
+
+export class InMemoryKafkaEventLog implements KafkaEventLog {
+  private events: Record<string, unknown>[] = [];
+
+  async publish(topic: string, message: Record<string, unknown>): Promise<void> {
+    this.events.push({ topic, ...clone(message) });
+  }
+
+  history(): Record<string, unknown>[] {
+    return this.events.slice();
+  }
+}
+
+export class InMemoryS3Storage implements ExportStorage {
+  private readonly bucket: Map<string, string> = new Map();
+
+  constructor(private readonly baseUri = 's3://dfe-fixtures') {}
+
+  async putObject(key: string, body: string): Promise<string> {
+    this.bucket.set(key, body);
+    return `${this.baseUri}/${key}`;
+  }
+
+  async getObject(key: string): Promise<string | undefined> {
+    return this.bucket.get(key);
+  }
+}

--- a/server/src/privacy/dsar/dfe.ts
+++ b/server/src/privacy/dsar/dfe.ts
@@ -1,0 +1,221 @@
+import { applyConnectorRedactions } from './redaction';
+import { buildDeletionProof, buildRectificationProof, hashDeterministic } from './proofs';
+import type {
+  DataSubjectFulfillmentOptions,
+  DSARConnector,
+  DSARRequest,
+  DSARResponse,
+  DSARResponseMeta,
+  ExportConnectorRecord,
+  ExportManifest,
+  IdentityVerification,
+} from './types';
+
+const cloneResponse = (response: DSARResponse): DSARResponse =>
+  JSON.parse(JSON.stringify(response)) as DSARResponse;
+
+export class DataSubjectFulfillmentEngine {
+  private readonly connectors: Map<string, DSARConnector> = new Map();
+  private readonly cache: Map<string, DSARResponse> = new Map();
+
+  constructor(private readonly options: DataSubjectFulfillmentOptions) {
+    options.connectors.forEach((connector) => {
+      if (this.connectors.has(connector.name)) {
+        throw new Error(`Duplicate connector registered: ${connector.name}`);
+      }
+      this.connectors.set(connector.name, connector);
+    });
+  }
+
+  async execute(request: DSARRequest): Promise<DSARResponse> {
+    const verification = await this.options.identityVerifier.verify(request);
+    if (!verification.verified) {
+      throw new Error(`Identity verification failed: ${verification.reason ?? 'unknown reason'}`);
+    }
+    const cacheKey = request.replayKey ?? request.requestId;
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      const cloned = cloneResponse(cached);
+      return {
+        ...cloned,
+        meta: this.buildMeta(true, verification),
+      };
+    }
+
+    let response: DSARResponse;
+    switch (request.operation) {
+      case 'export':
+        response = await this.handleExport(request, verification);
+        break;
+      case 'rectify':
+        response = await this.handleRectify(request, verification);
+        break;
+      case 'delete':
+        response = await this.handleDelete(request, verification);
+        break;
+      default:
+        throw new Error(`Unsupported DSAR operation: ${request.operation}`);
+    }
+
+    this.cache.set(cacheKey, response);
+    return response;
+  }
+
+  private buildMeta(idempotentReplay: boolean, verification: IdentityVerification): DSARResponseMeta {
+    return {
+      idempotentReplay,
+      identityVerification: verification,
+    };
+  }
+
+  private async handleExport(
+    request: DSARRequest,
+    verification: IdentityVerification,
+  ): Promise<DSARResponse> {
+    const connectorPayloads: { name: string; data: unknown; applied: string[]; hash: string }[] = [];
+    for (const connector of this.connectors.values()) {
+      const collected = await connector.collect(request.subjectId, request.tenantId);
+      const { data, applied } = applyConnectorRedactions(connector.name, collected, this.options.redactionRules);
+      connectorPayloads.push({
+        name: connector.name,
+        data,
+        applied,
+        hash: hashDeterministic(data),
+      });
+    }
+
+    const generatedAt = new Date().toISOString();
+    const manifest: ExportManifest = {
+      requestId: request.requestId,
+      subjectId: request.subjectId,
+      tenantId: request.tenantId,
+      generatedAt,
+      connectors: connectorPayloads
+        .map<ExportConnectorRecord>((entry) => ({
+          name: entry.name,
+          itemCount: Array.isArray(entry.data)
+            ? entry.data.length
+            : entry.data && typeof entry.data === 'object'
+              ? Object.keys(entry.data as Record<string, unknown>).length
+              : 1,
+          hash: entry.hash,
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+      redactionsApplied: Array.from(
+        new Set(connectorPayloads.flatMap((entry) => entry.applied)),
+      ).sort(),
+    };
+
+    const connectorsPayload = connectorPayloads
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .reduce<Record<string, unknown>>((acc, entry) => {
+        acc[entry.name] = entry.data;
+        return acc;
+      }, {});
+
+    const payload = JSON.stringify({
+      requestId: request.requestId,
+      subjectId: request.subjectId,
+      tenantId: request.tenantId,
+      generatedAt,
+      connectors: connectorsPayload,
+    });
+
+    const signedPack = this.options.signer.sign(payload, manifest);
+    const objectKey = `${request.tenantId}/${request.requestId}.json`;
+    const location = await this.options.storage.putObject(objectKey, JSON.stringify(signedPack));
+
+    await this.options.kafka.publish('dsar.fulfillment', {
+      requestId: request.requestId,
+      operation: 'export',
+      subjectId: request.subjectId,
+      tenantId: request.tenantId,
+      location,
+    });
+
+    const response: DSARResponse = {
+      type: 'export',
+      result: {
+        location,
+        pack: signedPack,
+      },
+      meta: this.buildMeta(false, verification),
+    };
+
+    return response;
+  }
+
+  private async handleRectify(
+    request: DSARRequest,
+    verification: IdentityVerification,
+  ): Promise<DSARResponse> {
+    const payload = (request.payload as Record<string, unknown>) ?? {};
+    const proofs = [];
+    for (const connector of this.connectors.values()) {
+      if (typeof connector.rectify !== 'function') {
+        continue;
+      }
+      const connectorPatch = payload[connector.name] as Record<string, unknown> | undefined;
+      if (!connectorPatch || Object.keys(connectorPatch).length === 0) {
+        continue;
+      }
+      const before = await connector.snapshot();
+      await connector.rectify(request.subjectId, request.tenantId, connectorPatch);
+      const after = await connector.snapshot();
+      proofs.push(buildRectificationProof(request.requestId, connector.name, before, after, connectorPatch));
+      await this.options.kafka.publish('dsar.fulfillment', {
+        requestId: request.requestId,
+        operation: 'rectify',
+        subjectId: request.subjectId,
+        tenantId: request.tenantId,
+        connector: connector.name,
+      });
+    }
+
+    return {
+      type: 'rectify',
+      result: { proofs },
+      meta: this.buildMeta(false, verification),
+    };
+  }
+
+  private async handleDelete(
+    request: DSARRequest,
+    verification: IdentityVerification,
+  ): Promise<DSARResponse> {
+    const proofs = [];
+    for (const connector of this.connectors.values()) {
+      if (typeof connector.delete !== 'function') {
+        continue;
+      }
+      await connector.delete(request.subjectId, request.tenantId);
+      const snapshot = await connector.snapshot();
+      proofs.push(buildDeletionProof(request.requestId, connector.name, request.subjectId, snapshot));
+      await this.options.kafka.publish('dsar.fulfillment', {
+        requestId: request.requestId,
+        operation: 'delete',
+        subjectId: request.subjectId,
+        tenantId: request.tenantId,
+        connector: connector.name,
+      });
+    }
+
+    return {
+      type: 'delete',
+      result: { proofs },
+      meta: this.buildMeta(false, verification),
+    };
+  }
+}
+
+export const registerConnector = (
+  engine: DataSubjectFulfillmentEngine,
+  connector: DSARConnector,
+): void => {
+  const map = (engine as unknown as { connectors: Map<string, DSARConnector> }).connectors;
+  if (map.has(connector.name)) {
+    throw new Error(`Connector ${connector.name} already registered`);
+  }
+  map.set(connector.name, connector);
+};

--- a/server/src/privacy/dsar/identity.ts
+++ b/server/src/privacy/dsar/identity.ts
@@ -1,0 +1,17 @@
+import type { DSARRequest, IdentityVerification, IdentityVerifier } from './types';
+
+export class StaticIdentityVerifier implements IdentityVerifier {
+  constructor(private readonly expectedTokens: Record<string, string>) {}
+
+  async verify(request: DSARRequest): Promise<IdentityVerification> {
+    const expected = this.expectedTokens[request.subjectId];
+    const provided = request.identityProof?.token;
+    const verified = Boolean(expected && provided && expected === provided);
+    return {
+      verified,
+      reason: verified ? undefined : 'identity token mismatch',
+      verifierId: 'static-fixture',
+      proofMethod: request.identityProof?.method,
+    };
+  }
+}

--- a/server/src/privacy/dsar/index.ts
+++ b/server/src/privacy/dsar/index.ts
@@ -1,0 +1,7 @@
+export * from './connectors';
+export * from './dfe';
+export * from './identity';
+export * from './proofs';
+export * from './redaction';
+export * from './signing';
+export * from './types';

--- a/server/src/privacy/dsar/proofs.ts
+++ b/server/src/privacy/dsar/proofs.ts
@@ -1,0 +1,98 @@
+import * as crypto from 'crypto';
+import type { ConnectorSnapshot } from './types';
+
+const sortObject = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortObject(item));
+  }
+  if (value && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortObject((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+};
+
+export const hashDeterministic = (value: unknown): string => {
+  const normalized = JSON.stringify(sortObject(value));
+  return crypto.createHash('sha256').update(normalized).digest('hex');
+};
+
+export interface RectificationProof {
+  requestId: string;
+  connector: string;
+  beforeHash: string;
+  afterHash: string;
+  afterSnapshot: ConnectorSnapshot;
+  changes: Record<string, unknown>;
+}
+
+export const buildRectificationProof = (
+  requestId: string,
+  connector: string,
+  before: ConnectorSnapshot,
+  after: ConnectorSnapshot,
+  changes: Record<string, unknown>,
+): RectificationProof => ({
+  requestId,
+  connector,
+  beforeHash: hashDeterministic(before),
+  afterHash: hashDeterministic(after),
+  afterSnapshot: after,
+  changes,
+});
+
+export const validateRectificationProof = (proof: RectificationProof): boolean => {
+  if (!proof.afterSnapshot) {
+    return false;
+  }
+  const recomputedAfter = hashDeterministic(proof.afterSnapshot);
+  return recomputedAfter === proof.afterHash && proof.afterHash !== proof.beforeHash;
+};
+
+export interface DeletionProof {
+  requestId: string;
+  connector: string;
+  subjectId: string;
+  subjectHash: string;
+  remainingSubjectIds: string[];
+  subjectListHash: string;
+  dataHash: string;
+}
+
+export const buildDeletionProof = (
+  requestId: string,
+  connector: string,
+  subjectId: string,
+  snapshot: ConnectorSnapshot,
+): DeletionProof => ({
+  requestId,
+  connector,
+  subjectId,
+  subjectHash: hashDeterministic(subjectId),
+  remainingSubjectIds: [...snapshot.subjectIds],
+  subjectListHash: hashDeterministic(snapshot.subjectIds),
+  dataHash: hashDeterministic(snapshot.data),
+});
+
+export const validateDeletionProof = (proof: DeletionProof): boolean => {
+  const subjectMissing = !proof.remainingSubjectIds.includes(proof.subjectId);
+  const listHashMatches = hashDeterministic(proof.remainingSubjectIds) === proof.subjectListHash;
+  return subjectMissing && listHashMatches && typeof proof.dataHash === 'string' && proof.dataHash.length === 64;
+};
+
+export const validateDeletionProofAgainstSnapshot = (
+  proof: DeletionProof,
+  snapshot: ConnectorSnapshot,
+): boolean => {
+  const subjectMissing = !snapshot.subjectIds.includes(proof.subjectId);
+  const subjectListHashMatches = hashDeterministic(snapshot.subjectIds) === proof.subjectListHash;
+  const dataHashMatches = hashDeterministic(snapshot.data) === proof.dataHash;
+  return subjectMissing && subjectListHashMatches && dataHashMatches;
+};
+
+export const validateDeletionProofs = (proofs: DeletionProof[], subjectId: string): boolean =>
+  proofs.every((proof) => validateDeletionProof(proof) && proof.subjectId === subjectId);

--- a/server/src/privacy/dsar/redaction.ts
+++ b/server/src/privacy/dsar/redaction.ts
@@ -1,0 +1,90 @@
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  Object.prototype.toString.call(value) === '[object Object]';
+
+export interface RedactionRule {
+  connector: string;
+  description: string;
+  apply(input: unknown): unknown;
+}
+
+export interface RedactionOutcome<T = unknown> {
+  data: T;
+  applied: string[];
+}
+
+const maskValue = (value: unknown, mask: string): unknown => {
+  if (typeof value === 'string' && value.length > mask.length) {
+    return `${mask}${value.slice(mask.length)}`;
+  }
+  return mask;
+};
+
+const clone = <T>(value: T): T => {
+  if (typeof structuredClone === 'function') {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value)) as T;
+};
+
+type TraverseCallback = (args: { key: string; value: unknown; parent: Record<string, unknown> | unknown[] }) => void;
+
+const traverse = (value: unknown, cb: TraverseCallback): void => {
+  if (Array.isArray(value)) {
+    value.forEach((item, idx, arr) => {
+      cb({ key: String(idx), value: item, parent: arr });
+      traverse(item, cb);
+    });
+    return;
+  }
+  if (isPlainObject(value)) {
+    Object.entries(value as Record<string, unknown>).forEach(([key, val]) => {
+      cb({ key, value: val, parent: value as Record<string, unknown> });
+      traverse(val, cb);
+    });
+  }
+};
+
+export const applyConnectorRedactions = <T = unknown>(
+  connector: string,
+  input: T,
+  rules: RedactionRule[] | undefined,
+): RedactionOutcome<T> => {
+  if (!rules?.length) {
+    return { data: input, applied: [] };
+  }
+  const applicable = rules.filter((rule) => rule.connector === connector);
+  if (!applicable.length) {
+    return { data: input, applied: [] };
+  }
+  let working: unknown = clone(input);
+  const applied: string[] = [];
+  for (const rule of applicable) {
+    working = rule.apply(clone(working));
+    applied.push(rule.description);
+  }
+  return { data: working as T, applied };
+};
+
+export const createFieldMaskRule = (
+  connector: string,
+  fields: string[],
+  mask = '[REDACTED]',
+  description = 'Mask sensitive fields',
+): RedactionRule => ({
+  connector,
+  description,
+  apply: (input: unknown) => {
+    const result = clone(input) as Record<string, unknown>;
+    const fieldSet = new Set(fields);
+    traverse(result, ({ key, value, parent }) => {
+      if (fieldSet.has(key)) {
+        if (Array.isArray(parent)) {
+          (parent as unknown[])[Number(key)] = maskValue(value, mask);
+        } else if (isPlainObject(parent)) {
+          (parent as Record<string, unknown>)[key] = maskValue(value, mask);
+        }
+      }
+    });
+    return result;
+  },
+});

--- a/server/src/privacy/dsar/signing.ts
+++ b/server/src/privacy/dsar/signing.ts
@@ -1,0 +1,32 @@
+import * as crypto from 'crypto';
+import type { ExportManifest, SignedExportPack } from './types';
+import { hashDeterministic } from './proofs';
+
+export class ExportPackSigner {
+  constructor(private readonly privateKeyPem: string, private readonly publicKeyPem: string) {}
+
+  sign(payload: string, manifest: ExportManifest): SignedExportPack {
+    const digest = crypto.createHash('sha256').update(payload).digest('hex');
+    const signer = crypto.createSign('RSA-SHA256');
+    signer.update(payload);
+    signer.end();
+    const signature = signer.sign(this.privateKeyPem, 'base64');
+    return {
+      manifest,
+      payload,
+      signature,
+      digest,
+    };
+  }
+
+  verify(payload: string, signature: string): boolean {
+    const verifier = crypto.createVerify('RSA-SHA256');
+    verifier.update(payload);
+    verifier.end();
+    return verifier.verify(this.publicKeyPem, signature, 'base64');
+  }
+
+  manifestDigest(manifest: ExportManifest): string {
+    return hashDeterministic(manifest);
+  }
+}

--- a/server/src/privacy/dsar/types.ts
+++ b/server/src/privacy/dsar/types.ts
@@ -1,0 +1,130 @@
+import type { RedactionRule } from './redaction';
+import type { RectificationProof, DeletionProof } from './proofs';
+
+export type DSAROperation = 'export' | 'rectify' | 'delete';
+
+export interface IdentityProof {
+  method: string;
+  token: string;
+  issuedAt?: string;
+  evidenceUri?: string;
+}
+
+export interface DSARRequest {
+  requestId: string;
+  subjectId: string;
+  tenantId: string;
+  operation: DSAROperation;
+  payload?: Record<string, unknown>;
+  identityProof?: IdentityProof;
+  replayKey?: string;
+}
+
+export interface IdentityVerification {
+  verified: boolean;
+  reason?: string;
+  verifierId?: string;
+  proofMethod?: string;
+}
+
+export interface IdentityVerifier {
+  verify(request: DSARRequest): Promise<IdentityVerification>;
+}
+
+export interface ConnectorSnapshot<T = unknown> {
+  data: T;
+  subjectIds: string[];
+}
+
+export interface DSARConnector<TCollect = unknown, TSnapshot = ConnectorSnapshot> {
+  readonly name: string;
+  collect(subjectId: string, tenantId: string): Promise<TCollect>;
+  snapshot(): Promise<TSnapshot>;
+  rectify?(subjectId: string, tenantId: string, patch: Record<string, unknown>): Promise<void>;
+  delete?(subjectId: string, tenantId: string): Promise<void>;
+}
+
+export interface KafkaEventLog {
+  publish(topic: string, message: Record<string, unknown>): Promise<void>;
+  history(): Record<string, unknown>[];
+}
+
+export interface ExportStorage {
+  putObject(key: string, body: string): Promise<string>;
+  getObject(key: string): Promise<string | undefined>;
+}
+
+export interface ExportConnectorRecord {
+  name: string;
+  itemCount: number;
+  hash: string;
+}
+
+export interface ExportManifest {
+  requestId: string;
+  subjectId: string;
+  tenantId: string;
+  generatedAt: string;
+  connectors: ExportConnectorRecord[];
+  redactionsApplied: string[];
+}
+
+export interface SignedExportPack {
+  manifest: ExportManifest;
+  payload: string;
+  signature: string;
+  digest: string;
+}
+
+export interface ExportResult {
+  location: string;
+  pack: SignedExportPack;
+}
+
+export interface RectificationResult {
+  proofs: RectificationProof[];
+}
+
+export interface DeletionResult {
+  proofs: DeletionProof[];
+}
+
+export interface DSARResponseMeta {
+  idempotentReplay: boolean;
+  identityVerification: IdentityVerification;
+}
+
+export interface DSARExportResponse {
+  type: 'export';
+  result: ExportResult;
+  meta: DSARResponseMeta;
+}
+
+export interface DSARRectificationResponse {
+  type: 'rectify';
+  result: RectificationResult;
+  meta: DSARResponseMeta;
+}
+
+export interface DSARDeletionResponse {
+  type: 'delete';
+  result: DeletionResult;
+  meta: DSARResponseMeta;
+}
+
+export type DSARResponse =
+  | DSARExportResponse
+  | DSARRectificationResponse
+  | DSARDeletionResponse;
+
+export interface DataSubjectFulfillmentOptions {
+  connectors: DSARConnector[];
+  storage: ExportStorage;
+  kafka: KafkaEventLog;
+  signer: {
+    sign(payload: string, manifest: ExportManifest): SignedExportPack;
+    verify(payload: string, signature: string): boolean;
+  };
+  identityVerifier: IdentityVerifier;
+  redactionRules?: RedactionRule[];
+}

--- a/server/tests/privacy/dfe.integration.ts
+++ b/server/tests/privacy/dfe.integration.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import * as crypto from 'crypto';
+import {
+  DataSubjectFulfillmentEngine,
+  ExportPackSigner,
+  InMemoryElasticsearchConnector,
+  InMemoryKafkaEventLog,
+  InMemoryPostgresConnector,
+  InMemoryS3Storage,
+  StaticIdentityVerifier,
+  createFieldMaskRule,
+  validateDeletionProof,
+  validateDeletionProofAgainstSnapshot,
+  validateRectificationProof,
+} from '../../src/privacy/dsar';
+
+const subjectId = 'sub-001';
+const tenantId = 'tenant-a';
+
+const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+const signer = new ExportPackSigner(
+  privateKey.export({ type: 'pkcs1', format: 'pem' }).toString(),
+  publicKey.export({ type: 'pkcs1', format: 'pem' }).toString(),
+);
+
+const postgres = new InMemoryPostgresConnector([
+  {
+    table: 'profile',
+    subjectId,
+    tenantId,
+    data: { email: 'original@example.com', name: 'Fixture User', ssn: '123-45-6789' },
+  },
+  {
+    table: 'sessions',
+    subjectId,
+    tenantId,
+    data: { lastLogin: '2025-09-01T00:00:00.000Z', ip: '203.0.113.5' },
+  },
+]);
+
+const elastic = new InMemoryElasticsearchConnector([
+  {
+    id: 'activity-1',
+    subjectId,
+    tenantId,
+    index: 'activity',
+    body: { action: 'login', email: 'original@example.com', timestamp: '2025-09-01T00:00:00.000Z' },
+  },
+  {
+    id: 'activity-2',
+    subjectId,
+    tenantId,
+    index: 'activity',
+    body: { action: 'purchase', amount: 49.99, currency: 'USD' },
+  },
+]);
+
+const kafka = new InMemoryKafkaEventLog();
+const storage = new InMemoryS3Storage('s3://fixtures-dsar');
+const engine = new DataSubjectFulfillmentEngine({
+  connectors: [postgres, elastic],
+  storage,
+  kafka,
+  signer,
+  identityVerifier: new StaticIdentityVerifier({ [subjectId]: 'token-123' }),
+  redactionRules: [
+    createFieldMaskRule('postgres', ['email', 'ssn'], '***-masked'),
+    createFieldMaskRule('elasticsearch', ['email'], '***-masked'),
+  ],
+});
+
+(async () => {
+  const exportRequest = {
+    requestId: 'req-export-1',
+    subjectId,
+    tenantId,
+    operation: 'export' as const,
+    identityProof: { method: 'email', token: 'token-123' },
+    replayKey: 'case-1',
+  };
+  const first = await engine.execute(exportRequest);
+  assert.equal(first.type, 'export');
+  assert.equal(first.meta.idempotentReplay, false);
+  const stored = await storage.getObject(`${tenantId}/${exportRequest.requestId}.json`);
+  assert.ok(stored, 'export pack stored in S3');
+  const parsed = JSON.parse(stored!);
+  assert.ok(signer.verify(parsed.payload, parsed.signature), 'signature verifies');
+  const second = await engine.execute(exportRequest);
+  assert.equal(second.meta.idempotentReplay, true);
+  assert.deepEqual(second.result, first.result);
+  assert.equal(postgres.calls.collect, 1);
+  assert.equal(elastic.calls.collect, 1);
+
+  const rectify = await engine.execute({
+    requestId: 'req-rectify-1',
+    subjectId,
+    tenantId,
+    operation: 'rectify' as const,
+    identityProof: { method: 'email', token: 'token-123' },
+    payload: {
+      postgres: { profile: { email: 'updated@example.com' } },
+      elasticsearch: { activity: { email: 'updated@example.com' } },
+    },
+  });
+  assert.equal(rectify.type, 'rectify');
+  assert.equal(rectify.result.proofs.length, 2);
+  rectify.result.proofs.forEach((proof) => assert.ok(validateRectificationProof(proof)));
+
+  const deletion = await engine.execute({
+    requestId: 'req-delete-1',
+    subjectId,
+    tenantId,
+    operation: 'delete' as const,
+    identityProof: { method: 'email', token: 'token-123' },
+  });
+  assert.equal(deletion.type, 'delete');
+  assert.equal(deletion.result.proofs.length, 2);
+  deletion.result.proofs.forEach((proof) => {
+    assert.ok(validateDeletionProof(proof));
+  });
+  const postgresSnapshot = await postgres.snapshot();
+  const elasticSnapshot = await elastic.snapshot();
+  deletion.result.proofs.forEach((proof) => {
+    const snapshot = proof.connector === 'postgres' ? postgresSnapshot : elasticSnapshot;
+    assert.ok(validateDeletionProofAgainstSnapshot(proof, snapshot));
+  });
+
+  console.log('DFE integration checks completed');
+})();

--- a/server/tests/privacy/dfe.test.ts
+++ b/server/tests/privacy/dfe.test.ts
@@ -1,0 +1,181 @@
+import * as crypto from 'crypto';
+import {
+  DataSubjectFulfillmentEngine,
+  ExportPackSigner,
+  InMemoryElasticsearchConnector,
+  InMemoryKafkaEventLog,
+  InMemoryPostgresConnector,
+  InMemoryS3Storage,
+  StaticIdentityVerifier,
+  createFieldMaskRule,
+  validateDeletionProof,
+  validateDeletionProofAgainstSnapshot,
+  validateRectificationProof,
+  type DSARDeletionResponse,
+  type DSARExportResponse,
+  type DSARRectificationResponse,
+} from '../../src/privacy/dsar';
+
+const subjectId = 'sub-001';
+const tenantId = 'tenant-a';
+
+const buildEngine = () => {
+  const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', {
+    modulusLength: 2048,
+  });
+
+  const signer = new ExportPackSigner(
+    privateKey.export({ type: 'pkcs1', format: 'pem' }).toString(),
+    publicKey.export({ type: 'pkcs1', format: 'pem' }).toString(),
+  );
+
+  const postgres = new InMemoryPostgresConnector([
+    {
+      table: 'profile',
+      subjectId,
+      tenantId,
+      data: { email: 'original@example.com', name: 'Fixture User', ssn: '123-45-6789' },
+    },
+    {
+      table: 'sessions',
+      subjectId,
+      tenantId,
+      data: { lastLogin: '2025-09-01T00:00:00.000Z', ip: '203.0.113.5' },
+    },
+  ]);
+
+  const elastic = new InMemoryElasticsearchConnector([
+    {
+      id: 'activity-1',
+      subjectId,
+      tenantId,
+      index: 'activity',
+      body: { action: 'login', email: 'original@example.com', timestamp: '2025-09-01T00:00:00.000Z' },
+    },
+    {
+      id: 'activity-2',
+      subjectId,
+      tenantId,
+      index: 'activity',
+      body: { action: 'purchase', amount: 49.99, currency: 'USD' },
+    },
+  ]);
+
+  const kafka = new InMemoryKafkaEventLog();
+  const storage = new InMemoryS3Storage('s3://fixtures-dsar');
+
+  const engine = new DataSubjectFulfillmentEngine({
+    connectors: [postgres, elastic],
+    storage,
+    kafka,
+    signer,
+    identityVerifier: new StaticIdentityVerifier({ [subjectId]: 'token-123' }),
+    redactionRules: [
+      createFieldMaskRule('postgres', ['email', 'ssn'], '***-masked'),
+      createFieldMaskRule('elasticsearch', ['email'], '***-masked'),
+    ],
+  });
+
+  return { engine, postgres, elastic, kafka, storage, signer };
+};
+
+describe('DataSubjectFulfillmentEngine', () => {
+  it('produces deterministic export packs with offline-verifiable signatures', async () => {
+    const { engine, postgres, elastic, storage, signer } = buildEngine();
+
+    const request = {
+      requestId: 'req-export-1',
+      subjectId,
+      tenantId,
+      operation: 'export' as const,
+      identityProof: { method: 'email', token: 'token-123' },
+      replayKey: 'case-1',
+    };
+
+    const first = await engine.execute(request);
+    expect(first.type).toBe('export');
+    const exportResult = (first as DSARExportResponse).result;
+    expect(first.meta.idempotentReplay).toBe(false);
+    expect(exportResult.pack.manifest.connectors).toHaveLength(2);
+
+    const stored = await storage.getObject(`${tenantId}/${request.requestId}.json`);
+    expect(stored).toBeDefined();
+    const parsed = JSON.parse(stored!);
+    expect(signer.verify(parsed.payload, parsed.signature)).toBe(true);
+
+    const second = await engine.execute(request);
+    expect(second.meta.idempotentReplay).toBe(true);
+    expect((second as DSARExportResponse).result).toEqual(exportResult);
+    expect(postgres.calls.collect).toBe(1);
+    expect(elastic.calls.collect).toBe(1);
+  });
+
+  it('rectifies records and emits validating proofs', async () => {
+    const { engine, postgres } = buildEngine();
+
+    const rectify = await engine.execute({
+      requestId: 'req-rectify-1',
+      subjectId,
+      tenantId,
+      operation: 'rectify',
+      identityProof: { method: 'email', token: 'token-123' },
+      payload: {
+        postgres: {
+          profile: { email: 'updated@example.com' },
+        },
+        elasticsearch: {
+          activity: { email: 'updated@example.com' },
+        },
+      },
+    });
+
+    expect(rectify.type).toBe('rectify');
+    const rectifyResult = (rectify as DSARRectificationResponse).result;
+    expect(rectifyResult.proofs).toHaveLength(2);
+    rectifyResult.proofs.forEach((proof) => {
+      expect(validateRectificationProof(proof)).toBe(true);
+    });
+
+    const rows = postgres.getRows(subjectId, tenantId);
+    const updatedProfile = rows.find((row) => row.table === 'profile');
+    expect(updatedProfile?.data.email).toBe('updated@example.com');
+  });
+
+  it('deletes records and produces inclusion-failure proofs', async () => {
+    const { engine, postgres, elastic } = buildEngine();
+
+    await engine.execute({
+      requestId: 'req-rectify-setup',
+      subjectId,
+      tenantId,
+      operation: 'rectify',
+      identityProof: { method: 'email', token: 'token-123' },
+      payload: {
+        postgres: { profile: { email: 'rectify@example.com' } },
+      },
+    });
+
+    const deletion = await engine.execute({
+      requestId: 'req-delete-1',
+      subjectId,
+      tenantId,
+      operation: 'delete',
+      identityProof: { method: 'email', token: 'token-123' },
+    });
+
+    expect(deletion.type).toBe('delete');
+    const deletionResult = (deletion as DSARDeletionResponse).result;
+    expect(deletionResult.proofs).toHaveLength(2);
+    deletionResult.proofs.forEach((proof) => {
+      expect(validateDeletionProof(proof)).toBe(true);
+    });
+
+    const postgresSnapshot = await postgres.snapshot();
+    const elasticSnapshot = await elastic.snapshot();
+
+    deletionResult.proofs.forEach((proof) => {
+      const snapshot = proof.connector === 'postgres' ? postgresSnapshot : elasticSnapshot;
+      expect(validateDeletionProofAgainstSnapshot(proof, snapshot)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement a data subject fulfillment engine with pluggable connectors, redaction, export signing, and replay-aware execution
- capture deterministic rectification/deletion proofs and provide integration tests covering export, rectify, and delete flows
- add a DSAR reviewer UI component plus tighten intelgraph-api package naming for clean installs

## Testing
- pnpm test -- tests/privacy/dfe.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d76f26cdd083339c04d4cf9bb2ca75