### PR TITLE
feat: add side-channel budget auditor harness

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts and packages for Summit tooling."""

--- a/tools/scba/README.md
+++ b/tools/scba/README.md
@@ -1,0 +1,56 @@
+# Side-Channel Budget Auditor (SCBA)
+
+SCBA is a lightweight harness for quantifying side-channel leakage across HTTP
+APIs and microservices. It focuses on micro-architectural and protocol-level
+signals such as latency, payload sizing, and cache hints.
+
+## Features
+
+- **Controlled runners** with deterministic seeds for reproducibility.
+- **Leak budget policies** per endpoint with mitigation toggles.
+- **Hypothesis testing** (Welch t-test with permutation fallback) to detect
+  statistically significant leakage.
+- **Canned attack modules** for length-based, cache warmness, and coarse timing
+  channels.
+- **CI gate integration** via JSON reports and non-zero exit codes when budgets
+  are exceeded.
+- **Polyglot entry points**: Python package and Go CLI wrapper.
+
+## Quickstart
+
+1. Define a policy file:
+
+```json
+{
+  "payments:create": {
+    "budget": {
+      "latency_ms": 8.0,
+      "payload_bytes": 16.0,
+      "cache_hint": 0.3
+    },
+    "mitigations": {
+      "padding": true
+    }
+  }
+}
+```
+
+2. Run the auditor against an endpoint:
+
+```bash
+python -m tools.scba.cli policy.json payments:create https://api.example.com/payments --attack length
+```
+
+The command prints JSON records summarising each attack. Non-compliant findings
+should be consumed by your CI job to fail the build.
+
+## Go wrapper
+
+A minimal Go front-end is provided under `tools/scba/cmd/scba`. Build it with:
+
+```bash
+(cd tools/scba/cmd/scba && go build)
+```
+
+The compiled binary mirrors the Python CLI arguments and forwards execution to
+the Python package via `python -m tools.scba.cli`.

--- a/tools/scba/__init__.py
+++ b/tools/scba/__init__.py
@@ -1,0 +1,22 @@
+"""Side-Channel Budget Auditor (SCBA).
+
+This package provides utilities for measuring side-channel leakage across
+services and enforcing per-endpoint leak budgets. It exposes a Python API,
+with a thin Go wrapper located in ``tools/scba/cmd`` for teams that prefer a
+static binary interface.
+"""
+
+from .attacks import CoarseTimerAttack, LengthLeakAttack, CacheWarmAttack
+from .policies import LeakBudget, EndpointPolicy, PolicyStore
+from .runner import SideChannelBudgetAuditor, AuditFinding
+
+__all__ = [
+    "CoarseTimerAttack",
+    "LengthLeakAttack",
+    "CacheWarmAttack",
+    "LeakBudget",
+    "EndpointPolicy",
+    "SideChannelBudgetAuditor",
+    "AuditFinding",
+    "PolicyStore",
+]

--- a/tools/scba/attacks.py
+++ b/tools/scba/attacks.py
@@ -1,0 +1,91 @@
+"""Canned attack strategies for the SCBA harness."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass, field
+from typing import Callable, List, Sequence
+
+from .measurements import Measurement
+from .probes import Probe
+
+
+@dataclass
+class AttackResult:
+    """Container for the collected observations of an attack."""
+
+    secret: str
+    samples: List[Measurement]
+
+
+class Attack:
+    """Base class for canned attacks."""
+
+    name: str
+    probe: Probe
+    secrets: Sequence[str]
+    samples_per_secret: int
+    selector: Callable[[random.Random, int, str], str]
+
+    def __init__(
+        self,
+        name: str,
+        probe: Probe,
+        secrets: Sequence[str],
+        samples_per_secret: int,
+        selector: Callable[[random.Random, int, str], str] | None = None,
+    ) -> None:
+        self.name = name
+        self.probe = probe
+        self.secrets = tuple(secrets)
+        self.samples_per_secret = samples_per_secret
+        self.selector = selector if selector else _default_selector
+
+    def collect(self, rng: random.Random) -> List[AttackResult]:
+        results: List[AttackResult] = []
+        for idx, secret in enumerate(self.secrets):
+            samples: List[Measurement] = []
+            for sample_idx in range(self.samples_per_secret):
+                chosen = self.selector(rng, sample_idx, secret)
+                measurement = self.probe.invoke(chosen, rng)
+                samples.append(measurement)
+            results.append(AttackResult(secret=secret, samples=samples))
+        return results
+
+
+def _default_selector(_: random.Random, __: int, secret: str) -> str:
+    return secret
+
+
+@dataclass
+class LengthLeakAttack(Attack):
+    """Attack that differentiates secrets based on payload length."""
+
+    def __init__(self, probe: Probe, secrets: Sequence[str] = ("0", "1"), samples_per_secret: int = 30):
+        super().__init__("length-leak", probe, secrets, samples_per_secret)
+
+
+@dataclass
+class CacheWarmAttack(Attack):
+    """Attack that inspects cache hint behaviour across requests."""
+
+    warmup: int = 3
+    history: List[float] = field(default_factory=list)
+
+    def __init__(self, probe: Probe, secrets: Sequence[str] = ("cold", "warm"), samples_per_secret: int = 20, warmup: int = 3):
+        super().__init__("cache-warm", probe, secrets, samples_per_secret)
+        self.warmup = warmup
+
+    def collect(self, rng: random.Random) -> List[AttackResult]:
+        # warm the cache to create a baseline
+        for _ in range(self.warmup):
+            self.probe.invoke(self.secrets[0], rng)
+        return super().collect(rng)
+
+
+@dataclass
+class CoarseTimerAttack(Attack):
+    """Attack that focuses on coarse timing differences."""
+
+    def __init__(self, probe: Probe, secrets: Sequence[str] = ("fast", "slow"), samples_per_secret: int = 40):
+        super().__init__("coarse-timer", probe, secrets, samples_per_secret)

