### PR TITLE
feat: add adaptive consent experience sdk

### DIFF
--- a/sdk/acx/__snapshots__/render.test.ts.snap
+++ b/sdk/acx/__snapshots__/render.test.ts.snap
@@ -1,0 +1,1081 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`AdaptiveConsentSDK rendering renders cs-CZ locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Přijmout vše",
+    "bulletPoints": [
+      "Základní funkce udržují službu bezpečnou",
+      "Analytika ukazuje, co zlepšit",
+      "Personalizace přizpůsobuje obsah",
+    ],
+    "footer": "Rozhodnutí můžete kdykoli změnit.",
+    "manageCta": "Spravovat nastavení",
+    "rejectCta": "Odmítnout doplňkové",
+    "summary": "Data používáme k poskytování, měření a přizpůsobení Summit.",
+    "title": "Vaše nastavení soukromí",
+  },
+  "locale": "cs-CZ",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders da-DK locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Accepter alt",
+    "bulletPoints": [
+      "Vigtige funktioner holder tjenesten sikker",
+      "Analyse hjælper os med at forbedre",
+      "Personalisering gør indhold relevant",
+    ],
+    "footer": "Du kan ændre dine valg når som helst.",
+    "manageCta": "Administrer indstillinger",
+    "rejectCta": "Afvis ekstra",
+    "summary": "Vi bruger data til at levere, måle og tilpasse Summit.",
+    "title": "Dine privatlivsvalg",
+  },
+  "locale": "da-DK",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders de-DE locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Alle zulassen",
+    "bulletPoints": [
+      "Essentielle Funktionen halten den Dienst sicher",
+      "Analysen zeigen Verbesserungsmöglichkeiten",
+      "Personalisierung passt Inhalte an",
+    ],
+    "footer": "Sie können Ihre Auswahl jederzeit ändern.",
+    "manageCta": "Einstellungen verwalten",
+    "rejectCta": "Nur Notwendiges",
+    "summary": "Wir verwenden Daten, um Summit bereitzustellen, zu messen und zu personalisieren.",
+    "title": "Ihre Datenschutzwahl",
+  },
+  "locale": "de-DE",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders en-GB locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Allow all",
+    "bulletPoints": [
+      "Essential cookies secure our services",
+      "Analytics helps us improve",
+      "Personalisation adapts content",
+    ],
+    "footer": "Change your decision whenever you like.",
+    "manageCta": "Review choices",
+    "rejectCta": "Decline extras",
+    "summary": "We process data to run Summit and improve the experience.",
+    "title": "Your privacy options",
+  },
+  "locale": "en-GB",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders en-US locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Accept all",
+    "bulletPoints": [
+      "Essential features keep Summit services secure",
+      "Analytics shows us what to improve",
+      "Personalization tailors content to you",
+    ],
+    "footer": "You can update preferences at any time.",
+    "manageCta": "Manage settings",
+    "rejectCta": "Reject non-essential",
+    "summary": "We use data to provide, measure, and personalize your experience.",
+    "title": "Your privacy choices",
+  },
+  "locale": "en-US",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders es-ES locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Aceptar todo",
+    "bulletPoints": [
+      "Las funciones esenciales mantienen el servicio seguro",
+      "La analítica nos ayuda a mejorar",
+      "La personalización ajusta el contenido",
+    ],
+    "footer": "Puedes cambiar tu decisión cuando quieras.",
+    "manageCta": "Administrar ajustes",
+    "rejectCta": "Rechazar lo no esencial",
+    "summary": "Usamos datos para ofrecer, medir y personalizar Summit.",
+    "title": "Tus opciones de privacidad",
+  },
+  "locale": "es-ES",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders es-MX locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Aceptar todo",
+    "bulletPoints": [
+      "Funciones esenciales protegen tu cuenta",
+      "Analítica muestra qué mejorar",
+      "Personalización crea contenido relevante",
+    ],
+    "footer": "Actualiza las preferencias en cualquier momento.",
+    "manageCta": "Gestionar opciones",
+    "rejectCta": "Rechazar adicionales",
+    "summary": "Usamos datos para operar Summit y mejorar tu experiencia.",
+    "title": "Configura tu privacidad",
+  },
+  "locale": "es-MX",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders fi-FI locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Hyväksy kaikki",
+    "bulletPoints": [
+      "Välttämättömät toiminnot pitävät palvelun turvallisena",
+      "Analytiikka kertoo mitä parantaa",
+      "Personointi tekee sisällöstä sinulle sopivaa",
+    ],
+    "footer": "Voit päivittää asetuksia milloin vain.",
+    "manageCta": "Hallinnoi asetuksia",
+    "rejectCta": "Hylkää lisätiedot",
+    "summary": "Käytämme tietoja palvelun tarjoamiseen, mittaamiseen ja personointiin.",
+    "title": "Tietosuoja-asetuksesi",
+  },
+  "locale": "fi-FI",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders fr-CA locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Accepter tout",
+    "bulletPoints": [
+      "Les fonctionnalités essentielles assurent la sécurité",
+      "Les analyses montrent quoi améliorer",
+      "La personnalisation adapte l'expérience",
+    ],
+    "footer": "Vos préférences sont modifiables en tout temps.",
+    "manageCta": "Modifier les paramètres",
+    "rejectCta": "Refuser le non essentiel",
+    "summary": "Nous utilisons des données pour offrir, mesurer et personnaliser Summit.",
+    "title": "Vos choix de confidentialité",
+  },
+  "locale": "fr-CA",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders fr-FR locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Tout accepter",
+    "bulletPoints": [
+      "Les fonctionnalités essentielles sécurisent le service",
+      "Les analyses guident nos améliorations",
+      "La personnalisation adapte le contenu",
+    ],
+    "footer": "Vous pouvez modifier vos choix à tout moment.",
+    "manageCta": "Gérer les paramètres",
+    "rejectCta": "Refuser le non-essentiel",
+    "summary": "Nous utilisons vos données pour fournir, mesurer et personnaliser Summit.",
+    "title": "Vos préférences de confidentialité",
+  },
+  "locale": "fr-FR",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders it-IT locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Accetta tutto",
+    "bulletPoints": [
+      "Le funzioni essenziali mantengono il servizio sicuro",
+      "L'analisi ci aiuta a migliorare",
+      "La personalizzazione adatta i contenuti",
+    ],
+    "footer": "Puoi aggiornare le preferenze in ogni momento.",
+    "manageCta": "Gestisci impostazioni",
+    "rejectCta": "Rifiuta il superfluo",
+    "summary": "Usiamo i dati per fornire, misurare e personalizzare Summit.",
+    "title": "Le tue scelte sulla privacy",
+  },
+  "locale": "it-IT",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders ja-JP locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "すべて許可",
+    "bulletPoints": [
+      "必要な機能がサービスを安全に保ちます",
+      "分析で改善点を把握します",
+      "パーソナライズで最適な体験を提供します",
+    ],
+    "footer": "設定はいつでも変更できます。",
+    "manageCta": "設定を管理",
+    "rejectCta": "必要最小限にする",
+    "summary": "Summit を提供・測定・パーソナライズするためにデータを利用します。",
+    "title": "プライバシー設定",
+  },
+  "locale": "ja-JP",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders ko-KR locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "모두 허용",
+    "bulletPoints": [
+      "필수 기능이 서비스를 안전하게 유지합니다",
+      "분석으로 개선점을 파악합니다",
+      "개인 맞춤으로 관련 콘텐츠를 제공합니다",
+    ],
+    "footer": "언제든지 선택을 변경할 수 있습니다.",
+    "manageCta": "설정 관리",
+    "rejectCta": "필수만 허용",
+    "summary": "Summit 서비스를 제공하고 맞춤화하기 위해 데이터를 사용합니다.",
+    "title": "개인정보 보호 설정",
+  },
+  "locale": "ko-KR",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders nl-NL locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Alles accepteren",
+    "bulletPoints": [
+      "Essentiële functies houden de dienst veilig",
+      "Analyse toont wat beter kan",
+      "Personalisatie maakt inhoud relevant",
+    ],
+    "footer": "Je kunt je keuze altijd wijzigen.",
+    "manageCta": "Voorkeuren beheren",
+    "rejectCta": "Alleen noodzakelijk",
+    "summary": "We gebruiken gegevens om Summit te leveren, meten en personaliseren.",
+    "title": "Jouw privacyvoorkeuren",
+  },
+  "locale": "nl-NL",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders no-NO locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Godta alt",
+    "bulletPoints": [
+      "Essensielle funksjoner holder tjenesten trygg",
+      "Analyse viser hva vi kan forbedre",
+      "Personalisering gjør innhold relevant",
+    ],
+    "footer": "Endre når som helst.",
+    "manageCta": "Administrer valg",
+    "rejectCta": "Avslå tillegg",
+    "summary": "Vi bruker data for å levere, måle og tilpasse Summit.",
+    "title": "Dine personvernvalg",
+  },
+  "locale": "no-NO",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders pl-PL locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Akceptuj wszystko",
+    "bulletPoints": [
+      "Niezbędne funkcje zapewniają bezpieczeństwo",
+      "Analityka pokazuje co ulepszyć",
+      "Personalizacja dostosowuje treści",
+    ],
+    "footer": "Możesz zmienić decyzję w dowolnym momencie.",
+    "manageCta": "Zarządzaj ustawieniami",
+    "rejectCta": "Odrzuć dodatkowe",
+    "summary": "Wykorzystujemy dane, aby dostarczać, mierzyć i personalizować Summit.",
+    "title": "Twoje ustawienia prywatności",
+  },
+  "locale": "pl-PL",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders pt-BR locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Aceitar tudo",
+    "bulletPoints": [
+      "Funções essenciais mantêm o serviço seguro",
+      "Métricas mostram onde melhorar",
+      "Personalização torna o conteúdo relevante",
+    ],
+    "footer": "Altere suas escolhas quando quiser.",
+    "manageCta": "Gerenciar preferências",
+    "rejectCta": "Recusar opcionais",
+    "summary": "Usamos dados para fornecer, medir e personalizar a Summit.",
+    "title": "Suas escolhas de privacidade",
+  },
+  "locale": "pt-BR",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders pt-PT locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Aceitar tudo",
+    "bulletPoints": [
+      "Funcionalidades essenciais mantêm o serviço seguro",
+      "Análises mostram o que melhorar",
+      "Personalização adapta o conteúdo",
+    ],
+    "footer": "Pode alterar a qualquer momento.",
+    "manageCta": "Gerir definições",
+    "rejectCta": "Recusar extra",
+    "summary": "Utilizamos dados para disponibilizar, medir e personalizar a Summit.",
+    "title": "As suas opções de privacidade",
+  },
+  "locale": "pt-PT",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders sv-SE locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "Godkänn allt",
+    "bulletPoints": [
+      "Viktiga funktioner håller tjänsten säker",
+      "Analys visar vad som kan förbättras",
+      "Personalisering gör innehållet relevant",
+    ],
+    "footer": "Du kan ändra när som helst.",
+    "manageCta": "Hantera inställningar",
+    "rejectCta": "Avvisa extra",
+    "summary": "Vi använder data för att leverera, mäta och anpassa Summit.",
+    "title": "Dina sekretessval",
+  },
+  "locale": "sv-SE",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;
+
+exports[`AdaptiveConsentSDK rendering renders zh-CN locale consistently 1`] = `
+{
+  "copy": {
+    "acceptCta": "全部接受",
+    "bulletPoints": [
+      "必要功能保障服务安全",
+      "分析帮助我们改进",
+      "个性化提供相关内容",
+    ],
+    "footer": "您可以随时更新偏好。",
+    "manageCta": "管理设置",
+    "rejectCta": "仅保留必要",
+    "summary": "我们使用数据来提供、衡量并个性化 Summit 服务。",
+    "title": "您的隐私选择",
+  },
+  "locale": "zh-CN",
+  "policyId": "acx-global-privacy",
+  "policyVersion": "1.0.0",
+  "purposes": [
+    {
+      "category": "core",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service",
+      },
+      "id": "essential",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "measurement",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit",
+      },
+      "id": "analytics",
+      "legalBasis": "consent",
+    },
+    {
+      "category": "experience",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations",
+      },
+      "id": "personalization",
+      "legalBasis": "consent",
+    },
+  ],
+  "variant": "control",
+}
+`;

--- a/sdk/acx/android/build.gradle.kts
+++ b/sdk/acx/android/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    id("com.android.library") version "8.5.1"
+    kotlin("android") version "1.9.25"
+}
+
+android {
+    namespace = "com.summit.acx"
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 24
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+}

--- a/sdk/acx/android/src/main/AndroidManifest.xml
+++ b/sdk/acx/android/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest package="com.summit.acx" />

--- a/sdk/acx/android/src/main/kotlin/com/summit/acx/AdaptiveConsent.kt
+++ b/sdk/acx/android/src/main/kotlin/com/summit/acx/AdaptiveConsent.kt
@@ -1,0 +1,173 @@
+package com.summit.acx
+
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.PublicKey
+import java.security.Signature
+import java.security.spec.PKCS8EncodedKeySpec
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+
+public data class PurposeDefinition(
+    val id: String,
+    val category: String,
+    val legalBasis: String,
+    val defaultEnabled: Boolean,
+    val description: Map<String, String>
+)
+
+public data class LocaleOverride(
+    val title: String? = null,
+    val summary: String? = null,
+    val bulletPoints: List<String>? = null,
+    val acceptCta: String? = null,
+    val rejectCta: String? = null,
+    val manageCta: String? = null,
+    val footer: String? = null
+)
+
+public data class LocaleTemplate(
+    val locale: String,
+    val title: String,
+    val summary: String,
+    val bulletPoints: List<String>,
+    val acceptCta: String,
+    val rejectCta: String,
+    val manageCta: String,
+    val footer: String,
+    val variantOverrides: Map<String, LocaleOverride>? = null
+)
+
+public data class PolicyTemplatePack(
+    val policyId: String,
+    val version: String,
+    val defaultLocale: String,
+    val purposes: List<PurposeDefinition>,
+    val locales: Map<String, LocaleTemplate>
+)
+
+public data class ConsentDialog(
+    val locale: String,
+    val title: String,
+    val summary: String,
+    val bulletPoints: List<String>,
+    val acceptCta: String,
+    val rejectCta: String,
+    val manageCta: String,
+    val footer: String,
+    val purposes: List<PurposeDefinition>,
+    val policyId: String,
+    val policyVersion: String,
+    val variant: String
+)
+
+public data class PurposeScope(val id: String, val enabled: Boolean)
+
+public data class ConsentRecord(
+    val policyId: String,
+    val policyVersion: String,
+    val userId: String,
+    val locale: String,
+    val decision: String,
+    val purposes: List<PurposeScope>,
+    val timestamp: String,
+    val variant: String
+)
+
+public data class ConsentArtifact(
+    val algorithm: String,
+    val signature: String,
+    val payload: ConsentRecord
+)
+
+public class DarkPatternException(message: String) : Exception(message)
+
+public class AdaptiveConsent(
+    private val pack: PolicyTemplatePack,
+    private val disallowed: List<String> = listOf("preselected", "you must accept")
+) {
+    init {
+        validate()
+    }
+
+    private fun validate() {
+        pack.locales.forEach { (locale, template) ->
+            inspect(locale, template.title)
+            inspect(locale, template.summary)
+            template.bulletPoints.forEach { inspect(locale, it) }
+            template.variantOverrides?.values?.forEach { override ->
+                override.summary?.let { inspect(locale, it) }
+            }
+        }
+    }
+
+    private fun inspect(locale: String, text: String) {
+        disallowed.forEach {
+            if (text.lowercase().contains(it)) {
+                throw DarkPatternException("$locale contains disallowed pattern $it")
+            }
+        }
+    }
+
+    public fun render(locale: String, scopedPurposes: List<String>? = null): ConsentDialog {
+        val template = pack.locales[locale] ?: pack.locales[pack.defaultLocale]
+            ?: throw IllegalArgumentException("Locale $locale not found")
+        val purposes = if (scopedPurposes == null) {
+            pack.purposes
+        } else {
+            val set = scopedPurposes.toSet()
+            pack.purposes.filter { set.contains(it.id) }
+        }
+        return ConsentDialog(
+            locale = template.locale,
+            title = template.title,
+            summary = template.summary,
+            bulletPoints = template.bulletPoints,
+            acceptCta = template.acceptCta,
+            rejectCta = template.rejectCta,
+            manageCta = template.manageCta,
+            footer = template.footer,
+            purposes = purposes,
+            policyId = pack.policyId,
+            policyVersion = pack.version,
+            variant = "control"
+        )
+    }
+
+    public fun sign(record: ConsentRecord, privateKeyPem: String): ConsentArtifact {
+        val privateKey = decodePrivateKey(privateKeyPem)
+        val signature = Signature.getInstance("SHA256withRSA")
+        signature.initSign(privateKey)
+        signature.update(record.toString().toByteArray(Charsets.UTF_8))
+        val signed = Base64.getEncoder().encodeToString(signature.sign())
+        return ConsentArtifact("SHA256withRSA", signed, record)
+    }
+
+    public fun verify(artifact: ConsentArtifact, publicKeyPem: String): Boolean {
+        val publicKey = decodePublicKey(publicKeyPem)
+        val signature = Signature.getInstance("SHA256withRSA")
+        signature.initVerify(publicKey)
+        signature.update(artifact.payload.toString().toByteArray(Charsets.UTF_8))
+        return signature.verify(Base64.getDecoder().decode(artifact.signature))
+    }
+
+    private fun decodePrivateKey(pem: String): PrivateKey {
+        val content = pem
+            .replace("-----BEGIN PRIVATE KEY-----", "")
+            .replace("-----END PRIVATE KEY-----", "")
+            .replace("\n", "")
+        val bytes = Base64.getDecoder().decode(content)
+        val spec = PKCS8EncodedKeySpec(bytes)
+        return KeyFactory.getInstance("RSA").generatePrivate(spec)
+    }
+
+    private fun decodePublicKey(pem: String): PublicKey {
+        val content = pem
+            .replace("-----BEGIN PUBLIC KEY-----", "")
+            .replace("-----END PUBLIC KEY-----", "")
+            .replace("\n", "")
+        val bytes = Base64.getDecoder().decode(content)
+        val spec = X509EncodedKeySpec(bytes)
+        return KeyFactory.getInstance("RSA").generatePublic(spec)
+    }
+}

--- a/sdk/acx/ios/Package.swift
+++ b/sdk/acx/ios/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "ACX",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(
+            name: "ACX",
+            targets: ["ACX"]
+        )
+    ],
+    targets: [
+        .target(
+            name: "ACX",
+            path: "Sources"
+        ),
+        .testTarget(
+            name: "ACXTests",
+            dependencies: ["ACX"],
+            path: "Tests"
+        )
+    ]
+)

--- a/sdk/acx/ios/Sources/ACX/AdaptiveConsent.swift
+++ b/sdk/acx/ios/Sources/ACX/AdaptiveConsent.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+public struct PurposeDefinition: Codable, Hashable {
+    public let id: String
+    public let category: String
+    public let legalBasis: String
+    public let defaultEnabled: Bool
+    public let description: [String: String]
+}
+
+public struct LocaleTemplate: Codable {
+    public let locale: String
+    public let title: String
+    public let summary: String
+    public let bulletPoints: [String]
+    public let acceptCta: String
+    public let rejectCta: String
+    public let manageCta: String
+    public let footer: String
+    public let variantOverrides: [String: LocaleOverride]?
+}
+
+public struct LocaleOverride: Codable {
+    public let title: String?
+    public let summary: String?
+    public let bulletPoints: [String]?
+    public let acceptCta: String?
+    public let rejectCta: String?
+    public let manageCta: String?
+    public let footer: String?
+}
+
+public struct PolicyTemplatePack: Codable {
+    public let policyId: String
+    public let version: String
+    public let defaultLocale: String
+    public let purposes: [PurposeDefinition]
+    public let locales: [String: LocaleTemplate]
+}
+
+public struct ConsentDialog: Codable {
+    public let locale: String
+    public let title: String
+    public let summary: String
+    public let bulletPoints: [String]
+    public let acceptCta: String
+    public let rejectCta: String
+    public let manageCta: String
+    public let footer: String
+    public let purposes: [PurposeDefinition]
+    public let policyId: String
+    public let policyVersion: String
+    public let variant: String
+}
+
+public struct PurposeScope: Codable {
+    public let id: String
+    public let enabled: Bool
+}
+
+public enum AdaptiveConsentError: Error {
+    case darkPatternFound(pattern: String)
+    case missingLocale
+}
+
+public final class AdaptiveConsent {
+    private let pack: PolicyTemplatePack
+    private let disallowedPatterns: [String]
+
+    public init(pack: PolicyTemplatePack, disallowedPatterns: [String] = ["preselected", "you must accept"]) throws {
+        self.pack = pack
+        self.disallowedPatterns = disallowedPatterns
+        try validate()
+    }
+
+    private func validate() throws {
+        for (locale, template) in pack.locales {
+            try inspect(locale: locale, template: template)
+        }
+    }
+
+    private func inspect(locale: String, template: LocaleTemplate) throws {
+        try inspect(locale: locale, value: template.title)
+        try inspect(locale: locale, value: template.summary)
+        try template.bulletPoints.forEach { try inspect(locale: locale, value: $0) }
+        if let overrides = template.variantOverrides {
+            for override in overrides.values {
+                if let summary = override.summary {
+                    try inspect(locale: locale, value: summary)
+                }
+            }
+        }
+    }
+
+    private func inspect(locale: String, value: String) throws {
+        for pattern in disallowedPatterns where value.lowercased().contains(pattern) {
+            throw AdaptiveConsentError.darkPatternFound(pattern: pattern)
+        }
+    }
+
+    public func render(locale: String, scopedPurposes: [String]? = nil) throws -> ConsentDialog {
+        guard let template = pack.locales[locale] ?? pack.locales[pack.defaultLocale] else {
+            throw AdaptiveConsentError.missingLocale
+        }
+        let purposes = scope(purposes: pack.purposes, requested: scopedPurposes)
+        return ConsentDialog(
+            locale: template.locale,
+            title: template.title,
+            summary: template.summary,
+            bulletPoints: template.bulletPoints,
+            acceptCta: template.acceptCta,
+            rejectCta: template.rejectCta,
+            manageCta: template.manageCta,
+            footer: template.footer,
+            purposes: purposes,
+            policyId: pack.policyId,
+            policyVersion: pack.version,
+            variant: "control"
+        )
+    }
+
+    private func scope(purposes: [PurposeDefinition], requested: [String]?) -> [PurposeDefinition] {
+        guard let requested else { return purposes }
+        let set = Set(requested)
+        return purposes.filter { set.contains($0.id) }
+    }
+}

--- a/sdk/acx/ios/Tests/ACXTests/AdaptiveConsentTests.swift
+++ b/sdk/acx/ios/Tests/ACXTests/AdaptiveConsentTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import ACX
+
+final class AdaptiveConsentTests: XCTestCase {
+    func testRenderScopesPurposes() throws {
+        let pack = PolicyTemplatePack(
+            policyId: "test",
+            version: "1.0.0",
+            defaultLocale: "en-US",
+            purposes: [
+                PurposeDefinition(id: "analytics", category: "measure", legalBasis: "consent", defaultEnabled: false, description: [:])
+            ],
+            locales: [
+                "en-US": LocaleTemplate(
+                    locale: "en-US",
+                    title: "Privacy",
+                    summary: "We use data.",
+                    bulletPoints: ["Analytics"],
+                    acceptCta: "Accept",
+                    rejectCta: "Reject",
+                    manageCta: "Manage",
+                    footer: "Update anytime",
+                    variantOverrides: nil
+                )
+            ]
+        )
+
+        let sdk = try AdaptiveConsent(pack: pack)
+        let dialog = try sdk.render(locale: "en-US", scopedPurposes: ["analytics"])
+        XCTAssertEqual(dialog.purposes.first?.id, "analytics")
+        XCTAssertEqual(dialog.variant, "control")
+    }
+}

--- a/sdk/acx/jest.config.js
+++ b/sdk/acx/jest.config.js
@@ -1,0 +1,16 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  rootDir: '.',
+  testMatch: ['**/test/**/*.test.ts'],
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts'],
+  snapshotResolver: '<rootDir>/test/snapshotResolver.cjs',
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { useESM: true, tsconfig: './tsconfig.json' }]
+  },
+  moduleNameMapper: {
+    '^(.*)\\.js$': '$1'
+  }
+};

--- a/sdk/acx/package.json
+++ b/sdk/acx/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@summit/acx",
+  "version": "0.1.0",
+  "description": "Adaptive Consent Experience SDK for web, iOS, and Android",
+  "type": "module",
+  "engines": {
+    "node": ">=18.18"
+  },
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "templates",
+    "ios",
+    "android"
+  ],
+  "scripts": {
+    "build": "npm run lint:patterns && tsc -p tsconfig.json",
+    "lint:patterns": "node ./scripts/check-dark-patterns.js",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/jest": "^30.0.0",
+    "@types/node": "^22.10.1",
+    "jest": "^30.1.2",
+    "ts-jest": "^29.4.1",
+    "typescript": "^5.9.2"
+  }
+}

--- a/sdk/acx/scripts/check-dark-patterns.js
+++ b/sdk/acx/scripts/check-dark-patterns.js
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const packPath = path.resolve(__dirname, '../templates/policyPack.json');
+const patternsPath = path.resolve(__dirname, '../src/dark-patterns.json');
+
+const pack = JSON.parse(readFileSync(packPath, 'utf-8'));
+const patterns = JSON.parse(readFileSync(patternsPath, 'utf-8'));
+
+const findings = [];
+
+const inspect = (locale, value) => {
+  if (typeof value === 'string') {
+    patterns.forEach((pattern) => {
+      if (value.toLowerCase().includes(pattern.toLowerCase())) {
+        findings.push({ locale, pattern, text: value });
+      }
+    });
+  } else if (Array.isArray(value)) {
+    value.forEach((item) => inspect(locale, item));
+  } else if (value && typeof value === 'object') {
+    Object.values(value).forEach((item) => inspect(locale, item));
+  }
+};
+
+Object.entries(pack.locales).forEach(([locale, copy]) => inspect(locale, copy));
+
+if (findings.length > 0) {
+  const details = findings.map((finding) => `${finding.locale}: disallowed pattern "${finding.pattern}" in \"${finding.text}\"`).join('\n');
+  console.error(`Dark pattern linter failed:\n${details}`);
+  process.exit(1);
+}

