### PR TITLE
feat: add SRPL macros and lint rule for safe retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "server",
     "packages/mcp-core",
     "apps/intelgraph-mcp",
-    "apps/maestro-mcp"
+    "apps/maestro-mcp",
+    "packages/srpl"
   ],
   "scripts": {
     "bootstrap": "pnpm install --frozen-lockfile",

--- a/packages/srpl/package.json
+++ b/packages/srpl/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@summit/srpl",
+  "version": "0.1.0",
+  "description": "Safe Retrieval Pattern Library with ESLint plugin for approved data access macros",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
+    "test": "vitest run",
+    "prepare": "npm run build"
+  },
+  "keywords": [
+    "sql",
+    "lint",
+    "macro",
+    "security"
+  ],
+  "author": "Summit",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "eslint": "^9.0.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/utils": "^8.44.0",
+    "@vitest/coverage-v8": "^2.1.4",
+    "eslint": "^9.36.0",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.9.2",
+    "vitest": "^2.1.4",
+    "@typescript-eslint/parser": "^8.44.0",
+    "@types/node": "^20.14.9"
+  }
+}

--- a/packages/srpl/src/index.ts
+++ b/packages/srpl/src/index.ts
@@ -1,0 +1,23 @@
+export type {
+  MacroDefinition,
+  MacroInvocationMetadata,
+  MacroName,
+  ParameterizedQuery,
+  PolicyId,
+} from './types.js';
+export type {
+  EntityByIdInput,
+  EntitiesByForeignKeyInput,
+  SearchByPrefixInput,
+  ListActiveInput,
+  OrderDirection,
+} from './macros.js';
+export {
+  entityById,
+  entitiesByForeignKey,
+  searchByPrefix,
+  listActive,
+  macroRegistry,
+} from './macros.js';
+export { POLICY_MAPPING, policyByMacro, policyById } from './policy.js';
+export { rules, configs, srplEslintPlugin } from './plugin/index.js';