--- a/tools/scba/ci.py
+++ b/tools/scba/ci.py
@@ -1,0 +1,18 @@
+"""CI gate helpers for SCBA."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from .runner import AuditFinding, SideChannelBudgetAuditor
+
+
+def gate(findings: Iterable[AuditFinding], output: Path | None = None) -> int:
+    """Persist findings and return an appropriate exit code."""
+
+    data = SideChannelBudgetAuditor.summarize(findings)
+    if output:
+        output.write_text(data)
+    failed = [finding for finding in findings if not finding.passed]
+    return 1 if failed else 0

--- a/tools/scba/cli.py
+++ b/tools/scba/cli.py
@@ -1,0 +1,64 @@
+"""Command line interface for the Side-Channel Budget Auditor."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .attacks import CacheWarmAttack, CoarseTimerAttack, LengthLeakAttack
+from .policies import EndpointPolicy, LeakBudget, PolicyStore
+from .probes import HttpProbe
+from .runner import SideChannelBudgetAuditor
+
+
+def load_policy(path: Path) -> PolicyStore:
+    data = json.loads(path.read_text())
+    store = PolicyStore()
+    for endpoint, cfg in data.items():
+        budget_cfg = cfg.get("budget", {})
+        policy = EndpointPolicy(
+            endpoint=endpoint,
+            budget=LeakBudget(
+                latency_ms=budget_cfg.get("latency_ms", 5.0),
+                payload_bytes=budget_cfg.get("payload_bytes", 32.0),
+                cache_hint=budget_cfg.get("cache_hint", 0.5),
+            ),
+            mitigation_toggles=cfg.get("mitigations"),
+        )
+        store.register(policy)
+    return store
+
+
+def build_cli(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Side-Channel Budget Auditor")
+    parser.add_argument("policy", type=Path, help="Path to the leak budget policy JSON file")
+    parser.add_argument("endpoint", type=str, help="Endpoint identifier defined in the policy")
+    parser.add_argument("url", type=str, help="URL to probe")
+    parser.add_argument("--method", default="GET", help="HTTP method to use")
+    parser.add_argument("--seed", type=int, default=0, help="Random seed for reproducibility")
+    parser.add_argument("--attack", choices=["length", "timer", "cache"], default="length")
+    parser.add_argument("--samples", type=int, default=30, help="Samples per secret")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_cli(argv)
+    policy_store = load_policy(args.policy)
+    auditor = SideChannelBudgetAuditor(policy_store, seed=args.seed)
+    probe = HttpProbe(method=args.method, url=args.url)
+    if args.attack == "length":
+        attack = LengthLeakAttack(probe, samples_per_secret=args.samples)
+    elif args.attack == "timer":
+        attack = CoarseTimerAttack(probe, samples_per_secret=args.samples)
+    else:
+        attack = CacheWarmAttack(probe, samples_per_secret=args.samples)
+    auditor.register_attack(args.endpoint, attack)
+    findings = auditor.run()
+    print(SideChannelBudgetAuditor.summarize(findings))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/scba/cmd/scba/main.go
+++ b/tools/scba/cmd/scba/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	python := os.Getenv("SCBA_PYTHON")
+	if python == "" {
+		python = "python3"
+	}
+	args := append([]string{"-m", "tools.scba.cli"}, os.Args[1:]...)
+	cmd := exec.Command(python, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "scba: %v\n", err)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		os.Exit(1)
+	}
+}

