### PR TITLE
feat: add query-time pseudonymization gateway service

### DIFF
--- a/sdk/qpg/README.md
+++ b/sdk/qpg/README.md
@@ -1,0 +1,33 @@
+# QPG Client SDKs
+
+This directory contains lightweight client helpers for interacting with the Query-Time Pseudonymization Gateway (QPG).
+
+## TypeScript
+
+Located in `sdk/qpg/typescript`.
+
+- Install dependencies: `npm install`
+- Build: `npm run build`
+- Usage:
+
+```ts
+import { QpgClient } from "@summit/qpg-client";
+
+const client = new QpgClient("http://localhost:8080", fetch);
+const result = await client.tokenize({
+  tenant: "acme",
+  purpose: "analytics",
+  payload: { ssn: "123456789" },
+});
+```
+
+## Python
+
+Located in `sdk/qpg/python`.
+
+```python
+from qpg import QpgClient
+
+client = QpgClient("http://localhost:8080")
+result = client.tokenize("acme", "analytics", {"ssn": "123456789"})
+```

--- a/sdk/qpg/python/__init__.py
+++ b/sdk/qpg/python/__init__.py
@@ -1,0 +1,4 @@
+"""Python client bindings for the Query-Time Pseudonymization Gateway."""
+from .qpg_client import QpgClient, QpgError, TokenizeResult
+
+__all__ = ["QpgClient", "QpgError", "TokenizeResult"]

--- a/sdk/qpg/python/qpg_client.py
+++ b/sdk/qpg/python/qpg_client.py
@@ -1,0 +1,64 @@
+"""Lightweight Python client for the Query-Time Pseudonymization Gateway."""
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional
+
+
+class QpgError(RuntimeError):
+    """Raised when the gateway returns a non-success status code."""
+
+
+@dataclass
+class TokenizeResult:
+    payload: Dict[str, Any]
+
+
+class QpgClient:
+    """Client for interacting with the QPG service."""
+
+    def __init__(self, base_url: str, opener: Optional[urllib.request.OpenerDirector] = None) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._opener = opener or urllib.request.build_opener()
+
+    def tokenize(self, tenant: str, purpose: str, payload: Dict[str, Any]) -> TokenizeResult:
+        body = json.dumps({"tenant": tenant, "purpose": purpose, "payload": payload}).encode("utf-8")
+        request = urllib.request.Request(
+            url=f"{self._base_url}/tokenize",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        response = self._execute(request)
+        data = json.loads(response.read().decode("utf-8"))
+        return TokenizeResult(payload=data["payload"])
+
+    def reveal(self, tenant: str, purpose: str, field: str, token: str, shares: Iterable[str]) -> str:
+        body = json.dumps(
+            {
+                "tenant": tenant,
+                "purpose": purpose,
+                "field": field,
+                "token": token,
+                "shares": list(shares),
+            }
+        ).encode("utf-8")
+        request = urllib.request.Request(
+            url=f"{self._base_url}/reveal",
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        response = self._execute(request)
+        data = json.loads(response.read().decode("utf-8"))
+        return data["value"]
+
+    def _execute(self, request: urllib.request.Request) -> urllib.response.addinfourl:
+        try:
+            response = self._opener.open(request)
+        except urllib.error.HTTPError as exc:  # pragma: no cover - thin wrapper
+            raise QpgError(f"gateway returned {exc.code}") from exc
+        return response

--- a/sdk/qpg/typescript/package.json
+++ b/sdk/qpg/typescript/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@summit/qpg-client",
+  "version": "0.1.0",
+  "description": "TypeScript client for the Query-Time Pseudonymization Gateway",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "keywords": ["qpg", "tokenization", "pseudonymization"],
+  "author": "Summit",
+  "license": "MIT",
+  "devDependencies": {
+    "typescript": "^5.4.0"
+  }
+}

--- a/sdk/qpg/typescript/src/index.ts
+++ b/sdk/qpg/typescript/src/index.ts
@@ -1,0 +1,55 @@
+export interface TokenizeRequest {
+  tenant: string;
+  purpose: string;
+  payload: Record<string, unknown>;
+}
+
+export interface TokenizeResponse {
+  payload: Record<string, unknown>;
+}
+
+export interface RevealRequest {
+  tenant: string;
+  purpose: string;
+  field: string;
+  token: string;
+  shares: string[];
+}
+
+export class QpgClient {
+  private readonly baseUrl: string;
+  private readonly fetcher: typeof fetch;
+
+  constructor(baseUrl: string, fetcher?: typeof fetch) {
+    this.baseUrl = baseUrl.replace(/\/+$/, "");
+    this.fetcher = fetcher ?? globalThis.fetch;
+    if (!this.fetcher) {
+      throw new Error("fetch is not available; provide a fetch implementation");
+    }
+  }
+
+  async tokenize(request: TokenizeRequest): Promise<TokenizeResponse> {
+    const response = await this.fetcher(`${this.baseUrl}/tokenize`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    });
+    if (!response.ok) {
+      throw new Error(`tokenize failed with status ${response.status}`);
+    }
+    return (await response.json()) as TokenizeResponse;
+  }
+
+  async reveal(request: RevealRequest): Promise<string> {
+    const response = await this.fetcher(`${this.baseUrl}/reveal`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    });
+    if (!response.ok) {
+      throw new Error(`reveal failed with status ${response.status}`);
+    }
+    const payload = (await response.json()) as { value: string };
+    return payload.value;
+  }
+}

