### PR TITLE
feat: add redaction consistent search indexer service

### DIFF
--- a/sdk/typescript/jest.config.cjs
+++ b/sdk/typescript/jest.config.cjs
@@ -1,0 +1,14 @@
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/test'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'mjs'],
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.json',
+      useESM: true,
+    },
+  },
+};
+

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,2 +1,3 @@
 export * from './client';
+export * from './rcsi';
 export * from '../sdk/ts/src/generated';

--- a/sdk/typescript/src/rcsi/client.ts
+++ b/sdk/typescript/src/rcsi/client.ts
@@ -1,0 +1,106 @@
+import type {
+  DocumentInput,
+  IndexSnapshot,
+  Proof,
+  ReconcileReport,
+  RedactionEvent,
+} from './types';
+import { validateProof } from './proof';
+
+export interface ClientOptions {
+  baseUrl: string;
+  fetchImpl?: typeof fetch;
+}
+
+const defaultHeaders = {
+  'Content-Type': 'application/json',
+};
+
+export class RCSIClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: ClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, '');
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async addDocument(document: DocumentInput): Promise<void> {
+    await this.post('/documents', document);
+  }
+
+  async applyRedaction(event: RedactionEvent): Promise<void> {
+    if (event.type === 'document') {
+      await this.post('/redactions/document', {
+        documentId: event.documentId,
+        reason: event.reason,
+      });
+    } else {
+      await this.post('/redactions/term', {
+        term: event.term,
+        documentId: event.documentId,
+        reason: event.reason,
+      });
+    }
+  }
+
+  async selectiveReindex(documentIds: string[]): Promise<void> {
+    await this.post('/reindex', { documentIds });
+  }
+
+  async reconcile(): Promise<ReconcileReport> {
+    return this.get<ReconcileReport>('/reconcile');
+  }
+
+  async snapshot(): Promise<IndexSnapshot> {
+    return this.get<IndexSnapshot>('/snapshot');
+  }
+
+  async getDocumentProof(documentId: string): Promise<Proof> {
+    const proof = await this.get<Proof>(`/proofs/doc/${encodeURIComponent(documentId)}`);
+    return proof;
+  }
+
+  async getTermProof(term: string, documentId: string): Promise<Proof> {
+    const proof = await this.get<Proof>(
+      `/proofs/term/${encodeURIComponent(term)}?documentId=${encodeURIComponent(documentId)}`,
+    );
+    return proof;
+  }
+
+  async validateDocumentProof(documentId: string, snapshot?: IndexSnapshot): Promise<void> {
+    const proof = await this.getDocumentProof(documentId);
+    const snap = snapshot ?? (await this.snapshot());
+    validateProof(proof, snap);
+  }
+
+  async validateTermProof(term: string, documentId: string, snapshot?: IndexSnapshot): Promise<void> {
+    const proof = await this.getTermProof(term, documentId);
+    const snap = snapshot ?? (await this.snapshot());
+    validateProof(proof, snap);
+  }
+
+  private async post(path: string, body: unknown): Promise<void> {
+    const response = await this.fetchImpl(this.buildUrl(path), {
+      method: 'POST',
+      headers: defaultHeaders,
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new Error(`request failed (${response.status}): ${await response.text()}`);
+    }
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    const response = await this.fetchImpl(this.buildUrl(path));
+    if (!response.ok) {
+      throw new Error(`request failed (${response.status}): ${await response.text()}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  private buildUrl(path: string): string {
+    return `${this.baseUrl}${path}`;
+  }
+}
+

--- a/sdk/typescript/src/rcsi/index.ts
+++ b/sdk/typescript/src/rcsi/index.ts
@@ -1,0 +1,4 @@
+export * from './client';
+export * from './proof';
+export * from './types';
+

--- a/sdk/typescript/src/rcsi/proof.ts
+++ b/sdk/typescript/src/rcsi/proof.ts
@@ -1,0 +1,92 @@
+import { createHash } from 'crypto';
+
+import type { IndexSnapshot, Proof } from './types';
+
+const NANOS_IN_MILLISECOND = 1_000_000n;
+
+function timestampToNanoseconds(value: string): bigint {
+  const baseMs = BigInt(Date.parse(value));
+  const match = value.match(/\.([0-9]+)(Z|[+-]\d{2}:?\d{2})?$/);
+  let nanos = baseMs * NANOS_IN_MILLISECOND;
+  if (match && match[1]) {
+    const fractional = match[1].padEnd(9, '0').slice(0, 9);
+    nanos += BigInt(fractional);
+  }
+  return nanos;
+}
+
+export function digestFor(
+  kind: 'document' | 'term',
+  term: string | undefined,
+  documentId: string,
+  sequence: number,
+  timestamp: string,
+  reason: string,
+  version: number,
+): string {
+  const components = [
+    kind,
+    term ?? '',
+    documentId,
+    sequence.toString(),
+    timestampToNanoseconds(timestamp).toString(),
+    reason,
+    version.toString(),
+  ];
+  return createHash('sha256').update(components.join('|')).digest('hex');
+}
+
+export function validateProof(proof: Proof, snapshot: IndexSnapshot): void {
+  if (proof.version > snapshot.version) {
+    throw new Error(`proof version ${proof.version} is ahead of snapshot ${snapshot.version}`);
+  }
+
+  if (proof.kind === 'document') {
+    const stillPresent = snapshot.documents.some((doc) => doc.id === proof.documentId);
+    if (stillPresent) {
+      throw new Error(`document ${proof.documentId} still present in snapshot`);
+    }
+    const tombstone = snapshot.documentTombstones.find((ts) => ts.documentId === proof.documentId);
+    if (!tombstone) {
+      throw new Error(`no tombstone for document ${proof.documentId}`);
+    }
+    const expected = digestFor(
+      'document',
+      tombstone.term,
+      tombstone.documentId,
+      tombstone.sequence,
+      tombstone.timestamp,
+      tombstone.reason,
+      tombstone.version,
+    );
+    if (expected !== tombstone.digest) {
+      throw new Error(`digest mismatch for document ${proof.documentId}`);
+    }
+  } else {
+    if (!proof.term) {
+      throw new Error('term proof requires term');
+    }
+    const posting = snapshot.inverted.find((entry) => entry.term === proof.term);
+    if (posting && posting.documents.includes(proof.documentId)) {
+      throw new Error(`term ${proof.term} still linked to document ${proof.documentId}`);
+    }
+    const group = snapshot.termTombstones.find((entry) => entry.term === proof.term);
+    const tombstone = group?.tombstones.find((ts) => ts.documentId === proof.documentId);
+    if (!tombstone) {
+      throw new Error(`no tombstone for term ${proof.term} and document ${proof.documentId}`);
+    }
+    const expected = digestFor(
+      'term',
+      proof.term,
+      proof.documentId,
+      tombstone.sequence,
+      tombstone.timestamp,
+      tombstone.reason,
+      tombstone.version,
+    );
+    if (expected !== tombstone.digest) {
+      throw new Error(`digest mismatch for term ${proof.term} and document ${proof.documentId}`);
+    }
+  }
+}
+

--- a/sdk/typescript/src/rcsi/types.ts
+++ b/sdk/typescript/src/rcsi/types.ts
@@ -1,0 +1,76 @@
+export type RedactionType = 'document' | 'term';
+
+export interface DocumentInput {
+  id: string;
+  tokens: string[];
+  vector: number[];
+  metadata?: Record<string, string>;
+}
+
+export interface RedactionEvent {
+  type: RedactionType;
+  documentId?: string;
+  term?: string;
+  reason: string;
+}
+
+export interface Tombstone {
+  term?: string;
+  documentId: string;
+  reason: string;
+  sequence: number;
+  timestamp: string;
+  digest: string;
+  version: number;
+}
+
+export interface DocumentView {
+  id: string;
+  tokens: string[];
+  vector: number[];
+  metadata?: Record<string, string>;
+  updatedAt: string;
+}
+
+export interface InvertedPosting {
+  term: string;
+  documents: string[];
+}
+
+export interface VectorEntry {
+  documentId: string;
+  vector: number[];
+}
+
+export interface TermTombstoneView {
+  term: string;
+  tombstones: Tombstone[];
+}
+
+export interface Proof {
+  kind: 'document' | 'term';
+  term?: string;
+  documentId: string;
+  query: string;
+  tombstone: Tombstone;
+  version: number;
+}
+
+export interface IndexSnapshot {
+  version: number;
+  documents: DocumentView[];
+  inverted: InvertedPosting[];
+  vectors: VectorEntry[];
+  documentTombstones: Tombstone[];
+  termTombstones: TermTombstoneView[];
+  proofs: Proof[];
+}
+
+export interface ReconcileReport {
+  version: number;
+  staleTokens: Record<string, string[]>;
+  staleVectors: string[];
+  missingTokens: Record<string, string[]>;
+  missingVectors: string[];
+}
+

--- a/sdk/typescript/test/rcsi.test.ts
+++ b/sdk/typescript/test/rcsi.test.ts
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { digestFor, validateProof } from '../src/rcsi/proof';
+import type { Proof } from '../src/rcsi/types';
+
+function loadSnapshot() {
+  const file = path.resolve(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'services',
+    'rcsi',
+    'internal',
+    'index',
+    'testdata',
+    'index_snapshot.json',
+  );
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+describe('RCSI snapshot compatibility', () => {
+  const snapshot = loadSnapshot();
+
+  it('validates document proofs against the snapshot', () => {
+    const tombstone = snapshot.documentTombstones.find((ts: any) => ts.documentId === 'doc-003');
+    expect(tombstone).toBeDefined();
+    if (!tombstone) {
+      return;
+    }
+    const proof: Proof = {
+      kind: 'document',
+      documentId: tombstone.documentId,
+      query: tombstone.documentId,
+      tombstone,
+      version: snapshot.version,
+    };
+    expect(() => validateProof(proof, snapshot)).not.toThrow();
+    expect(
+      digestFor(
+        'document',
+        tombstone.term,
+        tombstone.documentId,
+        tombstone.sequence,
+        tombstone.timestamp,
+        tombstone.reason,
+        tombstone.version,
+      ),
+    ).toEqual(tombstone.digest);
+  });
+
+  it('validates term proofs against the snapshot', () => {
+    const group = snapshot.termTombstones.find((entry: any) => entry.term === 'erasure');
+    expect(group).toBeDefined();
+    if (!group) {
+      return;
+    }
+    const tombstone = group.tombstones[0];
+    const proof: Proof = {
+      kind: 'term',
+      term: group.term,
+      documentId: tombstone.documentId,
+      query: `${group.term}#${tombstone.documentId}`,
+      tombstone,
+      version: snapshot.version,
+    };
+    expect(() => validateProof(proof, snapshot)).not.toThrow();
+  });
+
+  it('rejects tampered proofs', () => {
+    const tombstone = snapshot.documentTombstones[0];
+    const proof: Proof = {
+      kind: 'document',
+      documentId: 'doc-001',
+      query: 'doc-001',
+      tombstone,
+      version: snapshot.version,
+    };
+    expect(() => validateProof(proof, snapshot)).toThrow();
+  });
+});
+

