### PR TITLE
feat: add consent-aware feature flag platform

### DIFF
--- a/demos/caff-demo/.gitignore
+++ b/demos/caff-demo/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+out
+.DS_Store

--- a/demos/caff-demo/README.md
+++ b/demos/caff-demo/README.md
@@ -1,0 +1,18 @@
+# CAFF Next.js Demo
+
+This Next.js app visualizes the Consent-Aware Feature Flags workflow. It imports the TypeScript SDK directly to:
+
+- Build subject contexts (jurisdiction, audiences, consent map)
+- Run deterministic evaluations with explain paths
+- Call the Go evaluation service (when running locally)
+- Preview dry-run policy diffs highlighting impacted flags
+
+## Getting Started
+
+```bash
+cd demos/caff-demo
+npm install
+npm run dev
+```
+
+By default the page points to `http://localhost:8080` for service-backed evaluations. Start the Go service (`go run services/caff`) or update the base URL inside `app/page.tsx`.

--- a/demos/caff-demo/app/globals.css
+++ b/demos/caff-demo/app/globals.css
@@ -1,0 +1,24 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: radial-gradient(circle at top, #0e1f40, #050912 80%);
+  color: #f4f7ff;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+input, textarea {
+  font-family: inherit;
+}

--- a/demos/caff-demo/app/layout.tsx
+++ b/demos/caff-demo/app/layout.tsx
@@ -1,0 +1,16 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'Consent-Aware Feature Flags Demo',
+  description: 'Visualize CAFF evaluations, explain paths, and dry-run diffs.',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/demos/caff-demo/app/page.tsx
+++ b/demos/caff-demo/app/page.tsx
@@ -1,0 +1,405 @@
+'use client';
+
+import { useMemo, useState, type CSSProperties } from 'react';
+import type { EvaluateResponse, Policy, SubjectContext } from '@caff/sdk';
+import { CaffClient } from '@caff/sdk';
+
+type DryDiff = {
+  flagKey: string;
+  decisionChange?: { before: EvaluateResponse; after: EvaluateResponse };
+  changedFields: string[];
+};
+
+const FLAG_KEY = 'purposeful-beta';
+
+const basePolicy: Policy = {
+  flags: {
+    [FLAG_KEY]: {
+      key: FLAG_KEY,
+      description: 'Beta-only experience gated by analytics consent.',
+      purposes: ['analytics'],
+      jurisdictions: ['US', 'CA'],
+      audiences: ['beta'],
+      expiresAt: farFuture(),
+      rollout: { percentage: 50 },
+    },
+    'ads-personalization': {
+      key: 'ads-personalization',
+      description: 'Ads personalization requires explicit consent and EU residency.',
+      purposes: ['ads'],
+      jurisdictions: ['EU'],
+      audiences: ['ads'],
+      expiresAt: farFuture(),
+      rollout: { percentage: 100 },
+    },
+  },
+};
+
+const newPolicy: Policy = {
+  flags: {
+    [FLAG_KEY]: {
+      ...basePolicy.flags[FLAG_KEY],
+      purposes: ['analytics', 'personalization'],
+      rollout: { percentage: 25 },
+    },
+    'ads-personalization': {
+      ...basePolicy.flags['ads-personalization'],
+      expiresAt: soonExpiry(),
+    },
+  },
+};
+
+export default function Page() {
+  const client = useMemo(() => new CaffClient('http://localhost:8080'), []);
+  const [subjectId, setSubjectId] = useState('demo-user');
+  const [jurisdiction, setJurisdiction] = useState('US');
+  const [audiences, setAudiences] = useState('beta');
+  const [bucketId, setBucketId] = useState('demo-user');
+  const [consentInput, setConsentInput] = useState('analytics=granted');
+  const [localResult, setLocalResult] = useState<EvaluateResponse | null>(null);
+  const [remoteResult, setRemoteResult] = useState<EvaluateResponse | null>(null);
+  const [diff, setDiff] = useState<DryDiff[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const buildContext = (): SubjectContext => ({
+    subjectId: subjectId.trim() || 'demo-user',
+    bucketId: bucketId.trim() || undefined,
+    jurisdiction: jurisdiction.trim() || undefined,
+    audiences: audiences
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean),
+    consents: parseConsent(consentInput),
+    evaluatedAt: new Date().toISOString(),
+  });
+
+  const handleEvaluateLocal = () => {
+    try {
+      const context = buildContext();
+      const flag = basePolicy.flags[FLAG_KEY];
+      const result = client.evaluateLocal(flag, context);
+      setLocalResult(result);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleEvaluateRemote = async () => {
+    try {
+      const context = buildContext();
+      const result = await client.isEnabled(FLAG_KEY, context);
+      setRemoteResult(result);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  const handleDryRun = () => {
+    const context = buildContext();
+    const flag = basePolicy.flags[FLAG_KEY];
+    const newFlag = newPolicy.flags[FLAG_KEY];
+    const before = client.evaluateLocal(flag, context);
+    const after = client.evaluateLocal(newFlag, context);
+
+    const dryDiff: DryDiff[] = [
+      {
+        flagKey: FLAG_KEY,
+        decisionChange:
+          before.decision === after.decision && JSON.stringify(before.explainPath) === JSON.stringify(after.explainPath)
+            ? undefined
+            : { before, after },
+        changedFields: diffFields(basePolicy.flags[FLAG_KEY], newPolicy.flags[FLAG_KEY]),
+      },
+      {
+        flagKey: 'ads-personalization',
+        decisionChange: undefined,
+        changedFields: diffFields(basePolicy.flags['ads-personalization'], newPolicy.flags['ads-personalization']),
+      },
+    ];
+
+    setDiff(dryDiff);
+  };
+
+  return (
+    <main style={styles.main}>
+      <section style={styles.hero}>
+        <h1>Consent-Aware Feature Flags</h1>
+        <p>
+          Purpose-scoped toggles stay deterministic. Provide a context, evaluate locally via the SDK, call the Go service, and
+          preview dry-run diffs.
+        </p>
+      </section>
+
+      <section style={styles.panel}>
+        <h2>Subject context</h2>
+        <div style={styles.formGrid}>
+          <label style={styles.label}>
+            Subject ID
+            <input style={styles.input} value={subjectId} onChange={(event) => setSubjectId(event.target.value)} />
+          </label>
+          <label style={styles.label}>
+            Bucket ID
+            <input style={styles.input} value={bucketId} onChange={(event) => setBucketId(event.target.value)} />
+          </label>
+          <label style={styles.label}>
+            Jurisdiction
+            <input style={styles.input} value={jurisdiction} onChange={(event) => setJurisdiction(event.target.value)} />
+          </label>
+          <label style={styles.label}>
+            Audiences (comma separated)
+            <input style={styles.input} value={audiences} onChange={(event) => setAudiences(event.target.value)} />
+          </label>
+        </div>
+        <label style={styles.label}>
+          Consents (purpose=value)
+          <input style={styles.input} value={consentInput} onChange={(event) => setConsentInput(event.target.value)} />
+        </label>
+        <div style={styles.buttonRow}>
+          <button style={styles.button} onClick={handleEvaluateLocal}>
+            Evaluate with SDK
+          </button>
+          <button style={styles.button} onClick={handleEvaluateRemote}>
+            Call Go service
+          </button>
+          <button style={styles.secondaryButton} onClick={handleDryRun}>
+            Dry-run diff
+          </button>
+        </div>
+        {error ? <p style={styles.error}>⚠️ {error}</p> : null}
+      </section>
+
+      <section style={styles.resultRow}>
+        <ResultCard title="SDK decision" result={localResult} />
+        <ResultCard title="Service decision" result={remoteResult} />
+      </section>
+
+      <section style={styles.panel}>
+        <h2>Dry-run preview</h2>
+        {diff.length === 0 ? (
+          <p style={{ opacity: 0.7 }}>Run a dry-run to see how policy updates flip impacted flags.</p>
+        ) : (
+          <ul style={styles.diffList}>
+            {diff.map((item) => (
+              <li key={item.flagKey} style={styles.diffItem}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+                  <strong>{item.flagKey}</strong>
+                  <span style={{ fontSize: '0.85rem', opacity: 0.7 }}>
+                    {item.changedFields.length > 0 ? item.changedFields.join(', ') : 'no policy changes'}
+                  </span>
+                </div>
+                {item.decisionChange ? (
+                  <div style={styles.decisionChange}>
+                    <span>
+                      {item.decisionChange.before.decision} → {item.decisionChange.after.decision}
+                    </span>
+                    <details>
+                      <summary>Explain diff</summary>
+                      <pre style={styles.pre}>{JSON.stringify(item.decisionChange, null, 2)}</pre>
+                    </details>
+                  </div>
+                ) : (
+                  <p style={{ fontSize: '0.85rem', opacity: 0.7 }}>No decision change for provided context.</p>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}
+
+function ResultCard({ title, result }: { title: string; result: EvaluateResponse | null }) {
+  return (
+    <article style={styles.card}>
+      <h3>{title}</h3>
+      {result ? (
+        <>
+          <span style={styles.badge}>{result.decision}</span>
+          <pre style={styles.pre}>{JSON.stringify(result.explainPath, null, 2)}</pre>
+        </>
+      ) : (
+        <p style={{ opacity: 0.7 }}>No evaluation yet.</p>
+      )}
+    </article>
+  );
+}
+
+function parseConsent(input: string): Record<string, string> {
+  return input
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .reduce<Record<string, string>>((memo, entry) => {
+      const [purpose, value] = entry.split('=').map((part) => part.trim());
+      if (purpose) {
+        memo[purpose] = value ?? '';
+      }
+      return memo;
+    }, {});
+}
+
+function diffFields(baseFlag: Policy['flags'][string], nextFlag: Policy['flags'][string]): string[] {
+  const changed: string[] = [];
+  if (!sameSet(baseFlag.purposes, nextFlag.purposes)) {
+    changed.push('purposes');
+  }
+  if (!sameSet(baseFlag.jurisdictions, nextFlag.jurisdictions)) {
+    changed.push('jurisdictions');
+  }
+  if (!sameSet(baseFlag.audiences, nextFlag.audiences)) {
+    changed.push('audiences');
+  }
+  if (baseFlag.expiresAt !== nextFlag.expiresAt) {
+    changed.push('expiresAt');
+  }
+  if ((baseFlag.rollout?.percentage ?? 100) !== (nextFlag.rollout?.percentage ?? 100)) {
+    changed.push('rollout.percentage');
+  }
+  return changed;
+}
+
+function sameSet(a?: string[], b?: string[]): boolean {
+  const first = [...(a ?? [])].sort();
+  const second = [...(b ?? [])].sort();
+  return first.length === second.length && first.every((value, index) => value === second[index]);
+}
+
+function farFuture(): string {
+  return new Date('2099-12-31T23:59:59Z').toISOString();
+}
+
+function soonExpiry(): string {
+  const now = new Date();
+  now.setMonth(now.getMonth() + 1);
+  return now.toISOString();
+}
+
+const styles: Record<string, CSSProperties> = {
+  main: {
+    margin: '0 auto',
+    maxWidth: '960px',
+    padding: '3rem 1.5rem 4rem',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '2rem',
+  },
+  hero: {
+    textAlign: 'center',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.75rem',
+  },
+  panel: {
+    background: 'rgba(15, 30, 70, 0.65)',
+    borderRadius: '18px',
+    padding: '1.5rem',
+    boxShadow: '0 10px 40px rgba(0, 0, 0, 0.4)',
+    backdropFilter: 'blur(18px)',
+    border: '1px solid rgba(255, 255, 255, 0.08)',
+  },
+  formGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+    gap: '1rem',
+    marginBottom: '1rem',
+  },
+  label: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.4rem',
+    fontSize: '0.9rem',
+    opacity: 0.9,
+  },
+  input: {
+    padding: '0.55rem 0.75rem',
+    borderRadius: '12px',
+    border: '1px solid rgba(255, 255, 255, 0.2)',
+    background: 'rgba(3, 10, 28, 0.6)',
+    color: '#f4f7ff',
+  },
+  buttonRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: '0.75rem',
+    marginTop: '1rem',
+  },
+  button: {
+    padding: '0.65rem 1.1rem',
+    borderRadius: '999px',
+    border: 'none',
+    background: 'linear-gradient(135deg, #4cc0ff, #9c6bff)',
+    color: '#04060f',
+    fontWeight: 600,
+  },
+  secondaryButton: {
+    padding: '0.65rem 1.1rem',
+    borderRadius: '999px',
+    border: '1px solid rgba(255, 255, 255, 0.3)',
+    background: 'transparent',
+    color: '#f4f7ff',
+    fontWeight: 600,
+  },
+  error: {
+    marginTop: '0.75rem',
+    color: '#ffb4b4',
+  },
+  resultRow: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+    gap: '1.5rem',
+  },
+  card: {
+    background: 'rgba(10, 20, 50, 0.6)',
+    borderRadius: '18px',
+    padding: '1.5rem',
+    boxShadow: '0 10px 30px rgba(0, 0, 0, 0.4)',
+    border: '1px solid rgba(255, 255, 255, 0.1)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1rem',
+  },
+  badge: {
+    alignSelf: 'flex-start',
+    padding: '0.35rem 0.85rem',
+    borderRadius: '999px',
+    background: 'rgba(76, 192, 255, 0.18)',
+    color: '#8ce0ff',
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    fontSize: '0.75rem',
+    fontWeight: 700,
+  },
+  pre: {
+    margin: 0,
+    background: 'rgba(3, 10, 28, 0.6)',
+    borderRadius: '12px',
+    padding: '0.75rem',
+    fontSize: '0.8rem',
+    overflowX: 'auto',
+  },
+  diffList: {
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '1rem',
+  },
+  diffItem: {
+    background: 'rgba(8, 18, 40, 0.7)',
+    borderRadius: '14px',
+    padding: '1rem',
+    border: '1px solid rgba(255, 255, 255, 0.1)',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.5rem',
+  },
+  decisionChange: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: '0.4rem',
+  },
+};

--- a/demos/caff-demo/lib/caff.ts
+++ b/demos/caff-demo/lib/caff.ts
@@ -1,0 +1,1 @@
+export * from '../../../sdk/typescript/src/caff';

--- a/demos/caff-demo/next-env.d.ts
+++ b/demos/caff-demo/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/demos/caff-demo/next.config.mjs
+++ b/demos/caff-demo/next.config.mjs
@@ -1,0 +1,21 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true,
+    externalDir: true,
+  },
+  webpack: (config) => {
+    config.resolve = config.resolve || {};
+    config.resolve.alias = config.resolve.alias || {};
+    config.resolve.alias['@caff/sdk'] = path.resolve(__dirname, './lib/caff.ts');
+    return config;
+  },
+};
+
+export default nextConfig;

--- a/demos/caff-demo/package.json
+++ b/demos/caff-demo/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "caff-demo",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.7",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.10",
+    "@types/react": "18.3.5",
+    "@types/react-dom": "18.3.0",
+    "eslint": "8.57.1",
+    "eslint-config-next": "14.2.7",
+    "typescript": "5.5.4"
+  }
+}

--- a/demos/caff-demo/tsconfig.json
+++ b/demos/caff-demo/tsconfig.json
@@ -1,0 +1,45 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "baseUrl": ".",
+    "paths": {
+      "@caff/sdk": [
+        "./lib/caff"
+      ]
+    },
+    "types": [
+      "node"
+    ],
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/sdk/typescript/jest.config.cjs
+++ b/sdk/typescript/jest.config.cjs
@@ -1,0 +1,10 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  moduleNameMapper: {
+    '^@caff/sdk$': '<rootDir>/src/caff.ts',
+  },
+};

--- a/sdk/typescript/src/caff.ts
+++ b/sdk/typescript/src/caff.ts
@@ -1,0 +1,224 @@
+export type Decision = 'allow' | 'deny' | 'step-up';
+
+export interface ExplainStep {
+  rule: string;
+  result: string;
+  details?: string;
+}
+
+export interface Rollout {
+  percentage?: number;
+}
+
+export interface Flag {
+  key: string;
+  description?: string;
+  purposes?: string[];
+  jurisdictions?: string[];
+  audiences?: string[];
+  expiresAt: string;
+  rollout?: Rollout;
+}
+
+export interface SubjectContext {
+  subjectId: string;
+  bucketId?: string;
+  jurisdiction?: string;
+  audiences?: string[];
+  consents?: Record<string, string>;
+  evaluatedAt?: string;
+}
+
+export interface EvaluateRequest {
+  flagKey: string;
+  context: SubjectContext;
+}
+
+export interface EvaluateResponse {
+  decision: Decision;
+  explainPath: ExplainStep[];
+}
+
+export interface Policy {
+  flags: Record<string, Flag>;
+}
+
+export interface PolicyResponse {
+  policy: Policy;
+}
+
+export interface DryRunRequest {
+  oldPolicy: Policy;
+  newPolicy: Policy;
+  contexts?: EvaluateRequest[];
+}
+
+export interface DryRunDecisionChange {
+  flagKey: string;
+  context: SubjectContext;
+  oldDecision: EvaluateResponse;
+  newDecision: EvaluateResponse;
+}
+
+export interface DryRunResponse {
+  changes: Array<{
+    flag: string;
+    type: 'added' | 'removed' | 'updated';
+    changedFields?: string[];
+  }>;
+  decisions: DryRunDecisionChange[];
+}
+
+export class CaffClient {
+  private readonly fetcher: typeof fetch;
+
+  constructor(private readonly baseUrl: string, fetchImpl?: typeof fetch) {
+    this.fetcher = fetchImpl ?? (globalThis.fetch as typeof fetch);
+    if (!this.fetcher) {
+      throw new Error('Fetch API is required');
+    }
+  }
+
+  async getPolicy(): Promise<Policy> {
+    const res = await this.fetcher(this.joinUrl('/policy'));
+    if (!res.ok) {
+      throw new Error(`failed to fetch policy: ${res.statusText}`);
+    }
+    const body = (await res.json()) as PolicyResponse;
+    return body.policy;
+  }
+
+  async setPolicy(policy: Policy): Promise<Policy> {
+    const res = await this.fetcher(this.joinUrl('/policy'), {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ policy }),
+    });
+    if (!res.ok) {
+      const message = await this.safeError(res);
+      throw new Error(`failed to set policy: ${message}`);
+    }
+    const body = (await res.json()) as PolicyResponse;
+    return body.policy;
+  }
+
+  async isEnabled(flagKey: string, context: SubjectContext): Promise<EvaluateResponse> {
+    const res = await this.fetcher(this.joinUrl('/evaluate'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ flagKey, context }),
+    });
+    if (!res.ok) {
+      const message = await this.safeError(res);
+      throw new Error(`evaluation failed: ${message}`);
+    }
+    return (await res.json()) as EvaluateResponse;
+  }
+
+  async dryRun(request: DryRunRequest): Promise<DryRunResponse> {
+    const res = await this.fetcher(this.joinUrl('/dry-run'), {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(request),
+    });
+    if (!res.ok) {
+      const message = await this.safeError(res);
+      throw new Error(`dry-run failed: ${message}`);
+    }
+    return (await res.json()) as DryRunResponse;
+  }
+
+  evaluateLocal(flag: Flag, context: SubjectContext, now: Date = new Date()): EvaluateResponse {
+    const explainPath: ExplainStep[] = [{ rule: 'flag', result: flag.key }];
+    const expiry = new Date(flag.expiresAt);
+    if (expiry.getTime() <= now.getTime()) {
+      explainPath.push({ rule: 'expiry', result: 'deny', details: expiry.toISOString() });
+      return { decision: 'deny', explainPath };
+    }
+    explainPath.push({ rule: 'expiry', result: 'ok', details: expiry.toISOString() });
+
+    const jurisdiction = context.jurisdiction ?? '';
+    if (flag.jurisdictions && flag.jurisdictions.length > 0 && !includesInsensitive(flag.jurisdictions, jurisdiction)) {
+      explainPath.push({ rule: 'jurisdiction', result: 'deny', details: jurisdiction });
+      return { decision: 'deny', explainPath };
+    }
+    explainPath.push({ rule: 'jurisdiction', result: 'ok', details: jurisdiction });
+
+    const audiences = context.audiences ?? [];
+    if (flag.audiences && flag.audiences.length > 0 && !overlapsInsensitive(flag.audiences, audiences)) {
+      explainPath.push({ rule: 'audience', result: 'deny', details: audiences.join(',') });
+      return { decision: 'deny', explainPath };
+    }
+    explainPath.push({ rule: 'audience', result: 'ok', details: audiences.join(',') });
+
+    const consents = context.consents ?? {};
+    const missing: string[] = [];
+    const denied: string[] = [];
+    for (const purpose of flag.purposes ?? []) {
+      const consent = (consents[purpose] ?? '').toLowerCase();
+      if (['granted', 'allow', 'yes', 'true'].includes(consent)) {
+        explainPath.push({ rule: 'purpose', result: 'granted', details: purpose });
+        continue;
+      }
+      if (['denied', 'no', 'false'].includes(consent)) {
+        denied.push(purpose);
+      } else {
+        missing.push(purpose);
+      }
+    }
+    if (denied.length > 0) {
+      explainPath.push({ rule: 'purpose', result: 'deny', details: denied.join(',') });
+      return { decision: 'deny', explainPath };
+    }
+    if (missing.length > 0) {
+      explainPath.push({ rule: 'purpose', result: 'step-up', details: missing.join(',') });
+      return { decision: 'step-up', explainPath };
+    }
+
+    const rolloutPercentage = flag.rollout?.percentage ?? 100;
+    const bucketId = context.bucketId || context.subjectId;
+    const bucket = fnv1a(`${flag.key}::${bucketId}`);
+    explainPath.push({ rule: 'bucket', result: `${bucket}`, details: `rollout=${rolloutPercentage}` });
+    if (bucket >= rolloutPercentage) {
+      explainPath.push({ rule: 'rollout', result: 'deny' });
+      return { decision: 'deny', explainPath };
+    }
+    explainPath.push({ rule: 'rollout', result: 'allow' });
+
+    return { decision: 'allow', explainPath };
+  }
+
+  private joinUrl(path: string): string {
+    return `${this.baseUrl.replace(/\/$/, '')}${path}`;
+  }
+
+  private async safeError(res: Response): Promise<string> {
+    try {
+      const body = await res.json();
+      if (typeof body === 'object' && body && 'error' in body) {
+        return String((body as Record<string, unknown>).error);
+      }
+      return JSON.stringify(body);
+    } catch (err) {
+      return res.statusText;
+    }
+  }
+}
+
+function includesInsensitive(list: string[], value: string): boolean {
+  return list.some((item) => item.localeCompare(value, undefined, { sensitivity: 'accent' }) === 0);
+}
+
+function overlapsInsensitive(a: string[], b: string[]): boolean {
+  return a.some((value) => includesInsensitive(b, value));
+}
+
+function fnv1a(input: string): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+    hash >>>= 0;
+  }
+  return hash % 100;
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,2 +1,3 @@
 export * from './client';