--- a/sdk/qpg/typescript/tsconfig.json
+++ b/sdk/qpg/typescript/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/services/qpg/README.md
+++ b/services/qpg/README.md
@@ -1,0 +1,63 @@
+# Query-Time Pseudonymization Gateway (QPG)
+
+The Query-Time Pseudonymization Gateway provides policy-driven, format-preserving tokenization and salted hashing for sensitive fields at the boundary of analytical workloads. Tokens are recoverable only via a split-key recovery vault that enforces quorum authorization.
+
+## Features
+
+- **Format-preserving tokenization** with deterministic outputs tied to tenant, purpose, and field context.
+- **Salted hashing** for irreversible protection when reveal is not permitted.
+- **Split-key recovery vault** requiring a quorum of hashed shares to reveal stored tokens.
+- **Policy-driven transformations** loaded from `config/policies.yaml`.
+- **TypeScript and Python client libraries** located under `sdk/qpg/`.
+
+## Running the service
+
+```bash
+cd services/qpg
+export QPG_TOKEN_SECRET="replace-me"
+go run ./...
+```
+
+Command-line flags:
+
+- `-policies` – Path to the policy configuration file (default `config/policies.yaml`).
+- `-vault` – Path to the recovery share configuration file (default `config/vault.yaml`).
+- `-addr` – Listen address (default `:8080`).
+
+## API Overview
+
+### `POST /tokenize`
+
+```json
+{
+  "tenant": "acme",
+  "purpose": "analytics",
+  "payload": {
+    "ssn": "123456789",
+    "email": "user@example.com"
+  }
+}
+```
+
+Returns the payload with tokens or salted hashes applied according to policy.
+
+### `POST /reveal`
+
+```json
+{
+  "tenant": "acme",
+  "purpose": "support",
+  "field": "ticketId",
+  "token": "ABC-123",
+  "shares": ["alpha-key", "beta-key"]
+}
+```
+
+Requires a quorum of valid shares and a policy that allows reveal for the requested field. Returns the original value when authorized.
+
+## Testing
+
+```bash
+cd services/qpg
+go test ./...
+```