--- a/sdk/acx/src/artifact.ts
+++ b/sdk/acx/src/artifact.ts
@@ -1,0 +1,26 @@
+import { createSign, createVerify } from 'node:crypto';
+import { ConsentArtifact, ConsentRecord } from './types.js';
+
+export class ConsentArtifactSigner {
+  constructor(private readonly privateKeyPem: string, private readonly algorithm: string = 'RSA-SHA256') {}
+
+  public sign(record: ConsentRecord): ConsentArtifact {
+    const signer = createSign('RSA-SHA256');
+    const payload = JSON.stringify(record);
+    signer.update(payload);
+    signer.end();
+    const signature = signer.sign(this.privateKeyPem, 'base64');
+    return {
+      algorithm: this.algorithm,
+      signature,
+      payload: record
+    };
+  }
+
+  public static verify(artifact: ConsentArtifact, publicKeyPem: string): boolean {
+    const verifier = createVerify('RSA-SHA256');
+    verifier.update(JSON.stringify(artifact.payload));
+    verifier.end();
+    return verifier.verify(publicKeyPem, artifact.signature, 'base64');
+  }
+}

--- a/sdk/acx/src/dark-patterns.json
+++ b/sdk/acx/src/dark-patterns.json
@@ -1,0 +1,12 @@
+[
+  "preselected",
+  "pre-ticked",
+  "no option",
+  "forced consent",
+  "you must accept",
+  "only choice",
+  "can't refuse",
+  "limited functionality",
+  "just trust us",
+  "accept to continue"
+]