--- a/packages/srpl/src/macros.ts
+++ b/packages/srpl/src/macros.ts
@@ -1,0 +1,207 @@
+import type { MacroDefinition, MacroName, ParameterizedQuery, PolicyId } from './types.js';
+
+type OrderDirection = 'ASC' | 'DESC';
+
+const IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function assertIdentifier(value: string, field: string): string {
+  if (!IDENTIFIER_PATTERN.test(value)) {
+    throw new TypeError(`Invalid identifier for ${field}: ${value}`);
+  }
+  return value;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function normalizeColumns(columns?: ReadonlyArray<string>): string[] | undefined {
+  if (!columns || columns.length === 0) {
+    return undefined;
+  }
+  return columns.map((column, index) => quoteIdentifier(assertIdentifier(column, `columns[${index}]`)));
+}
+
+function buildSelectList(columns?: ReadonlyArray<string>): string {
+  if (!columns || columns.length === 0) {
+    return '*';
+  }
+  return columns.join(', ');
+}
+
+function normalizeLimit(limit?: number): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new TypeError(`Limit must be a positive integer. Received: ${limit}`);
+  }
+  return limit;
+}
+
+function normalizeOrder(order?: OrderDirection): OrderDirection | undefined {
+  if (!order) {
+    return undefined;
+  }
+  return order === 'DESC' ? 'DESC' : 'ASC';
+}
+
+function createMacro<Input>(
+  name: MacroName,
+  policy: PolicyId,
+  builder: (input: Input) => ParameterizedQuery,
+): MacroDefinition<Input> {
+  return Object.freeze({
+    name,
+    policy,
+    build(input: Input): ParameterizedQuery {
+      const emitted = builder(input);
+      return {
+        text: emitted.text,
+        values: [...emitted.values],
+      };
+    },
+  });
+}
+
+export interface EntityByIdInput {
+  table: string;
+  id: unknown;
+  idColumn?: string;
+  columns?: ReadonlyArray<string>;
+}
+
+const entityByIdDefinition = createMacro<EntityByIdInput>('entityById', 'SRPL-001', (input) => {
+  const table = quoteIdentifier(assertIdentifier(input.table, 'table'));
+  const idColumn = quoteIdentifier(assertIdentifier(input.idColumn ?? 'id', 'idColumn'));
+  const columns = normalizeColumns(input.columns);
+  const selectList = buildSelectList(columns);
+  return {
+    text: `SELECT ${selectList} FROM ${table} WHERE ${idColumn} = $1`,
+    values: [input.id],
+  };
+});
+
+export function entityById(input: EntityByIdInput): ParameterizedQuery {
+  return entityByIdDefinition.build(input);
+}
+
+export interface EntitiesByForeignKeyInput {
+  table: string;
+  foreignKeyColumn: string;
+  foreignKeyValue: unknown;
+  columns?: ReadonlyArray<string>;
+  limit?: number;
+  sortColumn?: string;
+  sortDirection?: OrderDirection;
+}
+
+const entitiesByForeignKeyDefinition = createMacro<EntitiesByForeignKeyInput>(
+  'entitiesByForeignKey',
+  'SRPL-002',
+  (input) => {
+    const table = quoteIdentifier(assertIdentifier(input.table, 'table'));
+    const fkColumn = quoteIdentifier(assertIdentifier(input.foreignKeyColumn, 'foreignKeyColumn'));
+    const columns = normalizeColumns(input.columns);
+    const selectList = buildSelectList(columns);
+    const limit = normalizeLimit(input.limit);
+    const sortColumn = input.sortColumn
+      ? quoteIdentifier(assertIdentifier(input.sortColumn, 'sortColumn'))
+      : undefined;
+    const sortDirection = normalizeOrder(input.sortDirection);
+
+    let text = `SELECT ${selectList} FROM ${table} WHERE ${fkColumn} = $1`;
+    if (sortColumn) {
+      text += ` ORDER BY ${sortColumn} ${sortDirection ?? 'ASC'}`;
+    }
+    if (limit !== undefined) {
+      text += ` LIMIT ${limit}`;
+    }
+    return {
+      text,
+      values: [input.foreignKeyValue],
+    };
+  },
+);
+
+export function entitiesByForeignKey(input: EntitiesByForeignKeyInput): ParameterizedQuery {
+  return entitiesByForeignKeyDefinition.build(input);
+}
+
+export interface SearchByPrefixInput {
+  table: string;
+  column: string;
+  prefix: string;
+  columns?: ReadonlyArray<string>;
+  limit?: number;
+  caseSensitive?: boolean;
+}
+
+const searchByPrefixDefinition = createMacro<SearchByPrefixInput>('searchByPrefix', 'SRPL-003', (input) => {
+  const table = quoteIdentifier(assertIdentifier(input.table, 'table'));
+  const column = quoteIdentifier(assertIdentifier(input.column, 'column'));
+  const columns = normalizeColumns(input.columns);
+  const selectList = buildSelectList(columns);
+  const limit = normalizeLimit(input.limit);
+  const comparator = input.caseSensitive ? 'LIKE' : 'ILIKE';
+
+  let text = `SELECT ${selectList} FROM ${table} WHERE ${column} ${comparator} $1`;
+  if (limit !== undefined) {
+    text += ` LIMIT ${limit}`;
+  }
+  return {
+    text,
+    values: [`${input.prefix}%`],
+  };
+});
+
+export function searchByPrefix(input: SearchByPrefixInput): ParameterizedQuery {
+  return searchByPrefixDefinition.build(input);
+}
+
+export interface ListActiveInput {
+  table: string;
+  activeValue?: unknown;
+  activeColumn?: string;
+  columns?: ReadonlyArray<string>;
+  limit?: number;
+  sortColumn?: string;
+  sortDirection?: OrderDirection;
+}
+
+const listActiveDefinition = createMacro<ListActiveInput>('listActive', 'SRPL-004', (input) => {
+  const table = quoteIdentifier(assertIdentifier(input.table, 'table'));
+  const activeColumn = quoteIdentifier(assertIdentifier(input.activeColumn ?? 'is_active', 'activeColumn'));
+  const columns = normalizeColumns(input.columns);
+  const selectList = buildSelectList(columns);
+  const limit = normalizeLimit(input.limit);
+  const sortColumn = input.sortColumn
+    ? quoteIdentifier(assertIdentifier(input.sortColumn, 'sortColumn'))
+    : undefined;
+  const sortDirection = normalizeOrder(input.sortDirection);
+
+  let text = `SELECT ${selectList} FROM ${table} WHERE ${activeColumn} = $1`;
+  if (sortColumn) {
+    text += ` ORDER BY ${sortColumn} ${sortDirection ?? 'ASC'}`;
+  }
+  if (limit !== undefined) {
+    text += ` LIMIT ${limit}`;
+  }
+  return {
+    text,
+    values: [input.activeValue ?? true],
+  };
+});
+
+export function listActive(input: ListActiveInput): ParameterizedQuery {
+  return listActiveDefinition.build(input);
+}
+
+export const macroRegistry: Record<MacroName, MacroDefinition<unknown>> = Object.freeze({
+  entityById: entityByIdDefinition,
+  entitiesByForeignKey: entitiesByForeignKeyDefinition,
+  searchByPrefix: searchByPrefixDefinition,
+  listActive: listActiveDefinition,
+});
+
+export type { OrderDirection };