--- a/services/qpg/config/policies.yaml
+++ b/services/qpg/config/policies.yaml
@@ -1,0 +1,27 @@
+- tenant: acme
+  purpose: analytics
+  rules:
+    - field: ssn
+      method: tokenize
+      allowReveal: false
+    - field: email
+      method: hash
+      allowReveal: false
+- tenant: acme
+  purpose: support
+  rules:
+    - field: ticketId
+      method: tokenize
+      allowReveal: true
+    - field: internalNote
+      method: tokenize
+      allowReveal: false
+- tenant: omni
+  purpose: analytics
+  rules:
+    - field: accountNumber
+      method: tokenize
+      allowReveal: true
+    - field: segment
+      method: passthrough
+      allowReveal: true

--- a/services/qpg/config/vault.yaml
+++ b/services/qpg/config/vault.yaml
@@ -1,0 +1,8 @@
+threshold: 2
+shares:
+  - id: ops
+    hash: 677509799af78b2efa2f2af71d0f906e0a0c50c048efd3b515625f788e92b99a
+  - id: risk
+    hash: 7a3d637bc601f7000cc2c33141c8c8a7554e02e319fa8b293a0c88c613b77620
+  - id: privacy
+    hash: 36c2c0e2d54b8df7e21c9f9afc50a206f2595fc23531fe933e4788e699e0e59d

--- a/services/qpg/go.mod
+++ b/services/qpg/go.mod
@@ -1,0 +1,13 @@
+module github.com/summit/qpg
+
+go 1.21
+
+require (
+	github.com/stretchr/testify v1.8.4
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+)

--- a/services/qpg/go.sum
+++ b/services/qpg/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/services/qpg/internal/config/config.go
+++ b/services/qpg/internal/config/config.go
@@ -1,0 +1,37 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/summit/qpg/internal/policy"
+	"github.com/summit/qpg/internal/tokenvault"
+)
+
+// LoadPolicies reads a YAML file and converts it into policy definitions.
+func LoadPolicies(path string) ([]policy.Definition, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read policies: %w", err)
+	}
+	var defs []policy.Definition
+	if err := yaml.Unmarshal(data, &defs); err != nil {
+		return nil, fmt.Errorf("parse policies: %w", err)
+	}
+	return defs, nil
+}
+
+// LoadVault reads a YAML file describing quorum shares.
+func LoadVault(path string) (*tokenvault.RecoveryGateConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read vault config: %w", err)
+	}
+	var cfg tokenvault.RecoveryGateConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse vault config: %w", err)
+	}
+	return &cfg, nil
+}

--- a/services/qpg/internal/policy/policy.go
+++ b/services/qpg/internal/policy/policy.go
@@ -1,0 +1,56 @@
+package policy
+
+import "strings"
+
+// Rule describes how a field should be transformed for a tenant/purpose pair.
+type Rule struct {
+	Field       string `yaml:"field" json:"field"`
+	Method      string `yaml:"method" json:"method"`
+	AllowReveal bool   `yaml:"allowReveal" json:"allowReveal"`
+}
+
+// Definition binds rules to a tenant and purpose.
+type Definition struct {
+	Tenant  string `yaml:"tenant" json:"tenant"`
+	Purpose string `yaml:"purpose" json:"purpose"`
+	Rules   []Rule `yaml:"rules" json:"rules"`
+}
+
+// Manager resolves policy definitions for requests.
+type Manager struct {
+	lookup map[string]Definition
+}
+
+// NewManager builds a manager from definitions.
+func NewManager(defs []Definition) *Manager {
+	lookup := make(map[string]Definition, len(defs))
+	for _, def := range defs {
+		key := makeKey(def.Tenant, def.Purpose)
+		lookup[key] = def
+	}
+	return &Manager{lookup: lookup}
+}
+
+// DefinitionFor returns the policy definition for a tenant/purpose, if any.
+func (m *Manager) DefinitionFor(tenant, purpose string) (Definition, bool) {
+	def, ok := m.lookup[makeKey(tenant, purpose)]
+	return def, ok
+}
+
+// RuleForField returns the rule for the supplied field.
+func (m *Manager) RuleForField(tenant, purpose, field string) (Rule, bool) {
+	def, ok := m.DefinitionFor(tenant, purpose)
+	if !ok {
+		return Rule{}, false
+	}
+	for _, rule := range def.Rules {
+		if strings.EqualFold(rule.Field, field) {
+			return rule, true
+		}
+	}
+	return Rule{}, false
+}
+
+func makeKey(parts ...string) string {
+	return strings.ToLower(strings.Join(parts, "::"))
+}