--- a/sdk/acx/src/index.ts
+++ b/sdk/acx/src/index.ts
@@ -1,0 +1,6 @@
+export * from './types.js';
+export * from './validators.js';
+export * from './variants.js';
+export * from './templatePack.js';
+export * from './artifact.js';
+export * from './sdk.js';

--- a/sdk/acx/src/sdk.ts
+++ b/sdk/acx/src/sdk.ts
@@ -1,0 +1,45 @@
+import { ConsentArtifactSigner } from './artifact.js';
+import { TemplatePack } from './templatePack.js';
+import {
+  ConsentArtifact,
+  ConsentDecision,
+  ConsentRecord,
+  ExperimentDefinition,
+  PolicyTemplatePack,
+  RenderOptions
+} from './types.js';
+
+export class AdaptiveConsentSDK {
+  private readonly templatePack: TemplatePack;
+
+  constructor(private readonly pack: PolicyTemplatePack) {
+    this.templatePack = new TemplatePack(pack);
+  }
+
+  public registerExperiment(definition: ExperimentDefinition): void {
+    this.templatePack.registerExperiment(definition);
+  }
+
+  public render(options: RenderOptions) {
+    return this.templatePack.render(options);
+  }
+
+  public createConsentRecord(userId: string, decision: ConsentDecision, options: RenderOptions): ConsentRecord {
+    return this.templatePack.createConsentRecord(userId, decision, options).record;
+  }
+
+  public emitSignedArtifact(
+    userId: string,
+    decision: ConsentDecision,
+    options: RenderOptions,
+    privateKeyPem: string
+  ): ConsentArtifact {
+    const record = this.createConsentRecord(userId, decision, options);
+    const signer = new ConsentArtifactSigner(privateKeyPem);
+    return signer.sign(record);
+  }
+
+  public static verifyArtifact(artifact: ConsentArtifact, publicKeyPem: string): boolean {
+    return ConsentArtifactSigner.verify(artifact, publicKeyPem);
+  }
+}