+export * from './caff';
 export * from '../sdk/ts/src/generated';

--- a/sdk/typescript/test/caff.test.ts
+++ b/sdk/typescript/test/caff.test.ts
@@ -1,0 +1,44 @@
+import { CaffClient, Flag, SubjectContext } from '../src/caff';
+
+describe('CAFF SDK', () => {
+  const client = new CaffClient('http://localhost:8080', async () => {
+    throw new Error('network not expected in unit tests');
+  });
+
+  it('produces deterministic bucket decisions', () => {
+    const flag: Flag = {
+      key: 'beta-feature',
+      purposes: ['analytics'],
+      jurisdictions: ['US'],
+      audiences: ['beta'],
+      expiresAt: new Date(Date.now() + 86400000).toISOString(),
+      rollout: { percentage: 30 },
+    };
+
+    const context: SubjectContext = {
+      subjectId: 'user-42',
+      jurisdiction: 'US',
+      audiences: ['beta'],
+      consents: { analytics: 'granted' },
+    };
+
+    const first = client.evaluateLocal(flag, context);
+    const second = client.evaluateLocal(flag, context);
+
+    expect(first.decision).toEqual(second.decision);
+    expect(first.explainPath).toEqual(second.explainPath);
+  });
+
+  it('requests step-up when consent missing', () => {
+    const flag: Flag = {
+      key: 'ads',
+      purposes: ['ads'],
+      expiresAt: new Date(Date.now() + 86400000).toISOString(),
+      rollout: { percentage: 100 },
+    };
+
+    const context: SubjectContext = { subjectId: 'u-1' };
+    const result = client.evaluateLocal(flag, context);
+    expect(result.decision).toBe('step-up');
+  });
+});