--- a/packages/srpl/src/plugin/index.ts
+++ b/packages/srpl/src/plugin/index.ts
@@ -1,0 +1,30 @@
+import { noUnsafeRetrievalRule } from './rules/no-unsafe-retrieval.js';
+
+export const rules = {
+  'no-unsafe-retrieval': noUnsafeRetrievalRule,
+} as const;
+
+type LegacyConfig = {
+  plugins?: string[];
+  rules?: Record<string, unknown>;
+};
+
+export const configs: Record<string, LegacyConfig> = {
+  recommended: {
+    plugins: ['srpl'],
+    rules: {
+      'srpl/no-unsafe-retrieval': 'error',
+    },
+  },
+};
+
+export const srplEslintPlugin = {
+  meta: {
+    name: '@summit/srpl',
+    version: '0.1.0',
+  },
+  rules,
+  configs,
+};
+
+export default srplEslintPlugin;

--- a/packages/srpl/src/plugin/rules/no-unsafe-retrieval.ts
+++ b/packages/srpl/src/plugin/rules/no-unsafe-retrieval.ts
@@ -1,0 +1,180 @@
+import type { TSESTree } from '@typescript-eslint/utils';
+import { ESLintUtils } from '@typescript-eslint/utils';
+import type { RuleFix, RuleFixer } from '@typescript-eslint/utils/ts-eslint';
+
+const createRule = ESLintUtils.RuleCreator(
+  (name) => `https://github.com/summit/srpl/tree/main/docs/rules/${name}.md`,
+);
+
+const SUSPICIOUS_MEMBER_CALLEES = new Set(['query', 'execute', 'raw']);
+const SUSPICIOUS_IDENTIFIERS = new Set(['query', 'sql', 'execute']);
+const IDENTIFIER_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function isSuspiciousCall(node: TSESTree.CallExpression): boolean {
+  const { callee } = node;
+  if (callee.type === 'MemberExpression' && !callee.computed && callee.property.type === 'Identifier') {
+    return SUSPICIOUS_MEMBER_CALLEES.has(callee.property.name);
+  }
+  if (callee.type === 'Identifier') {
+    return SUSPICIOUS_IDENTIFIERS.has(callee.name);
+  }
+  return false;
+}
+
+interface EntityByIdAnalysis {
+  readonly type: 'entityById';
+  readonly table: string;
+  readonly column: string;
+  readonly columns: ReadonlyArray<string> | undefined;
+  readonly expression: TSESTree.Expression;
+}
+
+type Analysis = EntityByIdAnalysis | null;
+
+const SELECT_WHERE_PATTERN = /select\s+([^]*?)\s+from\s+([A-Za-z_][A-Za-z0-9_]*)\s+where\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*$/i;
+
+function cleanIdentifier(value: string): string | null {
+  const trimmed = value.trim();
+  if (!IDENTIFIER_PATTERN.test(trimmed)) {
+    return null;
+  }
+  return trimmed;
+}
+
+function analyzeTemplate(node: TSESTree.TemplateLiteral): Analysis {
+  if (node.expressions.length !== 1 || node.quasis.length !== 2) {
+    return null;
+  }
+  const [head, tail] = node.quasis;
+  if (!head || !tail) {
+    return null;
+  }
+  if ((tail.value.cooked ?? tail.value.raw ?? '').trim().length > 0) {
+    return null;
+  }
+  const cooked = head.value.cooked ?? head.value.raw ?? '';
+  const match = cooked.match(SELECT_WHERE_PATTERN);
+  if (!match) {
+    return null;
+  }
+  const [, columnsChunk, rawTable, rawColumn] = match;
+  const table = cleanIdentifier(rawTable);
+  const column = cleanIdentifier(rawColumn);
+  if (!table || !column) {
+    return null;
+  }
+  const rawColumns = columnsChunk.trim();
+  let columns: string[] | undefined;
+  if (rawColumns !== '*' && rawColumns.length > 0) {
+    const parsed = rawColumns.split(',').map((part) => part.trim()).filter(Boolean);
+    if (parsed.length === 0) {
+      return null;
+    }
+    if (parsed.some((value) => !IDENTIFIER_PATTERN.test(value))) {
+      return null;
+    }
+    columns = parsed;
+  }
+  return {
+    type: 'entityById',
+    table,
+    column,
+    columns,
+    expression: node.expressions[0]!,
+  };
+}
+
+function toLiteral(value: string): string {
+  return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+}
+
+type CreateRuleContext = Readonly<Parameters<ReturnType<typeof createRule>['create']>[0]>;
+
+function ensureImport(context: CreateRuleContext, fixer: RuleFixer, macro: string): RuleFix | null {
+  const sourceCode = context.sourceCode;
+  const program = sourceCode.ast;
+  const importDeclaration = program.body.find(
+    (statement): statement is TSESTree.ImportDeclaration =>
+      statement.type === 'ImportDeclaration' && statement.source.value === '@summit/srpl',
+  );
+  if (!importDeclaration) {
+    return fixer.insertTextBeforeRange([0, 0], `import { ${macro} } from '@summit/srpl';\n`);
+  }
+  const hasSpecifier = importDeclaration.specifiers.some(
+    (specifier) => specifier.type === 'ImportSpecifier' && specifier.imported.type === 'Identifier' && specifier.imported.name === macro,
+  );
+  if (hasSpecifier) {
+    return null;
+  }
+  const importSpecifiers = importDeclaration.specifiers.filter(
+    (specifier): specifier is TSESTree.ImportSpecifier => specifier.type === 'ImportSpecifier',
+  );
+  if (importSpecifiers.length === 0) {
+    return fixer.insertTextBefore(importDeclaration.source, `{ ${macro} } `);
+  }
+  const lastSpecifier = importSpecifiers[importSpecifiers.length - 1]!;
+  return fixer.insertTextAfter(lastSpecifier, `, ${macro}`);
+}
+
+function buildEntityByIdFix(context: CreateRuleContext, node: TSESTree.TemplateLiteral, analysis: EntityByIdAnalysis) {
+  return (fixer: RuleFixer): RuleFix | RuleFix[] | null => {
+    const sourceCode = context.sourceCode;
+    const exprText = sourceCode.getText(analysis.expression);
+    const parts = [`table: ${toLiteral(analysis.table)}`];
+    if (analysis.columns && analysis.columns.length > 0) {
+      const columnList = analysis.columns.map((column) => toLiteral(column)).join(', ');
+      parts.push(`columns: [${columnList}]`);
+    }
+    if (analysis.column !== 'id') {
+      parts.push(`idColumn: ${toLiteral(analysis.column)}`);
+    }
+    parts.push(`id: ${exprText}`);
+    const replacement = `entityById({ ${parts.join(', ')} })`;
+    const fixes: RuleFix[] = [fixer.replaceText(node, replacement)];
+    const importFix = ensureImport(context, fixer, 'entityById');
+    if (importFix) {
+      fixes.push(importFix);
+    }
+    return fixes;
+  };
+}
+
+export const noUnsafeRetrievalRule = createRule<[], 'unsafeQuery'>({
+  name: 'no-unsafe-retrieval',
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow unsafe SQL template literals in favor of SRPL macros.',
+    },
+    schema: [],
+    messages: {
+      unsafeQuery: 'Use the SRPL macro {{macro}} instead of raw SQL templates.',
+    },
+    hasSuggestions: false,
+    fixable: 'code',
+  },
+  defaultOptions: [],
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isSuspiciousCall(node)) {
+          return;
+        }
+        const [firstArgument] = node.arguments;
+        if (!firstArgument || firstArgument.type !== 'TemplateLiteral') {
+          return;
+        }
+        if (firstArgument.expressions.length === 0) {
+          return;
+        }
+        const analysis = analyzeTemplate(firstArgument);
+        context.report({
+          node: firstArgument,
+          messageId: 'unsafeQuery',
+          data: { macro: analysis?.type === 'entityById' ? 'entityById' : 'an SRPL macro' },
+          fix: analysis ? buildEntityByIdFix(context, firstArgument, analysis) : null,
+        });
+      },
+    };
+  },
+});