--- a/services/qpg/internal/server/server.go
+++ b/services/qpg/internal/server/server.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/summit/qpg/internal/policy"
+	"github.com/summit/qpg/internal/tokenvault"
+)
+
+type Server struct {
+	policies *policy.Manager
+	vault    *tokenvault.TokenVault
+	gate     *tokenvault.RecoveryGate
+}
+
+type TokenizeRequest struct {
+	Tenant  string         `json:"tenant"`
+	Purpose string         `json:"purpose"`
+	Payload map[string]any `json:"payload"`
+}
+
+type TokenizeResponse struct {
+	Payload map[string]any `json:"payload"`
+}
+
+type RevealRequest struct {
+	Tenant  string   `json:"tenant"`
+	Purpose string   `json:"purpose"`
+	Field   string   `json:"field"`
+	Token   string   `json:"token"`
+	Shares  []string `json:"shares"`
+}
+
+type RevealResponse struct {
+	Value string `json:"value"`
+}
+
+func New(policies *policy.Manager, vault *tokenvault.TokenVault, gate *tokenvault.RecoveryGate) *Server {
+	return &Server{policies: policies, vault: vault, gate: gate}
+}
+
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tokenize", s.handleTokenize)
+	mux.HandleFunc("/reveal", s.handleReveal)
+	return mux
+}
+
+func (s *Server) handleTokenize(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req TokenizeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if _, ok := s.policies.DefinitionFor(req.Tenant, req.Purpose); !ok {
+		http.Error(w, "policy not found", http.StatusNotFound)
+		return
+	}
+	transformed := make(map[string]any, len(req.Payload))
+	for field, raw := range req.Payload {
+		rule, hasRule := s.policies.RuleForField(req.Tenant, req.Purpose, field)
+		if !hasRule || strings.EqualFold(rule.Method, "passthrough") {
+			transformed[field] = raw
+			continue
+		}
+		strVal, ok := raw.(string)
+		if !ok {
+			transformed[field] = raw
+			continue
+		}
+		ctx := tokenvault.Context{Tenant: req.Tenant, Purpose: req.Purpose, Field: field}
+		switch strings.ToLower(rule.Method) {
+		case "tokenize":
+			transformed[field] = s.vault.Tokenize(ctx, strVal)
+		case "hash":
+			transformed[field] = s.vault.Hash(ctx, strVal)
+		default:
+			transformed[field] = raw
+		}
+	}
+	// Ensure non-mentioned fields are still copied.
+	for field, raw := range req.Payload {
+		if _, exists := transformed[field]; !exists {
+			transformed[field] = raw
+		}
+	}
+	writeJSON(w, http.StatusOK, TokenizeResponse{Payload: transformed})
+}
+
+func (s *Server) handleReveal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var req RevealRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	rule, ok := s.policies.RuleForField(req.Tenant, req.Purpose, req.Field)
+	if !ok || !rule.AllowReveal || !strings.EqualFold(rule.Method, "tokenize") {
+		http.Error(w, "reveal not permitted", http.StatusForbidden)
+		return
+	}
+	if !s.gate.Authorize(req.Shares) {
+		http.Error(w, "quorum required", http.StatusForbidden)
+		return
+	}
+	ctx := tokenvault.Context{Tenant: req.Tenant, Purpose: req.Purpose, Field: req.Field}
+	value, found := s.vault.Reveal(ctx, req.Token)
+	if !found {
+		http.Error(w, "token not found", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, RevealResponse{Value: value})
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		fmt.Printf("failed to encode response: %v\n", err)
+	}
+}