--- a/services/caff/README.md
+++ b/services/caff/README.md
@@ -1,0 +1,31 @@
+# Consent-Aware Feature Flags (CAFF)
+
+CAFF is a Go microservice for evaluating purpose-scoped feature flags. Flags bind to consent purposes, jurisdiction, audience, and expiry metadata. Evaluations return deterministic `allow`, `deny`, or `step-up` decisions alongside an explainability path that lists the rules involved.
+
+## Features
+
+- Purpose-aware, jurisdiction-aware, and audience-aware flag rules
+- Sticky bucketing with deterministic hashing
+- Dry-run policy diffing to preview impacted flags and decision changes
+- REST API with JSON payloads
+- TypeScript SDK and Next.js demo app (see `sdk/typescript` and `demos/caff-demo`)
+
+## Running Locally
+
+```bash
+go mod tidy
+go test ./...
+go run .
+```
+
+By default the service listens on `:8080`. Override with `CAFF_HTTP_ADDR`.
+
+## API Surface
+
+- `GET /healthz`
+- `GET /policy`
+- `PUT /policy` — replace the current policy
+- `POST /evaluate` — body `{ "flagKey": "flag", "context": { ... } }`
+- `POST /dry-run` — body `{ "oldPolicy": {...}, "newPolicy": {...}, "contexts": [...] }`
+
+All responses include deterministic explain paths that enumerate the rules that were evaluated for traceability.