--- a/packages/srpl/src/policy.ts
+++ b/packages/srpl/src/policy.ts
@@ -1,0 +1,53 @@
+import type { MacroName, PolicyId } from './types.js';
+
+export interface PolicyMappingEntry {
+  readonly id: PolicyId;
+  readonly macro: MacroName;
+  readonly rule: string;
+  readonly rationale: string;
+  readonly notes: string;
+}
+
+export const POLICY_MAPPING: ReadonlyArray<PolicyMappingEntry> = Object.freeze([
+  {
+    id: 'SRPL-001',
+    macro: 'entityById',
+    rule: 'Single-record lookups MUST bind identifiers rather than interpolating user input.',
+    rationale:
+      'Ensures primary key fetches leverage a fixed statement with positional bind parameters, '
+      + 'eliminating SQL injection risk on id equality filters.',
+    notes: 'Use when retrieving a single row by its unique identifier. Optional columns limit projection.',
+  },
+  {
+    id: 'SRPL-002',
+    macro: 'entitiesByForeignKey',
+    rule: 'One-to-many traversals MUST constrain on a foreign key with stable ordering and optional row caps.',
+    rationale:
+      'Avoids dynamic SQL construction for relationship queries and enforces deterministic pagination semantics.',
+    notes: 'Supports optional sorting and row limits to keep fan-out under control.',
+  },
+  {
+    id: 'SRPL-003',
+    macro: 'searchByPrefix',
+    rule: 'Search inputs MUST apply wildcard operators via bind parameters rather than string concatenation.',
+    rationale:
+      'Guards prefix matching workloads against injection while normalizing comparison semantics.',
+    notes: 'Automatically appends % to the prefix and defaults to case-insensitive ILIKE matching.',
+  },
+  {
+    id: 'SRPL-004',
+    macro: 'listActive',
+    rule: 'Status filters MUST rely on canonical flags with bounded result sets.',
+    rationale:
+      'Encourages centralized activation semantics and keeps list queries scoped to active records only.',
+    notes: 'Default active flag is `is_active = true`; accepts optional projections and limits.',
+  },
+]);
+
+export const policyByMacro: ReadonlyMap<MacroName, PolicyMappingEntry> = new Map(
+  POLICY_MAPPING.map((entry) => [entry.macro, entry]),
+);
+
+export const policyById: ReadonlyMap<PolicyId, PolicyMappingEntry> = new Map(
+  POLICY_MAPPING.map((entry) => [entry.id, entry]),
+);