--- a/sdk/acx/src/templatePack.ts
+++ b/sdk/acx/src/templatePack.ts
@@ -1,0 +1,182 @@
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const darkPatterns: string[] = require('./dark-patterns.json');
+
+import {
+  ConsentDialog,
+  ConsentRecord,
+  ExperimentDefinition,
+  LocaleCopy,
+  LocaleTemplate,
+  PolicyTemplatePack,
+  PurposeDefinition,
+  PurposeScope,
+  RenderOptions
+} from './types.js';
+import { DarkPatternLinter } from './validators.js';
+import { ExperimentEngine } from './variants.js';
+
+export class TemplatePack {
+  private readonly linter: DarkPatternLinter;
+  private readonly experiments: Map<string, ExperimentDefinition> = new Map();
+  private readonly experimentEngine: ExperimentEngine;
+
+  constructor(private readonly pack: PolicyTemplatePack) {
+    this.linter = new DarkPatternLinter(darkPatterns);
+    this.experimentEngine = new ExperimentEngine();
+    this.assertIntegrity();
+  }
+
+  private assertIntegrity(): void {
+    if (!this.pack.policyId) {
+      throw new Error('policyId is required');
+    }
+    if (!this.pack.version) {
+      throw new Error('version is required');
+    }
+    if (!this.pack.defaultLocale) {
+      throw new Error('defaultLocale is required');
+    }
+    if (!this.pack.locales[this.pack.defaultLocale]) {
+      throw new Error(`defaultLocale ${this.pack.defaultLocale} is not defined`);
+    }
+
+    const lintResults = this.linter.lintPack(this.pack);
+    if (lintResults.length > 0) {
+      const message = lintResults.map((result) => `${result.locale}: ${result.message}`).join('\n');
+      throw new Error(`Dark pattern linter failed:\n${message}`);
+    }
+  }
+
+  public registerExperiment(definition: ExperimentDefinition): void {
+    this.validateExperiment(definition);
+    this.experiments.set(definition.name, definition);
+    this.experimentEngine.register(definition);
+  }
+
+  private validateExperiment(definition: ExperimentDefinition): void {
+    const locales = Object.keys(this.pack.locales);
+    locales.forEach((locale) => {
+      const base = this.pack.locales[locale];
+      const controlCopy = this.applyOverrides(base, definition.controlVariant.uiOverrides, definition.controlVariant.id);
+      definition.variants.forEach((variant) => {
+        const variantCopy = this.applyOverrides(base, variant.uiOverrides, variant.id);
+        this.assertSemanticParity(controlCopy, variantCopy, locale, variant.id);
+      });
+    });
+  }
+
+  private assertSemanticParity(control: LocaleCopy, variant: LocaleCopy, locale: string, variantId: string): void {
+    const canonicalControl = this.semanticSignature(control);
+    const canonicalVariant = this.semanticSignature(variant);
+    if (canonicalControl !== canonicalVariant) {
+      throw new Error(
+        `Variant ${variantId} for locale ${locale} changes consent semantics. Expected signature ${canonicalControl} but received ${canonicalVariant}.`
+      );
+    }
+  }
+
+  private semanticSignature(copy: LocaleCopy): string {
+    return [copy.summary, ...copy.bulletPoints, copy.footer].join('|').toLowerCase();
+  }
+
+  private applyOverrides(
+    base: LocaleTemplate,
+    overrides: Partial<LocaleCopy> | undefined,
+    variantId: string
+  ): LocaleCopy {
+    const variantOverrides = base.variantOverrides?.[variantId] ?? {};
+    const merged: LocaleCopy = {
+      title: base.title,
+      summary: base.summary,
+      bulletPoints: [...base.bulletPoints],
+      acceptCta: base.acceptCta,
+      rejectCta: base.rejectCta,
+      manageCta: base.manageCta,
+      footer: base.footer
+    };
+
+    const layers = [variantOverrides, overrides].filter(Boolean);
+    layers.forEach((layer) => {
+      if (!layer) return;
+      if (layer.bulletPoints) {
+        merged.bulletPoints = [...layer.bulletPoints];
+      }
+      merged.title = layer.title ?? merged.title;
+      merged.summary = layer.summary ?? merged.summary;
+      merged.acceptCta = layer.acceptCta ?? merged.acceptCta;
+      merged.rejectCta = layer.rejectCta ?? merged.rejectCta;
+      merged.manageCta = layer.manageCta ?? merged.manageCta;
+      merged.footer = layer.footer ?? merged.footer;
+    });
+
+    return merged;
+  }
+
+  private getLocale(locale: string): LocaleTemplate {
+    return this.pack.locales[locale] ?? this.pack.locales[this.pack.defaultLocale];
+  }
+
+  private scopePurposes(requested: string[] | undefined): PurposeDefinition[] {
+    if (!requested || requested.length === 0) {
+      return this.pack.purposes;
+    }
+    const requestedSet = new Set(requested);
+    return this.pack.purposes.filter((purpose) => requestedSet.has(purpose.id));
+  }
+
+  private normalizeScopes(purposes: PurposeDefinition[], scopedPurposes?: string[]): PurposeScope[] {
+    const scopeSet = new Set(scopedPurposes ?? purposes.map((p) => p.id));
+    return purposes.map((purpose) => ({ id: purpose.id, enabled: scopeSet.has(purpose.id) }));
+  }
+
+  public render(options: RenderOptions): ConsentDialog {
+    const localeTemplate = this.getLocale(options.locale);
+    const purposes = this.scopePurposes(options.scopedPurposes);
+    const selection = this.experimentEngine.select(options.experiment);
+    const variantId = selection?.id ?? 'control';
+    const overrides = selection?.uiOverrides;
+    const copy = this.applyOverrides(localeTemplate, overrides, variantId);
+
+    return {
+      locale: localeTemplate.locale,
+      copy,
+      purposes,
+      policyId: this.pack.policyId,
+      policyVersion: this.pack.version,
+      variant: variantId
+    };
+  }
+
+  public createConsentRecord(
+    userId: string,
+    decision: 'accept' | 'reject' | 'custom',
+    options: RenderOptions
+  ): ConsentRecordWithScopes {
+    const dialog = this.render(options);
+    const scopes = this.normalizeScopes(dialog.purposes, options.scopedPurposes);
+    const record: ConsentRecord = {
+      policyId: dialog.policyId,
+      policyVersion: dialog.policyVersion,
+      userId,
+      locale: dialog.locale,
+      decision,
+      purposes: scopes,
+      timestamp: new Date().toISOString(),
+      variant: dialog.variant
+    };
+    return {
+      dialog,
+      record
+    };
+  }
+
+  public getExperiment(name: string): ExperimentDefinition | undefined {
+    return this.experiments.get(name);
+  }
+}
+
+export interface ConsentRecordWithScopes {
+  dialog: ConsentDialog;
+  record: ConsentRecord;
+}