--- a/tools/scba/go.mod
+++ b/tools/scba/go.mod
@@ -1,0 +1,3 @@
+module github.com/summit/scba
+
+go 1.21

--- a/tools/scba/measurements.py
+++ b/tools/scba/measurements.py
@@ -1,0 +1,43 @@
+"""Measurement primitives for the Side-Channel Budget Auditor."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class Measurement:
+    """Represents a single observation for an API invocation.
+
+    Attributes
+    ----------
+    latency_ms:
+        Wall clock latency in milliseconds.
+    payload_bytes:
+        Size of the response payload in bytes.
+    cache_hint:
+        Numeric representation of cache hint behaviour. This is a float so
+        that higher-order statistics (e.g. hit ratios) can be captured. The
+        default HTTP probe maps cache headers to this channel, while synthetic
+        probes may use domain-specific semantics.
+    meta:
+        Optional structured metadata attached to the observation. Metadata is
+        ignored by default but can be surfaced in reports.
+    """
+
+    latency_ms: float
+    payload_bytes: int
+    cache_hint: float
+    meta: Dict[str, float] | None = None
+
+    def channel(self, name: str) -> float:
+        """Return a measurement channel by name."""
+
+        if name == "latency_ms":
+            return self.latency_ms
+        if name == "payload_bytes":
+            return float(self.payload_bytes)
+        if name == "cache_hint":
+            return self.cache_hint
+        raise KeyError(f"unknown measurement channel: {name}")

--- a/tools/scba/policies.py
+++ b/tools/scba/policies.py
@@ -1,0 +1,52 @@
+"""Leak budget policies for SCBA."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional
+
+
+@dataclass
+class LeakBudget:
+    """Thresholds for the different side-channel categories."""
+
+    latency_ms: float
+    payload_bytes: float
+    cache_hint: float
+
+    def as_dict(self) -> Dict[str, float]:
+        return {
+            "latency_ms": self.latency_ms,
+            "payload_bytes": self.payload_bytes,
+            "cache_hint": self.cache_hint,
+        }
+
+
+@dataclass
+class EndpointPolicy:
+    """Policy definition for a single endpoint."""
+
+    endpoint: str
+    budget: LeakBudget
+    mitigation_toggles: Dict[str, bool] | None = None
+
+    def is_toggle_enabled(self, name: str) -> bool:
+        if not self.mitigation_toggles:
+            return False
+        return bool(self.mitigation_toggles.get(name, False))
+
+
+class PolicyStore:
+    """Container for endpoint policies."""
+
+    def __init__(self, policies: Mapping[str, EndpointPolicy] | None = None) -> None:
+        self._policies = dict(policies or {})
+
+    def register(self, policy: EndpointPolicy) -> None:
+        self._policies[policy.endpoint] = policy
+
+    def get(self, endpoint: str) -> Optional[EndpointPolicy]:
+        return self._policies.get(endpoint)
+
+    def __iter__(self):
+        return iter(self._policies.values())