--- a/packages/srpl/src/types.ts
+++ b/packages/srpl/src/types.ts
@@ -1,0 +1,26 @@
+export interface ParameterizedQuery {
+  /** The parameterized SQL or DSL statement produced by a macro. */
+  readonly text: string;
+  /** The positional bind values to be passed into the database driver. */
+  readonly values: ReadonlyArray<unknown>;
+}
+
+export type MacroName =
+  | 'entityById'
+  | 'entitiesByForeignKey'
+  | 'searchByPrefix'
+  | 'listActive';
+
+export type PolicyId = 'SRPL-001' | 'SRPL-002' | 'SRPL-003' | 'SRPL-004';
+
+export interface MacroDefinition<Input> {
+  readonly name: MacroName;
+  readonly policy: PolicyId;
+  build(input: Input): ParameterizedQuery;
+}
+
+export interface MacroInvocationMetadata<Input> {
+  readonly definition: MacroDefinition<Input>;
+  readonly input: Input;
+  readonly emitted: ParameterizedQuery;
+}

--- a/packages/srpl/test/golden/cases/safe-macro/input.ts
+++ b/packages/srpl/test/golden/cases/safe-macro/input.ts
@@ -1,0 +1,6 @@
+import { entityById } from '@summit/srpl';
+import type { Database } from './types';
+
+export async function loadUser(db: Database, id: string) {
+  return db.query(entityById({ table: 'users', id }));
+}

