### PR TITLE
feat: add explainable sampling auditor toolkit

### DIFF
--- a/tools/esa/README.md
+++ b/tools/esa/README.md
@@ -1,0 +1,21 @@
+# Explainable Sampling Auditor (ESA)
+
+ESA is a Python toolkit and CLI for evaluating sampling plans used in analytics jobs. It supports multiple sampling strategies, computes explainability artifacts, and produces auditable Markdown reports that can be enforced in CI pipelines.
+
+## Features
+
+- **Sampling plans**: uniform, stratified, probability proportional to size (PPS), and reservoir sampling.
+- **Explainability**: sampling proofs containing seed, RNG state hash, inclusion probabilities, and sampled rows.
+- **Diagnostics**: bias and variance checks against analytical expectations for common estimators.
+- **What-if simulator**: explore alternative sample sizes or stratification choices before executing a job.
+- **Markdown audit reports**: generate ready-to-commit evidence for compliance reviews.
+- **CI gate**: fail builds when sampling error exceeds configured tolerances.
+
+## Getting Started
+
+```bash
+cd tools/esa
+python -m esa.cli evaluate --plan examples/uniform_plan.json --dataset examples/orders.csv
+```
+
+See `esa/cli.py` for additional commands.

--- a/tools/esa/esa/__init__.py
+++ b/tools/esa/esa/__init__.py
@@ -1,0 +1,5 @@
+"""Explainable Sampling Auditor (ESA)."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/tools/esa/esa/cli.py
+++ b/tools/esa/esa/cli.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from .evaluation import Evaluation, evaluate
+from .reporting import render_markdown, write_markdown
+from .sampling import SamplingPlan
+from .utils import load_dataset, load_json_or_yaml
+
+
+class CLIError(Exception):
+    pass
+
+
+def load_plan(config_path: Path) -> Dict[str, Any]:
+    if not config_path.exists():
+        raise CLIError(f"Sampling plan file not found: {config_path}")
+    return load_json_or_yaml(config_path)
+
+
+def evaluate_plan(plan_cfg: Dict[str, Any], dataset_path: Path, metric: str) -> Evaluation:
+    records = load_dataset(dataset_path)
+    plan = SamplingPlan.from_config(plan_cfg)
+    result = plan.execute(records)
+    return evaluate(result, records, metric)
+
+
+def evaluation_to_dict(evaluation: Evaluation) -> Dict[str, Any]:
+    return {
+        "plan_type": evaluation.plan_type,
+        "proof": evaluation.proof,
+        "population": evaluation.population,
+        "sample": evaluation.sample,
+        "expected_bias": evaluation.expected_bias,
+        "observed_bias": evaluation.observed_bias,
+        "expected_variance": evaluation.expected_variance,
+        "observed_variance": evaluation.observed_variance,
+    }
+
+
+def handle_evaluate(args: argparse.Namespace) -> int:
+    plan_cfg = load_plan(Path(args.plan))
+    evaluation = evaluate_plan(plan_cfg, Path(args.dataset), args.metric)
+    payload = evaluation_to_dict(evaluation)
+    if args.output:
+        Path(args.output).write_text(json.dumps(payload, indent=2))
+    else:
+        json.dump(payload, sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    return 0
+
+
+def parse_variant(token: str) -> tuple[str, List[str]]:
+    if "=" not in token:
+        raise CLIError("Variants must be in key=value1,value2 format")
+    key, values = token.split("=", 1)
+    return key, [value.strip() for value in values.split(",") if value.strip()]
+
+
+def apply_variant(base: Dict[str, Any], key: str, value: str) -> Dict[str, Any]:
+    variant = deepcopy(base)
+    cursor: Dict[str, Any] = variant
+    parts = key.split(".")
+    for part in parts[:-1]:
+        if part not in cursor or not isinstance(cursor[part], dict):
+            cursor[part] = {}
+        cursor = cursor[part]
+    final_key = parts[-1]
+    parsed_value: Any
+    if value.lower() in {"true", "false"}:
+        parsed_value = value.lower() == "true"
+    else:
+        try:
+            if "." in value:
+                parsed_value = float(value)
+            else:
+                parsed_value = int(value)
+        except ValueError:
+            parsed_value = value
+    cursor[final_key] = parsed_value
+    return variant
+
+
+def handle_simulate(args: argparse.Namespace) -> int:
+    base_plan = load_plan(Path(args.plan))
+    dataset_path = Path(args.dataset)
+    variants: Dict[str, List[str]] = {}
+    for token in args.vary or []:
+        key, values = parse_variant(token)
+        variants[key] = values
+
+    results: List[Dict[str, Any]] = []
+    for key, values in variants.items():
+        for value in values:
+            plan_cfg = apply_variant(base_plan, key, value)
+            evaluation = evaluate_plan(plan_cfg, dataset_path, args.metric)
+            payload = evaluation_to_dict(evaluation)
+            payload["variant"] = {key: value}
+            results.append(payload)
+    json.dump(results, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 0
+
+
+def handle_report(args: argparse.Namespace) -> int:
+    plan_cfg = load_plan(Path(args.plan))
+    dataset_path = Path(args.dataset)
+    evaluation = evaluate_plan(plan_cfg, dataset_path, args.metric)
+    output_path = Path(args.output)
+    if args.stdout:
+        sys.stdout.write(
+            render_markdown(
+                evaluation,
+                plan_path=Path(args.plan),
+                dataset_path=dataset_path,
+                title=args.title or "Sampling Audit Report",
+            )
+        )
+    else:
+        write_markdown(
+            evaluation,
+            output_path,
+            plan_path=Path(args.plan),
+            dataset_path=dataset_path,
+            title=args.title or "Sampling Audit Report",
+        )
+    return 0
+
+
+def handle_ci_check(args: argparse.Namespace) -> int:
+    plan_cfg = load_plan(Path(args.plan))
+    dataset_path = Path(args.dataset)
+    evaluation = evaluate_plan(plan_cfg, dataset_path, args.metric)
+    tolerances = load_json_or_yaml(Path(args.tolerances)) if args.tolerances else {}
+    bias_tol = float(tolerances.get("bias", args.bias_tolerance))
+    variance_tol = float(tolerances.get("variance", args.variance_tolerance))
+    bias_ok = abs(evaluation.observed_bias) <= bias_tol
+    variance_ok = evaluation.observed_variance <= variance_tol
+    if not (bias_ok and variance_ok):
+        message = "Sampling plan failed tolerances:"
+        if not bias_ok:
+            message += f" bias {evaluation.observed_bias:.6f} exceeds {bias_tol}"
+        if not variance_ok:
+            message += f" variance {evaluation.observed_variance:.6f} exceeds {variance_tol}"
+        raise CLIError(message)
+    if args.output:
+        Path(args.output).write_text(json.dumps(evaluation_to_dict(evaluation), indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Explainable Sampling Auditor")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    eval_parser = subparsers.add_parser("evaluate", help="Evaluate a sampling plan")
+    eval_parser.add_argument("--plan", required=True, help="Path to sampling plan config")
+    eval_parser.add_argument("--dataset", required=True, help="Path to CSV dataset")
+    eval_parser.add_argument("--metric", required=True, help="Numeric metric column to evaluate")
+    eval_parser.add_argument("--output", help="Optional JSON output path")
+    eval_parser.set_defaults(func=handle_evaluate)
+
+    sim_parser = subparsers.add_parser("simulate", help="Run what-if simulations")
+    sim_parser.add_argument("--plan", required=True, help="Base sampling plan config")
+    sim_parser.add_argument("--dataset", required=True, help="Path to CSV dataset")
+    sim_parser.add_argument("--metric", required=True, help="Metric column")
+    sim_parser.add_argument(
+        "--vary",
+        nargs="*",
+        help="Variant specifications like sample_size=100,200 or stratified.allocations.A=5",
+    )
+    sim_parser.set_defaults(func=handle_simulate)
+
+    report_parser = subparsers.add_parser("report", help="Generate Markdown report")
+    report_parser.add_argument("--plan", required=True)
+    report_parser.add_argument("--dataset", required=True)
+    report_parser.add_argument("--metric", required=True)
+    report_parser.add_argument("--output", required=True)
+    report_parser.add_argument("--title", help="Report title")
+    report_parser.add_argument("--stdout", action="store_true", help="Print report to stdout")
+    report_parser.set_defaults(func=handle_report)
+
+    gate_parser = subparsers.add_parser("ci-check", help="Fail when diagnostics exceed tolerances")
+    gate_parser.add_argument("--plan", required=True)
+    gate_parser.add_argument("--dataset", required=True)
+    gate_parser.add_argument("--metric", required=True)
+    gate_parser.add_argument("--tolerances", help="Path to JSON/YAML tolerance config")
+    gate_parser.add_argument("--bias-tolerance", type=float, default=0.01)
+    gate_parser.add_argument("--variance-tolerance", type=float, default=1.0)
+    gate_parser.add_argument("--output", help="Optional JSON export path")
+    gate_parser.set_defaults(func=handle_ci_check)
+
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except CLIError as exc:  # type: ignore[attr-defined]
+        parser.error(str(exc))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/esa/esa/evaluation.py
+++ b/tools/esa/esa/evaluation.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean
+from typing import Dict, List, Sequence
+
+from .sampling import SampleResult
+from .utils import Record, group_by
+
+
+def population_stats(records: Sequence[Record], metric: str) -> Dict[str, float]:
+    values = [record.metric(metric) for record in records]
+    n = len(values)
+    pop_mean = mean(values)
+    sum_sq = sum((value - pop_mean) ** 2 for value in values)
+    variance = sum_sq / (n - 1) if n > 1 else 0.0
+    return {
+        "count": n,
+        "mean": pop_mean,
+        "variance": variance,
+    }
+
+
+def sample_stats(result: SampleResult, metric: str) -> Dict[str, float]:
+    values: List[float] = []
+    for item in result.sampled:
+        value = item.record.metric(metric)
+        if item.draw_count > 1:
+            values.extend([value] * item.draw_count)
+        else:
+            values.append(value)
+    n = len(values)
+    sample_mean = mean(values)
+    sum_sq = sum((value - sample_mean) ** 2 for value in values)
+    variance = sum_sq / (n - 1) if n > 1 else 0.0
+    return {
+        "count": n,
+        "mean": sample_mean,
+        "variance": variance,
+    }
+
+
+@dataclass
+class Evaluation:
+    plan_type: str
+    proof: Dict[str, object]
+    population: Dict[str, float]
+    sample: Dict[str, float]
+    expected_bias: float
+    observed_bias: float
+    expected_variance: float
+    observed_variance: float
+
+
+def evaluate(result: SampleResult, population: Sequence[Record], metric: str) -> Evaluation:
+    pop_stats = population_stats(population, metric)
+    sample_stats_result = sample_stats(result, metric)
+    expected_bias, expected_variance = analytical_expectations(
+        result, population, metric, pop_stats
+    )
+    observed_bias = sample_stats_result["mean"] - pop_stats["mean"]
+    observed_variance = estimate_variance(
+        result,
+        population,
+        metric,
+        sample_stats_result,
+    )
+    return Evaluation(
+        plan_type=result.plan_type,
+        proof={
+            "seed": result.seed,
+            "rng_state_hash": result.proof().rng_state_hash,
+            "inclusion_probabilities": result.proof().inclusion_probabilities,
+        },
+        population=pop_stats,
+        sample=sample_stats_result,
+        expected_bias=expected_bias,
+        observed_bias=observed_bias,
+        expected_variance=expected_variance,
+        observed_variance=observed_variance,
+    )
+
+
+def estimate_variance(
+    result: SampleResult,
+    population: Sequence[Record],
+    metric: str,
+    sample_stats_result: Dict[str, float],
+) -> float:
+    metadata = result.metadata or {}
+    n_population = len(population)
+    if result.plan_type in {"uniform", "reservoir"}:
+        n_sample = sample_stats_result["count"]
+        if n_sample <= 1 or n_population <= 1:
+            return 0.0
+        f = n_sample / n_population
+        return (1 - f) * sample_stats_result["variance"] / n_sample
+    if result.plan_type == "stratified":
+        strata_keys = metadata.get("strata_keys", [])
+        strata_groups = group_by(population, strata_keys)
+        sample_records = group_by([item.record for item in result.sampled], strata_keys)
+        total = 0.0
+        for key, population_records in strata_groups.items():
+            Nh = len(population_records)
+            if Nh <= 1:
+                continue
+            Wh = Nh / n_population
+            sampled_records = sample_records.get(key, [])
+            nh = len(sampled_records)
+            if nh <= 1:
+                continue
+            sh2 = population_stats(sampled_records, metric)["variance"]
+            total += (Wh**2) * ((1 - nh / Nh) * sh2 / nh)
+        return total
+    if result.plan_type == "pps":
+        metadata_probs: Dict[int, float] = metadata.get("probabilities", {})  # type: ignore[arg-type]
+        draws = max(1, int(metadata.get("draws", 1)))
+        contributions: List[float] = []
+        for item in result.sampled:
+            base_prob = metadata_probs.get(item.record.index)
+            if base_prob is None or base_prob == 0:
+                continue
+            contributions.extend([item.record.metric(metric) / base_prob] * item.draw_count)
+        if not contributions:
+            return 0.0
+        estimator_mean = mean(contributions)
+        variance = sum((value - estimator_mean) ** 2 for value in contributions) / (
+            draws - 1 if draws > 1 else 1
+        )
+        variance /= draws
+        return variance
+    raise ValueError(f"Unsupported plan type for variance estimation: {result.plan_type}")
+
+
+def analytical_expectations(
+    result: SampleResult,
+    population: Sequence[Record],
+    metric: str,
+    pop_stats: Dict[str, float],
+) -> tuple[float, float]:
+    n_population = len(population)
+    metadata = result.metadata or {}
+    if result.plan_type == "pps":
+        n_sample = int(metadata.get("draws", 0))
+    else:
+        n_sample = int(metadata.get("sample_size", len(result.sampled)))
+    if result.plan_type in {"uniform", "reservoir"}:
+        expected_bias = 0.0
+        if n_population <= 1 or n_sample == 0:
+            expected_variance = 0.0
+        else:
+            expected_variance = (
+                (1 - n_sample / n_population)
+                * pop_stats["variance"]
+                / n_sample
+            )
+        return expected_bias, expected_variance
+    if result.plan_type == "stratified":
+        expected_bias = 0.0
+        strata_keys = metadata.get("strata_keys", [])
+        strata_groups = group_by(population, strata_keys)
+        strata_meta: Dict[str, Dict[str, int]] = metadata.get("strata", {})
+        expected_variance = 0.0
+        for key, records_in_stratum in strata_groups.items():
+            Nh = len(records_in_stratum)
+            if Nh <= 1:
+                continue
+            Wh = Nh / n_population
+            Sh2 = population_stats(records_in_stratum, metric)["variance"]
+            nh = int(strata_meta.get(key, {}).get("sample", 0))
+            if nh <= 1:
+                continue
+            expected_variance += (Wh**2) * ((1 - nh / Nh) * Sh2 / nh)
+        return expected_bias, expected_variance
+    if result.plan_type == "pps":
+        # Hansen-Hurwitz estimator variance
+        probability_map: Dict[int, float] = metadata.get("probabilities", {})  # type: ignore[arg-type]
+        draws = max(1, int(metadata.get("draws", 1)))
+        contributions: List[float] = []
+        for item in result.sampled:
+            base_prob = probability_map.get(item.record.index)
+            if base_prob is None or base_prob == 0:
+                continue
+            contributions.extend([item.record.metric(metric) / base_prob] * item.draw_count)
+        if not contributions:
+            return 0.0, 0.0
+        estimator_mean = mean(contributions)
+        expected_bias = 0.0
+        variance = sum((value - estimator_mean) ** 2 for value in contributions) / (
+            draws - 1 if draws > 1 else 1
+        )
+        variance /= draws
+        return expected_bias, variance
+    raise ValueError(f"Unsupported plan type for expectations: {result.plan_type}")

--- a/tools/esa/esa/reporting.py
+++ b/tools/esa/esa/reporting.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from .evaluation import Evaluation
+
+
+def render_markdown(
+    evaluation: Evaluation,
+    plan_path: Optional[Path] = None,
+    dataset_path: Optional[Path] = None,
+    title: str = "Sampling Audit Report",
+) -> str:
+    timestamp = datetime.now(timezone.utc).isoformat()
+    lines = [
+        f"# {title}",
+        "",
+        f"- Generated: `{timestamp}`",
+    ]
+    if plan_path:
+        lines.append(f"- Sampling plan: `{plan_path}`")
+    if dataset_path:
+        lines.append(f"- Dataset: `{dataset_path}`")
+    lines.extend(
+        [
+            "",
+            "## Sampling Proof",
+            "",
+            f"- RNG seed: `{evaluation.proof['seed']}`",
+            f"- RNG state hash: `{evaluation.proof['rng_state_hash']}`",
+            "- Inclusion probabilities:",
+        ]
+    )
+    for record_id, probability in sorted(evaluation.proof["inclusion_probabilities"].items()):
+        lines.append(f"  - Record {record_id}: {probability:.6f}")
+    lines.extend(
+        [
+            "",
+            "## Bias and Variance Diagnostics",
+            "",
+            "| Metric | Population | Sample | Expected | Observed |",
+            "| --- | --- | --- | --- | --- |",
+            f"| Mean | {evaluation.population['mean']:.6f} | {evaluation.sample['mean']:.6f} | 0.000000 | {evaluation.observed_bias:.6f} |",
+            f"| Variance | {evaluation.population['variance']:.6f} | {evaluation.sample['variance']:.6f} | {evaluation.expected_variance:.6f} | {evaluation.observed_variance:.6f} |",
+        ]
+    )
+    lines.extend(
+        [
+            "",
+            "## Notes",
+            "",
+            "- Expected bias of 0 indicates an unbiased estimator under the stated plan assumptions.",
+            "- Variance diagnostics compare analytical formulas with empirical sample variance.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_markdown(
+    evaluation: Evaluation,
+    output_path: Path,
+    plan_path: Optional[Path] = None,
+    dataset_path: Optional[Path] = None,
+    title: str = "Sampling Audit Report",
+) -> None:
+    markdown = render_markdown(
+        evaluation,
+        plan_path=plan_path,
+        dataset_path=dataset_path,
+        title=title,
+    )
+    output_path.write_text(markdown)

--- a/tools/esa/esa/sampling.py
+++ b/tools/esa/esa/sampling.py
@@ -1,0 +1,284 @@
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from .utils import Record, SamplingProof, group_by, hash_rng_state
+
+
+@dataclass
+class SampledRecord:
+    record: Record
+    inclusion_probability: float
+    draw_count: int = 1
+
+
+@dataclass
+class SampleResult:
+    plan_type: str
+    seed: int
+    rng_state: Tuple
+    sampled: List[SampledRecord]
+    metadata: Dict[str, object] | None = None
+
+    def proof(self) -> SamplingProof:
+        return SamplingProof(
+            seed=self.seed,
+            rng_state_hash=hash_rng_state(self.rng_state),
+            inclusion_probabilities={
+                item.record.index: item.inclusion_probability for item in self.sampled
+            },
+        )
+
+
+class SamplingPlan:
+    plan_type: str
+
+    def __init__(self, seed: Optional[int] = None) -> None:
+        self.seed = seed if seed is not None else random.randrange(0, 2**32 - 1)
+
+    def random(self) -> random.Random:
+        return random.Random(self.seed)
+
+    def execute(self, records: Sequence[Record]) -> SampleResult:
+        raise NotImplementedError
+
+    @staticmethod
+    def from_config(config: Dict) -> "SamplingPlan":
+        plan_type = config.get("type")
+        if not plan_type:
+            raise ValueError("Sampling plan must specify a 'type'")
+        seed = config.get("seed")
+        if plan_type == "uniform":
+            return UniformSamplingPlan(
+                sample_size=config.get("sample_size"),
+                fraction=config.get("fraction"),
+                seed=seed,
+            )
+        if plan_type == "stratified":
+            return StratifiedSamplingPlan(
+                sample_size=config.get("sample_size"),
+                strata=config.get("strata", []),
+                allocations=config.get("allocations"),
+                seed=seed,
+            )
+        if plan_type == "pps":
+            weight_column = config.get("weight_column")
+            if not weight_column:
+                raise ValueError("PPS plan requires a 'weight_column'")
+            return PPSSamplingPlan(
+                sample_size=config.get("sample_size"),
+                weight_column=weight_column,
+                seed=seed,
+            )
+        if plan_type == "reservoir":
+            return ReservoirSamplingPlan(sample_size=config.get("sample_size"), seed=seed)
+        raise ValueError(f"Unsupported sampling plan type: {plan_type}")
+
+
+class UniformSamplingPlan(SamplingPlan):
+    plan_type = "uniform"
+
+    def __init__(self, sample_size: Optional[int], fraction: Optional[float], seed: Optional[int]) -> None:
+        super().__init__(seed)
+        self.sample_size = sample_size
+        self.fraction = fraction
+        if self.sample_size is None and self.fraction is None:
+            raise ValueError("Uniform plan requires 'sample_size' or 'fraction'")
+
+    def execute(self, records: Sequence[Record]) -> SampleResult:
+        population = list(records)
+        n_population = len(population)
+        if self.sample_size is None:
+            size = max(1, math.floor(self.fraction * n_population))
+        else:
+            size = self.sample_size
+        if size <= 0:
+            raise ValueError("Sample size must be positive")
+        if size > n_population:
+            raise ValueError("Sample size cannot exceed population size for uniform sampling")
+
+        rng = self.random()
+        sampled_records = rng.sample(population, size)
+        inclusion_probability = size / n_population
+        sampled = [
+            SampledRecord(record=record, inclusion_probability=inclusion_probability)
+            for record in sampled_records
+        ]
+        return SampleResult(
+            plan_type=self.plan_type,
+            seed=self.seed,
+            rng_state=rng.getstate(),
+            sampled=sampled,
+            metadata={
+                "population_size": n_population,
+                "sample_size": size,
+            },
+        )
+
+
+class StratifiedSamplingPlan(SamplingPlan):
+    plan_type = "stratified"
+
+    def __init__(
+        self,
+        sample_size: Optional[int],
+        strata: Sequence[str],
+        allocations: Optional[Dict[str, int]],
+        seed: Optional[int],
+    ) -> None:
+        super().__init__(seed)
+        self.sample_size = sample_size
+        self.strata = list(strata)
+        self.allocations = allocations or {}
+        if self.sample_size is None and not self.allocations:
+            raise ValueError("Stratified plan requires 'sample_size' or explicit 'allocations'")
+
+    def execute(self, records: Sequence[Record]) -> SampleResult:
+        groups = group_by(records, self.strata)
+        population_total = sum(len(group) for group in groups.values())
+        if self.allocations:
+            allocation = dict(self.allocations)
+        else:
+            if self.sample_size is None:
+                raise ValueError("Sample size must be provided when allocations omitted")
+            allocation = {
+                name: max(1, round(self.sample_size * len(group) / population_total))
+                for name, group in groups.items()
+            }
+        rng = self.random()
+        sampled: List[SampledRecord] = []
+        strata_metadata: Dict[str, Dict[str, int]] = {}
+        for name, group in groups.items():
+            group_size = len(group)
+            desired = min(allocation.get(name, 0), group_size)
+            strata_metadata[name] = {
+                "population": group_size,
+                "sample": desired,
+            }
+            if desired <= 0:
+                continue
+            sampled_records = rng.sample(group, desired)
+            inclusion_probability = desired / group_size
+            for record in sampled_records:
+                sampled.append(
+                    SampledRecord(record=record, inclusion_probability=inclusion_probability)
+                )
+        return SampleResult(
+            plan_type=self.plan_type,
+            seed=self.seed,
+            rng_state=rng.getstate(),
+            sampled=sampled,
+            metadata={
+                "strata": strata_metadata,
+                "allocations": allocation,
+                "strata_keys": self.strata,
+                "sample_size": sum(item["sample"] for item in strata_metadata.values()),
+            },
+        )
+
+
+class PPSSamplingPlan(SamplingPlan):
+    plan_type = "pps"
+
+    def __init__(self, sample_size: int, weight_column: str, seed: Optional[int]) -> None:
+        super().__init__(seed)
+        if sample_size is None:
+            raise ValueError("PPS plan requires 'sample_size'")
+        self.sample_size = int(sample_size)
+        self.weight_column = weight_column
+        if self.sample_size <= 0:
+            raise ValueError("Sample size must be positive")
+
+    def execute(self, records: Sequence[Record]) -> SampleResult:
+        population = list(records)
+        weights: List[float] = []
+        for record in population:
+            value = record.values.get(self.weight_column)
+            if value is None:
+                raise KeyError(
+                    f"Weight column '{self.weight_column}' missing for record {record.index}"
+                )
+            try:
+                weight = float(value)
+            except (TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Weight column '{self.weight_column}' must be numeric"
+                ) from exc
+            if weight < 0:
+                raise ValueError("Weight must be non-negative")
+            weights.append(weight)
+        total_weight = sum(weights)
+        if total_weight <= 0:
+            raise ValueError("Sum of weights must be positive for PPS sampling")
+
+        rng = self.random()
+        probabilities = [w / total_weight for w in weights]
+        probability_map = {record.index: p for record, p in zip(population, probabilities)}
+        sampled: Dict[int, SampledRecord] = {}
+        for _ in range(self.sample_size):
+            pick = rng.choices(population, weights=probabilities, k=1)[0]
+            prob = probability_map[pick.index]
+            entry = sampled.get(pick.index)
+            if entry:
+                entry.draw_count += 1
+            else:
+                inclusion_prob = 1 - (1 - prob) ** self.sample_size
+                sampled[pick.index] = SampledRecord(
+                    record=pick, inclusion_probability=inclusion_prob, draw_count=1
+                )
+        return SampleResult(
+            plan_type=self.plan_type,
+            seed=self.seed,
+            rng_state=rng.getstate(),
+            sampled=list(sampled.values()),
+            metadata={
+                "draws": self.sample_size,
+                "probabilities": probability_map,
+                "weight_column": self.weight_column,
+            },
+        )
+
+
+class ReservoirSamplingPlan(SamplingPlan):
+    plan_type = "reservoir"
+
+    def __init__(self, sample_size: int, seed: Optional[int]) -> None:
+        super().__init__(seed)
+        if sample_size is None or sample_size <= 0:
+            raise ValueError("Reservoir plan requires positive 'sample_size'")
+        self.sample_size = int(sample_size)
+
+    def execute(self, records: Sequence[Record]) -> SampleResult:
+        population = list(records)
+        if not population:
+            raise ValueError("Population must contain at least one record")
+        rng = self.random()
+        reservoir: List[Record] = []
+        for idx, record in enumerate(population):
+            if idx < self.sample_size:
+                reservoir.append(record)
+            else:
+                j = rng.randint(0, idx)
+                if j < self.sample_size:
+                    reservoir[j] = record
+        population_size = len(population)
+        actual_sample_size = min(self.sample_size, population_size)
+        reservoir = reservoir[:actual_sample_size]
+        inclusion_probability = min(1.0, self.sample_size / max(population_size, 1))
+        sampled = [
+            SampledRecord(record=record, inclusion_probability=inclusion_probability)
+            for record in reservoir
+        ]
+        return SampleResult(
+            plan_type=self.plan_type,
+            seed=self.seed,
+            rng_state=rng.getstate(),
+            sampled=sampled,
+            metadata={
+                "population_size": population_size,
+                "sample_size": len(reservoir),
+            },
+        )

--- a/tools/esa/esa/utils.py
+++ b/tools/esa/esa/utils.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Sequence
+
+
+@dataclass
+class Record:
+    """Data record loaded from a dataset."""
+
+    index: int
+    values: Dict[str, Any]
+
+    def metric(self, column: str) -> float:
+        value = self.values.get(column)
+        if value is None:
+            raise KeyError(f"Metric column '{column}' missing for record {self.index}")
+        try:
+            return float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Metric column '{column}' must be numeric (record {self.index})"
+            ) from exc
+
+
+@dataclass
+class SamplingProof:
+    seed: int
+    rng_state_hash: str
+    inclusion_probabilities: Dict[int, float]
+
+
+def hash_rng_state(state: Sequence[Any]) -> str:
+    """Hash an RNG state tuple for compact inclusion in proofs."""
+
+    state_bytes = json.dumps(state, default=str).encode("utf-8")
+    return hashlib.sha256(state_bytes).hexdigest()
+
+
+def load_json_or_yaml(path: Path) -> Dict[str, Any]:
+    """Load configuration from JSON or YAML without requiring PyYAML."""
+
+    text = path.read_text()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            import yaml  # type: ignore
+        except ModuleNotFoundError as exc:
+            raise ValueError(
+                "Configuration is not valid JSON and PyYAML is not installed"
+            ) from exc
+        return yaml.safe_load(text)
+
+
+def load_dataset(path: Path) -> List[Record]:
+    """Load a CSV dataset into a list of :class:`Record` objects."""
+
+    import csv
+
+    with path.open(newline="") as handle:
+        reader = csv.DictReader(handle)
+        records: List[Record] = []
+        for idx, row in enumerate(reader):
+            records.append(Record(index=idx, values=row))
+    if not records:
+        raise ValueError("Dataset is empty; sampling requires at least one record")
+    return records
+
+
+def group_by(records: Iterable[Record], keys: Sequence[str]) -> Dict[str, List[Record]]:
+    """Group records by concatenated key values."""
+
+    groups: Dict[str, List[Record]] = {}
+    for record in records:
+        if not keys:
+            groups.setdefault("__all__", []).append(record)
+            continue
+        group_key = "|".join(str(record.values.get(k, "__missing__")) for k in keys)
+        groups.setdefault(group_key, []).append(record)
+    return groups

--- a/tools/esa/pyproject.toml
+++ b/tools/esa/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "esa"
+version = "0.1.0"
+description = "Explainable Sampling Auditor (ESA) toolkit and CLI"
+authors = [{name = "Summit AI", email = "engineering@summit.ai"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.scripts]
+esa = "esa.cli:main"

--- a/tools/esa/tests/conftest.py
+++ b/tools/esa/tests/conftest.py
@@ -1,0 +1,24 @@
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the ESA package can be imported without installation
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))
+
+
+@pytest.fixture
+def dataset_file(tmp_path: Path) -> Path:
+    path = tmp_path / "dataset.csv"
+    rows = [
+        {"id": i, "group": "A" if i < 5 else "B", "weight": 1 + i, "value": 10 + i}
+        for i in range(10)
+    ]
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["id", "group", "weight", "value"])
+        writer.writeheader()
+        writer.writerows(rows)
+    return path

--- a/tools/esa/tests/test_ci_gate.py
+++ b/tools/esa/tests/test_ci_gate.py
@@ -1,0 +1,57 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from esa.cli import evaluate_plan
+
+
+def write_plan(path: Path, config: dict) -> None:
+    path.write_text(json.dumps(config))
+
+
+def test_ci_gate_blocks_bad_plan(tmp_path: Path, dataset_file: Path) -> None:
+    plan_path = tmp_path / "plan.json"
+    plan_config = {"type": "uniform", "sample_size": 1, "seed": 1}
+    write_plan(plan_path, plan_config)
+    cmd = [
+        sys.executable,
+        "-m",
+        "esa.cli",
+        "ci-check",
+        "--plan",
+        str(plan_path),
+        "--dataset",
+        str(dataset_file),
+        "--metric",
+        "value",
+        "--bias-tolerance",
+        "0.0001",
+    ]
+    completed = subprocess.run(cmd, cwd=Path(__file__).resolve().parents[1])
+    assert completed.returncode != 0
+
+
+def test_ci_gate_passes_with_relaxed_threshold(tmp_path: Path, dataset_file: Path) -> None:
+    plan_config = {"type": "uniform", "sample_size": 1, "seed": 1}
+    evaluation = evaluate_plan(plan_config, dataset_file, "value")
+    assert abs(evaluation.observed_bias) > 0.0001
+    # Now run with generous tolerance
+    plan_path = tmp_path / "plan.json"
+    write_plan(plan_path, plan_config)
+    cmd = [
+        sys.executable,
+        "-m",
+        "esa.cli",
+        "ci-check",
+        "--plan",
+        str(plan_path),
+        "--dataset",
+        str(dataset_file),
+        "--metric",
+        "value",
+        "--bias-tolerance",
+        "10",
+    ]
+    completed = subprocess.run(cmd, cwd=Path(__file__).resolve().parents[1])
+    assert completed.returncode == 0

--- a/tools/esa/tests/test_sampling.py
+++ b/tools/esa/tests/test_sampling.py
@@ -1,0 +1,79 @@
+from pathlib import Path
+
+import pytest
+
+from esa.evaluation import population_stats
+from esa.sampling import SamplingPlan
+from esa.utils import group_by, load_dataset
+
+
+def test_uniform_sampling_deterministic(dataset_file: Path) -> None:
+    plan_config = {"type": "uniform", "sample_size": 4, "seed": 99}
+    records = load_dataset(dataset_file)
+    plan = SamplingPlan.from_config(plan_config)
+    first = plan.execute(records)
+    second = SamplingPlan.from_config(plan_config).execute(records)
+    assert [item.record.index for item in first.sampled] == [
+        item.record.index for item in second.sampled
+    ]
+
+
+@pytest.mark.parametrize(
+    "plan_config",
+    [
+        {"type": "uniform", "sample_size": 5, "seed": 7},
+        {"type": "reservoir", "sample_size": 5, "seed": 7},
+    ],
+)
+def test_unbiased_uniform_family(plan_config, dataset_file: Path) -> None:
+    from esa.cli import evaluate_plan
+
+    records = load_dataset(dataset_file)
+    evaluation = evaluate_plan(plan_config, dataset_file, "value")
+    pop = population_stats(records, "value")
+    sample_size = evaluation.sample["count"]
+    f = sample_size / pop["count"]
+    expected_variance = (1 - f) * pop["variance"] / sample_size
+    assert pytest.approx(evaluation.expected_bias, abs=1e-9) == 0.0
+    assert pytest.approx(evaluation.expected_variance, rel=1e-9) == expected_variance
+
+
+def test_stratified_plan_diagnostics(dataset_file: Path) -> None:
+    from esa.cli import evaluate_plan
+
+    plan_config = {
+        "type": "stratified",
+        "seed": 21,
+        "sample_size": 6,
+        "strata": ["group"],
+    }
+    records = load_dataset(dataset_file)
+    plan = SamplingPlan.from_config(plan_config)
+    result = plan.execute(records)
+    evaluation = evaluate_plan(plan_config, dataset_file, "value")
+    groups = group_by(records, ["group"])
+    pop_count = len(records)
+    theoretical = 0.0
+    for key, members in groups.items():
+        Nh = len(members)
+        Wh = Nh / pop_count
+        Sh2 = population_stats(members, "value")["variance"]
+        nh = result.metadata["strata"][key]["sample"]  # type: ignore[index]
+        if nh <= 1:
+            continue
+        theoretical += (Wh**2) * ((1 - nh / Nh) * Sh2 / nh)
+    assert pytest.approx(evaluation.expected_variance, rel=1e-9) == theoretical
+
+
+def test_pps_plan_variance(dataset_file: Path) -> None:
+    from esa.cli import evaluate_plan
+
+    plan_config = {
+        "type": "pps",
+        "seed": 3,
+        "sample_size": 8,
+        "weight_column": "weight",
+    }
+    evaluation = evaluate_plan(plan_config, dataset_file, "value")
+    assert pytest.approx(evaluation.expected_bias, abs=1e-9) == 0.0
+    assert evaluation.expected_variance >= 0


### PR DESCRIPTION
## Summary
- add a Python-based Explainable Sampling Auditor (ESA) toolkit with CLI commands for evaluation, simulation, reporting, and CI gating of sampling plans
- implement sampling strategies (uniform, stratified, PPS, reservoir) with reproducible proofs, diagnostics, and Markdown report generation
- cover new functionality with pytest suites verifying deterministic sampling, analytical diagnostics, and CI gate enforcement

## Testing
- pytest tools/esa/tests

------
https://chatgpt.com/codex/tasks/task_e_68d77b8acec483338f85aad89c351ee5