--- a/sdk/acx/src/types.ts
+++ b/sdk/acx/src/types.ts
@@ -1,0 +1,81 @@
+export type ConsentDecision = 'accept' | 'reject' | 'custom';
+
+export interface PurposeDefinition {
+  id: string;
+  category: string;
+  legalBasis: 'consent' | 'legitimate-interest';
+  defaultEnabled: boolean;
+  description: Record<string, string>;
+}
+
+export interface PurposeScope {
+  id: string;
+  enabled: boolean;
+}
+
+export interface LocaleCopy {
+  title: string;
+  summary: string;
+  bulletPoints: string[];
+  acceptCta: string;
+  rejectCta: string;
+  manageCta: string;
+  footer: string;
+}
+
+export interface LocaleTemplate extends LocaleCopy {
+  locale: string;
+  variantOverrides?: Record<string, Partial<LocaleCopy>>;
+}
+
+export interface PolicyTemplatePack {
+  policyId: string;
+  version: string;
+  defaultLocale: string;
+  purposes: PurposeDefinition[];
+  locales: Record<string, LocaleTemplate>;
+}
+
+export interface ConsentDialog {
+  locale: string;
+  copy: LocaleCopy;
+  purposes: PurposeDefinition[];
+  policyId: string;
+  policyVersion: string;
+  variant: string;
+}
+
+export interface ConsentRecord {
+  policyId: string;
+  policyVersion: string;
+  userId: string;
+  locale: string;
+  decision: ConsentDecision;
+  purposes: PurposeScope[];
+  timestamp: string;
+  variant: string;
+}
+
+export interface ConsentArtifact {
+  algorithm: string;
+  signature: string;
+  payload: ConsentRecord;
+}
+
+export interface ExperimentVariant {
+  id: string;
+  probability: number;
+  uiOverrides?: Partial<LocaleCopy>;
+}
+
+export interface ExperimentDefinition {
+  name: string;
+  controlVariant: ExperimentVariant;
+  variants: ExperimentVariant[];
+}
+
+export interface RenderOptions {
+  locale: string;
+  experiment?: string;
+  scopedPurposes?: string[];
+}

--- a/sdk/acx/src/validators.ts
+++ b/sdk/acx/src/validators.ts
@@ -1,0 +1,39 @@
+import { PolicyTemplatePack } from './types.js';
+
+export interface LintFinding {
+  locale: string;
+  message: string;
+  pattern: string;
+}
+
+export class DarkPatternLinter {
+  constructor(private readonly disallowedPatterns: string[]) {}
+
+  public lintPack(pack: PolicyTemplatePack): LintFinding[] {
+    return Object.values(pack.locales).flatMap((locale) => this.lintLocale(locale.locale, locale));
+  }
+
+  private lintLocale(locale: string, copy: unknown): LintFinding[] {
+    const findings: LintFinding[] = [];
+    const inspect = (value: unknown): void => {
+      if (typeof value === 'string') {
+        this.disallowedPatterns.forEach((pattern) => {
+          if (value.toLowerCase().includes(pattern.toLowerCase())) {
+            findings.push({
+              locale,
+              message: `Found disallowed pattern "${pattern}" in text: ${value}`,
+              pattern
+            });
+          }
+        });
+      } else if (Array.isArray(value)) {
+        value.forEach(inspect);
+      } else if (value && typeof value === 'object') {
+        Object.values(value as Record<string, unknown>).forEach(inspect);
+      }
+    };
+
+    inspect(copy);
+    return findings;
+  }
+}

--- a/sdk/acx/src/variants.ts
+++ b/sdk/acx/src/variants.ts
@@ -1,0 +1,46 @@
+import { ExperimentDefinition, ExperimentVariant } from './types.js';
+
+export class ExperimentEngine {
+  private readonly experiments: Map<string, ExperimentDefinition> = new Map();
+  private readonly lastSelection: Map<string, ExperimentVariant> = new Map();
+
+  public register(definition: ExperimentDefinition): void {
+    this.experiments.set(definition.name, definition);
+  }
+
+  public select(experimentName: string | undefined): ExperimentVariant | undefined {
+    if (!experimentName) {
+      return undefined;
+    }
+    const experiment = this.experiments.get(experimentName);
+    if (!experiment) {
+      throw new Error(`Experiment ${experimentName} is not registered`);
+    }
+
+    const roll = Math.random();
+    let cumulative = experiment.controlVariant.probability;
+    if (roll < cumulative) {
+      this.lastSelection.set(experimentName, experiment.controlVariant);
+      return experiment.controlVariant;
+    }
+
+    for (const variant of experiment.variants) {
+      cumulative += variant.probability;
+      if (roll < cumulative) {
+        this.lastSelection.set(experimentName, variant);
+        return variant;
+      }
+    }
+
+    const fallback = experiment.variants[experiment.variants.length - 1] ?? experiment.controlVariant;
+    this.lastSelection.set(experimentName, fallback);
+    return fallback;
+  }
+
+  public getLastSelection(experimentName: string | undefined): ExperimentVariant | undefined {
+    if (!experimentName) {
+      return undefined;
+    }
+    return this.lastSelection.get(experimentName);
+  }
+}