--- a/packages/srpl/test/golden/cases/safe-macro/types.ts
+++ b/packages/srpl/test/golden/cases/safe-macro/types.ts
@@ -1,0 +1,3 @@
+export interface Database {
+  query<T>(statement: unknown): Promise<T>;
+}

--- a/packages/srpl/test/golden/cases/unsafe-inline-select/expected-fixed.ts
+++ b/packages/srpl/test/golden/cases/unsafe-inline-select/expected-fixed.ts
@@ -1,0 +1,6 @@
+import { entityById } from '@summit/srpl';
+import type { Database } from './types';
+
+export async function loadUser(db: Database, id: string) {
+  return db.query(entityById({ table: 'users', columns: ['id', 'email'], id: id }));
+}

--- a/packages/srpl/test/golden/cases/unsafe-inline-select/input.ts
+++ b/packages/srpl/test/golden/cases/unsafe-inline-select/input.ts
@@ -1,0 +1,5 @@
+import type { Database } from './types';
+
+export async function loadUser(db: Database, id: string) {
+  return db.query(`SELECT id, email FROM users WHERE id = ${id}`);
+}

--- a/packages/srpl/test/golden/cases/unsafe-inline-select/types.ts
+++ b/packages/srpl/test/golden/cases/unsafe-inline-select/types.ts
@@ -1,0 +1,3 @@
+export interface Database {
+  query<T>(statement: unknown): Promise<T>;
+}

