### PR TITLE
feat: add legal hold orchestrator and UI

### DIFF
--- a/client/src/features/lho/LhoDashboard.test.tsx
+++ b/client/src/features/lho/LhoDashboard.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen, within } from '@testing-library/react';
+import { LhoDashboard } from './LhoDashboard';
+
+describe('LhoDashboard', () => {
+  it('renders summary and verifies custody chain', async () => {
+    render(<LhoDashboard />);
+
+    expect(screen.getByText('Hold Summary')).toBeInTheDocument();
+    expect(await screen.findByText('Chain intact')).toBeInTheDocument();
+    expect(screen.getByText('hold-123')).toBeInTheDocument();
+  });
+
+  it('shows deterministic diff ordering', async () => {
+    render(<LhoDashboard />);
+
+    const addedPanel = screen.getByText('Added').closest('div');
+    expect(addedPanel).toBeTruthy();
+    const list = within(addedPanel as HTMLElement).getAllByRole('listitem');
+    const systems = list.map((item) => item.textContent?.split(':')[0]?.trim());
+    expect(systems).toEqual(['elasticsearch', 'kafka', 'lifecycle', 'postgres', 's3']);
+  });
+});

--- a/client/src/features/lho/LhoDashboard.tsx
+++ b/client/src/features/lho/LhoDashboard.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useMemo, useState } from 'react';
+import holdData from './data/sampleHold.json';
+import type { HoldDataset } from './types';
+import { verifyCustodyChain } from './utils';
+
+type VerificationState = {
+  valid: boolean;
+  message?: string;
+};
+
+const dataset = holdData as HoldDataset;
+
+function formatDateRange(start: string, end: string): string {
+  const startDate = new Date(start);
+  const endDate = new Date(end);
+  return `${startDate.toUTCString()} → ${endDate.toUTCString()}`;
+}
+
+export function LhoDashboard() {
+  const [verification, setVerification] = useState<VerificationState | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    verifyCustodyChain(dataset.custodyChain)
+      .then((result) => {
+        if (!cancelled) {
+          setVerification(result);
+        }
+      })
+      .catch((error: Error) => {
+        if (!cancelled) {
+          setVerification({ valid: false, message: error.message });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const systemKeys = useMemo(() => Object.keys(dataset.scope).sort(), []);
+  const diffSections = useMemo(() => {
+    return [
+      { label: 'Added', data: dataset.scopeDiff.added },
+      { label: 'Removed', data: dataset.scopeDiff.removed },
+      { label: 'Unchanged', data: dataset.scopeDiff.unchanged },
+    ];
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <section className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-800">Hold Summary</h2>
+        <dl className="mt-2 grid gap-3 sm:grid-cols-2">
+          <div>
+            <dt className="text-sm font-medium text-slate-500">Hold Identifier</dt>
+            <dd className="text-base font-semibold text-slate-900">{dataset.holdId}</dd>
+          </div>
+          <div>
+            <dt className="text-sm font-medium text-slate-500">Issued At</dt>
+            <dd className="text-base text-slate-900">{new Date(dataset.issuedAt).toUTCString()}</dd>
+          </div>
+          <div className="sm:col-span-2">
+            <dt className="text-sm font-medium text-slate-500">Preservation Window</dt>
+            <dd className="text-base text-slate-900">{formatDateRange(dataset.window.start, dataset.window.end)}</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-800">Scope Overview</h2>
+        <table className="mt-3 w-full text-left text-sm">
+          <thead className="text-xs uppercase tracking-wide text-slate-500">
+            <tr>
+              <th className="pb-2">System</th>
+              <th className="pb-2">Resources</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-200">
+            {systemKeys.map((system) => (
+              <tr key={system}>
+                <td className="py-2 font-medium text-slate-700">{system}</td>
+                <td className="py-2 text-slate-900">
+                  <ul className="list-inside list-disc space-y-1">
+                    {dataset.scope[system].map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-800">Deterministic Scope Diff</h2>
+        <div className="mt-3 grid gap-4 md:grid-cols-3">
+          {diffSections.map(({ label, data }) => (
+            <div key={label} className="rounded border border-slate-100 bg-slate-50 p-3">
+              <h3 className="text-sm font-semibold text-slate-600">{label}</h3>
+              {Object.keys(data).length === 0 ? (
+                <p className="mt-2 text-xs text-slate-500">None</p>
+              ) : (
+                <ul className="mt-2 space-y-2 text-sm text-slate-700">
+                  {Object.entries(data)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .map(([system, resources]) => (
+                      <li key={system}>
+                        <span className="font-medium">{system}:</span>
+                        <ul className="ml-4 list-disc space-y-1">
+                          {resources.map((resource) => (
+                            <li key={resource}>{resource}</li>
+                          ))}
+                        </ul>
+                      </li>
+                    ))}
+                </ul>
+              )}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold text-slate-800">Custody Verification</h2>
+          <span
+            className={`rounded-full px-3 py-1 text-sm font-semibold ${
+              verification?.valid ? 'bg-green-100 text-green-800' : 'bg-amber-100 text-amber-800'
+            }`}
+          >
+            {verification?.valid ? 'Chain intact' : verification ? 'Attention required' : 'Checking...'}
+          </span>
+        </div>
+        {verification?.message && !verification.valid && (
+          <p className="mt-2 text-sm text-amber-700">{verification.message}</p>
+        )}
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[480px] text-left text-sm">
+            <thead className="text-xs uppercase tracking-wide text-slate-500">
+              <tr>
+                <th className="pb-2">Seq</th>
+                <th className="pb-2">System</th>
+                <th className="pb-2">Action</th>
+                <th className="pb-2">Timestamp (UTC)</th>
+                <th className="pb-2">Scope Fingerprint</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200">
+              {dataset.custodyChain.map((event) => (
+                <tr key={event.sequence}>
+                  <td className="py-2 text-slate-600">{event.sequence}</td>
+                  <td className="py-2 font-medium text-slate-700">{event.system}</td>
+                  <td className="py-2 text-slate-600">{event.action}</td>
+                  <td className="py-2 text-slate-600">{new Date(event.timestamp).toUTCString()}</td>
+                  <td className="py-2 text-slate-600">
+                    <code className="break-all text-xs text-slate-500">{event.scopeFingerprint}</code>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section className="rounded-md border border-slate-200 bg-white p-4 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-800">System Reports</h2>
+        <div className="mt-3 grid gap-4 md:grid-cols-2">
+          {dataset.reports
+            .slice()
+            .sort((a, b) => a.system.localeCompare(b.system))
+            .map((report) => (
+              <div key={report.system} className="rounded border border-slate-100 bg-slate-50 p-3">
+                <h3 className="text-sm font-semibold text-slate-700">{report.system}</h3>
+                <dl className="mt-2 space-y-2 text-sm text-slate-600">
+                  <div>
+                    <dt className="font-medium text-slate-500">Frozen</dt>
+                    <dd>{report.frozenResources.join(', ') || 'None'}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-slate-500">Snapshots</dt>
+                    <dd>{report.snapshotted.length > 0 ? report.snapshotted.join(', ') : 'None'}</dd>
+                  </div>
+                  <div>
+                    <dt className="font-medium text-slate-500">Tags</dt>
+                    <dd>
+                      {Object.keys(report.tagged).length === 0 ? (
+                        'None'
+                      ) : (
+                        <ul className="list-inside list-disc space-y-1">
+                          {Object.entries(report.tagged)
+                            .sort(([a], [b]) => a.localeCompare(b))
+                            .map(([resource, tags]) => (
+                              <li key={resource}>
+                                <span className="font-medium text-slate-600">{resource}:</span>{' '}
+                                {Object.entries(tags)
+                                  .map(([key, value]) => `${key}=${value}`)
+                                  .join(', ')}
+                              </li>
+                            ))}
+                        </ul>
+                      )}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+            ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default LhoDashboard;

--- a/client/src/features/lho/data/sampleHold.json
+++ b/client/src/features/lho/data/sampleHold.json
@@ -1,0 +1,167 @@
+{
+  "holdId": "hold-123",
+  "issuedAt": "2025-09-27T06:23:39Z",
+  "window": {
+    "start": "2025-09-27T05:23:39.286979858Z",
+    "end": "2025-09-27T07:23:39.286980147Z"
+  },
+  "scope": {
+    "elasticsearch": ["logs/doc-1"],
+    "kafka": ["audit:1"],
+    "lifecycle": ["session-9"],
+    "postgres": ["events/42"],
+    "s3": ["key-a", "key-b"]
+  },
+  "scopeDiff": {
+    "added": {
+      "elasticsearch": ["logs/doc-1"],
+      "kafka": ["audit:1"],
+      "lifecycle": ["session-9"],
+      "postgres": ["events/42"],
+      "s3": ["key-a", "key-b"]
+    },
+    "removed": {},
+    "unchanged": {}
+  },
+  "custodyChain": [
+    {
+      "sequence": 1,
+      "timestamp": "2025-09-27T06:23:39.287581681Z",
+      "holdId": "hold-123",
+      "system": "s3",
+      "action": "apply",
+      "scopeFingerprint": "hold-123|s3|[key-a:true:true:false,key-b:true:true:false]",
+      "prevHash": "",
+      "hash": "5aba7f9107f7f6e00f998f0b1c803c47873397cf0155adbbcbfcf3aa40613937"
+    },
+    {
+      "sequence": 2,
+      "timestamp": "2025-09-27T06:23:39.287721651Z",
+      "holdId": "hold-123",
+      "system": "postgres",
+      "action": "apply",
+      "scopeFingerprint": "hold-123|postgres|[events/42:true:false]",
+      "prevHash": "5aba7f9107f7f6e00f998f0b1c803c47873397cf0155adbbcbfcf3aa40613937",
+      "hash": "b231adb7e3f8c3e48b03be7f11a4230f29a1b06108af63b97352727528afb332"
+    },
+    {
+      "sequence": 3,
+      "timestamp": "2025-09-27T06:23:39.287889669Z",
+      "holdId": "hold-123",
+      "system": "kafka",
+      "action": "apply",
+      "scopeFingerprint": "hold-123|kafka|[audit:1:true:false:true]",
+      "prevHash": "b231adb7e3f8c3e48b03be7f11a4230f29a1b06108af63b97352727528afb332",
+      "hash": "ac0500ef28d6cac5ed5aa54893534b96803d320a7a4d31c1792f14714563226a"
+    },
+    {
+      "sequence": 4,
+      "timestamp": "2025-09-27T06:23:39.288000771Z",
+      "holdId": "hold-123",
+      "system": "elasticsearch",
+      "action": "apply",
+      "scopeFingerprint": "hold-123|elasticsearch|[logs/doc-1:true:false:true]",
+      "prevHash": "ac0500ef28d6cac5ed5aa54893534b96803d320a7a4d31c1792f14714563226a",
+      "hash": "041492e6ae1014b994c7c79132b00116ffa6c303c2f35c4c27412c21ccee1d2d"
+    },
+    {
+      "sequence": 5,
+      "timestamp": "2025-09-27T06:23:39.288062791Z",
+      "holdId": "hold-123",
+      "system": "lifecycle",
+      "action": "apply",
+      "scopeFingerprint": "hold-123|lifecycle|[session-9:true:false]",
+      "prevHash": "041492e6ae1014b994c7c79132b00116ffa6c303c2f35c4c27412c21ccee1d2d",
+      "hash": "aecec7f4a84ce363593ec0c540986edae69bbe9fc4c22ed447c0d2e3c9a4c6a5"
+    },
+    {
+      "sequence": 6,
+      "timestamp": "2025-09-27T06:23:39.288335339Z",
+      "holdId": "hold-123",
+      "system": "s3",
+      "action": "verify",
+      "scopeFingerprint": "hold-123|s3|[key-a:true:true:false,key-b:true:true:false]",
+      "prevHash": "aecec7f4a84ce363593ec0c540986edae69bbe9fc4c22ed447c0d2e3c9a4c6a5",
+      "hash": "2d54c0ea7a86318100276bd6a24a7394ce34fa67519e92755e5b874dc0d90e77"
+    },
+    {
+      "sequence": 7,
+      "timestamp": "2025-09-27T06:23:39.288350921Z",
+      "holdId": "hold-123",
+      "system": "postgres",
+      "action": "verify",
+      "scopeFingerprint": "hold-123|postgres|[events/42:true:false]",
+      "prevHash": "2d54c0ea7a86318100276bd6a24a7394ce34fa67519e92755e5b874dc0d90e77",
+      "hash": "e842607f92831c8f8ad126b0f31293bfe60512b0c8f28beb64ed9fabce76b9e9"
+    },
+    {
+      "sequence": 8,
+      "timestamp": "2025-09-27T06:23:39.28835697Z",
+      "holdId": "hold-123",
+      "system": "kafka",
+      "action": "verify",
+      "scopeFingerprint": "hold-123|kafka|[audit:1:true:false:true]",
+      "prevHash": "e842607f92831c8f8ad126b0f31293bfe60512b0c8f28beb64ed9fabce76b9e9",
+      "hash": "5a9a177bf53161ed0bc0b105b0870e0372c5d0e020441716fd6abf2b5bcb0d62"
+    },
+    {
+      "sequence": 9,
+      "timestamp": "2025-09-27T06:23:39.288362105Z",
+      "holdId": "hold-123",
+      "system": "elasticsearch",
+      "action": "verify",
+      "scopeFingerprint": "hold-123|elasticsearch|[logs/doc-1:true:false:true]",
+      "prevHash": "5a9a177bf53161ed0bc0b105b0870e0372c5d0e020441716fd6abf2b5bcb0d62",
+      "hash": "929d81fe769c639945df72ef9731e817dc99959a62d238237f5dab6722dad3fe"
+    },
+    {
+      "sequence": 10,
+      "timestamp": "2025-09-27T06:23:39.288515526Z",
+      "holdId": "hold-123",
+      "system": "lifecycle",
+      "action": "verify",
+      "scopeFingerprint": "hold-123|lifecycle|[session-9:true:false]",
+      "prevHash": "929d81fe769c639945df72ef9731e817dc99959a62d238237f5dab6722dad3fe",
+      "hash": "9633c95679c7880eebc81677fdec5ef8f50693a04598eed9fc66cfb24bd289e8"
+    }
+  ],
+  "reports": [
+    {
+      "system": "s3",
+      "frozenResources": ["key-a", "key-b"],
+      "snapshotted": ["key-a", "key-b"],
+      "tagged": {
+        "key-a": {"lho": "active"},
+        "key-b": {"lho": "active"}
+      }
+    },
+    {
+      "system": "postgres",
+      "frozenResources": ["events/42"],
+      "snapshotted": [],
+      "tagged": {}
+    },
+    {
+      "system": "kafka",
+      "frozenResources": ["audit:1"],
+      "snapshotted": [],
+      "tagged": {}
+    },
+    {
+      "system": "elasticsearch",
+      "frozenResources": ["logs/doc-1"],
+      "snapshotted": ["logs/doc-1"],
+      "tagged": {
+        "logs/doc-1": {"lho": "active"}
+      }
+    },
+    {
+      "system": "lifecycle",
+      "frozenResources": ["session-9"],
+      "snapshotted": [],
+      "tagged": {
+        "session-9": {"lho": "active"}
+      }
+    }
+  ]
+}

--- a/client/src/features/lho/types.ts
+++ b/client/src/features/lho/types.ts
@@ -1,0 +1,36 @@
+export interface ScopeDiff {
+  added: Record<string, string[]>;
+  removed: Record<string, string[]>;
+  unchanged: Record<string, string[]>;
+}
+
+export interface CustodyEvent {
+  sequence: number;
+  timestamp: string;
+  holdId: string;
+  system: string;
+  action: 'apply' | 'verify';
+  scopeFingerprint: string;
+  prevHash: string;
+  hash: string;
+}
+
+export interface HoldReport {
+  system: string;
+  frozenResources: string[];
+  snapshotted: string[];
+  tagged: Record<string, Record<string, string>>;
+}
+
+export interface HoldDataset {
+  holdId: string;
+  issuedAt: string;
+  window: {
+    start: string;
+    end: string;
+  };
+  scope: Record<string, string[]>;
+  scopeDiff: ScopeDiff;
+  custodyChain: CustodyEvent[];
+  reports: HoldReport[];
+}

--- a/client/src/features/lho/utils.ts
+++ b/client/src/features/lho/utils.ts
@@ -1,0 +1,96 @@
+import type { CustodyEvent } from './types';
+
+type VerificationResult = {
+  valid: boolean;
+  message?: string;
+};
+
+function timestampToUnixNano(timestamp: string): string {
+  const match = timestamp.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?Z$/);
+  if (!match) {
+    throw new Error(`invalid timestamp ${timestamp}`);
+  }
+
+  const [, year, month, day, hour, minute, second, fraction = ''] = match;
+  const secondsSinceEpoch = BigInt(
+    Date.UTC(
+      Number(year),
+      Number(month) - 1,
+      Number(day),
+      Number(hour),
+      Number(minute),
+      Number(second)
+    ) / 1000
+  );
+
+  const nanos = BigInt((fraction.padEnd(9, '0')).slice(0, 9));
+  return (secondsSinceEpoch * 1_000_000_000n + nanos).toString();
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  if (typeof globalThis.crypto !== 'undefined' && globalThis.crypto.subtle) {
+    const encoder = new TextEncoder();
+    const digest = await globalThis.crypto.subtle.digest('SHA-256', encoder.encode(input));
+    return Array.from(new Uint8Array(digest))
+      .map((byte) => byte.toString(16).padStart(2, '0'))
+      .join('');
+  }
+
+  const { createHash } = await import('crypto');
+  return createHash('sha256').update(input).digest('hex');
+}
+
+async function computeHash(prevHash: string, event: CustodyEvent): Promise<string> {
+  const unixNano = timestampToUnixNano(event.timestamp);
+  const payload = `${prevHash}|${event.holdId}|${event.system}|${event.action}|${unixNano}|${event.scopeFingerprint}`;
+  return sha256Hex(payload);
+}
+
+export async function verifyCustodyChain(events: CustodyEvent[]): Promise<VerificationResult> {
+  if (events.length === 0) {
+    return { valid: false, message: 'No custody events recorded.' };
+  }
+
+  const applyFingerprints = new Map<string, string>();
+  const verifiedSystems = new Set<string>();
+  let prevHash = '';
+
+  for (const event of events) {
+    const expectedHash = await computeHash(prevHash, event);
+    if (expectedHash !== event.hash) {
+      return {
+        valid: false,
+        message: `Hash mismatch at sequence ${event.sequence} for ${event.system}.`,
+      };
+    }
+
+    if (event.action === 'apply') {
+      applyFingerprints.set(event.system, event.scopeFingerprint);
+    }
+
+    if (event.action === 'verify') {
+      const fingerprint = applyFingerprints.get(event.system);
+      if (!fingerprint) {
+        return {
+          valid: false,
+          message: `Verification encountered before apply for ${event.system}.`,
+        };
+      }
+      if (fingerprint !== event.scopeFingerprint) {
+        return {
+          valid: false,
+          message: `Fingerprint changed for ${event.system}.`,
+        };
+      }
+      verifiedSystems.add(event.system);
+    }
+
+    prevHash = event.hash;
+  }
+
+  if (verifiedSystems.size === 0) {
+    return { valid: false, message: 'No verification events were captured.' };
+  }
+
+  return { valid: true };
+}

--- a/lho/cmd/lho/main.go
+++ b/lho/cmd/lho/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"time"
+
+	"github.com/summit/lho/internal/custody"
+	"github.com/summit/lho/internal/diff"
+	"github.com/summit/lho/internal/model"
+	"github.com/summit/lho/internal/orchestrator"
+	"github.com/summit/lho/internal/systems"
+)
+
+func main() {
+	ctx := context.Background()
+
+	s3 := systems.NewS3Fixture("legal-holds", map[string]*systems.S3Object{
+		"key-a": {Key: "key-a", Data: "version-a"},
+		"key-b": {Key: "key-b", Data: "version-b"},
+	})
+
+	postgres := systems.NewPostgresFixture(map[string]*systems.Table{
+		"events": {Name: "events", Rows: map[string]*systems.Row{
+			"42": {PrimaryKey: "42", Data: map[string]any{"case": "alpha"}},
+		}},
+	})
+
+	kafka := systems.NewKafkaFixture(map[string]*systems.KafkaTopic{
+		"audit": {Name: "audit", Messages: map[int]*systems.KafkaMessage{
+			1: {Offset: 1, Payload: "event"},
+		}},
+	})
+
+	elastic := systems.NewElasticsearchFixture(map[string]*systems.Index{
+		"logs": {Name: "logs", Docs: map[string]*systems.Document{
+			"doc-1": {ID: "doc-1", Data: map[string]any{"event": "alpha"}},
+		}},
+	})
+
+	lifecycle := systems.NewLifecycleFixture(map[string]*systems.LifecycleObject{
+		"session-9": {ID: "session-9", ExpiresAt: time.Now().Add(-1 * time.Hour)},
+	})
+
+	systemsList := []systems.System{s3, postgres, kafka, elastic, lifecycle}
+	ledger := &custody.Ledger{}
+	orch := orchestrator.New(systemsList, ledger)
+
+	scope := model.Scope{Systems: map[string][]string{
+		s3.Name():        {"key-a", "key-b"},
+		postgres.Name():  {"events/42"},
+		kafka.Name():     {"audit:1"},
+		elastic.Name():   {"logs/doc-1"},
+		lifecycle.Name(): {"session-9"},
+	}}
+
+	req := orchestrator.HoldRequest{
+		ID:         "hold-123",
+		Scope:      scope,
+		Freeze:     true,
+		Snapshot:   true,
+		PreventTTL: true,
+		Tags: map[string]string{
+			"lho": "active",
+		},
+		Window: custody.Window{Start: time.Now().Add(-1 * time.Hour), End: time.Now().Add(1 * time.Hour)},
+	}
+
+	result, err := orch.IssueHold(ctx, req)
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := orch.VerifyHold(ctx, req); err != nil {
+		panic(err)
+	}
+
+	type report struct {
+		System          string                       `json:"system"`
+		FrozenResources []string                     `json:"frozenResources"`
+		Snapshotted     []string                     `json:"snapshotted"`
+		Tagged          map[string]map[string]string `json:"tagged"`
+	}
+
+	reports := make([]report, 0, len(result.Reports))
+	for system, r := range result.Reports {
+		reports = append(reports, report{
+			System:          system,
+			FrozenResources: append([]string(nil), r.FrozenResources...),
+			Snapshotted:     append([]string(nil), r.Snapshotted...),
+			Tagged:          r.Tagged,
+		})
+	}
+
+	scopeDiff := diff.Calculate(model.Scope{Systems: map[string][]string{}}, scope)
+
+	output := map[string]any{
+		"holdId":       req.ID,
+		"issuedAt":     time.Now().UTC().Format(time.RFC3339),
+		"window":       req.Window,
+		"scope":        scope.Systems,
+		"scopeDiff":    scopeDiff,
+		"custodyChain": orch.Ledger().ProofForHold(req.ID),
+		"reports":      reports,
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(output); err != nil {
+		panic(err)
+	}
+}

--- a/lho/go.mod
+++ b/lho/go.mod
@@ -1,0 +1,11 @@
+module github.com/summit/lho
+
+go 1.22.2
+
+require github.com/stretchr/testify v1.8.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/lho/go.sum
+++ b/lho/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/lho/internal/custody/ledger.go
+++ b/lho/internal/custody/ledger.go
@@ -1,0 +1,153 @@
+package custody
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// Window describes the timeframe a hold must cover.
+type Window struct {
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
+}
+
+// Event captures an action recorded for a hold.
+type Event struct {
+	Sequence         int       `json:"sequence"`
+	Timestamp        time.Time `json:"timestamp"`
+	HoldID           string    `json:"holdId"`
+	System           string    `json:"system"`
+	Action           string    `json:"action"`
+	ScopeFingerprint string    `json:"scopeFingerprint"`
+	PrevHash         string    `json:"prevHash"`
+	Hash             string    `json:"hash"`
+}
+
+// Ledger maintains an append-only log of custody events.
+type Ledger struct {
+	events []Event
+}
+
+// Record appends an event to the ledger and returns the resulting event.
+func (l *Ledger) Record(holdID, system, action string, fingerprintParts []string, ts time.Time) Event {
+	sort.Strings(fingerprintParts)
+	fingerprint := fmt.Sprintf("%s|%s|%s", holdID, system, joinParts(fingerprintParts))
+
+	prevHash := ""
+	seq := len(l.events) + 1
+	if seq > 1 {
+		prevHash = l.events[len(l.events)-1].Hash
+	}
+
+	hash := computeHash(prevHash, holdID, system, action, fingerprint, ts)
+	event := Event{
+		Sequence:         seq,
+		Timestamp:        ts.UTC(),
+		HoldID:           holdID,
+		System:           system,
+		Action:           action,
+		ScopeFingerprint: fingerprint,
+		PrevHash:         prevHash,
+		Hash:             hash,
+	}
+
+	l.events = append(l.events, event)
+	return event
+}
+
+// Events returns all ledger events.
+func (l *Ledger) Events() []Event {
+	clone := make([]Event, len(l.events))
+	copy(clone, l.events)
+	return clone
+}
+
+// ProofForHold returns the events related to a particular hold identifier.
+func (l *Ledger) ProofForHold(holdID string) []Event {
+	var proof []Event
+	for _, event := range l.events {
+		if event.HoldID == holdID {
+			proof = append(proof, event)
+		}
+	}
+	return proof
+}
+
+// VerifyProof validates the event chain for a hold and ensures every
+// verification event matches its corresponding apply fingerprint.
+func VerifyProof(events []Event) error {
+	if len(events) == 0 {
+		return fmt.Errorf("no custody events supplied")
+	}
+
+	var prevHash string
+	applyFingerprints := make(map[string]string)
+	verifiedSystems := make(map[string]struct{})
+
+	for _, event := range events {
+		expectedHash := computeHash(prevHash, event.HoldID, event.System, event.Action, event.ScopeFingerprint, event.Timestamp)
+		if event.Hash != expectedHash {
+			return fmt.Errorf("custody hash mismatch at sequence %d", event.Sequence)
+		}
+
+		if event.Action == "apply" {
+			applyFingerprints[event.System] = event.ScopeFingerprint
+		}
+
+		if event.Action == "verify" {
+			fingerprint, ok := applyFingerprints[event.System]
+			if !ok {
+				return fmt.Errorf("verify event encountered before apply for system %s", event.System)
+			}
+			if fingerprint != event.ScopeFingerprint {
+				return fmt.Errorf("verification fingerprint changed for system %s", event.System)
+			}
+			verifiedSystems[event.System] = struct{}{}
+		}
+
+		prevHash = event.Hash
+	}
+
+	if len(verifiedSystems) == 0 {
+		return fmt.Errorf("no verification events present")
+	}
+
+	return nil
+}
+
+func computeHash(prevHash, holdID, system, action, fingerprint string, ts time.Time) string {
+	digest := fmt.Sprintf("%s|%s|%s|%s|%d|%s", prevHash, holdID, system, action, ts.UnixNano(), fingerprint)
+	sum := sha256.Sum256([]byte(digest))
+	return hex.EncodeToString(sum[:])
+}
+
+func joinParts(parts []string) string {
+	return fmt.Sprintf("[%s]", join(parts, ","))
+}
+
+func join(parts []string, sep string) string {
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	}
+
+	size := len(sep) * (len(parts) - 1)
+	for _, part := range parts {
+		size += len(part)
+	}
+
+	buf := make([]byte, 0, size)
+	for idx, part := range parts {
+		buf = append(buf, part...)
+		if idx < len(parts)-1 {
+			buf = append(buf, sep...)
+		}
+	}
+
+	return string(buf)
+}

--- a/lho/internal/diff/diff.go
+++ b/lho/internal/diff/diff.go
@@ -1,0 +1,85 @@
+package diff
+
+import (
+	"sort"
+
+	"github.com/summit/lho/internal/model"
+)
+
+// Result captures the delta between two scopes.
+type Result struct {
+	Added     map[string][]string `json:"added"`
+	Removed   map[string][]string `json:"removed"`
+	Unchanged map[string][]string `json:"unchanged"`
+}
+
+// Calculate produces a deterministic scope diff. Results are sorted to ensure
+// stable presentation for both API consumers and the UI layer.
+func Calculate(previous, next model.Scope) Result {
+	prev := previous.Normalized()
+	nxt := next.Normalized()
+
+	result := Result{
+		Added:     make(map[string][]string),
+		Removed:   make(map[string][]string),
+		Unchanged: make(map[string][]string),
+	}
+
+	allSystems := map[string]struct{}{}
+	for _, key := range prev.Keys() {
+		allSystems[key] = struct{}{}
+	}
+	for _, key := range nxt.Keys() {
+		allSystems[key] = struct{}{}
+	}
+
+	systems := make([]string, 0, len(allSystems))
+	for key := range allSystems {
+		systems = append(systems, key)
+	}
+	sort.Strings(systems)
+
+	for _, system := range systems {
+		prevResources := prev.Systems[system]
+		nextResources := nxt.Systems[system]
+
+		prevSet := make(map[string]struct{}, len(prevResources))
+		for _, id := range prevResources {
+			prevSet[id] = struct{}{}
+		}
+
+		nextSet := make(map[string]struct{}, len(nextResources))
+		for _, id := range nextResources {
+			nextSet[id] = struct{}{}
+		}
+
+		var added, removed, unchanged []string
+		for id := range nextSet {
+			if _, ok := prevSet[id]; !ok {
+				added = append(added, id)
+			} else {
+				unchanged = append(unchanged, id)
+			}
+		}
+		for id := range prevSet {
+			if _, ok := nextSet[id]; !ok {
+				removed = append(removed, id)
+			}
+		}
+
+		if len(added) > 0 {
+			sort.Strings(added)
+			result.Added[system] = added
+		}
+		if len(removed) > 0 {
+			sort.Strings(removed)
+			result.Removed[system] = removed
+		}
+		if len(unchanged) > 0 {
+			sort.Strings(unchanged)
+			result.Unchanged[system] = unchanged
+		}
+	}
+
+	return result
+}

--- a/lho/internal/model/scope.go
+++ b/lho/internal/model/scope.go
@@ -1,0 +1,40 @@
+package model
+
+import "sort"
+
+// Scope represents a collection of system specific resource identifiers that
+// should be preserved by a hold directive.
+type Scope struct {
+	Systems map[string][]string `json:"systems"`
+}
+
+// Normalized returns a copy of the scope with resource identifiers sorted to
+// ensure deterministic processing order.
+func (s Scope) Normalized() Scope {
+	clone := Scope{Systems: make(map[string][]string, len(s.Systems))}
+	for system, resources := range s.Systems {
+		items := append([]string(nil), resources...)
+		sort.Strings(items)
+		clone.Systems[system] = items
+	}
+	return clone
+}
+
+// Keys returns the system identifiers sorted alphabetically.
+func (s Scope) Keys() []string {
+	keys := make([]string, 0, len(s.Systems))
+	for key := range s.Systems {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// Clone creates a deep copy of the scope without normalizing order.
+func (s Scope) Clone() Scope {
+	clone := Scope{Systems: make(map[string][]string, len(s.Systems))}
+	for system, resources := range s.Systems {
+		clone.Systems[system] = append([]string(nil), resources...)
+	}
+	return clone
+}

--- a/lho/internal/orchestrator/orchestrator.go
+++ b/lho/internal/orchestrator/orchestrator.go
@@ -1,0 +1,98 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/summit/lho/internal/custody"
+	"github.com/summit/lho/internal/model"
+	"github.com/summit/lho/internal/systems"
+)
+
+// HoldRequest describes a hold invocation across systems.
+type HoldRequest struct {
+	ID         string
+	Scope      model.Scope
+	Freeze     bool
+	Snapshot   bool
+	Tags       map[string]string
+	PreventTTL bool
+	Window     custody.Window
+}
+
+// HoldResult aggregates per-system responses.
+type HoldResult struct {
+	Reports map[string]systems.Report
+	Events  []custody.Event
+}
+
+// Orchestrator applies hold directives and tracks custody chain entries.
+type Orchestrator struct {
+	systems []systems.System
+	ledger  *custody.Ledger
+}
+
+func New(systems []systems.System, ledger *custody.Ledger) *Orchestrator {
+	return &Orchestrator{systems: systems, ledger: ledger}
+}
+
+// IssueHold applies the directive to each configured system and records
+// custody events.
+func (o *Orchestrator) IssueHold(ctx context.Context, req HoldRequest) (HoldResult, error) {
+	if req.ID == "" {
+		return HoldResult{}, fmt.Errorf("hold id required")
+	}
+
+	result := HoldResult{Reports: make(map[string]systems.Report)}
+
+	for _, system := range o.systems {
+		report, err := system.ApplyHold(ctx, req.Scope, req.Freeze, req.Snapshot, req.Tags, req.PreventTTL)
+		if err != nil {
+			return HoldResult{}, fmt.Errorf("apply hold on %s: %w", system.Name(), err)
+		}
+		if len(report.FingerprintValues) > 0 {
+			fingerprint := append([]string(nil), report.FingerprintValues...)
+			event := o.ledger.Record(req.ID, system.Name(), "apply", fingerprint, time.Now())
+			result.Events = append(result.Events, event)
+		}
+		result.Reports[system.Name()] = report
+	}
+
+	return result, nil
+}
+
+// VerifyHold checks each system and records verification events when the hold
+// remains intact throughout the window.
+func (o *Orchestrator) VerifyHold(ctx context.Context, req HoldRequest) ([]custody.Event, error) {
+	var events []custody.Event
+
+	for _, system := range o.systems {
+		ids := req.Scope.Systems[system.Name()]
+		if len(ids) == 0 {
+			continue
+		}
+
+		if err := system.Verify(ctx, req.Scope); err != nil {
+			return nil, fmt.Errorf("verify hold on %s: %w", system.Name(), err)
+		}
+
+		tempScope := model.Scope{Systems: map[string][]string{system.Name(): append([]string(nil), ids...)}}
+		summary, err := system.ApplyHold(context.Background(), tempScope, false, false, nil, false)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot fingerprint for %s: %w", system.Name(), err)
+		}
+
+		if len(summary.FingerprintValues) > 0 {
+			event := o.ledger.Record(req.ID, system.Name(), "verify", append([]string(nil), summary.FingerprintValues...), time.Now())
+			events = append(events, event)
+		}
+	}
+
+	return events, nil
+}
+
+// Ledger returns the custody ledger.
+func (o *Orchestrator) Ledger() *custody.Ledger {
+	return o.ledger
+}

--- a/lho/internal/systems/elasticsearch.go
+++ b/lho/internal/systems/elasticsearch.go
@@ -1,0 +1,198 @@
+package systems
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/summit/lho/internal/model"
+)
+
+type Document struct {
+	ID        string
+	Frozen    bool
+	Deleted   bool
+	Tags      map[string]string
+	Snapshots []map[string]any
+	Data      map[string]any
+}
+
+type Index struct {
+	Name       string
+	Docs       map[string]*Document
+	RtbBlocked bool
+}
+
+type ElasticsearchFixture struct {
+	mu      sync.RWMutex
+	Indices map[string]*Index
+}
+
+func NewElasticsearchFixture(indices map[string]*Index) *ElasticsearchFixture {
+	return &ElasticsearchFixture{Indices: indices}
+}
+
+func (e *ElasticsearchFixture) Name() string { return "elasticsearch" }
+
+func (e *ElasticsearchFixture) ApplyHold(ctx context.Context, scope model.Scope, freeze, snapshot bool, tags map[string]string, preventTTL bool) (Report, error) {
+	select {
+	case <-ctx.Done():
+		return Report{}, ctx.Err()
+	default:
+	}
+
+	ids := scope.Systems[e.Name()]
+	if len(ids) == 0 {
+		return Report{}, nil
+	}
+
+	report := Report{Tagged: make(map[string]map[string]string)}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	for _, composite := range ids {
+		indexName, docID, err := splitIndexDoc(composite)
+		if err != nil {
+			return Report{}, err
+		}
+
+		index, ok := e.Indices[indexName]
+		if !ok {
+			return Report{}, fmt.Errorf("index %s missing", indexName)
+		}
+
+		doc, ok := index.Docs[docID]
+		if !ok {
+			return Report{}, fmt.Errorf("document %s missing", composite)
+		}
+
+		if freeze {
+			doc.Frozen = true
+			report.FrozenResources = append(report.FrozenResources, composite)
+		}
+
+		if snapshot {
+			clone := make(map[string]any, len(doc.Data))
+			for k, v := range doc.Data {
+				clone[k] = v
+			}
+			doc.Snapshots = append(doc.Snapshots, clone)
+			report.Snapshotted = append(report.Snapshotted, composite)
+		}
+
+		if tags != nil {
+			if doc.Tags == nil {
+				doc.Tags = make(map[string]string)
+			}
+			report.Tagged[composite] = make(map[string]string)
+			for k, v := range tags {
+				doc.Tags[k] = v
+				report.Tagged[composite][k] = v
+			}
+		}
+
+		if preventTTL {
+			index.RtbBlocked = true
+		}
+	}
+
+	report.FingerprintValues = e.fingerprint(ids)
+
+	return report, nil
+}
+
+func (e *ElasticsearchFixture) Verify(ctx context.Context, scope model.Scope) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	ids := scope.Systems[e.Name()]
+	for _, composite := range ids {
+		indexName, docID, err := splitIndexDoc(composite)
+		if err != nil {
+			return err
+		}
+
+		index, ok := e.Indices[indexName]
+		if !ok {
+			return fmt.Errorf("index %s missing", indexName)
+		}
+		doc, ok := index.Docs[docID]
+		if !ok {
+			return fmt.Errorf("document %s missing", composite)
+		}
+		if doc.Deleted {
+			return fmt.Errorf("document %s deleted during hold", composite)
+		}
+		if !doc.Frozen {
+			return fmt.Errorf("document %s not frozen", composite)
+		}
+		if !index.RtbBlocked {
+			return fmt.Errorf("index %s rtbf unblocked", indexName)
+		}
+	}
+
+	return nil
+}
+
+func (e *ElasticsearchFixture) DeleteDocument(indexName, docID string) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	index, ok := e.Indices[indexName]
+	if !ok {
+		return fmt.Errorf("index %s not found", indexName)
+	}
+	doc, ok := index.Docs[docID]
+	if !ok {
+		return fmt.Errorf("document %s not found", docID)
+	}
+	if doc.Frozen {
+		return fmt.Errorf("document %s frozen under hold", docID)
+	}
+	doc.Deleted = true
+	return nil
+}
+
+func (e *ElasticsearchFixture) fingerprint(ids []string) []string {
+	parts := make([]string, 0, len(ids))
+	for _, composite := range ids {
+		indexName, docID, err := splitIndexDoc(composite)
+		if err != nil {
+			parts = append(parts, fmt.Sprintf("%s:badid", composite))
+			continue
+		}
+
+		index, ok := e.Indices[indexName]
+		if !ok {
+			parts = append(parts, fmt.Sprintf("%s:index-missing", composite))
+			continue
+		}
+
+		doc, ok := index.Docs[docID]
+		if !ok {
+			parts = append(parts, fmt.Sprintf("%s:doc-missing", composite))
+			continue
+		}
+
+		parts = append(parts, fmt.Sprintf("%s:%t:%t:%t", composite, doc.Frozen, doc.Deleted, index.RtbBlocked))
+	}
+	sort.Strings(parts)
+	return parts
+}
+
+func splitIndexDoc(input string) (string, string, error) {
+	for i := 0; i < len(input); i++ {
+		if input[i] == '/' {
+			return input[:i], input[i+1:], nil
+		}
+	}
+	return "", "", fmt.Errorf("invalid elasticsearch identifier %s", input)
+}

--- a/lho/internal/systems/kafka.go
+++ b/lho/internal/systems/kafka.go
@@ -1,0 +1,179 @@
+package systems
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/summit/lho/internal/model"
+)
+
+type KafkaMessage struct {
+	Offset    int
+	Payload   string
+	Frozen    bool
+	Deleted   bool
+	Timestamp int64
+}
+
+type KafkaTopic struct {
+	Name            string
+	Messages        map[int]*KafkaMessage
+	RetentionPaused bool
+}
+
+type KafkaFixture struct {
+	mu     sync.RWMutex
+	Topics map[string]*KafkaTopic
+}
+
+func NewKafkaFixture(topics map[string]*KafkaTopic) *KafkaFixture {
+	return &KafkaFixture{Topics: topics}
+}
+
+func (k *KafkaFixture) Name() string { return "kafka" }
+
+func (k *KafkaFixture) ApplyHold(ctx context.Context, scope model.Scope, freeze, snapshot bool, tags map[string]string, preventTTL bool) (Report, error) {
+	select {
+	case <-ctx.Done():
+		return Report{}, ctx.Err()
+	default:
+	}
+
+	ids := scope.Systems[k.Name()]
+	if len(ids) == 0 {
+		return Report{}, nil
+	}
+
+	report := Report{}
+
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	for _, composite := range ids {
+		topicName, offset, err := splitTopicOffset(composite)
+		if err != nil {
+			return Report{}, err
+		}
+		topic, ok := k.Topics[topicName]
+		if !ok {
+			return Report{}, fmt.Errorf("topic %s not found", topicName)
+		}
+
+		msg, ok := topic.Messages[offset]
+		if !ok {
+			return Report{}, fmt.Errorf("message %s missing", composite)
+		}
+
+		if freeze {
+			msg.Frozen = true
+			report.FrozenResources = append(report.FrozenResources, composite)
+		}
+		if preventTTL {
+			topic.RetentionPaused = true
+		}
+	}
+
+	report.FingerprintValues = k.fingerprint(ids)
+
+	return report, nil
+}
+
+func (k *KafkaFixture) Verify(ctx context.Context, scope model.Scope) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+
+	ids := scope.Systems[k.Name()]
+	for _, composite := range ids {
+		topicName, offset, err := splitTopicOffset(composite)
+		if err != nil {
+			return err
+		}
+		topic, ok := k.Topics[topicName]
+		if !ok {
+			return fmt.Errorf("topic %s missing", topicName)
+		}
+		msg, ok := topic.Messages[offset]
+		if !ok {
+			return fmt.Errorf("message %d missing", offset)
+		}
+		if msg.Deleted {
+			return fmt.Errorf("message %d deleted during hold", offset)
+		}
+		if !msg.Frozen {
+			return fmt.Errorf("message %d not frozen", offset)
+		}
+		if !topic.RetentionPaused {
+			return fmt.Errorf("topic %s retention resumed", topicName)
+		}
+	}
+
+	return nil
+}
+
+func (k *KafkaFixture) DeleteMessage(topicName string, offset int) error {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+
+	topic, ok := k.Topics[topicName]
+	if !ok {
+		return fmt.Errorf("topic %s not found", topicName)
+	}
+
+	msg, ok := topic.Messages[offset]
+	if !ok {
+		return fmt.Errorf("message %d not found", offset)
+	}
+
+	if msg.Frozen {
+		return fmt.Errorf("message %d is frozen under hold", offset)
+	}
+
+	msg.Deleted = true
+	return nil
+}
+
+func (k *KafkaFixture) fingerprint(ids []string) []string {
+	parts := make([]string, 0, len(ids))
+	for _, composite := range ids {
+		topicName, offset, err := splitTopicOffset(composite)
+		if err != nil {
+			parts = append(parts, fmt.Sprintf("%s:badid", composite))
+			continue
+		}
+		topic, ok := k.Topics[topicName]
+		if !ok {
+			parts = append(parts, fmt.Sprintf("%s:topic-missing", composite))
+			continue
+		}
+		msg, ok := topic.Messages[offset]
+		if !ok {
+			parts = append(parts, fmt.Sprintf("%s:message-missing", composite))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s:%t:%t:%t", composite, msg.Frozen, msg.Deleted, topic.RetentionPaused))
+	}
+	sort.Strings(parts)
+	return parts
+}
+
+func splitTopicOffset(input string) (string, int, error) {
+	parts := strings.SplitN(input, ":", 2)
+	if len(parts) != 2 {
+		return "", 0, fmt.Errorf("invalid kafka composite id %s", input)
+	}
+	offset, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return "", 0, fmt.Errorf("invalid kafka offset in %s", input)
+	}
+	return parts[0], offset, nil
+}

--- a/lho/internal/systems/lifecycle.go
+++ b/lho/internal/systems/lifecycle.go
@@ -1,0 +1,126 @@
+package systems
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/summit/lho/internal/model"
+)
+
+type LifecycleObject struct {
+	ID         string
+	ExpiresAt  time.Time
+	Held       bool
+	Deleted    bool
+	Attributes map[string]string
+}
+
+type LifecycleFixture struct {
+	mu      sync.RWMutex
+	Objects map[string]*LifecycleObject
+}
+
+func NewLifecycleFixture(objects map[string]*LifecycleObject) *LifecycleFixture {
+	return &LifecycleFixture{Objects: objects}
+}
+
+func (l *LifecycleFixture) Name() string { return "lifecycle" }
+
+func (l *LifecycleFixture) ApplyHold(ctx context.Context, scope model.Scope, freeze, snapshot bool, tags map[string]string, preventTTL bool) (Report, error) {
+	select {
+	case <-ctx.Done():
+		return Report{}, ctx.Err()
+	default:
+	}
+
+	ids := scope.Systems[l.Name()]
+	if len(ids) == 0 {
+		return Report{}, nil
+	}
+
+	report := Report{Tagged: make(map[string]map[string]string)}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for _, id := range ids {
+		obj, ok := l.Objects[id]
+		if !ok {
+			return Report{}, fmt.Errorf("lifecycle object %s not found", id)
+		}
+		obj.Held = true
+		report.FrozenResources = append(report.FrozenResources, id)
+		if tags != nil {
+			if obj.Attributes == nil {
+				obj.Attributes = make(map[string]string)
+			}
+			report.Tagged[id] = make(map[string]string)
+			for k, v := range tags {
+				obj.Attributes[k] = v
+				report.Tagged[id][k] = v
+			}
+		}
+	}
+
+	report.FingerprintValues = l.fingerprint(ids)
+
+	return report, nil
+}
+
+func (l *LifecycleFixture) Verify(ctx context.Context, scope model.Scope) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+
+	ids := scope.Systems[l.Name()]
+	for _, id := range ids {
+		obj, ok := l.Objects[id]
+		if !ok {
+			return fmt.Errorf("lifecycle object %s missing", id)
+		}
+		if obj.Deleted {
+			return fmt.Errorf("lifecycle object %s deleted", id)
+		}
+		if !obj.Held {
+			return fmt.Errorf("lifecycle object %s released", id)
+		}
+	}
+
+	return nil
+}
+
+func (l *LifecycleFixture) ProcessExpirations(now time.Time) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for _, obj := range l.Objects {
+		if obj.Held {
+			continue
+		}
+		if now.After(obj.ExpiresAt) && !obj.Deleted {
+			obj.Deleted = true
+		}
+	}
+}
+
+func (l *LifecycleFixture) fingerprint(ids []string) []string {
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		obj, ok := l.Objects[id]
+		if !ok {
+			parts = append(parts, fmt.Sprintf("%s:missing", id))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s:%t:%t", id, obj.Held, obj.Deleted))
+	}
+	sort.Strings(parts)
+	return parts
+}

--- a/lho/internal/systems/postgres.go
+++ b/lho/internal/systems/postgres.go
@@ -1,0 +1,166 @@
+package systems
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/summit/lho/internal/model"
+)
+
+type Row struct {
+	PrimaryKey string
+	Frozen     bool
+	Deleted    bool
+	Data       map[string]any
+}
+
+type Table struct {
+	Name string
+	Rows map[string]*Row
+}
+
+type PostgresFixture struct {
+	mu     sync.RWMutex
+	Tables map[string]*Table
+}
+
+func NewPostgresFixture(tables map[string]*Table) *PostgresFixture {
+	return &PostgresFixture{Tables: tables}
+}
+
+func (p *PostgresFixture) Name() string { return "postgres" }
+
+func (p *PostgresFixture) ApplyHold(ctx context.Context, scope model.Scope, freeze, snapshot bool, tags map[string]string, preventTTL bool) (Report, error) {
+	select {
+	case <-ctx.Done():
+		return Report{}, ctx.Err()
+	default:
+	}
+
+	ids := scope.Systems[p.Name()]
+	if len(ids) == 0 {
+		return Report{}, nil
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	report := Report{}
+	for _, composite := range ids {
+		tableName, rowID, err := splitCompositeID(composite)
+		if err != nil {
+			return Report{}, err
+		}
+
+		table, ok := p.Tables[tableName]
+		if !ok {
+			return Report{}, fmt.Errorf("table %s not found", tableName)
+		}
+
+		row, ok := table.Rows[rowID]
+		if !ok {
+			return Report{}, fmt.Errorf("row %s missing", rowID)
+		}
+
+		if freeze {
+			row.Frozen = true
+			report.FrozenResources = append(report.FrozenResources, composite)
+		}
+	}
+
+	report.FingerprintValues = p.fingerprint(ids)
+
+	return report, nil
+}
+
+func (p *PostgresFixture) Verify(ctx context.Context, scope model.Scope) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	ids := scope.Systems[p.Name()]
+	for _, composite := range ids {
+		tableName, rowID, err := splitCompositeID(composite)
+		if err != nil {
+			return err
+		}
+		table, ok := p.Tables[tableName]
+		if !ok {
+			return fmt.Errorf("table %s missing during verification", tableName)
+		}
+		row, ok := table.Rows[rowID]
+		if !ok {
+			return fmt.Errorf("row %s missing during verification", rowID)
+		}
+		if row.Deleted {
+			return fmt.Errorf("row %s deleted during hold", rowID)
+		}
+		if !row.Frozen {
+			return fmt.Errorf("row %s not frozen", rowID)
+		}
+	}
+
+	return nil
+}
+
+func (p *PostgresFixture) DeleteRow(tableName, rowID string) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	table, ok := p.Tables[tableName]
+	if !ok {
+		return fmt.Errorf("table %s not found", tableName)
+	}
+
+	row, ok := table.Rows[rowID]
+	if !ok {
+		return fmt.Errorf("row %s not found", rowID)
+	}
+
+	if row.Frozen {
+		return fmt.Errorf("row %s is frozen under legal hold", rowID)
+	}
+
+	row.Deleted = true
+	return nil
+}
+
+func (p *PostgresFixture) fingerprint(ids []string) []string {
+	parts := make([]string, 0, len(ids))
+	for _, composite := range ids {
+		tableName, rowID, err := splitCompositeID(composite)
+		if err != nil {
+			parts = append(parts, fmt.Sprintf("%s:badid", composite))
+			continue
+		}
+		table, ok := p.Tables[tableName]
+		if !ok {
+			parts = append(parts, fmt.Sprintf("%s:table-missing", composite))
+			continue
+		}
+		row, ok := table.Rows[rowID]
+		if !ok {
+			parts = append(parts, fmt.Sprintf("%s:row-missing", composite))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s:%t:%t", composite, row.Frozen, row.Deleted))
+	}
+	sort.Strings(parts)
+	return parts
+}
+
+func splitCompositeID(input string) (string, string, error) {
+	for i := 0; i < len(input); i++ {
+		if input[i] == '/' {
+			return input[:i], input[i+1:], nil
+		}
+	}
+	return "", "", fmt.Errorf("composite identifier %s missing separator", input)
+}

--- a/lho/internal/systems/s3.go
+++ b/lho/internal/systems/s3.go
@@ -1,0 +1,146 @@
+package systems
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/summit/lho/internal/model"
+)
+
+type S3Object struct {
+	Key          string
+	Data         string
+	Frozen       bool
+	Snapshots    []string
+	Tags         map[string]string
+	Deleted      bool
+	TTLDisabled  bool
+	LastSnapshot string
+}
+
+type S3Fixture struct {
+	mu      sync.RWMutex
+	Bucket  string
+	Objects map[string]*S3Object
+}
+
+func NewS3Fixture(bucket string, objects map[string]*S3Object) *S3Fixture {
+	return &S3Fixture{Bucket: bucket, Objects: objects}
+}
+
+func (s *S3Fixture) Name() string { return "s3" }
+
+func (s *S3Fixture) ApplyHold(ctx context.Context, scope model.Scope, freeze, snapshot bool, tags map[string]string, preventTTL bool) (Report, error) {
+	select {
+	case <-ctx.Done():
+		return Report{}, ctx.Err()
+	default:
+	}
+
+	ids := scope.Systems[s.Name()]
+	if len(ids) == 0 {
+		return Report{}, nil
+	}
+
+	report := Report{Tagged: make(map[string]map[string]string)}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, id := range ids {
+		obj, ok := s.Objects[id]
+		if !ok {
+			return Report{}, fmt.Errorf("s3 object %s not found", id)
+		}
+
+		if freeze {
+			obj.Frozen = true
+			report.FrozenResources = append(report.FrozenResources, id)
+		}
+
+		if snapshot {
+			obj.LastSnapshot = obj.Data
+			obj.Snapshots = append(obj.Snapshots, obj.Data)
+			report.Snapshotted = append(report.Snapshotted, id)
+		}
+
+		if preventTTL {
+			obj.TTLDisabled = true
+		}
+
+		if tags != nil {
+			if obj.Tags == nil {
+				obj.Tags = make(map[string]string)
+			}
+			report.Tagged[id] = make(map[string]string)
+			for k, v := range tags {
+				obj.Tags[k] = v
+				report.Tagged[id][k] = v
+			}
+		}
+	}
+
+	report.FingerprintValues = s.fingerprint(ids)
+
+	return report, nil
+}
+
+func (s *S3Fixture) Verify(ctx context.Context, scope model.Scope) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	ids := scope.Systems[s.Name()]
+	for _, id := range ids {
+		obj, ok := s.Objects[id]
+		if !ok {
+			return fmt.Errorf("s3 object %s missing during verification", id)
+		}
+		if obj.Deleted {
+			return fmt.Errorf("s3 object %s deleted during hold", id)
+		}
+		if !obj.Frozen {
+			return fmt.Errorf("s3 object %s thawed during hold", id)
+		}
+		if !obj.TTLDisabled {
+			return fmt.Errorf("s3 object %s ttl re-enabled", id)
+		}
+	}
+	return nil
+}
+
+func (s *S3Fixture) DeleteObject(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	obj, ok := s.Objects[id]
+	if !ok {
+		return fmt.Errorf("object %s not found", id)
+	}
+	if obj.Frozen {
+		return fmt.Errorf("object %s is frozen under legal hold", id)
+	}
+
+	obj.Deleted = true
+	return nil
+}
+
+func (s *S3Fixture) fingerprint(ids []string) []string {
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if obj, ok := s.Objects[id]; ok {
+			parts = append(parts, fmt.Sprintf("%s:%t:%t:%t", id, obj.Frozen, obj.TTLDisabled, obj.Deleted))
+		} else {
+			parts = append(parts, fmt.Sprintf("%s:missing", id))
+		}
+	}
+	sort.Strings(parts)
+	return parts
+}

--- a/lho/internal/systems/system.go
+++ b/lho/internal/systems/system.go
@@ -1,0 +1,35 @@
+package systems
+
+import (
+	"context"
+
+	"github.com/summit/lho/internal/model"
+)
+
+// Report captures the result of applying a hold to a system.
+type Report struct {
+	FrozenResources   []string
+	Snapshotted       []string
+	Tagged            map[string]map[string]string
+	FingerprintValues []string
+}
+
+// System describes a storage or messaging substrate that can participate in a
+// legal hold.
+type System interface {
+	Name() string
+	ApplyHold(ctx context.Context, scope model.Scope, freeze, snapshot bool, tags map[string]string, preventTTL bool) (Report, error)
+	Verify(ctx context.Context, scope model.Scope) error
+}
+
+// Fingerprint produces canonical state descriptions for the supplied resource
+// identifiers. The orchestrator uses this to produce custody proofs.
+type Fingerprint interface {
+	Fingerprint(scope model.Scope) ([]string, error)
+}
+
+// HoldLifecycle represents systems that expose TTL or RTBF processing that must
+// be paused while a hold is active.
+type HoldLifecycle interface {
+	PauseExpirations(ids []string)
+}

--- a/lho/orchestrator_test.go
+++ b/lho/orchestrator_test.go
@@ -1,0 +1,141 @@
+package lho_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/summit/lho/internal/custody"
+	"github.com/summit/lho/internal/diff"
+	"github.com/summit/lho/internal/model"
+	"github.com/summit/lho/internal/orchestrator"
+	"github.com/summit/lho/internal/systems"
+)
+
+func TestHoldPreventsDeletes(t *testing.T) {
+	ctx := context.Background()
+
+	s3 := systems.NewS3Fixture("legal-holds", map[string]*systems.S3Object{
+		"key-a": {Key: "key-a", Data: "version-a"},
+		"key-b": {Key: "key-b", Data: "version-b"},
+	})
+
+	postgres := systems.NewPostgresFixture(map[string]*systems.Table{
+		"events": {Name: "events", Rows: map[string]*systems.Row{
+			"42": {PrimaryKey: "42", Data: map[string]any{"case": "alpha"}},
+		}},
+	})
+
+	kafka := systems.NewKafkaFixture(map[string]*systems.KafkaTopic{
+		"audit": {Name: "audit", Messages: map[int]*systems.KafkaMessage{
+			1: {Offset: 1, Payload: "event"},
+		}},
+	})
+
+	elastic := systems.NewElasticsearchFixture(map[string]*systems.Index{
+		"logs": {Name: "logs", Docs: map[string]*systems.Document{
+			"doc-1": {ID: "doc-1", Data: map[string]any{"event": "alpha"}},
+		}},
+	})
+
+	lifecycle := systems.NewLifecycleFixture(map[string]*systems.LifecycleObject{
+		"session-9": {ID: "session-9", ExpiresAt: time.Now().Add(-1 * time.Hour)},
+	})
+
+	ledger := &custody.Ledger{}
+	torch := orchestrator.New([]systems.System{s3, postgres, kafka, elastic, lifecycle}, ledger)
+
+	scope := model.Scope{Systems: map[string][]string{
+		s3.Name():        {"key-a", "key-b"},
+		postgres.Name():  {"events/42"},
+		kafka.Name():     {"audit:1"},
+		elastic.Name():   {"logs/doc-1"},
+		lifecycle.Name(): {"session-9"},
+	}}
+
+	req := orchestrator.HoldRequest{
+		ID:         "hold-123",
+		Scope:      scope,
+		Freeze:     true,
+		Snapshot:   true,
+		PreventTTL: true,
+		Tags: map[string]string{
+			"lho": "active",
+		},
+		Window: custody.Window{Start: time.Now().Add(-1 * time.Hour), End: time.Now().Add(1 * time.Hour)},
+	}
+
+	_, err := torch.IssueHold(ctx, req)
+	require.NoError(t, err)
+
+	require.Error(t, s3.DeleteObject("key-a"))
+	require.Error(t, postgres.DeleteRow("events", "42"))
+	require.Error(t, kafka.DeleteMessage("audit", 1))
+	require.Error(t, elastic.DeleteDocument("logs", "doc-1"))
+
+	lifecycle.ProcessExpirations(time.Now())
+	require.NoError(t, lifecycle.Verify(ctx, scope))
+}
+
+func TestScopeDiffDeterministic(t *testing.T) {
+	baseline := model.Scope{Systems: map[string][]string{
+		"s3":       {"b", "a"},
+		"postgres": {"events/2", "events/1"},
+	}}
+
+	updated := model.Scope{Systems: map[string][]string{
+		"s3":       {"a", "c"},
+		"postgres": {"events/1"},
+	}}
+
+	diffA := diff.Calculate(baseline, updated)
+	diffB := diff.Calculate(baseline, updated)
+
+	require.Equal(t, diffA, diffB)
+	require.Equal(t, []string{"c"}, diffA.Added["s3"])
+	require.Equal(t, []string{"b"}, diffA.Removed["s3"])
+	require.Equal(t, []string{"a"}, diffA.Unchanged["s3"])
+}
+
+func TestCustodyProofVerification(t *testing.T) {
+	ctx := context.Background()
+
+	s3 := systems.NewS3Fixture("legal-holds", map[string]*systems.S3Object{
+		"key-a": {Key: "key-a", Data: "version-a"},
+	})
+	postgres := systems.NewPostgresFixture(map[string]*systems.Table{
+		"events": {Name: "events", Rows: map[string]*systems.Row{
+			"42": {PrimaryKey: "42", Data: map[string]any{"case": "alpha"}},
+		}},
+	})
+
+	ledger := &custody.Ledger{}
+	torch := orchestrator.New([]systems.System{s3, postgres}, ledger)
+
+	scope := model.Scope{Systems: map[string][]string{
+		s3.Name():       {"key-a"},
+		postgres.Name(): {"events/42"},
+	}}
+
+	req := orchestrator.HoldRequest{
+		ID:         "hold-proof",
+		Scope:      scope,
+		Freeze:     true,
+		PreventTTL: true,
+		Window:     custody.Window{Start: time.Now(), End: time.Now().Add(1 * time.Hour)},
+		Tags:       map[string]string{"case": "alpha"},
+		Snapshot:   false,
+	}
+
+	_, err := torch.IssueHold(ctx, req)
+	require.NoError(t, err)
+
+	_, err = torch.VerifyHold(ctx, req)
+	require.NoError(t, err)
+
+	proof := torch.Ledger().ProofForHold("hold-proof")
+	require.Len(t, proof, 4)
+	require.NoError(t, custody.VerifyProof(proof))
+}


### PR DESCRIPTION
## Summary
- implement a Go-based legal hold orchestrator, custody ledger, and system fixtures covering S3, Postgres, Kafka, Elasticsearch, and lifecycle resources
- add a CLI example and Go tests to prove deletes/TTL blocks, deterministic scope diffs, and custody proof verification
- deliver a React dashboard that renders the hold scope, diff, custody chain verification, and system reports with accompanying unit tests

## Testing
- go test ./...
- npm --prefix client run test:jest -- LhoDashboard *(fails: jest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7806da480833391de148cdc0287e0