--- a/services/rcsi/cmd/rcsi/main.go
+++ b/services/rcsi/cmd/rcsi/main.go
@@ -1,0 +1,329 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"rcsi/internal/index"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(1)
+	}
+
+	cmd := os.Args[1]
+	args := os.Args[2:]
+
+	switch cmd {
+	case "serve":
+		if err := cmdServe(args); err != nil {
+			log.Fatalf("serve: %v", err)
+		}
+	case "reconcile":
+		if err := cmdReconcile(args); err != nil {
+			log.Fatalf("reconcile: %v", err)
+		}
+	case "snapshot":
+		if err := cmdSnapshot(args); err != nil {
+			log.Fatalf("snapshot: %v", err)
+		}
+	case "proof":
+		if err := cmdProof(args); err != nil {
+			log.Fatalf("proof: %v", err)
+		}
+	default:
+		usage()
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "rcsi <serve|reconcile|snapshot|proof> [flags]\n")
+}
+
+func cmdServe(args []string) error {
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	addr := fs.String("addr", ":8080", "listen address")
+	corpus := fs.String("corpus", "", "path to corpus fixture")
+	redactions := fs.String("redactions", "", "path to redaction fixture")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	idx := index.New()
+	if err := hydrateIndex(idx, *corpus, *redactions); err != nil {
+		return err
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/documents", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var doc index.Document
+		if err := decodeJSON(r, &doc); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := idx.AddDocument(doc); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{"status": "indexed"})
+	})
+
+	mux.HandleFunc("/redactions/document", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var payload struct {
+			DocumentID string `json:"documentId"`
+			Reason     string `json:"reason"`
+		}
+		if err := decodeJSON(r, &payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := idx.RedactDocument(payload.DocumentID, payload.Reason); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{"status": "redacted"})
+	})
+
+	mux.HandleFunc("/redactions/term", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var payload struct {
+			Term       string `json:"term"`
+			DocumentID string `json:"documentId"`
+			Reason     string `json:"reason"`
+		}
+		if err := decodeJSON(r, &payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := idx.RedactTerm(payload.Term, payload.DocumentID, payload.Reason); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusAccepted, map[string]any{"status": "redacted"})
+	})
+
+	mux.HandleFunc("/reindex", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var payload struct {
+			DocumentIDs []string `json:"documentIds"`
+		}
+		if err := decodeJSON(r, &payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		idx.SelectiveReindex(payload.DocumentIDs)
+		writeJSON(w, http.StatusAccepted, map[string]any{"status": "reindexed"})
+	})
+
+	mux.HandleFunc("/reconcile", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		report := idx.Reconcile()
+		writeJSON(w, http.StatusOK, report)
+	})
+
+	mux.HandleFunc("/snapshot", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		snapshot := idx.Snapshot()
+		writeJSON(w, http.StatusOK, snapshot)
+	})
+
+	mux.HandleFunc("/proofs/doc/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		id := strings.TrimPrefix(r.URL.Path, "/proofs/doc/")
+		proof, err := idx.NegativeProofDocument(id)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, proof)
+	})
+
+	mux.HandleFunc("/proofs/term/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		path := strings.TrimPrefix(r.URL.Path, "/proofs/term/")
+		documentID := r.URL.Query().Get("documentId")
+		proof, err := idx.NegativeProofTerm(path, documentID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, proof)
+	})
+
+	log.Printf("rcsi listening on %s", *addr)
+	return http.ListenAndServe(*addr, mux)
+}
+
+func cmdReconcile(args []string) error {
+	fs := flag.NewFlagSet("reconcile", flag.ContinueOnError)
+	corpus := fs.String("corpus", "", "path to corpus fixture")
+	redactions := fs.String("redactions", "", "path to redaction fixture")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	idx := index.New()
+	if err := hydrateIndex(idx, *corpus, *redactions); err != nil {
+		return err
+	}
+	report := idx.Reconcile()
+	return encodeToStdout(report)
+}
+
+func cmdSnapshot(args []string) error {
+	fs := flag.NewFlagSet("snapshot", flag.ContinueOnError)
+	corpus := fs.String("corpus", "", "path to corpus fixture")
+	redactions := fs.String("redactions", "", "path to redaction fixture")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	idx := index.New()
+	if err := hydrateIndex(idx, *corpus, *redactions); err != nil {
+		return err
+	}
+	snapshot := idx.Snapshot()
+	return encodeToStdout(snapshot)
+}
+
+func cmdProof(args []string) error {
+	fs := flag.NewFlagSet("proof", flag.ContinueOnError)
+	kind := fs.String("kind", "document", "proof kind: document|term")
+	corpus := fs.String("corpus", "", "path to corpus fixture")
+	redactions := fs.String("redactions", "", "path to redaction fixture")
+	documentID := fs.String("document", "", "document identifier")
+	term := fs.String("term", "", "term (for term proofs)")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	idx := index.New()
+	if err := hydrateIndex(idx, *corpus, *redactions); err != nil {
+		return err
+	}
+
+	switch *kind {
+	case "document":
+		proof, err := idx.NegativeProofDocument(*documentID)
+		if err != nil {
+			return err
+		}
+		return encodeToStdout(proof)
+	case "term":
+		proof, err := idx.NegativeProofTerm(*term, *documentID)
+		if err != nil {
+			return err
+		}
+		return encodeToStdout(proof)
+	default:
+		return fmt.Errorf("unsupported proof kind %s", *kind)
+	}
+}
+
+func hydrateIndex(idx *index.Index, corpusPath, redactionsPath string) error {
+	docs, err := loadDocuments(corpusPath)
+	if err != nil {
+		return err
+	}
+	events, err := loadRedactions(redactionsPath)
+	if err != nil {
+		return err
+	}
+	return idx.ApplyFixtures(docs, events)
+}
+
+func loadDocuments(path string) ([]index.Document, error) {
+	if path == "" {
+		return nil, nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	content, err := os.ReadFile(abs)
+	if err != nil {
+		return nil, err
+	}
+	var docs []index.Document
+	if err := json.Unmarshal(content, &docs); err != nil {
+		return nil, err
+	}
+	return docs, nil
+}
+
+func loadRedactions(path string) ([]index.RedactionEvent, error) {
+	if path == "" {
+		return nil, nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	content, err := os.ReadFile(abs)
+	if err != nil {
+		return nil, err
+	}
+	var events []index.RedactionEvent
+	if err := json.Unmarshal(content, &events); err != nil {
+		return nil, err
+	}
+	return events, nil
+}
+
+func decodeJSON(r *http.Request, target any) error {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	return nil
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		log.Printf("error writing response: %v", err)
+	}
+}
+
+func encodeToStdout(payload any) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(payload)
+}