--- a/packages/srpl/test/golden/golden.test.ts
+++ b/packages/srpl/test/golden/golden.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { ESLint } from 'eslint';
+import parser from '@typescript-eslint/parser';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import srplPlugin from '../../src/plugin/index.js';
+
+const CASES_ROOT = fileURLToPath(new URL('./cases', import.meta.url));
+
+async function listCases(): Promise<string[]> {
+  const entries = await readdir(CASES_ROOT, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+const CASE_NAMES = await listCases();
+
+describe('srpl/no-unsafe-retrieval golden fixtures', () => {
+  it('has at least one fixture', () => {
+    expect(CASE_NAMES.length).toBeGreaterThan(0);
+  });
+
+  for (const caseName of CASE_NAMES) {
+    it(caseName, async () => {
+      const caseDir = join(CASES_ROOT, caseName);
+      const inputPath = join(caseDir, 'input.ts');
+      const expectedPath = join(caseDir, 'expected-fixed.ts');
+      const hasExpected = await stat(expectedPath).then(
+        () => true,
+        () => false,
+      );
+
+      const run = async (fix: boolean) => {
+        const eslint = new ESLint({
+          fix,
+          overrideConfigFile: true,
+          overrideConfig: [
+            {
+              files: ['**/*.*'],
+              plugins: {
+                srpl: srplPlugin,
+              },
+              rules: {
+                'srpl/no-unsafe-retrieval': 'error',
+              },
+              languageOptions: {
+                parser,
+                parserOptions: {
+                  ecmaVersion: 'latest',
+                  sourceType: 'module',
+                },
+              },
+            },
+          ],
+        });
+        const [result] = await eslint.lintFiles([inputPath]);
+        return result;
+      };
+
+      const first = await run(false);
+      const second = await run(false);
+      expect(first.errorCount).toEqual(second.errorCount);
+      expect(first.warningCount).toEqual(second.warningCount);
+      expect(first.messages).toEqual(second.messages);
+
+      if (hasExpected) {
+        expect(first.errorCount).toBeGreaterThan(0);
+        const fixed = await run(true);
+        const expectedFixed = await readFile(expectedPath, 'utf8');
+        expect((fixed.output ?? '').trim()).toEqual(expectedFixed.trim());
+        const secondFixed = await run(true);
+        expect(secondFixed.output).toEqual(fixed.output);
+      } else {
+        expect(first.errorCount).toBe(0);
+        expect(first.warningCount).toBe(0);
+        const fixed = await run(true);
+        expect(fixed.output).toBeUndefined();
+      }
+    });
+  }
+});

--- a/packages/srpl/test/macros.test.ts
+++ b/packages/srpl/test/macros.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  entityById,
+  entitiesByForeignKey,
+  searchByPrefix,
+  listActive,
+  macroRegistry,
+  POLICY_MAPPING,
+} from '../src/index.js';
+
+describe('SRPL macros', () => {
+  it('emits deterministic single-record queries', () => {
+    const resultA = entityById({ table: 'users', id: 42 });
+    const resultB = entityById({ table: 'users', id: 42 });
+    expect(resultA).toEqual({
+      text: 'SELECT * FROM "users" WHERE "id" = $1',
+      values: [42],
+    });
+    expect(resultA).toEqual(resultB);
+  });
+
+  it('honors explicit projections and column names', () => {
+    const query = entityById({
+      table: 'accounts',
+      id: 'acct_1',
+      idColumn: 'account_id',
+      columns: ['account_id', 'owner'],
+    });
+    expect(query).toEqual({
+      text: 'SELECT "account_id", "owner" FROM "accounts" WHERE "account_id" = $1',
+      values: ['acct_1'],
+    });
+  });
+
+  it('builds relationship traversals with ordering and limits', () => {
+    const query = entitiesByForeignKey({
+      table: 'events',
+      foreignKeyColumn: 'account_id',
+      foreignKeyValue: 'acct_1',
+      sortColumn: 'created_at',
+      sortDirection: 'DESC',
+      limit: 10,
+    });
+    expect(query).toEqual({
+      text: 'SELECT * FROM "events" WHERE "account_id" = $1 ORDER BY "created_at" DESC LIMIT 10',
+      values: ['acct_1'],
+    });
+  });
+
+  it('supports prefix search with case-insensitive comparison by default', () => {
+    const query = searchByPrefix({ table: 'people', column: 'family_name', prefix: 'Sm', limit: 5 });
+    expect(query).toEqual({
+      text: 'SELECT * FROM "people" WHERE "family_name" ILIKE $1 LIMIT 5',
+      values: ['Sm%'],
+    });
+  });
+
+  it('lists active records with defaults', () => {
+    const query = listActive({ table: 'teams' });
+    expect(query).toEqual({
+      text: 'SELECT * FROM "teams" WHERE "is_active" = $1',
+      values: [true],
+    });
+  });
+
+  it('validates identifiers to protect against injection', () => {
+    expect(() => entityById({ table: 'users; DROP TABLE', id: 1 })).toThrowError(/Invalid identifier/);
+  });
+
+  it('keeps macro registry aligned with policy mapping', () => {
+    const macroNames = Object.keys(macroRegistry);
+    expect(new Set(macroNames)).toEqual(new Set(POLICY_MAPPING.map((entry) => entry.macro)));
+  });
+});

--- a/packages/srpl/tsconfig.json
+++ b/packages/srpl/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "composite": false,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": [
+      "node"
+    ],
+    "allowImportingTsExtensions": false,
+    "typeRoots": [
+      "./node_modules/@types"
+    ]
+  },
+  "include": [
+    "src/**/*"
+  ]
+}

--- a/packages/srpl/vitest.config.ts
+++ b/packages/srpl/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add the @summit/srpl workspace with parameterized retrieval macros and policy mapping
- provide an ESLint rule that blocks unsafe template SQL and offers autofix migrations
- cover the plugin with golden fixtures to ensure deterministic violations and fixes

## Testing
- npm test (packages/srpl)


------
https://chatgpt.com/codex/tasks/task_e_68d774f8904c83339fcb1e0f8fa50705