--- a/sdk/acx/templates/policyPack.json
+++ b/sdk/acx/templates/policyPack.json
@@ -1,0 +1,324 @@
+{
+  "policyId": "acx-global-privacy",
+  "version": "1.0.0",
+  "defaultLocale": "en-US",
+  "purposes": [
+    {
+      "id": "essential",
+      "category": "core",
+      "legalBasis": "consent",
+      "defaultEnabled": true,
+      "description": {
+        "en-US": "Required for the service to function",
+        "fr-FR": "Nécessaire au fonctionnement du service"
+      }
+    },
+    {
+      "id": "analytics",
+      "category": "measurement",
+      "legalBasis": "consent",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Helps us understand product usage",
+        "fr-FR": "Nous aide à comprendre l'utilisation du produit"
+      }
+    },
+    {
+      "id": "personalization",
+      "category": "experience",
+      "legalBasis": "consent",
+      "defaultEnabled": false,
+      "description": {
+        "en-US": "Improves recommendations",
+        "fr-FR": "Améliore les recommandations"
+      }
+    }
+  ],
+  "locales": {
+    "en-US": {
+      "locale": "en-US",
+      "title": "Your privacy choices",
+      "summary": "We use data to provide, measure, and personalize your experience.",
+      "bulletPoints": [
+        "Essential features keep Summit services secure",
+        "Analytics shows us what to improve",
+        "Personalization tailors content to you"
+      ],
+      "acceptCta": "Accept all",
+      "rejectCta": "Reject non-essential",
+      "manageCta": "Manage settings",
+      "footer": "You can update preferences at any time.",
+      "variantOverrides": {
+        "minimal": {
+          "title": "Update privacy settings"
+        }
+      }
+    },
+    "en-GB": {
+      "locale": "en-GB",
+      "title": "Your privacy options",
+      "summary": "We process data to run Summit and improve the experience.",
+      "bulletPoints": [
+        "Essential cookies secure our services",
+        "Analytics helps us improve",
+        "Personalisation adapts content"
+      ],
+      "acceptCta": "Allow all",
+      "rejectCta": "Decline extras",
+      "manageCta": "Review choices",
+      "footer": "Change your decision whenever you like."
+    },
+    "fr-FR": {
+      "locale": "fr-FR",
+      "title": "Vos préférences de confidentialité",
+      "summary": "Nous utilisons vos données pour fournir, mesurer et personnaliser Summit.",
+      "bulletPoints": [
+        "Les fonctionnalités essentielles sécurisent le service",
+        "Les analyses guident nos améliorations",
+        "La personnalisation adapte le contenu"
+      ],
+      "acceptCta": "Tout accepter",
+      "rejectCta": "Refuser le non-essentiel",
+      "manageCta": "Gérer les paramètres",
+      "footer": "Vous pouvez modifier vos choix à tout moment."
+    },
+    "fr-CA": {
+      "locale": "fr-CA",
+      "title": "Vos choix de confidentialité",
+      "summary": "Nous utilisons des données pour offrir, mesurer et personnaliser Summit.",
+      "bulletPoints": [
+        "Les fonctionnalités essentielles assurent la sécurité",
+        "Les analyses montrent quoi améliorer",
+        "La personnalisation adapte l'expérience"
+      ],
+      "acceptCta": "Accepter tout",
+      "rejectCta": "Refuser le non essentiel",
+      "manageCta": "Modifier les paramètres",
+      "footer": "Vos préférences sont modifiables en tout temps."
+    },
+    "es-ES": {
+      "locale": "es-ES",
+      "title": "Tus opciones de privacidad",
+      "summary": "Usamos datos para ofrecer, medir y personalizar Summit.",
+      "bulletPoints": [
+        "Las funciones esenciales mantienen el servicio seguro",
+        "La analítica nos ayuda a mejorar",
+        "La personalización ajusta el contenido"
+      ],
+      "acceptCta": "Aceptar todo",
+      "rejectCta": "Rechazar lo no esencial",
+      "manageCta": "Administrar ajustes",
+      "footer": "Puedes cambiar tu decisión cuando quieras."
+    },
+    "es-MX": {
+      "locale": "es-MX",
+      "title": "Configura tu privacidad",
+      "summary": "Usamos datos para operar Summit y mejorar tu experiencia.",
+      "bulletPoints": [
+        "Funciones esenciales protegen tu cuenta",
+        "Analítica muestra qué mejorar",
+        "Personalización crea contenido relevante"
+      ],
+      "acceptCta": "Aceptar todo",
+      "rejectCta": "Rechazar adicionales",
+      "manageCta": "Gestionar opciones",
+      "footer": "Actualiza las preferencias en cualquier momento."
+    },
+    "de-DE": {
+      "locale": "de-DE",
+      "title": "Ihre Datenschutzwahl",
+      "summary": "Wir verwenden Daten, um Summit bereitzustellen, zu messen und zu personalisieren.",
+      "bulletPoints": [
+        "Essentielle Funktionen halten den Dienst sicher",
+        "Analysen zeigen Verbesserungsmöglichkeiten",
+        "Personalisierung passt Inhalte an"
+      ],
+      "acceptCta": "Alle zulassen",
+      "rejectCta": "Nur Notwendiges",
+      "manageCta": "Einstellungen verwalten",
+      "footer": "Sie können Ihre Auswahl jederzeit ändern."
+    },
+    "it-IT": {
+      "locale": "it-IT",
+      "title": "Le tue scelte sulla privacy",
+      "summary": "Usiamo i dati per fornire, misurare e personalizzare Summit.",
+      "bulletPoints": [
+        "Le funzioni essenziali mantengono il servizio sicuro",
+        "L'analisi ci aiuta a migliorare",
+        "La personalizzazione adatta i contenuti"
+      ],
+      "acceptCta": "Accetta tutto",
+      "rejectCta": "Rifiuta il superfluo",
+      "manageCta": "Gestisci impostazioni",
+      "footer": "Puoi aggiornare le preferenze in ogni momento."
+    },
+    "pt-BR": {
+      "locale": "pt-BR",
+      "title": "Suas escolhas de privacidade",
+      "summary": "Usamos dados para fornecer, medir e personalizar a Summit.",
+      "bulletPoints": [
+        "Funções essenciais mantêm o serviço seguro",
+        "Métricas mostram onde melhorar",
+        "Personalização torna o conteúdo relevante"
+      ],
+      "acceptCta": "Aceitar tudo",
+      "rejectCta": "Recusar opcionais",
+      "manageCta": "Gerenciar preferências",
+      "footer": "Altere suas escolhas quando quiser."
+    },
+    "pt-PT": {
+      "locale": "pt-PT",
+      "title": "As suas opções de privacidade",
+      "summary": "Utilizamos dados para disponibilizar, medir e personalizar a Summit.",
+      "bulletPoints": [
+        "Funcionalidades essenciais mantêm o serviço seguro",
+        "Análises mostram o que melhorar",
+        "Personalização adapta o conteúdo"
+      ],
+      "acceptCta": "Aceitar tudo",
+      "rejectCta": "Recusar extra",
+      "manageCta": "Gerir definições",
+      "footer": "Pode alterar a qualquer momento."
+    },
+    "nl-NL": {
+      "locale": "nl-NL",
+      "title": "Jouw privacyvoorkeuren",
+      "summary": "We gebruiken gegevens om Summit te leveren, meten en personaliseren.",
+      "bulletPoints": [
+        "Essentiële functies houden de dienst veilig",
+        "Analyse toont wat beter kan",
+        "Personalisatie maakt inhoud relevant"
+      ],
+      "acceptCta": "Alles accepteren",
+      "rejectCta": "Alleen noodzakelijk",
+      "manageCta": "Voorkeuren beheren",
+      "footer": "Je kunt je keuze altijd wijzigen."
+    },
+    "sv-SE": {
+      "locale": "sv-SE",
+      "title": "Dina sekretessval",
+      "summary": "Vi använder data för att leverera, mäta och anpassa Summit.",
+      "bulletPoints": [
+        "Viktiga funktioner håller tjänsten säker",
+        "Analys visar vad som kan förbättras",
+        "Personalisering gör innehållet relevant"
+      ],
+      "acceptCta": "Godkänn allt",
+      "rejectCta": "Avvisa extra",
+      "manageCta": "Hantera inställningar",
+      "footer": "Du kan ändra när som helst."
+    },
+    "da-DK": {
+      "locale": "da-DK",
+      "title": "Dine privatlivsvalg",
+      "summary": "Vi bruger data til at levere, måle og tilpasse Summit.",
+      "bulletPoints": [
+        "Vigtige funktioner holder tjenesten sikker",
+        "Analyse hjælper os med at forbedre",
+        "Personalisering gør indhold relevant"
+      ],
+      "acceptCta": "Accepter alt",
+      "rejectCta": "Afvis ekstra",
+      "manageCta": "Administrer indstillinger",
+      "footer": "Du kan ændre dine valg når som helst."
+    },
+    "no-NO": {
+      "locale": "no-NO",
+      "title": "Dine personvernvalg",
+      "summary": "Vi bruker data for å levere, måle og tilpasse Summit.",
+      "bulletPoints": [
+        "Essensielle funksjoner holder tjenesten trygg",
+        "Analyse viser hva vi kan forbedre",
+        "Personalisering gjør innhold relevant"
+      ],
+      "acceptCta": "Godta alt",
+      "rejectCta": "Avslå tillegg",
+      "manageCta": "Administrer valg",
+      "footer": "Endre når som helst."
+    },
+    "fi-FI": {
+      "locale": "fi-FI",
+      "title": "Tietosuoja-asetuksesi",
+      "summary": "Käytämme tietoja palvelun tarjoamiseen, mittaamiseen ja personointiin.",
+      "bulletPoints": [
+        "Välttämättömät toiminnot pitävät palvelun turvallisena",
+        "Analytiikka kertoo mitä parantaa",
+        "Personointi tekee sisällöstä sinulle sopivaa"
+      ],
+      "acceptCta": "Hyväksy kaikki",
+      "rejectCta": "Hylkää lisätiedot",
+      "manageCta": "Hallinnoi asetuksia",
+      "footer": "Voit päivittää asetuksia milloin vain."
+    },
+    "pl-PL": {
+      "locale": "pl-PL",
+      "title": "Twoje ustawienia prywatności",
+      "summary": "Wykorzystujemy dane, aby dostarczać, mierzyć i personalizować Summit.",
+      "bulletPoints": [
+        "Niezbędne funkcje zapewniają bezpieczeństwo",
+        "Analityka pokazuje co ulepszyć",
+        "Personalizacja dostosowuje treści"
+      ],
+      "acceptCta": "Akceptuj wszystko",
+      "rejectCta": "Odrzuć dodatkowe",
+      "manageCta": "Zarządzaj ustawieniami",
+      "footer": "Możesz zmienić decyzję w dowolnym momencie."
+    },
+    "cs-CZ": {
+      "locale": "cs-CZ",
+      "title": "Vaše nastavení soukromí",
+      "summary": "Data používáme k poskytování, měření a přizpůsobení Summit.",
+      "bulletPoints": [
+        "Základní funkce udržují službu bezpečnou",
+        "Analytika ukazuje, co zlepšit",
+        "Personalizace přizpůsobuje obsah"
+      ],
+      "acceptCta": "Přijmout vše",
+      "rejectCta": "Odmítnout doplňkové",
+      "manageCta": "Spravovat nastavení",
+      "footer": "Rozhodnutí můžete kdykoli změnit."
+    },
+    "ja-JP": {
+      "locale": "ja-JP",
+      "title": "プライバシー設定",
+      "summary": "Summit を提供・測定・パーソナライズするためにデータを利用します。",
+      "bulletPoints": [
+        "必要な機能がサービスを安全に保ちます",
+        "分析で改善点を把握します",
+        "パーソナライズで最適な体験を提供します"
+      ],
+      "acceptCta": "すべて許可",
+      "rejectCta": "必要最小限にする",
+      "manageCta": "設定を管理",
+      "footer": "設定はいつでも変更できます。"
+    },
+    "ko-KR": {
+      "locale": "ko-KR",
+      "title": "개인정보 보호 설정",
+      "summary": "Summit 서비스를 제공하고 맞춤화하기 위해 데이터를 사용합니다.",
+      "bulletPoints": [
+        "필수 기능이 서비스를 안전하게 유지합니다",
+        "분석으로 개선점을 파악합니다",
+        "개인 맞춤으로 관련 콘텐츠를 제공합니다"
+      ],
+      "acceptCta": "모두 허용",
+      "rejectCta": "필수만 허용",
+      "manageCta": "설정 관리",
+      "footer": "언제든지 선택을 변경할 수 있습니다."
+    },
+    "zh-CN": {
+      "locale": "zh-CN",
+      "title": "您的隐私选择",
+      "summary": "我们使用数据来提供、衡量并个性化 Summit 服务。",
+      "bulletPoints": [
+        "必要功能保障服务安全",
+        "分析帮助我们改进",
+        "个性化提供相关内容"
+      ],
+      "acceptCta": "全部接受",
+      "rejectCta": "仅保留必要",
+      "manageCta": "管理设置",
+      "footer": "您可以随时更新偏好。"
+    }
+  }
+}