--- a/services/rcsi/doc.go
+++ b/services/rcsi/doc.go
@@ -1,0 +1,2 @@
+// Package rcsi documents the Redaction-Consistent Search Indexer module.
+package rcsi

--- a/services/rcsi/fixtures/corpus.json
+++ b/services/rcsi/fixtures/corpus.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "doc-001",
+    "tokens": ["privacy", "policy", "rtbf"],
+    "vector": [0.12, 0.34, 0.56]
+  },
+  {
+    "id": "doc-002",
+    "tokens": ["user", "request", "erasure"],
+    "vector": [0.91, 0.17, 0.38]
+  },
+  {
+    "id": "doc-003",
+    "tokens": ["legacy", "record", "archive"],
+    "vector": [0.42, 0.58, 0.33]
+  }
+]

--- a/services/rcsi/fixtures/redactions.json
+++ b/services/rcsi/fixtures/redactions.json
@@ -1,0 +1,13 @@
+[
+  {
+    "type": "term",
+    "term": "erasure",
+    "documentId": "doc-002",
+    "reason": "rtbf-accepted"
+  },
+  {
+    "type": "document",
+    "documentId": "doc-003",
+    "reason": "rtbf-erase"
+  }
+]

--- a/services/rcsi/go.mod
+++ b/services/rcsi/go.mod
@@ -1,0 +1,4 @@
+module rcsi
+
+go 1.21
+