--- a/tools/scba/probes.py
+++ b/tools/scba/probes.py
@@ -1,0 +1,79 @@
+"""Probe implementations used by the SCBA harness."""
+
+from __future__ import annotations
+
+import random
+import time
+from dataclasses import dataclass
+from typing import Callable, Iterable, Protocol
+
+import requests
+
+from .measurements import Measurement
+
+
+class Probe(Protocol):
+    """A probe collects measurements for a given secret or scenario."""
+
+    def invoke(self, secret: str, rng: random.Random) -> Measurement:
+        ...
+
+
+@dataclass
+class HttpProbe:
+    """Probe that issues HTTP requests against a configurable endpoint.
+
+    The probe allows callers to control headers, query strings and payloads via
+    a *builder* function. The builder receives the randomly chosen secret value
+    and the RNG instance so that experiments can remain deterministic.
+    """
+
+    method: str
+    url: str
+    build_request: Callable[[str, random.Random], dict] | None = None
+    session_factory: Callable[[], requests.Session] | None = None
+    timeout: float | None = 5.0
+
+    def invoke(self, secret: str, rng: random.Random) -> Measurement:
+        session = self.session_factory() if self.session_factory else requests.Session()
+        try:
+            request_kwargs = self.build_request(secret, rng) if self.build_request else {}
+            start = time.perf_counter()
+            response = session.request(self.method, self.url, timeout=self.timeout, **request_kwargs)
+            elapsed_ms = (time.perf_counter() - start) * 1000.0
+            cache_header = response.headers.get("X-Cache", "0")
+            cache_hint = 1.0 if cache_header.lower().startswith("hit") else 0.0
+            return Measurement(
+                latency_ms=elapsed_ms,
+                payload_bytes=len(response.content),
+                cache_hint=cache_hint,
+                meta={"status_code": float(response.status_code)},
+            )
+        finally:
+            session.close()
+
+
+@dataclass
+class SyntheticProbe:
+    """Probe backed by a deterministic callable for tests and local services."""
+
+    fn: Callable[[str, random.Random], Measurement]
+
+    def invoke(self, secret: str, rng: random.Random) -> Measurement:
+        return self.fn(secret, rng)
+
+
+def cycle_secrets(secrets: Iterable[str]) -> Callable[[random.Random, int, str], str]:
+    """Return a helper that cycles through a fixed set of secrets.
+
+    The resulting callable accepts ``(rng, idx)`` and returns the secret to use
+    for a given sample index. It preserves reproducibility by ignoring the RNG
+    when a deterministic ordering is required.
+    """
+
+    secrets = tuple(secrets)
+
+    def _select(_: random.Random, idx: int, __: str) -> str:
+        return secrets[idx % len(secrets)]
+
+    return _select

--- a/tools/scba/runner.py
+++ b/tools/scba/runner.py
@@ -1,0 +1,97 @@
+"""Core orchestration logic for the Side-Channel Budget Auditor."""
+
+from __future__ import annotations
+
+import json
+import random
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+from .attacks import Attack, AttackResult
+from .measurements import Measurement
+from .policies import EndpointPolicy, PolicyStore
+from .stats import effect_size, welch_p_value
+
+
+@dataclass
+class ChannelMeasurement:
+    channel: str
+    effect: float
+    p_value: float
+
+    def to_dict(self) -> Dict[str, float]:
+        return {"effect": self.effect, "p_value": self.p_value}
+
+
+@dataclass
+class AuditFinding:
+    endpoint: str
+    attack: str
+    channel_measurements: Dict[str, ChannelMeasurement]
+    passed: bool
+    budget: Dict[str, float]
+
+    def to_json(self) -> str:
+        payload = {
+            "endpoint": self.endpoint,
+            "attack": self.attack,
+            "passed": self.passed,
+            "budget": self.budget,
+            "channels": {name: measurement.to_dict() for name, measurement in self.channel_measurements.items()},
+        }
+        return json.dumps(payload, indent=2, sort_keys=True)
+
+
+class SideChannelBudgetAuditor:
+    """Executes canned attacks against registered endpoints."""
+
+    def __init__(self, policies: PolicyStore | None = None, seed: int = 0) -> None:
+        self.policies = policies or PolicyStore()
+        self.seed = seed
+        self.attacks: Dict[str, List[Attack]] = {}
+
+    def register_attack(self, endpoint: str, attack: Attack) -> None:
+        self.attacks.setdefault(endpoint, []).append(attack)
+
+    def run(self) -> List[AuditFinding]:
+        rng = random.Random(self.seed)
+        findings: List[AuditFinding] = []
+        for endpoint, attacks in self.attacks.items():
+            policy = self.policies.get(endpoint)
+            if not policy:
+                raise ValueError(f"missing policy for endpoint {endpoint}")
+            for attack in attacks:
+                results = attack.collect(rng)
+                finding = self._analyse_attack(policy, attack, results)
+                findings.append(finding)
+        return findings
+
+    def _analyse_attack(self, policy: EndpointPolicy, attack: Attack, results: List[AttackResult]) -> AuditFinding:
+        measurements: Dict[str, ChannelMeasurement] = {}
+        channels = policy.budget.as_dict().keys()
+        for channel in channels:
+            channel_samples = [[sample.channel(channel) for sample in result.samples] for result in results]
+            # Compare each secret to baseline and take the worst leakage observed.
+            worst_effect = 0.0
+            worst_p_value = 1.0
+            for sample_set in channel_samples[1:]:
+                effect = effect_size(channel_samples[0], sample_set)
+                p_value = welch_p_value(channel_samples[0], sample_set)
+                if effect > worst_effect:
+                    worst_effect = effect
+                if p_value < worst_p_value:
+                    worst_p_value = p_value
+            measurements[channel] = ChannelMeasurement(channel=channel, effect=worst_effect, p_value=worst_p_value)
+        passed = all(measurements[ch].effect <= policy.budget.as_dict()[ch] for ch in channels)
+        return AuditFinding(
+            endpoint=policy.endpoint,
+            attack=attack.name,
+            channel_measurements=measurements,
+            passed=passed,
+            budget=policy.budget.as_dict(),
+        )
+
+    @staticmethod
+    def summarize(findings: Iterable[AuditFinding]) -> str:
+        data = [finding.to_json() for finding in findings]
+        return "\n".join(data)