--- a/sdk/acx/test/artifact.test.ts
+++ b/sdk/acx/test/artifact.test.ts
@@ -1,0 +1,66 @@
+import { createRequire } from 'node:module';
+import { AdaptiveConsentSDK } from '../src/sdk.js';
+import { ConsentArtifact, ConsentDecision, PolicyTemplatePack } from '../src/types.js';
+
+const require = createRequire(import.meta.url);
+const pack = require('../templates/policyPack.json') as PolicyTemplatePack;
+
+const PRIVATE_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC4ZMiSBOZ92zaa
+RVrz/A1ZG8XvA+qBAAr7+OnmjPFJNizky28ruCgYpwpraTClOS/dOPRUR9BV+3P8
+3mazx1qpQQ2yoqcyMyHi6+rozAIZ7TQNTIbzN/tJdFtrwBANOh8yIF+l1LKU3aRT
+V5E0z5fJrNMK31oTxpHVPKZ5rUZH810FJ1x4xvytYESd5R7RSgz431Jjzoo5rUou
+0It+U9l4BF1nICuhJdI0YUHBcciY4yW+KblwypqVt2jr+GhuVQNuqmejMINnOB6t
+kc5YWnRbQAaEP1z44MmJyjicgIjSuDBQpR0s8b209VFJByOwRrujKa3HQtXveOCl
+1QCifFIdAgMBAAECggEARjS1OwdbnNKwjPdYJGo0yNcuuwzCJgCWrg49PDcwjR/v
+4uLj/oDc31oGORQxXc8Svsd3G3nGRF57cG1bLBr8lVG7/eY5A399aPFLHPzD1gw+
+08tt3D/V0MdZIYLcebTF+Odjk3eS0OQ8szC1jCZ4E+TV659TpBDoKIixl8VV64GC
+nWJRWPINatDhiV7vYxNqGG1VcV64YJOMORLFltTPV/LE8kfbejtE0ilVgwzMEVwg
+oGy0zFhNxWNKM11pvSg0XZzYKx8eBf1GbMDA3Cd3nXpdiDyB/5pVLUGOAzY8HPje
+iP/Js2XviSJis7YjYsEDJouCwS3wh7t15AgqU9L3TwKBgQDuq3rHNRrtYfZM8Tx0
+Ycp+PXEThUSdpkuzPQ8Po8Q3xvr5JieCLuhCJKfLGeywTFqf6SMZBukRiuWL/Kmy
+4DW3XLp7B47gLdb8pUjDF/n1nGznBiky7JcuJyHgPVyAT3ntk1nEzCiXNIRmJMJR
+HxnVTgkmJ69Qp8RwJR/ziAljhwKBgQDFyGPhxZV+0l6PeKitsqyhgOalrsYmYola
+M6hfPS0k0MNUo2nGeX3NUQJYW/ngpQzZkH/TKWI2vRfeJiINvrt42Cihdm7DsHAS
+VxYvvYTU2pjruipvQeUl9Z4Jar8wefVjL7mzDK/xiU+sn9yIpgdjCoyVtnqEHneH
+ED9J/lcOOwKBgGLxYf/tqxEYGISDSZ2x4MF+9T6zc+OrShyvRmwkZzb8XZUmVSCq
+E41AJvOS9sWLkdJTU0KP09V68HidMTi/rGUsov5X/so/Fq48UzLV4MEKrTcFHdVH
+sdDnVirhJVToHdL40DE+teEhW3YA7TG2I/6C0FYqA4r7Uftv2JQcJFBHAoGAUjBd
+4VpcL2F4TiKT5eqT9mE8d6lTSmw0K7m/xCQF+ICQS0HFGOcvsfxx/wnposKzvk1f
+8P4HhDu8CWLLT+7stOEOsVon2UYerGBoJdqZsmJMndi0/ZrigI266KrlXF2x7U/N
+2WvySWsIIvIjkN19wFiH50b3TqPig8vqoPMCdjUCgYEAiCaAi+uXglgE709Xm5Oe
+GHYmc0bFjY9PeqCeK335tJBVLDWTNDWuB1YQKFie/yW7aJS5580DvsMzV0SxK4xw
+ENF514k0OjOaLggeG3dkYYDjOOCxVbVHAbiPAgdW0jYhjOixCSzZhmLgujhEhF27
+OMSe69p4+hmWFeysEsHnF2A=
+-----END PRIVATE KEY-----`;
+
+const PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAuGTIkgTmfds2mkVa8/wN
+WRvF7wPqgQAK+/jp5ozxSTYs5MtvK7goGKcKa2kwpTkv3Tj0VEfQVftz/N5ms8da
+qUENsqKnMjMh4uvq6MwCGe00DUyG8zf7SXRba8AQDTofMiBfpdSylN2kU1eRNM+X
+yazTCt9aE8aR1Tymea1GR/NdBSdceMb8rWBEneUe0UoM+N9SY86KOa1KLtCLflPZ
+eARdZyAroSXSNGFBwXHImOMlvim5cMqalbdo6/hoblUDbqpnozCDZzgerZHOWFp0
+W0AGhD9c+ODJico4nICI0rgwUKUdLPG9tPVRSQcjsEa7oymtx0LV73jgpdUAonxS
+HQIDAQAB
+-----END PUBLIC KEY-----`;
+
+describe('Consent artifacts', () => {
+  const sdk = new AdaptiveConsentSDK(pack);
+
+  it('signs and verifies artifacts offline', () => {
+    const artifact = sdk.emitSignedArtifact('user-123', 'accept', { locale: 'en-US' }, PRIVATE_KEY);
+    expect(AdaptiveConsentSDK.verifyArtifact(artifact, PUBLIC_KEY)).toBe(true);
+  });
+
+  it('fails verification when payload is altered', () => {
+    const artifact = sdk.emitSignedArtifact('user-123', 'accept', { locale: 'en-US' }, PRIVATE_KEY);
+    const tampered: ConsentArtifact = {
+      ...artifact,
+      payload: {
+        ...artifact.payload,
+        decision: 'reject' as ConsentDecision
+      }
+    };
+    expect(AdaptiveConsentSDK.verifyArtifact(tampered, PUBLIC_KEY)).toBe(false);
+  });
+});