--- a/services/caff/evaluator/evaluator.go
+++ b/services/caff/evaluator/evaluator.go
@@ -1,0 +1,121 @@
+package evaluator
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+	"time"
+
+	"github.com/summit/caff/policy"
+)
+
+type Evaluator struct{}
+
+func New() *Evaluator {
+	return &Evaluator{}
+}
+
+type Result struct {
+	Decision    policy.Decision      `json:"decision"`
+	ExplainPath []policy.ExplainStep `json:"explainPath"`
+}
+
+func (e *Evaluator) Evaluate(flag policy.Flag, ctx policy.SubjectContext) Result {
+	explain := []policy.ExplainStep{
+		{Rule: "flag", Result: flag.Key},
+	}
+
+	now := ctx.EvaluatedAt
+	if now.IsZero() {
+		now = time.Now().UTC()
+		ctx.EvaluatedAt = now
+	}
+
+	if flag.ExpiresAt.Before(now) {
+		explain = append(explain, policy.ExplainStep{Rule: "expiry", Result: "deny", Details: fmt.Sprintf("expired at %s", flag.ExpiresAt.UTC().Format(time.RFC3339))})
+		return Result{Decision: policy.DecisionDeny, ExplainPath: explain}
+	}
+	explain = append(explain, policy.ExplainStep{Rule: "expiry", Result: "ok", Details: flag.ExpiresAt.UTC().Format(time.RFC3339)})
+
+	if len(flag.Jurisdictions) > 0 && !contains(flag.Jurisdictions, ctx.Jurisdiction) {
+		explain = append(explain, policy.ExplainStep{Rule: "jurisdiction", Result: "deny", Details: ctx.Jurisdiction})
+		return Result{Decision: policy.DecisionDeny, ExplainPath: explain}
+	}
+	explain = append(explain, policy.ExplainStep{Rule: "jurisdiction", Result: "ok", Details: ctx.Jurisdiction})
+
+	if len(flag.Audiences) > 0 && !overlap(flag.Audiences, ctx.Audiences) {
+		explain = append(explain, policy.ExplainStep{Rule: "audience", Result: "deny", Details: strings.Join(ctx.Audiences, ",")})
+		return Result{Decision: policy.DecisionDeny, ExplainPath: explain}
+	}
+	explain = append(explain, policy.ExplainStep{Rule: "audience", Result: "ok", Details: strings.Join(ctx.Audiences, ",")})
+
+	missing := []string{}
+	denied := []string{}
+	consents := ctx.Consents
+	if consents == nil {
+		consents = map[string]string{}
+	}
+	for _, purpose := range flag.Purposes {
+		consent := strings.ToLower(consents[purpose])
+		switch consent {
+		case "granted", "allow", "yes", "true":
+			explain = append(explain, policy.ExplainStep{Rule: "purpose", Result: "granted", Details: purpose})
+		case "denied", "no", "false":
+			denied = append(denied, purpose)
+		default:
+			missing = append(missing, purpose)
+		}
+	}
+	if len(denied) > 0 {
+		explain = append(explain, policy.ExplainStep{Rule: "purpose", Result: "deny", Details: strings.Join(denied, ",")})
+		return Result{Decision: policy.DecisionDeny, ExplainPath: explain}
+	}
+	if len(missing) > 0 {
+		explain = append(explain, policy.ExplainStep{Rule: "purpose", Result: "step-up", Details: strings.Join(missing, ",")})
+		return Result{Decision: policy.DecisionStepUp, ExplainPath: explain}
+	}
+
+	rollout := flag.Rollout
+	if rollout.Percentage <= 0 {
+		rollout = policy.DefaultRollout()
+	}
+	bucketID := ctx.BucketID
+	if bucketID == "" {
+		bucketID = ctx.SubjectID
+	}
+	bucket := hashBucket(flag.Key + "::" + bucketID)
+	explain = append(explain, policy.ExplainStep{Rule: "bucket", Result: fmt.Sprintf("%d", bucket), Details: fmt.Sprintf("rollout=%d", rollout.Percentage)})
+	if bucket >= rollout.Percentage {
+		explain = append(explain, policy.ExplainStep{Rule: "rollout", Result: "deny"})
+		return Result{Decision: policy.DecisionDeny, ExplainPath: explain}
+	}
+	explain = append(explain, policy.ExplainStep{Rule: "rollout", Result: "allow"})
+
+	return Result{Decision: policy.DecisionAllow, ExplainPath: explain}
+}
+
+func contains(list []string, item string) bool {
+	for _, v := range list {
+		if strings.EqualFold(v, item) {
+			return true
+		}
+	}
+	return false
+}
+
+func overlap(a, b []string) bool {
+	for _, v := range a {
+		for _, w := range b {
+			if strings.EqualFold(v, w) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hashBucket(seed string) int {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(seed))
+	return int(h.Sum32() % 100)
+}

--- a/services/caff/evaluator/evaluator_test.go
+++ b/services/caff/evaluator/evaluator_test.go
@@ -1,0 +1,51 @@
+package evaluator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/summit/caff/policy"
+)
+
+func TestEvaluateDeterministic(t *testing.T) {
+	flag := policy.Flag{
+		Key:           "demo",
+		Purposes:      []string{"analytics"},
+		Jurisdictions: []string{"US"},
+		Audiences:     []string{"beta"},
+		ExpiresAt:     time.Now().Add(24 * time.Hour),
+		Rollout:       policy.Rollout{Percentage: 50},
+	}
+	ctx := policy.SubjectContext{
+		SubjectID:    "user-123",
+		Jurisdiction: "US",
+		Audiences:    []string{"beta"},
+		Consents:     map[string]string{"analytics": "granted"},
+		EvaluatedAt:  time.Now().UTC(),
+	}
+
+	eval := New()
+	first := eval.Evaluate(flag, ctx)
+	second := eval.Evaluate(flag, ctx)
+
+	if first.Decision != second.Decision {
+		t.Fatalf("expected deterministic decision, got %s and %s", first.Decision, second.Decision)
+	}
+	if len(first.ExplainPath) == 0 {
+		t.Fatalf("expected explain path")
+	}
+}
+
+func TestEvaluateStepUpWhenConsentMissing(t *testing.T) {
+	flag := policy.Flag{
+		Key:       "demo",
+		Purposes:  []string{"ads"},
+		ExpiresAt: time.Now().Add(24 * time.Hour),
+		Rollout:   policy.DefaultRollout(),
+	}
+	ctx := policy.SubjectContext{SubjectID: "abc"}
+	result := New().Evaluate(flag, ctx)
+	if result.Decision != policy.DecisionStepUp {
+		t.Fatalf("expected step-up, got %s", result.Decision)
+	}
+}

--- a/services/caff/go.mod
+++ b/services/caff/go.mod
@@ -1,0 +1,5 @@
+module github.com/summit/caff
+
+go 1.21
+
+require github.com/go-chi/chi/v5 v5.1.0

--- a/services/caff/go.sum
+++ b/services/caff/go.sum
@@ -1,0 +1,2 @@
+github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=
+github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=

--- a/services/caff/main.go
+++ b/services/caff/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/summit/caff/server"
+)
+
+func main() {
+	addr := getEnv("CAFF_HTTP_ADDR", ":8080")
+	srv := server.New()
+
+	log.Printf("CAFF listening on %s", addr)
+	if err := http.ListenAndServe(addr, srv.Router()); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
+}
+
+func getEnv(key, fallback string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return fallback
+}