--- a/tools/scba/stats.py
+++ b/tools/scba/stats.py
@@ -1,0 +1,83 @@
+"""Statistical utilities for the SCBA harness."""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Iterable, List, Sequence, Tuple
+
+
+def difference_of_means(sample_a: Sequence[float], sample_b: Sequence[float]) -> float:
+    return mean(sample_a) - mean(sample_b)
+
+
+def mean(values: Sequence[float]) -> float:
+    return sum(values) / float(len(values))
+
+
+def variance(values: Sequence[float]) -> float:
+    if len(values) < 2:
+        return 0.0
+    mu = mean(values)
+    return sum((x - mu) ** 2 for x in values) / float(len(values) - 1)
+
+
+def pooled_standard_error(sample_a: Sequence[float], sample_b: Sequence[float]) -> float:
+    return math.sqrt(variance(sample_a) / max(len(sample_a), 1) + variance(sample_b) / max(len(sample_b), 1))
+
+
+def welch_t(sample_a: Sequence[float], sample_b: Sequence[float]) -> float:
+    se = pooled_standard_error(sample_a, sample_b)
+    diff = difference_of_means(sample_a, sample_b)
+    if se == 0:
+        if diff == 0:
+            return 0.0
+        return float("inf")
+    return diff / se
+
+
+def welch_degrees_of_freedom(sample_a: Sequence[float], sample_b: Sequence[float]) -> float:
+    var_a = variance(sample_a)
+    var_b = variance(sample_b)
+    n_a = len(sample_a)
+    n_b = len(sample_b)
+    numerator = (var_a / n_a + var_b / n_b) ** 2
+    denominator = ((var_a / n_a) ** 2) / (n_a - 1) + ((var_b / n_b) ** 2) / (n_b - 1)
+    if denominator == 0:
+        return float("inf")
+    return numerator / denominator
+
+
+def normal_cdf(x: float) -> float:
+    return 0.5 * (1 + math.erf(x / math.sqrt(2)))
+
+
+def welch_p_value(sample_a: Sequence[float], sample_b: Sequence[float]) -> float:
+    t_stat = abs(welch_t(sample_a, sample_b))
+    if math.isinf(t_stat):
+        return 0.0
+    df = welch_degrees_of_freedom(sample_a, sample_b)
+    # Approximate the Student-t CDF with the normal distribution when df is large.
+    if df > 30:
+        return 2 * (1 - normal_cdf(t_stat))
+    # For smaller df we fall back to a permutation test.
+    return permutation_test(sample_a, sample_b, iterations=2000)
+
+
+def permutation_test(sample_a: Sequence[float], sample_b: Sequence[float], iterations: int = 1000) -> float:
+    combined = list(sample_a) + list(sample_b)
+    observed = abs(difference_of_means(sample_a, sample_b))
+    count = 0
+    rng = random.Random(0)
+    for _ in range(iterations):
+        shuffled = combined[:]
+        rng.shuffle(shuffled)
+        new_a = shuffled[: len(sample_a)]
+        new_b = shuffled[len(sample_a) :]
+        if abs(difference_of_means(new_a, new_b)) >= observed:
+            count += 1
+    return count / iterations
+
+
+def effect_size(sample_a: Sequence[float], sample_b: Sequence[float]) -> float:
+    return abs(difference_of_means(sample_a, sample_b))