--- a/sdk/acx/test/experiment.test.ts
+++ b/sdk/acx/test/experiment.test.ts
@@ -1,0 +1,67 @@
+import { createRequire } from 'node:module';
+import { jest } from '@jest/globals';
+import { AdaptiveConsentSDK } from '../src/sdk.js';
+import { PolicyTemplatePack } from '../src/types.js';
+
+const require = createRequire(import.meta.url);
+const pack = require('../templates/policyPack.json') as PolicyTemplatePack;
+
+const createSdk = () => new AdaptiveConsentSDK(pack);
+
+describe('Experiment handling', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('allows UI-only variants', () => {
+    const sdk = createSdk();
+    sdk.registerExperiment({
+      name: 'dialog-theme',
+      controlVariant: {
+        id: 'control',
+        probability: 0.5,
+        uiOverrides: {
+          title: 'Your privacy choices'
+        }
+      },
+      variants: [
+        {
+          id: 'compact',
+          probability: 0.5,
+          uiOverrides: {
+            title: 'Privacy settings',
+            manageCta: 'Adjust preferences'
+          }
+        }
+      ]
+    });
+
+    jest.spyOn(Math, 'random').mockReturnValue(0.8);
+    const dialog = sdk.render({ locale: 'en-US', experiment: 'dialog-theme' });
+    expect(dialog.variant).toBe('compact');
+    expect(dialog.copy.manageCta).toBe('Adjust preferences');
+    expect(dialog.purposes.map((p) => p.id)).toEqual(['essential', 'analytics', 'personalization']);
+  });
+
+  it('rejects variants that alter semantics', () => {
+    const sdk = createSdk();
+    expect(() =>
+      sdk.registerExperiment({
+        name: 'bad-variant',
+        controlVariant: {
+          id: 'control',
+          probability: 1
+        },
+        variants: [
+          {
+            id: 'coerce',
+            probability: 0,
+            uiOverrides: {
+              summary: 'Accept to continue'
+            }
+          }
+        ]
+      })
+    ).toThrow('changes consent semantics');
+  });
+});

--- a/sdk/acx/test/linter.test.ts
+++ b/sdk/acx/test/linter.test.ts
@@ -1,0 +1,31 @@
+import { createRequire } from 'node:module';
+import { DarkPatternLinter } from '../src/validators.js';
+import patterns from '../src/dark-patterns.json';
+import { PolicyTemplatePack } from '../src/types.js';
+
+const require = createRequire(import.meta.url);
+const pack = require('../templates/policyPack.json') as PolicyTemplatePack;
+
+describe('DarkPatternLinter', () => {
+  it('produces no findings for the curated pack', () => {
+    const linter = new DarkPatternLinter(patterns);
+    expect(linter.lintPack(pack)).toEqual([]);
+  });
+
+  it('flags disallowed language', () => {
+    const linter = new DarkPatternLinter(patterns);
+    const mutated: PolicyTemplatePack = {
+      ...pack,
+      locales: {
+        ...pack.locales,
+        'en-US': {
+          ...pack.locales['en-US'],
+          summary: 'You must accept to continue'
+        }
+      }
+    };
+    const findings = linter.lintPack(mutated);
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings[0].locale).toBe('en-US');
+  });
+});

--- a/sdk/acx/test/render.test.ts
+++ b/sdk/acx/test/render.test.ts
@@ -1,0 +1,16 @@
+import { createRequire } from 'node:module';
+import { AdaptiveConsentSDK } from '../src/sdk.js';
+import { PolicyTemplatePack } from '../src/types.js';
+
+const require = createRequire(import.meta.url);
+const pack = require('../templates/policyPack.json') as PolicyTemplatePack;
+
+describe('AdaptiveConsentSDK rendering', () => {
+  const sdk = new AdaptiveConsentSDK(pack);
+  const locales = Object.keys(pack.locales);
+
+  test.each(locales)('renders %s locale consistently', (locale) => {
+    const dialog = sdk.render({ locale });
+    expect(dialog).toMatchSnapshot();
+  });
+});

--- a/sdk/acx/test/scope.test.ts
+++ b/sdk/acx/test/scope.test.ts
@@ -1,0 +1,14 @@
+import { createRequire } from 'node:module';
+import { AdaptiveConsentSDK } from '../src/sdk.js';
+import { PolicyTemplatePack } from '../src/types.js';
+
+const require = createRequire(import.meta.url);
+const pack = require('../templates/policyPack.json') as PolicyTemplatePack;
+
+describe('Purpose scoping', () => {
+  it('filters purposes according to scope', () => {
+    const sdk = new AdaptiveConsentSDK(pack);
+    const scoped = sdk.render({ locale: 'en-US', scopedPurposes: ['essential', 'analytics'] });
+    expect(scoped.purposes.map((p) => p.id)).toEqual(['essential', 'analytics']);
+  });
+});

--- a/sdk/acx/test/snapshotResolver.cjs
+++ b/sdk/acx/test/snapshotResolver.cjs
@@ -1,0 +1,13 @@
+const path = require('path');
+
+module.exports = {
+  resolveSnapshotPath: (testPath, snapshotExtension) => {
+    const testFile = path.basename(testPath);
+    return path.join(path.dirname(testPath), '..', '__snapshots__', `${testFile}${snapshotExtension}`);
+  },
+  resolveTestPath: (snapshotFilePath, snapshotExtension) => {
+    const snapshotFile = path.basename(snapshotFilePath, snapshotExtension);
+    return path.join(path.dirname(snapshotFilePath), '..', 'test', snapshotFile);
+  },
+  testPathForConsistencyCheck: path.join('test', 'render.test.ts')
+};

--- a/sdk/acx/tsconfig.json
+++ b/sdk/acx/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "isolatedModules": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["test", "__snapshots__"]
+}


### PR DESCRIPTION
## Summary
- add the adaptive consent SDK with template pack rendering, experiment management, dark-pattern linting, and consent artifact signing
- ship a global policy/locale pack with 20 locales plus snapshot, lint, scope, and artifact verification tests
- provide companion Swift and Kotlin packages and build-time guard scripts for web, iOS, and Android consumers

## Testing
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7808906c883338803298568c1dc2c