--- a/services/rcsi/internal/index/index.go
+++ b/services/rcsi/internal/index/index.go
@@ -1,0 +1,640 @@
+package index
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Document represents a searchable record tracked by the index service.
+type Document struct {
+	ID        string            `json:"id"`
+	Tokens    []string          `json:"tokens"`
+	Vector    []float64         `json:"vector"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	UpdatedAt time.Time         `json:"updatedAt"`
+}
+
+// RedactionEvent captures a redaction/RTBF mutation that needs to be applied.
+type RedactionEvent struct {
+	Type       RedactionType `json:"type"`
+	DocumentID string        `json:"documentId,omitempty"`
+	Term       string        `json:"term,omitempty"`
+	Reason     string        `json:"reason"`
+}
+
+// RedactionType enumerates the types of redactions the index tracks.
+type RedactionType string
+
+const (
+	// RedactionTypeDocument fully removes a document from all indices.
+	RedactionTypeDocument RedactionType = "document"
+	// RedactionTypeTerm removes a specific term/document association.
+	RedactionTypeTerm RedactionType = "term"
+)
+
+// ProofKind distinguishes the supported negative proof flavours.
+type ProofKind string
+
+const (
+	ProofKindDocument ProofKind = "document"
+	ProofKindTerm     ProofKind = "term"
+)
+
+// Tombstone captures an immutable deletion record.
+type Tombstone struct {
+	Term       string    `json:"term,omitempty"`
+	DocumentID string    `json:"documentId"`
+	Reason     string    `json:"reason"`
+	Sequence   uint64    `json:"sequence"`
+	Timestamp  time.Time `json:"timestamp"`
+	Digest     string    `json:"digest"`
+	Version    uint64    `json:"version"`
+}
+
+// tombstoneView is used to provide deterministic JSON snapshots.
+type tombstoneView struct {
+	Term       string `json:"term,omitempty"`
+	DocumentID string `json:"documentId"`
+	Reason     string `json:"reason"`
+	Sequence   uint64 `json:"sequence"`
+	Timestamp  string `json:"timestamp"`
+	Digest     string `json:"digest"`
+	Version    uint64 `json:"version"`
+}
+
+// Proof provides an offline verifiable negative inclusion proof.
+type Proof struct {
+	Kind      ProofKind `json:"kind"`
+	Term      string    `json:"term,omitempty"`
+	Document  string    `json:"documentId"`
+	Query     string    `json:"query"`
+	Tombstone Tombstone `json:"tombstone"`
+	Version   uint64    `json:"version"`
+}
+
+// proofView is used for deterministic snapshots of proofs.
+type proofView struct {
+	Kind      ProofKind     `json:"kind"`
+	Term      string        `json:"term,omitempty"`
+	Document  string        `json:"documentId"`
+	Query     string        `json:"query"`
+	Tombstone tombstoneView `json:"tombstone"`
+	Version   uint64        `json:"version"`
+}
+
+// InvertedPosting is a deterministic view of a postings list.
+type InvertedPosting struct {
+	Term      string   `json:"term"`
+	Documents []string `json:"documents"`
+}
+
+// VectorEntry is a deterministic snapshot of a vector index entry.
+type VectorEntry struct {
+	DocumentID string    `json:"documentId"`
+	Vector     []float64 `json:"vector"`
+}
+
+// DocumentView is a deterministic view of a document.
+type DocumentView struct {
+	ID        string            `json:"id"`
+	Tokens    []string          `json:"tokens"`
+	Vector    []float64         `json:"vector"`
+	Metadata  map[string]string `json:"metadata,omitempty"`
+	UpdatedAt string            `json:"updatedAt"`
+}
+
+// TermTombstoneView groups tombstones by term.
+type TermTombstoneView struct {
+	Term       string          `json:"term"`
+	Tombstones []tombstoneView `json:"tombstones"`
+}
+
+// IndexSnapshot fully describes the index in a deterministic form.
+type IndexSnapshot struct {
+	Version            uint64              `json:"version"`
+	Documents          []DocumentView      `json:"documents"`
+	InvertedPostings   []InvertedPosting   `json:"inverted"`
+	VectorEntries      []VectorEntry       `json:"vectors"`
+	DocumentTombstones []tombstoneView     `json:"documentTombstones"`
+	TermTombstones     []TermTombstoneView `json:"termTombstones"`
+	Proofs             []proofView         `json:"proofs"`
+}
+
+// ReconcileReport captures the outcome of reconciling the corpus against the indices.
+type ReconcileReport struct {
+	Version        uint64              `json:"version"`
+	StaleTokens    map[string][]string `json:"staleTokens"`
+	StaleVectors   []string            `json:"staleVectors"`
+	MissingTokens  map[string][]string `json:"missingTokens"`
+	MissingVectors []string            `json:"missingVectors"`
+}
+
+// clockFn provides a hook for deterministic time sources.
+type clockFn func() time.Time
+
+// Index manages inverted and vector indices while tracking tombstones.
+type Index struct {
+	mu sync.RWMutex
+
+	clock clockFn
+
+	version  uint64
+	sequence uint64
+
+	corpus   map[string]Document
+	inverted map[string]map[string]struct{}
+	vectors  map[string][]float64
+
+	documentTombstones map[string]Tombstone
+	termTombstones     map[string]map[string]Tombstone
+}
+
+// Option configures the index instance.
+type Option func(*Index)
+
+// WithClock overrides the default clock used for timestamps.
+func WithClock(fn clockFn) Option {
+	return func(i *Index) {
+		if fn != nil {
+			i.clock = fn
+		}
+	}
+}
+
+// New creates a new Index.
+func New(opts ...Option) *Index {
+	idx := &Index{
+		clock:              time.Now,
+		corpus:             make(map[string]Document),
+		inverted:           make(map[string]map[string]struct{}),
+		vectors:            make(map[string][]float64),
+		documentTombstones: make(map[string]Tombstone),
+		termTombstones:     make(map[string]map[string]Tombstone),
+	}
+	for _, opt := range opts {
+		opt(idx)
+	}
+	return idx
+}
+
+// AddDocument indexes the provided document.
+func (idx *Index) AddDocument(doc Document) error {
+	if doc.ID == "" {
+		return errors.New("document id is required")
+	}
+
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	now := idx.clock()
+	doc.UpdatedAt = now
+	cloned := cloneDocument(doc)
+
+	idx.corpus[doc.ID] = cloned
+	idx.vectors[doc.ID] = append([]float64(nil), doc.Vector...)
+
+	idx.removeDocFromInvertedLocked(doc.ID)
+	for _, token := range doc.Tokens {
+		if token == "" {
+			continue
+		}
+		if _, ok := idx.inverted[token]; !ok {
+			idx.inverted[token] = make(map[string]struct{})
+		}
+		idx.inverted[token][doc.ID] = struct{}{}
+	}
+
+	idx.version++
+	return nil
+}
+
+// RedactDocument completely removes a document from the index.
+func (idx *Index) RedactDocument(id, reason string) error {
+	if id == "" {
+		return errors.New("document id is required")
+	}
+
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	doc, ok := idx.corpus[id]
+	if ok {
+		for _, token := range doc.Tokens {
+			if postings, exists := idx.inverted[token]; exists {
+				delete(postings, id)
+				if len(postings) == 0 {
+					delete(idx.inverted, token)
+				}
+			}
+		}
+		delete(idx.corpus, id)
+	}
+
+	delete(idx.vectors, id)
+
+	idx.sequence++
+	ts := Tombstone{
+		DocumentID: id,
+		Reason:     reason,
+		Sequence:   idx.sequence,
+		Timestamp:  idx.clock(),
+		Version:    idx.version + 1,
+	}
+	ts.Digest = digestFor("document", ts.Term, ts.DocumentID, ts.Sequence, ts.Timestamp, ts.Reason, ts.Version)
+	idx.documentTombstones[id] = ts
+
+	idx.version++
+	return nil
+}
+
+// RedactTerm removes a specific term/document association.
+func (idx *Index) RedactTerm(term, documentID, reason string) error {
+	if term == "" {
+		return errors.New("term is required")
+	}
+	if documentID == "" {
+		return errors.New("document id is required")
+	}
+
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	if postings, ok := idx.inverted[term]; ok {
+		delete(postings, documentID)
+		if len(postings) == 0 {
+			delete(idx.inverted, term)
+		}
+	}
+
+	if doc, ok := idx.corpus[documentID]; ok {
+		filtered := make([]string, 0, len(doc.Tokens))
+		for _, token := range doc.Tokens {
+			if token == term {
+				continue
+			}
+			filtered = append(filtered, token)
+		}
+		doc.Tokens = filtered
+		idx.corpus[documentID] = doc
+	}
+
+	idx.sequence++
+	ts := Tombstone{
+		Term:       term,
+		DocumentID: documentID,
+		Reason:     reason,
+		Sequence:   idx.sequence,
+		Timestamp:  idx.clock(),
+		Version:    idx.version + 1,
+	}
+	ts.Digest = digestFor("term", ts.Term, ts.DocumentID, ts.Sequence, ts.Timestamp, ts.Reason, ts.Version)
+
+	if _, ok := idx.termTombstones[term]; !ok {
+		idx.termTombstones[term] = make(map[string]Tombstone)
+	}
+	idx.termTombstones[term][documentID] = ts
+
+	idx.version++
+	return nil
+}
+
+// SelectiveReindex rebuilds a subset of the indices.
+func (idx *Index) SelectiveReindex(documentIDs []string) {
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	for _, id := range documentIDs {
+		doc, ok := idx.corpus[id]
+		if !ok {
+			continue
+		}
+		idx.removeDocFromInvertedLocked(id)
+		for _, token := range doc.Tokens {
+			if token == "" {
+				continue
+			}
+			if _, ok := idx.inverted[token]; !ok {
+				idx.inverted[token] = make(map[string]struct{})
+			}
+			idx.inverted[token][doc.ID] = struct{}{}
+		}
+		idx.vectors[id] = append([]float64(nil), doc.Vector...)
+	}
+
+	idx.version++
+}
+
+// Snapshot returns a deterministic representation of the indices.
+func (idx *Index) Snapshot() IndexSnapshot {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	snapshot := IndexSnapshot{
+		Version: idx.version,
+	}
+
+	docs := make([]DocumentView, 0, len(idx.corpus))
+	for _, doc := range idx.corpus {
+		view := DocumentView{
+			ID:        doc.ID,
+			Tokens:    append([]string(nil), doc.Tokens...),
+			Vector:    append([]float64(nil), doc.Vector...),
+			UpdatedAt: doc.UpdatedAt.UTC().Format(time.RFC3339Nano),
+		}
+		if doc.Metadata != nil {
+			view.Metadata = cloneMap(doc.Metadata)
+		}
+		docs = append(docs, view)
+	}
+	sort.Slice(docs, func(i, j int) bool {
+		return docs[i].ID < docs[j].ID
+	})
+	snapshot.Documents = docs
+
+	inverted := make([]InvertedPosting, 0, len(idx.inverted))
+	for term, postings := range idx.inverted {
+		docIDs := make([]string, 0, len(postings))
+		for docID := range postings {
+			docIDs = append(docIDs, docID)
+		}
+		sort.Strings(docIDs)
+		inverted = append(inverted, InvertedPosting{Term: term, Documents: docIDs})
+	}
+	sort.Slice(inverted, func(i, j int) bool {
+		return inverted[i].Term < inverted[j].Term
+	})
+	snapshot.InvertedPostings = inverted
+
+	vectors := make([]VectorEntry, 0, len(idx.vectors))
+	for docID, vec := range idx.vectors {
+		vectors = append(vectors, VectorEntry{DocumentID: docID, Vector: append([]float64(nil), vec...)})
+	}
+	sort.Slice(vectors, func(i, j int) bool {
+		return vectors[i].DocumentID < vectors[j].DocumentID
+	})
+	snapshot.VectorEntries = vectors
+
+	docTombstones := make([]tombstoneView, 0, len(idx.documentTombstones))
+	for _, ts := range idx.documentTombstones {
+		docTombstones = append(docTombstones, toTombstoneView(ts))
+	}
+	sort.Slice(docTombstones, func(i, j int) bool {
+		if docTombstones[i].Sequence == docTombstones[j].Sequence {
+			return docTombstones[i].DocumentID < docTombstones[j].DocumentID
+		}
+		return docTombstones[i].Sequence < docTombstones[j].Sequence
+	})
+	snapshot.DocumentTombstones = docTombstones
+
+	termTombstones := make([]TermTombstoneView, 0, len(idx.termTombstones))
+	for term, tombstones := range idx.termTombstones {
+		group := TermTombstoneView{Term: term}
+		for _, ts := range tombstones {
+			group.Tombstones = append(group.Tombstones, toTombstoneView(ts))
+		}
+		sort.Slice(group.Tombstones, func(i, j int) bool {
+			if group.Tombstones[i].Sequence == group.Tombstones[j].Sequence {
+				return group.Tombstones[i].DocumentID < group.Tombstones[j].DocumentID
+			}
+			return group.Tombstones[i].Sequence < group.Tombstones[j].Sequence
+		})
+		termTombstones = append(termTombstones, group)
+	}
+	sort.Slice(termTombstones, func(i, j int) bool {
+		return termTombstones[i].Term < termTombstones[j].Term
+	})
+	snapshot.TermTombstones = termTombstones
+
+	// Proofs for each tombstone to aid snapshot-based proof validation.
+	proofs := make([]proofView, 0, len(docTombstones)+len(termTombstones))
+	for _, ts := range snapshot.DocumentTombstones {
+		proofs = append(proofs, proofView{
+			Kind:      ProofKindDocument,
+			Document:  ts.DocumentID,
+			Query:     ts.DocumentID,
+			Tombstone: ts,
+			Version:   idx.version,
+		})
+	}
+	for _, group := range snapshot.TermTombstones {
+		for _, ts := range group.Tombstones {
+			proofs = append(proofs, proofView{
+				Kind:      ProofKindTerm,
+				Term:      group.Term,
+				Document:  ts.DocumentID,
+				Query:     fmt.Sprintf("%s#%s", group.Term, ts.DocumentID),
+				Tombstone: ts,
+				Version:   idx.version,
+			})
+		}
+	}
+	sort.Slice(proofs, func(i, j int) bool {
+		if proofs[i].Kind == proofs[j].Kind {
+			if proofs[i].Term == proofs[j].Term {
+				return proofs[i].Document < proofs[j].Document
+			}
+			return proofs[i].Term < proofs[j].Term
+		}
+		return proofs[i].Kind < proofs[j].Kind
+	})
+	snapshot.Proofs = proofs
+
+	return snapshot
+}
+
+// NegativeProofDocument issues a proof that a document has been redacted.
+func (idx *Index) NegativeProofDocument(id string) (Proof, error) {
+	if id == "" {
+		return Proof{}, errors.New("document id is required")
+	}
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	if _, exists := idx.corpus[id]; exists {
+		return Proof{}, fmt.Errorf("document %s still present", id)
+	}
+	tombstone, ok := idx.documentTombstones[id]
+	if !ok {
+		return Proof{}, fmt.Errorf("no tombstone for document %s", id)
+	}
+
+	return Proof{
+		Kind:      ProofKindDocument,
+		Document:  id,
+		Query:     id,
+		Tombstone: tombstone,
+		Version:   idx.version,
+	}, nil
+}
+
+// NegativeProofTerm issues a proof that a term/document association has been redacted.
+func (idx *Index) NegativeProofTerm(term, documentID string) (Proof, error) {
+	if term == "" {
+		return Proof{}, errors.New("term is required")
+	}
+	if documentID == "" {
+		return Proof{}, errors.New("document id is required")
+	}
+
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	if postings, ok := idx.inverted[term]; ok {
+		if _, exists := postings[documentID]; exists {
+			return Proof{}, fmt.Errorf("document %s still contains term %s", documentID, term)
+		}
+	}
+
+	tombstones, ok := idx.termTombstones[term]
+	if !ok {
+		return Proof{}, fmt.Errorf("no tombstones for term %s", term)
+	}
+	tombstone, ok := tombstones[documentID]
+	if !ok {
+		return Proof{}, fmt.Errorf("no tombstone for term %s and document %s", term, documentID)
+	}
+
+	return Proof{
+		Kind:      ProofKindTerm,
+		Term:      term,
+		Document:  documentID,
+		Query:     fmt.Sprintf("%s#%s", term, documentID),
+		Tombstone: tombstone,
+		Version:   idx.version,
+	}, nil
+}
+
+// Reconcile compares the corpus with the indices and tombstones.
+func (idx *Index) Reconcile() ReconcileReport {
+	idx.mu.RLock()
+	defer idx.mu.RUnlock()
+
+	report := ReconcileReport{
+		Version:       idx.version,
+		StaleTokens:   make(map[string][]string),
+		MissingTokens: make(map[string][]string),
+	}
+
+	// Identify stale tokens (documents referenced by postings but missing from corpus).
+	for term, postings := range idx.inverted {
+		for docID := range postings {
+			if _, ok := idx.corpus[docID]; !ok {
+				report.StaleTokens[term] = append(report.StaleTokens[term], docID)
+			}
+		}
+	}
+
+	// Identify stale vectors.
+	for docID := range idx.vectors {
+		if _, ok := idx.corpus[docID]; !ok {
+			report.StaleVectors = append(report.StaleVectors, docID)
+		}
+	}
+
+	// Identify missing tokens and vectors for documents still in corpus.
+	for docID, doc := range idx.corpus {
+		for _, token := range doc.Tokens {
+			postings := idx.inverted[token]
+			if postings == nil {
+				report.MissingTokens[token] = append(report.MissingTokens[token], docID)
+				continue
+			}
+			if _, ok := postings[docID]; !ok {
+				report.MissingTokens[token] = append(report.MissingTokens[token], docID)
+			}
+		}
+		if _, ok := idx.vectors[docID]; !ok {
+			report.MissingVectors = append(report.MissingVectors, docID)
+		}
+	}
+
+	for term := range report.StaleTokens {
+		sort.Strings(report.StaleTokens[term])
+	}
+	for term := range report.MissingTokens {
+		sort.Strings(report.MissingTokens[term])
+	}
+	sort.Strings(report.StaleVectors)
+	sort.Strings(report.MissingVectors)
+
+	return report
+}
+
+// ApplyFixtures loads documents and applies redactions from fixtures.
+func (idx *Index) ApplyFixtures(docs []Document, redactions []RedactionEvent) error {
+	for _, doc := range docs {
+		if err := idx.AddDocument(doc); err != nil {
+			return err
+		}
+	}
+	for _, event := range redactions {
+		switch event.Type {
+		case RedactionTypeDocument:
+			if err := idx.RedactDocument(event.DocumentID, event.Reason); err != nil {
+				return err
+			}
+		case RedactionTypeTerm:
+			if err := idx.RedactTerm(event.Term, event.DocumentID, event.Reason); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported redaction type %s", event.Type)
+		}
+	}
+	return nil
+}
+
+// ExportSnapshot renders the snapshot as a formatted JSON payload.
+func ExportSnapshot(snapshot IndexSnapshot) ([]byte, error) {
+	return json.MarshalIndent(snapshot, "", "  ")
+}
+
+func cloneDocument(doc Document) Document {
+	cloned := Document{
+		ID:        doc.ID,
+		Tokens:    append([]string(nil), doc.Tokens...),
+		Vector:    append([]float64(nil), doc.Vector...),
+		UpdatedAt: doc.UpdatedAt,
+	}
+	if doc.Metadata != nil {
+		cloned.Metadata = cloneMap(doc.Metadata)
+	}
+	return cloned
+}
+
+func cloneMap(m map[string]string) map[string]string {
+	if m == nil {
+		return nil
+	}
+	cloned := make(map[string]string, len(m))
+	for k, v := range m {
+		cloned[k] = v
+	}
+	return cloned
+}
+
+func toTombstoneView(ts Tombstone) tombstoneView {
+	return tombstoneView{
+		Term:       ts.Term,
+		DocumentID: ts.DocumentID,
+		Reason:     ts.Reason,
+		Sequence:   ts.Sequence,
+		Timestamp:  ts.Timestamp.UTC().Format(time.RFC3339Nano),
+		Digest:     ts.Digest,
+		Version:    ts.Version,
+	}
+}
+
+func (idx *Index) removeDocFromInvertedLocked(documentID string) {
+	for term, postings := range idx.inverted {
+		delete(postings, documentID)
+		if len(postings) == 0 {
+			delete(idx.inverted, term)
+		}
+	}
+}

--- a/services/rcsi/internal/index/index_test.go
+++ b/services/rcsi/internal/index/index_test.go
@@ -1,0 +1,134 @@
+package index_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"rcsi/internal/index"
+)
+
+func TestIndexSnapshotAndProofs(t *testing.T) {
+	clockFactory := func() func() time.Time {
+		base := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
+		cursor := 0
+		return func() time.Time {
+			t := base.Add(time.Duration(cursor) * time.Hour)
+			cursor++
+			return t
+		}
+	}
+
+	idx := index.New(index.WithClock(clockFactory()))
+
+	docs := mustLoadDocuments(t, filepath.Join("..", "..", "fixtures", "corpus.json"))
+	redactions := mustLoadRedactions(t, filepath.Join("..", "..", "fixtures", "redactions.json"))
+
+	if err := idx.ApplyFixtures(docs, redactions); err != nil {
+		t.Fatalf("apply fixtures: %v", err)
+	}
+
+	// Ensure selective reindex leaves the state stable and deterministic.
+	idx.SelectiveReindex([]string{"doc-001", "doc-002"})
+
+	report := idx.Reconcile()
+	if len(report.StaleTokens) != 0 || len(report.StaleVectors) != 0 {
+		t.Fatalf("expected no stale tokens/vectors, got %+v", report)
+	}
+
+	snapshot := idx.Snapshot()
+	data, err := index.ExportSnapshot(snapshot)
+	if err != nil {
+		t.Fatalf("export snapshot: %v", err)
+	}
+
+	snapshotPath := filepath.Join("testdata", "index_snapshot.json")
+	if os.Getenv("UPDATE_SNAPSHOT") == "1" {
+		if err := os.WriteFile(snapshotPath, data, 0o644); err != nil {
+			t.Fatalf("update snapshot: %v", err)
+		}
+	}
+
+	expected, err := os.ReadFile(snapshotPath)
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+
+	if string(expected) != string(data) {
+		t.Fatalf("snapshot mismatch\nexpected:%s\nactual:%s", expected, data)
+	}
+
+	docProof, err := idx.NegativeProofDocument("doc-003")
+	if err != nil {
+		t.Fatalf("document proof: %v", err)
+	}
+	if err := index.ValidateProof(docProof, snapshot); err != nil {
+		t.Fatalf("validate document proof: %v", err)
+	}
+
+	termProof, err := idx.NegativeProofTerm("erasure", "doc-002")
+	if err != nil {
+		t.Fatalf("term proof: %v", err)
+	}
+	if err := index.ValidateProof(termProof, snapshot); err != nil {
+		t.Fatalf("validate term proof: %v", err)
+	}
+
+	// Deterministic run check: rebuild from scratch and compare snapshots.
+	idx2 := index.New(index.WithClock(clockFactory()))
+	if err := idx2.ApplyFixtures(docs, redactions); err != nil {
+		t.Fatalf("apply fixtures second run: %v", err)
+	}
+	idx2.SelectiveReindex([]string{"doc-001", "doc-002"})
+
+	snapshot2 := idx2.Snapshot()
+	data2, err := index.ExportSnapshot(snapshot2)
+	if err != nil {
+		t.Fatalf("export snapshot second run: %v", err)
+	}
+	if string(data) != string(data2) {
+		t.Fatalf("snapshots diverged between runs")
+	}
+
+	// Proofs remain valid against independent snapshot.
+	if err := index.ValidateProof(docProof, snapshot2); err != nil {
+		t.Fatalf("validate doc proof on second snapshot: %v", err)
+	}
+	if err := index.ValidateProof(termProof, snapshot2); err != nil {
+		t.Fatalf("validate term proof on second snapshot: %v", err)
+	}
+}
+
+func mustLoadDocuments(t *testing.T, path string) []index.Document {
+	t.Helper()
+	if path == "" {
+		return nil
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read documents: %v", err)
+	}
+	var docs []index.Document
+	if err := json.Unmarshal(content, &docs); err != nil {
+		t.Fatalf("parse documents: %v", err)
+	}
+	return docs
+}
+
+func mustLoadRedactions(t *testing.T, path string) []index.RedactionEvent {
+	t.Helper()
+	if path == "" {
+		return nil
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read redactions: %v", err)
+	}
+	var events []index.RedactionEvent
+	if err := json.Unmarshal(content, &events); err != nil {
+		t.Fatalf("parse redactions: %v", err)
+	}
+	return events
+}

--- a/services/rcsi/internal/index/proof.go
+++ b/services/rcsi/internal/index/proof.go
@@ -1,0 +1,117 @@
+package index
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ValidateProof verifies a proof against a snapshot of the index state.
+func ValidateProof(proof Proof, snapshot IndexSnapshot) error {
+	if proof.Version > snapshot.Version {
+		return fmt.Errorf("proof version %d is ahead of snapshot version %d", proof.Version, snapshot.Version)
+	}
+
+	switch proof.Kind {
+	case ProofKindDocument:
+		if proof.Document == "" {
+			return errors.New("document proof missing document id")
+		}
+		if containsDocument(snapshot.Documents, proof.Document) {
+			return fmt.Errorf("document %s still present in snapshot", proof.Document)
+		}
+		ts, ok := findDocumentTombstone(snapshot.DocumentTombstones, proof.Document)
+		if !ok {
+			return fmt.Errorf("no tombstone present for document %s", proof.Document)
+		}
+		expected := digestFor("document", ts.Term, ts.DocumentID, ts.Sequence, mustParseTime(ts.Timestamp), ts.Reason, ts.Version)
+		if expected != ts.Digest {
+			return fmt.Errorf("digest mismatch for document %s", proof.Document)
+		}
+	case ProofKindTerm:
+		if proof.Term == "" {
+			return errors.New("term proof missing term")
+		}
+		if proof.Document == "" {
+			return errors.New("term proof missing document id")
+		}
+		if postingExists(snapshot.InvertedPostings, proof.Term, proof.Document) {
+			return fmt.Errorf("term %s still linked to document %s", proof.Term, proof.Document)
+		}
+		ts, ok := findTermTombstone(snapshot.TermTombstones, proof.Term, proof.Document)
+		if !ok {
+			return fmt.Errorf("no term tombstone for %s/%s", proof.Term, proof.Document)
+		}
+		expected := digestFor("term", proof.Term, proof.Document, ts.Sequence, mustParseTime(ts.Timestamp), ts.Reason, ts.Version)
+		if expected != ts.Digest {
+			return fmt.Errorf("digest mismatch for term %s and document %s", proof.Term, proof.Document)
+		}
+	default:
+		return fmt.Errorf("unsupported proof kind %s", proof.Kind)
+	}
+
+	return nil
+}
+
+func digestFor(kind, term, docID string, sequence uint64, ts time.Time, reason string, version uint64) string {
+	payload := fmt.Sprintf("%s|%s|%s|%d|%d|%s|%d", kind, term, docID, sequence, ts.UnixNano(), reason, version)
+	sum := sha256.Sum256([]byte(payload))
+	return hex.EncodeToString(sum[:])
+}
+
+func containsDocument(documents []DocumentView, id string) bool {
+	for _, doc := range documents {
+		if doc.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func postingExists(postings []InvertedPosting, term, docID string) bool {
+	for _, posting := range postings {
+		if posting.Term != term {
+			continue
+		}
+		for _, candidate := range posting.Documents {
+			if candidate == docID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func findDocumentTombstone(tombstones []tombstoneView, docID string) (tombstoneView, bool) {
+	for _, ts := range tombstones {
+		if ts.DocumentID == docID {
+			return ts, true
+		}
+	}
+	return tombstoneView{}, false
+}
+
+func findTermTombstone(groups []TermTombstoneView, term, docID string) (tombstoneView, bool) {
+	for _, group := range groups {
+		if group.Term != term {
+			continue
+		}
+		for _, ts := range group.Tombstones {
+			if ts.DocumentID == docID {
+				return ts, true
+			}
+		}
+	}
+	return tombstoneView{}, false
+}
+
+func mustParseTime(value string) time.Time {
+	ts, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		// Fallback to zero value if parsing fails to ensure deterministic behaviour in validation errors.
+		return time.Unix(0, 0).UTC()
+	}
+	return ts
+}

--- a/services/rcsi/internal/index/testdata/index_snapshot.json
+++ b/services/rcsi/internal/index/testdata/index_snapshot.json
@@ -1,0 +1,140 @@
+{
+  "version": 6,
+  "documents": [
+    {
+      "id": "doc-001",
+      "tokens": [
+        "privacy",
+        "policy",
+        "rtbf"
+      ],
+      "vector": [
+        0.12,
+        0.34,
+        0.56
+      ],
+      "updatedAt": "2024-01-01T00:00:00Z"
+    },
+    {
+      "id": "doc-002",
+      "tokens": [
+        "user",
+        "request"
+      ],
+      "vector": [
+        0.91,
+        0.17,
+        0.38
+      ],
+      "updatedAt": "2024-01-01T01:00:00Z"
+    }
+  ],
+  "inverted": [
+    {
+      "term": "policy",
+      "documents": [
+        "doc-001"
+      ]
+    },
+    {
+      "term": "privacy",
+      "documents": [
+        "doc-001"
+      ]
+    },
+    {
+      "term": "request",
+      "documents": [
+        "doc-002"
+      ]
+    },
+    {
+      "term": "rtbf",
+      "documents": [
+        "doc-001"
+      ]
+    },
+    {
+      "term": "user",
+      "documents": [
+        "doc-002"
+      ]
+    }
+  ],
+  "vectors": [
+    {
+      "documentId": "doc-001",
+      "vector": [
+        0.12,
+        0.34,
+        0.56
+      ]
+    },
+    {
+      "documentId": "doc-002",
+      "vector": [
+        0.91,
+        0.17,
+        0.38
+      ]
+    }
+  ],
+  "documentTombstones": [
+    {
+      "documentId": "doc-003",
+      "reason": "rtbf-erase",
+      "sequence": 2,
+      "timestamp": "2024-01-01T04:00:00Z",
+      "digest": "9669b9cf5ed7cd9818f5954eaf7be008bc6c61e2539da50d5ffd6c6d208343a0",
+      "version": 5
+    }
+  ],
+  "termTombstones": [
+    {
+      "term": "erasure",
+      "tombstones": [
+        {
+          "term": "erasure",
+          "documentId": "doc-002",
+          "reason": "rtbf-accepted",
+          "sequence": 1,
+          "timestamp": "2024-01-01T03:00:00Z",
+          "digest": "e991fd0664501f2a848542aa33cf5c0961f8b38b8811991d8c75e3bad1845bbb",
+          "version": 4
+        }
+      ]
+    }
+  ],
+  "proofs": [
+    {
+      "kind": "document",
+      "documentId": "doc-003",
+      "query": "doc-003",
+      "tombstone": {
+        "documentId": "doc-003",
+        "reason": "rtbf-erase",
+        "sequence": 2,
+        "timestamp": "2024-01-01T04:00:00Z",
+        "digest": "9669b9cf5ed7cd9818f5954eaf7be008bc6c61e2539da50d5ffd6c6d208343a0",
+        "version": 5
+      },
+      "version": 6
+    },
+    {
+      "kind": "term",
+      "term": "erasure",
+      "documentId": "doc-002",
+      "query": "erasure#doc-002",
+      "tombstone": {
+        "term": "erasure",
+        "documentId": "doc-002",
+        "reason": "rtbf-accepted",
+        "sequence": 1,
+        "timestamp": "2024-01-01T03:00:00Z",
+        "digest": "e991fd0664501f2a848542aa33cf5c0961f8b38b8811991d8c75e3bad1845bbb",
+        "version": 4
+      },
+      "version": 6
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- implement the rcsi Go service with inverted/vector indexes, tombstone tracking, selective reindexing, negative proofs, and an HTTP/CLI interface
- add fixtures and deterministic snapshot tests ensuring reconciles stay clean and proofs validate after redactions
- deliver a TypeScript SDK with proof validation helpers, ESM-friendly Jest config, and tests exercising the shared snapshot

## Testing
- go test ./...
- npm --prefix sdk/typescript test -- rcsi

------
https://chatgpt.com/codex/tasks/task_e_68d774caaac08333a570761cf694776d