--- a/tools/scba/tests/test_scba.py
+++ b/tools/scba/tests/test_scba.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from tools.scba import (
+    CacheWarmAttack,
+    CoarseTimerAttack,
+    EndpointPolicy,
+    LeakBudget,
+    LengthLeakAttack,
+    PolicyStore,
+    SideChannelBudgetAuditor,
+)
+from tools.scba.measurements import Measurement
+from tools.scba.probes import SyntheticProbe
+
+
+def make_policy(padding: bool, jitter: bool, cache_bust: bool) -> EndpointPolicy:
+    return EndpointPolicy(
+        endpoint="payments:create",
+        budget=LeakBudget(latency_ms=2.0, payload_bytes=4.0, cache_hint=0.2),
+        mitigation_toggles={
+            "padding": padding,
+            "jitter": jitter,
+            "cache-bust": cache_bust,
+        },
+    )
+
+
+def make_probe(policy: EndpointPolicy) -> SyntheticProbe:
+    def _invoke(secret: str, rng) -> Measurement:
+        base_latency = 30.0
+        base_size = 128
+        base_cache = 0.1
+
+        latency = base_latency
+        size = base_size
+        cache_hint = base_cache
+
+        if secret in {"1", "slow", "warm"}:
+            latency += 8.0
+            size += 24
+            cache_hint = 1.0
+
+        if policy.is_toggle_enabled("padding"):
+            size = base_size + 16
+
+        if policy.is_toggle_enabled("jitter"):
+            latency = base_latency + rng.uniform(-0.5, 0.5)
+
+        if policy.is_toggle_enabled("cache-bust"):
+            cache_hint = 0.15
+
+        return Measurement(
+            latency_ms=latency,
+            payload_bytes=size,
+            cache_hint=cache_hint,
+            meta={},
+        )
+
+    return SyntheticProbe(_invoke)
+
+
+def run_attacks(policy: EndpointPolicy) -> list:
+    store = PolicyStore({policy.endpoint: policy})
+    auditor = SideChannelBudgetAuditor(store, seed=1337)
+    probe = make_probe(policy)
+    auditor.register_attack(policy.endpoint, LengthLeakAttack(probe, secrets=("0", "1"), samples_per_secret=15))
+    auditor.register_attack(policy.endpoint, CoarseTimerAttack(probe, secrets=("fast", "slow"), samples_per_secret=15))
+    auditor.register_attack(policy.endpoint, CacheWarmAttack(probe, secrets=("cold", "warm"), samples_per_secret=15))
+    return auditor.run()
+
+
+def test_seeded_leaks_are_flagged_when_over_budget():
+    policy = make_policy(padding=False, jitter=False, cache_bust=False)
+    findings = run_attacks(policy)
+    assert any(not finding.passed for finding in findings)
+    for finding in findings:
+        if not finding.passed:
+            assert any(
+                measurement.effect > finding.budget[channel]
+                for channel, measurement in finding.channel_measurements.items()
+            )
+
+
+def test_mitigations_reduce_leakage_below_budget():
+    policy = make_policy(padding=True, jitter=True, cache_bust=True)
+    findings = run_attacks(policy)
+    assert all(finding.passed for finding in findings)
+    serialized = [json.loads(finding.to_json()) for finding in findings]
+    for record in serialized:
+        for channel, metrics in record["channels"].items():
+            assert metrics["effect"] <= record["budget"][channel]


### PR DESCRIPTION
## Summary
- add a Python-based Side-Channel Budget Auditor with measurement primitives, canned attacks, policy enforcement, and statistical analysis utilities
- provide a CLI, CI helper, and Go wrapper plus documentation for running the harness
- cover seeded-leak detection and mitigation toggles with reproducible synthetic tests

## Testing
- pytest tools/scba/tests/test_scba.py

------
https://chatgpt.com/codex/tasks/task_e_68d7740c2bcc83338ec09a1dcfcac6e2