--- a/services/caff/policy/diff.go
+++ b/services/caff/policy/diff.go
@@ -1,0 +1,93 @@
+package policy
+
+import (
+	"encoding/json"
+	"sort"
+)
+
+type ChangeType string
+
+const (
+	ChangeAdded   ChangeType = "added"
+	ChangeRemoved ChangeType = "removed"
+	ChangeUpdated ChangeType = "updated"
+)
+
+type FlagChange struct {
+	Flag          string     `json:"flag"`
+	Type          ChangeType `json:"type"`
+	ChangedFields []string   `json:"changedFields,omitempty"`
+}
+
+func Diff(old Policy, new Policy) []FlagChange {
+	changes := []FlagChange{}
+	seen := map[string]struct{}{}
+	for k := range old.Flags {
+		seen[k] = struct{}{}
+	}
+	for k := range new.Flags {
+		seen[k] = struct{}{}
+	}
+
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		oldFlag, oldOK := old.Flags[key]
+		newFlag, newOK := new.Flags[key]
+
+		switch {
+		case !oldOK && newOK:
+			changes = append(changes, FlagChange{Flag: key, Type: ChangeAdded})
+		case oldOK && !newOK:
+			changes = append(changes, FlagChange{Flag: key, Type: ChangeRemoved})
+		case oldOK && newOK:
+			if fields := compareFlags(oldFlag, newFlag); len(fields) > 0 {
+				changes = append(changes, FlagChange{Flag: key, Type: ChangeUpdated, ChangedFields: fields})
+			}
+		}
+	}
+	return changes
+}
+
+func compareFlags(old, new Flag) []string {
+	var fields []string
+	if !equalStrings(old.Purposes, new.Purposes) {
+		fields = append(fields, "purposes")
+	}
+	if !equalStrings(old.Jurisdictions, new.Jurisdictions) {
+		fields = append(fields, "jurisdictions")
+	}
+	if !equalStrings(old.Audiences, new.Audiences) {
+		fields = append(fields, "audiences")
+	}
+	if !old.ExpiresAt.Equal(new.ExpiresAt) {
+		fields = append(fields, "expiresAt")
+	}
+	if old.Rollout.Percentage != new.Rollout.Percentage {
+		fields = append(fields, "rollout.percentage")
+	}
+	if old.Description != new.Description {
+		fields = append(fields, "description")
+	}
+	return fields
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aa := append([]string{}, a...)
+	bb := append([]string{}, b...)
+	sort.Strings(aa)
+	sort.Strings(bb)
+	return string(mustJSON(aa)) == string(mustJSON(bb))
+}
+
+func mustJSON(v any) []byte {
+	b, _ := json.Marshal(v)
+	return b
+}

