### PR TITLE
feat: add bayesian fusion to early warning ensemble

### DIFF
--- a/analysis/early_warning.py
+++ b/analysis/early_warning.py
@@ -1,11 +1,85 @@
 """Early-warning ensemble scoring for deepfake influence detection.
 
-Implements `score_alert` for combining multi-model signals with provenance
-and policy gating. This is a minimal skeleton aligned with committee
-recommendations and prioritises traceability over raw prediction.
+Implements ``score_alert`` for combining multi-model signals with provenance
+and policy gating. The fusion strategy follows a simple Bayesian evidence
+update so that each model contributes probabilistic evidence instead of
+naively averaging raw scores. This emphasises calibrated risk estimation and
+explicit uncertainty tracking which downstream reviewers can audit.
 """
 
-from typing import Any
+from __future__ import annotations
+
+from math import sqrt
+from typing import Any, Iterable, Tuple
+
+
+def _extract_signal(signal: dict[str, Any]) -> Tuple[float, float]:
+    """Normalise a model signal into (score, weight).
+
+    Scores are clamped to ``[0, 1]``. ``confidence`` (or ``weight``) metadata is
+    interpreted as the strength of evidence for the Bayesian update. When not
+    provided we fall back to ``1.0`` which keeps behaviour compatible with
+    legacy callers.
+    """
+
+    raw_score = float(signal.get("score", 0.0))
+    score = min(max(raw_score, 0.0), 1.0)
+
+    weight = float(signal.get("confidence", signal.get("weight", 1.0)))
+    if weight < 0:
+        weight = 0.0
+
+    return score, weight
+
+
+def _bayesian_fuse(signals: Iterable[Tuple[str, dict[str, Any]]]) -> dict[str, Any]:
+    """Fuse detector signals with a Beta-Bernoulli posterior."""
+
+    alpha = 1.0  # prior success pseudo-count
+    beta = 1.0  # prior failure pseudo-count
+    weights: list[float] = []
+    scores: list[float] = []
+    explain: dict[str, Any] = {}
+    model_weights: dict[str, float] = {}
+
+    for name, signal in signals:
+        score, weight = _extract_signal(signal)
+        explain[name] = signal.get("explain")
+        model_weights[name] = round(weight, 3)
+
+        if weight == 0:
+            continue
+
+        alpha += score * weight
+        beta += (1.0 - score) * weight
+        weights.append(weight)
+        scores.append(score)
+
+    total_weight = sum(weights)
+    if total_weight:
+        mean = sum(w * s for w, s in zip(weights, scores)) / total_weight
+        variance = sum(w * (s - mean) ** 2 for w, s in zip(weights, scores)) / total_weight
+        disagreement = sqrt(variance)
+    else:
+        mean = 0.0
+        disagreement = 0.0
+
+    posterior_mass = alpha + beta
+    posterior_mean = alpha / posterior_mass if posterior_mass else 0.0
+    posterior_var = (alpha * beta) / (
+        posterior_mass**2 * (posterior_mass + 1.0)
+    ) if posterior_mass > 0 else 0.0
+
+    return {
+        "posterior_mean": posterior_mean,
+        "posterior_std": sqrt(posterior_var) if posterior_var > 0 else 0.0,
+        "disagreement": disagreement,
+        "explain": explain,
+        "model_weights": model_weights,
+        "alpha": alpha,
+        "beta": beta,
+        "evidence_mean": mean,
+    }
 
 
 def score_alert(evidence: dict[str, Any], models: Any, policy: Any) -> dict[str, Any]:
@@ -25,25 +99,26 @@ def score_alert(evidence: dict[str, Any], models: Any, policy: Any) -> dict[str,
     Returns
     -------
     Dict[str, Any]
-        Alert payload with risk score, disagreement metric and explanations.
+        Alert payload with Bayesian risk score, disagreement metric and
+        explanations suitable for audit trails.
     """
-    text_sig = models.text_clf.predict_proba(evidence["transcript"])
-    av_sig = models.av_forgery.detect(evidence["media_bytes"])
-    meta_sig = models.meta_anom.score(evidence["metadata"])
 
-    consensus = (text_sig["score"] + av_sig["score"] + meta_sig["score"]) / 3
-    disagree = max(text_sig["score"], av_sig["score"], meta_sig["score"]) - min(
-        text_sig["score"], av_sig["score"], meta_sig["score"]
-    )
+    signals = [
+        ("text", models.text_clf.predict_proba(evidence["transcript"])),
+        ("av", models.av_forgery.detect(evidence["media_bytes"])),
+        ("meta", models.meta_anom.score(evidence["metadata"])),
+    ]
+
+    fused = _bayesian_fuse(signals)
 
     return {
-        "risk_score": round(consensus * (1 + disagree), 3),
-        "disagreement": round(disagree, 3),
+        "risk_score": round(fused["posterior_mean"], 3),
+        "disagreement": round(fused["disagreement"], 3),
+        "uncertainty": round(fused["posterior_std"], 3),
         "provenance": evidence.get("provenance_chain", []),
         "policy_gate": policy.reasoner(evidence),
-        "explain": {
-            "text": text_sig.get("explain"),
-            "av": av_sig.get("explain"),
-            "meta": meta_sig.get("explain"),
-        },
+        "explain": fused["explain"],
+        "model_weights": fused["model_weights"],
+        "posterior": {"alpha": round(fused["alpha"], 3), "beta": round(fused["beta"], 3)},
+        "evidence_mean": round(fused["evidence_mean"], 3),
     }

--- a/tests/test_early_warning.py
+++ b/tests/test_early_warning.py
@@ -40,7 +40,44 @@ def test_score_alert_combines_models():
         "provenance_chain": ["src"],
     }
     alert = score_alert(evidence, _Models(), _Policy())
-    assert alert["risk_score"] == 0.96
-    assert alert["disagreement"] == 0.6
+
+    assert alert["risk_score"] == 0.56
+    assert alert["disagreement"] == 0.245
+    assert alert["uncertainty"] == 0.203
     assert alert["provenance"] == ["src"]
     assert alert["policy_gate"]["status"] == "allow"
+    assert alert["model_weights"] == {"text": 1.0, "av": 1.0, "meta": 1.0}
+    assert alert["posterior"] == {"alpha": 2.8, "beta": 2.2}
+    assert alert["evidence_mean"] == 0.6
+
+
+class _WeightedText:
+    def predict_proba(self, _text):
+        return {"score": 0.8, "confidence": 3.0, "explain": "text"}
+
+
+class _WeightedAV:
+    def detect(self, _bytes):
+        return {"score": 0.2, "confidence": 0.1, "explain": "av"}
+
+
+class _WeightedMeta:
+    def score(self, _metadata):
+        return {"score": 0.4, "explain": "meta"}
+
+
+class _WeightedModels:
+    text_clf = _WeightedText()
+    av_forgery = _WeightedAV()
+    meta_anom = _WeightedMeta()
+
+
+def test_score_alert_respects_confidence_weights():
+    evidence = {"transcript": "", "media_bytes": b"", "metadata": {}}
+
+    alert = score_alert(evidence, _WeightedModels(), _Policy())
+
+    assert alert["risk_score"] == 0.626
+    assert alert["disagreement"] == 0.188
+    assert alert["model_weights"] == {"text": 3.0, "av": 0.1, "meta": 1.0}
+    assert alert["posterior"] == {"alpha": 3.82, "beta": 2.28}


### PR DESCRIPTION
## Summary
- replace naive averaging with beta-bernoulli bayesian fusion for multi-model risk scoring
- surface posterior uncertainty, model weights, and evidence summaries for downstream audits
- extend early warning tests to validate bayesian outputs and confidence weighting

## Testing
- pytest tests/test_early_warning.py

------
https://chatgpt.com/codex/tasks/task_e_68d775efa9c48333a74cad101e84d485