--- a/services/qpg/internal/server/server_test.go
+++ b/services/qpg/internal/server/server_test.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/summit/qpg/internal/config"
+	"github.com/summit/qpg/internal/policy"
+	"github.com/summit/qpg/internal/tokenvault"
+)
+
+func setupTestServer(t *testing.T) http.Handler {
+	t.Helper()
+	defs, err := config.LoadPolicies("../../config/policies.yaml")
+	require.NoError(t, err)
+	mgr := policy.NewManager(defs)
+	gateCfg, err := config.LoadVault("../../config/vault.yaml")
+	require.NoError(t, err)
+	gate, err := tokenvault.NewRecoveryGate(*gateCfg)
+	require.NoError(t, err)
+	vault := tokenvault.NewTokenVault("unit-test-secret")
+	srv := New(mgr, vault, gate)
+	return srv.Handler()
+}
+
+func TestTokenizeTransformsAccordingToPolicy(t *testing.T) {
+	handler := setupTestServer(t)
+	reqBody := TokenizeRequest{
+		Tenant:  "acme",
+		Purpose: "analytics",
+		Payload: map[string]any{
+			"ssn":   "123456789",
+			"email": "user@example.com",
+			"name":  "Alice",
+		},
+	}
+	resp := performTokenize(t, handler, reqBody)
+	ssn := resp.Payload["ssn"].(string)
+	email := resp.Payload["email"].(string)
+	name := resp.Payload["name"].(string)
+
+	require.NotEqual(t, "123456789", ssn)
+	require.Equal(t, 9, len(ssn))
+	require.NotEqual(t, "user@example.com", email)
+	require.Equal(t, 64, len(email))
+	require.Equal(t, "Alice", name)
+}
+
+func TestRevealRequiresQuorum(t *testing.T) {
+	handler := setupTestServer(t)
+	tokenResp := performTokenize(t, handler, TokenizeRequest{
+		Tenant:  "acme",
+		Purpose: "support",
+		Payload: map[string]any{
+			"ticketId":     "TCK-123",
+			"internalNote": "Handle with care",
+		},
+	})
+
+	token := tokenResp.Payload["ticketId"].(string)
+	revealReq := RevealRequest{
+		Tenant:  "acme",
+		Purpose: "support",
+		Field:   "ticketId",
+		Token:   token,
+		Shares:  []string{"alpha-key"},
+	}
+	body, _ := json.Marshal(revealReq)
+	r := httptest.NewRequest(http.MethodPost, "/reveal", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	require.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestRevealSucceedsWithQuorum(t *testing.T) {
+	handler := setupTestServer(t)
+	tokenResp := performTokenize(t, handler, TokenizeRequest{
+		Tenant:  "acme",
+		Purpose: "support",
+		Payload: map[string]any{
+			"ticketId": "TCK-123",
+		},
+	})
+
+	token := tokenResp.Payload["ticketId"].(string)
+	revealReq := RevealRequest{
+		Tenant:  "acme",
+		Purpose: "support",
+		Field:   "ticketId",
+		Token:   token,
+		Shares:  []string{"alpha-key", "beta-key"},
+	}
+	body, _ := json.Marshal(revealReq)
+	r := httptest.NewRequest(http.MethodPost, "/reveal", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp RevealResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, "TCK-123", resp.Value)
+}
+
+func performTokenize(t *testing.T, handler http.Handler, req TokenizeRequest) TokenizeResponse {
+	t.Helper()
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/tokenize", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, r)
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp TokenizeResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	return resp
+}

--- a/services/qpg/internal/tokenvault/tokenvault.go
+++ b/services/qpg/internal/tokenvault/tokenvault.go
@@ -1,0 +1,180 @@
+package tokenvault
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"unicode"
+)
+
+type Context struct {
+	Tenant  string
+	Purpose string
+	Field   string
+}
+
+type TokenVault struct {
+	secret  []byte
+	mu      sync.RWMutex
+	reverse map[string]string
+}
+
+func NewTokenVault(secret string) *TokenVault {
+	return &TokenVault{
+		secret:  []byte(secret),
+		reverse: make(map[string]string),
+	}
+}
+
+func (v *TokenVault) key(ctx Context, token string) string {
+	parts := []string{strings.ToLower(ctx.Tenant), strings.ToLower(ctx.Purpose), strings.ToLower(ctx.Field), token}
+	return strings.Join(parts, "::")
+}
+
+func (v *TokenVault) Tokenize(ctx Context, value string) string {
+	token := v.formatPreservingToken(ctx, value)
+	v.mu.Lock()
+	v.reverse[v.key(ctx, token)] = value
+	v.mu.Unlock()
+	return token
+}
+
+func (v *TokenVault) Reveal(ctx Context, token string) (string, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	val, ok := v.reverse[v.key(ctx, token)]
+	return val, ok
+}
+
+func (v *TokenVault) Hash(ctx Context, value string) string {
+	mac := hmac.New(sha256.New, v.secret)
+	mac.Write([]byte("hash::"))
+	mac.Write([]byte(strings.ToLower(ctx.Tenant)))
+	mac.Write([]byte("::"))
+	mac.Write([]byte(strings.ToLower(ctx.Purpose)))
+	mac.Write([]byte("::"))
+	mac.Write([]byte(strings.ToLower(ctx.Field)))
+	mac.Write([]byte("::"))
+	mac.Write([]byte(value))
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func (v *TokenVault) formatPreservingToken(ctx Context, value string) string {
+	mac := hmac.New(sha256.New, v.secret)
+	mac.Write([]byte(strings.ToLower(ctx.Tenant)))
+	mac.Write([]byte("::"))
+	mac.Write([]byte(strings.ToLower(ctx.Purpose)))
+	mac.Write([]byte("::"))
+	mac.Write([]byte(strings.ToLower(ctx.Field)))
+	mac.Write([]byte("::"))
+	mac.Write([]byte(value))
+	digest := mac.Sum(nil)
+
+	digits := digitAlphabet()
+	upper := upperAlphabet()
+	lower := lowerAlphabet()
+
+	var builder strings.Builder
+	builder.Grow(len(value))
+	idx := 0
+	for _, r := range value {
+		switch {
+		case unicode.IsDigit(r):
+			builder.WriteByte(digits[int(digest[idx%len(digest)])%len(digits)])
+		case unicode.IsUpper(r):
+			builder.WriteByte(upper[int(digest[idx%len(digest)])%len(upper)])
+		case unicode.IsLower(r):
+			builder.WriteByte(lower[int(digest[idx%len(digest)])%len(lower)])
+		default:
+			builder.WriteRune(r)
+			idx++
+			continue
+		}
+		idx++
+	}
+	return builder.String()
+}
+
+func digitAlphabet() []byte {
+	return []byte("0123456789")
+}
+
+func upperAlphabet() []byte {
+	return []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+}
+
+func lowerAlphabet() []byte {
+	return []byte("abcdefghijklmnopqrstuvwxyz")
+}
+
+// RecoveryGateConfig is used for YAML unmarshalling.
+type RecoveryGateConfig struct {
+	Threshold int                 `yaml:"threshold"`
+	Shares    []RecoveryGateShare `yaml:"shares"`
+}
+
+type RecoveryGateShare struct {
+	ID   string `yaml:"id"`
+	Hash string `yaml:"hash"`
+}
+
+type storedShare struct {
+	id     string
+	digest [32]byte
+}
+
+type RecoveryGate struct {
+	threshold int
+	shares    []storedShare
+}
+
+func NewRecoveryGate(cfg RecoveryGateConfig) (*RecoveryGate, error) {
+	if cfg.Threshold <= 0 {
+		return nil, fmt.Errorf("threshold must be positive")
+	}
+	if len(cfg.Shares) < cfg.Threshold {
+		return nil, fmt.Errorf("threshold %d exceeds share count %d", cfg.Threshold, len(cfg.Shares))
+	}
+	shares := make([]storedShare, 0, len(cfg.Shares))
+	for _, share := range cfg.Shares {
+		digest, err := hex.DecodeString(share.Hash)
+		if err != nil {
+			return nil, fmt.Errorf("decode share %s: %w", share.ID, err)
+		}
+		if len(digest) != sha256.Size {
+			return nil, fmt.Errorf("share %s has invalid digest length", share.ID)
+		}
+		var arr [32]byte
+		copy(arr[:], digest)
+		shares = append(shares, storedShare{id: share.ID, digest: arr})
+	}
+	return &RecoveryGate{threshold: cfg.Threshold, shares: shares}, nil
+}
+
+func (r *RecoveryGate) Authorize(provided []string) bool {
+	if len(provided) == 0 {
+		return false
+	}
+	matched := 0
+	used := make(map[string]struct{})
+	for _, share := range provided {
+		digest := sha256.Sum256([]byte(share))
+		for _, stored := range r.shares {
+			if _, exists := used[stored.id]; exists {
+				continue
+			}
+			if hmac.Equal(digest[:], stored.digest[:]) {
+				matched++
+				used[stored.id] = struct{}{}
+				break
+			}
+		}
+		if matched >= r.threshold {
+			return true
+		}
+	}
+	return matched >= r.threshold
+}

--- a/services/qpg/main.go
+++ b/services/qpg/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/summit/qpg/internal/config"
+	"github.com/summit/qpg/internal/policy"
+	"github.com/summit/qpg/internal/server"
+	"github.com/summit/qpg/internal/tokenvault"
+)
+
+func main() {
+	var (
+		policyPath string
+		vaultPath  string
+		addr       string
+	)
+	flag.StringVar(&policyPath, "policies", "config/policies.yaml", "path to the policy definition file")
+	flag.StringVar(&vaultPath, "vault", "config/vault.yaml", "path to the vault share definition file")
+	flag.StringVar(&addr, "addr", ":8080", "listen address")
+	flag.Parse()
+
+	defs, err := config.LoadPolicies(policyPath)
+	if err != nil {
+		log.Fatalf("load policies: %v", err)
+	}
+	policyMgr := policy.NewManager(defs)
+
+	vaultSecret := os.Getenv("QPG_TOKEN_SECRET")
+	if vaultSecret == "" {
+		vaultSecret = "change-me-qpg-secret"
+	}
+	vault := tokenvault.NewTokenVault(vaultSecret)
+
+	gateCfg, err := config.LoadVault(vaultPath)
+	if err != nil {
+		log.Fatalf("load vault config: %v", err)
+	}
+	gate, err := tokenvault.NewRecoveryGate(*gateCfg)
+	if err != nil {
+		log.Fatalf("init recovery gate: %v", err)
+	}
+
+	srv := server.New(policyMgr, vault, gate)
+
+	log.Printf("QPG listening on %s", addr)
+	if err := http.ListenAndServe(addr, srv.Handler()); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go-based Query-Time Pseudonymization Gateway with policy-driven tokenization and split-key recovery
- define default policies, vault shares, and README guidance plus tests covering quorum reveal behavior
- publish lightweight TypeScript and Python client SDKs for the gateway

## Testing
- go test ./... (from services/qpg)


------
https://chatgpt.com/codex/tasks/task_e_68d7740903c88333aff4c38071641494