--- a/services/caff/policy/store.go
+++ b/services/caff/policy/store.go
@@ -1,0 +1,31 @@
+package policy
+
+import "sync"
+
+type Store struct {
+	mu     sync.RWMutex
+	policy Policy
+}
+
+func NewStore() *Store {
+	return &Store{policy: Policy{Flags: map[string]Flag{}}}
+}
+
+func (s *Store) Get() Policy {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.policy.Copy()
+}
+
+func (s *Store) Set(p Policy) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	copied := Policy{Flags: make(map[string]Flag, len(p.Flags))}
+	for k, v := range p.Flags {
+		if v.Rollout.Percentage == 0 {
+			v.Rollout = DefaultRollout()
+		}
+		copied.Flags[k] = v
+	}
+	s.policy = copied
+}

--- a/services/caff/policy/types.go
+++ b/services/caff/policy/types.go
@@ -1,0 +1,56 @@
+package policy
+
+import "time"
+
+type Decision string
+
+const (
+	DecisionAllow  Decision = "allow"
+	DecisionDeny   Decision = "deny"
+	DecisionStepUp Decision = "step-up"
+)
+
+type ExplainStep struct {
+	Rule    string `json:"rule"`
+	Result  string `json:"result"`
+	Details string `json:"details,omitempty"`
+}
+
+type Flag struct {
+	Key           string    `json:"key"`
+	Description   string    `json:"description,omitempty"`
+	Purposes      []string  `json:"purposes,omitempty"`
+	Jurisdictions []string  `json:"jurisdictions,omitempty"`
+	Audiences     []string  `json:"audiences,omitempty"`
+	ExpiresAt     time.Time `json:"expiresAt"`
+	Rollout       Rollout   `json:"rollout"`
+}
+
+type Rollout struct {
+	Percentage int `json:"percentage"`
+}
+
+type Policy struct {
+	Flags map[string]Flag `json:"flags"`
+}
+
+type SubjectContext struct {
+	SubjectID    string            `json:"subjectId"`
+	BucketID     string            `json:"bucketId,omitempty"`
+	Jurisdiction string            `json:"jurisdiction"`
+	Audiences    []string          `json:"audiences,omitempty"`
+	Consents     map[string]string `json:"consents,omitempty"`
+	EvaluatedAt  time.Time         `json:"evaluatedAt"`
+}
+
+func (p Policy) Copy() Policy {
+	out := Policy{Flags: make(map[string]Flag, len(p.Flags))}
+	for k, v := range p.Flags {
+		out.Flags[k] = v
+	}
+	return out
+}
+
+func DefaultRollout() Rollout {
+	return Rollout{Percentage: 100}
+}

--- a/services/caff/server/server.go
+++ b/services/caff/server/server.go
@@ -1,0 +1,209 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/summit/caff/evaluator"
+	"github.com/summit/caff/policy"
+)
+
+type Server struct {
+	router *chi.Mux
+	store  *policy.Store
+	eval   *evaluator.Evaluator
+}
+
+type EvaluateRequest struct {
+	FlagKey string                `json:"flagKey"`
+	Context policy.SubjectContext `json:"context"`
+}
+
+type EvaluateResponse struct {
+	Decision    policy.Decision      `json:"decision"`
+	ExplainPath []policy.ExplainStep `json:"explainPath"`
+}
+
+type PolicyResponse struct {
+	Policy policy.Policy `json:"policy"`
+}
+
+type DryRunRequest struct {
+	OldPolicy policy.Policy     `json:"oldPolicy"`
+	NewPolicy policy.Policy     `json:"newPolicy"`
+	Contexts  []EvaluateRequest `json:"contexts,omitempty"`
+}
+
+type DryRunResponse struct {
+	Changes   []policy.FlagChange    `json:"changes"`
+	Decisions []DryRunDecisionChange `json:"decisions"`
+}
+
+type DryRunDecisionChange struct {
+	FlagKey     string                `json:"flagKey"`
+	Context     policy.SubjectContext `json:"context"`
+	OldDecision evaluator.Result      `json:"oldDecision"`
+	NewDecision evaluator.Result      `json:"newDecision"`
+}
+
+func New() *Server {
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	s := &Server{
+		router: r,
+		store:  policy.NewStore(),
+		eval:   evaluator.New(),
+	}
+
+	r.Get("/healthz", s.handleHealth)
+	r.Get("/policy", s.handleGetPolicy)
+	r.Put("/policy", s.handleSetPolicy)
+	r.Post("/evaluate", s.handleEvaluate)
+	r.Post("/dry-run", s.handleDryRun)
+
+	return s
+}
+
+func (s *Server) Router() http.Handler {
+	return s.router
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleGetPolicy(w http.ResponseWriter, r *http.Request) {
+	respondJSON(w, http.StatusOK, PolicyResponse{Policy: s.store.Get()})
+}
+
+func (s *Server) handleSetPolicy(w http.ResponseWriter, r *http.Request) {
+	var payload PolicyResponse
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		respondErr(w, http.StatusBadRequest, err)
+		return
+	}
+	sanitizePolicy(&payload.Policy)
+	s.store.Set(payload.Policy)
+	respondJSON(w, http.StatusOK, PolicyResponse{Policy: s.store.Get()})
+}
+
+func (s *Server) handleEvaluate(w http.ResponseWriter, r *http.Request) {
+	var req EvaluateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondErr(w, http.StatusBadRequest, err)
+		return
+	}
+	pol := s.store.Get()
+	flag, ok := pol.Flags[req.FlagKey]
+	if !ok {
+		respondJSON(w, http.StatusOK, EvaluateResponse{
+			Decision:    policy.DecisionDeny,
+			ExplainPath: []policy.ExplainStep{{Rule: "flag", Result: "not-found", Details: req.FlagKey}},
+		})
+		return
+	}
+	ensureTimestamp(&req.Context)
+	res := s.eval.Evaluate(flag, req.Context)
+	respondJSON(w, http.StatusOK, EvaluateResponse{Decision: res.Decision, ExplainPath: res.ExplainPath})
+}
+
+func (s *Server) handleDryRun(w http.ResponseWriter, r *http.Request) {
+	var req DryRunRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		respondErr(w, http.StatusBadRequest, err)
+		return
+	}
+	sanitizePolicy(&req.OldPolicy)
+	sanitizePolicy(&req.NewPolicy)
+
+	resp := DryRunResponse{
+		Changes:   policy.Diff(req.OldPolicy, req.NewPolicy),
+		Decisions: []DryRunDecisionChange{},
+	}
+
+	eval := evaluator.New()
+	for _, ctx := range req.Contexts {
+		ensureTimestamp(&ctx.Context)
+		oldFlag, oldOK := req.OldPolicy.Flags[ctx.FlagKey]
+		newFlag, newOK := req.NewPolicy.Flags[ctx.FlagKey]
+		if !oldOK && !newOK {
+			continue
+		}
+		var oldRes evaluator.Result
+		if oldOK {
+			oldRes = eval.Evaluate(oldFlag, ctx.Context)
+		} else {
+			oldRes = evaluator.Result{Decision: policy.DecisionDeny, ExplainPath: []policy.ExplainStep{{Rule: "flag", Result: "not-found"}}}
+		}
+		var newRes evaluator.Result
+		if newOK {
+			newRes = eval.Evaluate(newFlag, ctx.Context)
+		} else {
+			newRes = evaluator.Result{Decision: policy.DecisionDeny, ExplainPath: []policy.ExplainStep{{Rule: "flag", Result: "not-found"}}}
+		}
+		if newRes.Decision != oldRes.Decision || !explainEqual(oldRes.ExplainPath, newRes.ExplainPath) {
+			resp.Decisions = append(resp.Decisions, DryRunDecisionChange{
+				FlagKey:     ctx.FlagKey,
+				Context:     ctx.Context,
+				OldDecision: oldRes,
+				NewDecision: newRes,
+			})
+		}
+	}
+
+	respondJSON(w, http.StatusOK, resp)
+}
+
+func respondJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func respondErr(w http.ResponseWriter, status int, err error) {
+	respondJSON(w, status, map[string]string{"error": err.Error()})
+}
+
+func explainEqual(a, b []policy.ExplainStep) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func ensureTimestamp(ctx *policy.SubjectContext) {
+	if ctx.EvaluatedAt.IsZero() {
+		ctx.EvaluatedAt = time.Now().UTC()
+	}
+}
+
+func sanitizePolicy(p *policy.Policy) {
+	if p.Flags == nil {
+		p.Flags = map[string]policy.Flag{}
+		return
+	}
+	for key, flag := range p.Flags {
+		if flag.Rollout.Percentage <= 0 {
+			flag.Rollout = policy.DefaultRollout()
+		}
+		if flag.ExpiresAt.IsZero() {
+			flag.ExpiresAt = time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
+		} else {
+			flag.ExpiresAt = flag.ExpiresAt.UTC()
+		}
+		flag.Key = key
+		p.Flags[key] = flag
+	}
+}


### PR DESCRIPTION
## Summary
- introduce the CAFF Go service with consent-scoped evaluation APIs, explain paths, sticky bucketing, and dry-run policy diffs
- add a TypeScript SDK for deterministic local/service evaluations plus Jest coverage
- scaffold a Next.js demo that visualizes evaluations, consent inputs, and dry-run impacts

## Testing
- `cd services/caff && go test ./...`
- `cd sdk/typescript && npm test -- caff`


------
https://chatgpt.com/codex/tasks/task_e_68d7722dc7e48333b6e1127f0c3a6187