### PR TITLE
feat: add deterministic prompt execution cache package

### DIFF
--- a/packages/dpec/AGENTS.md
+++ b/packages/dpec/AGENTS.md
@@ -1,0 +1,2 @@
+- Follow repository default TypeScript style (2 spaces, eslint/prettier conventions).
+- Keep adapters free of direct runtime dependencies on vendor SDKs; type-only shims are acceptable.

--- a/packages/dpec/package.json
+++ b/packages/dpec/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@summit/dpec",
+  "version": "0.1.0",
+  "description": "Deterministic Prompt Execution Cache with attestable artifacts and client adapters",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rimraf dist",
+    "lint": "eslint . --ext .ts",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^24.5.2",
+    "eslint": "^9.36.0",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.9.2",
+    "vitest": "^2.1.4"
+  }
+}

--- a/packages/dpec/src/adapters/anthropic.ts
+++ b/packages/dpec/src/adapters/anthropic.ts
@@ -1,0 +1,117 @@
+import { DeterministicPromptExecutionCache } from '../cache.js';
+import { canonicalDigest, sha256, stableStringify } from '../hash.js';
+import type { AdapterResolution, CacheKeyComponents } from '../types.js';
+
+export interface AnthropicMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: unknown;
+}
+
+export interface AnthropicToolDefinition {
+  name: string;
+  description?: string;
+  input_schema?: Record<string, unknown>;
+}
+
+export interface AnthropicMessagesRequest {
+  model: string;
+  messages: AnthropicMessage[];
+  system?: string;
+  tools?: AnthropicToolDefinition[];
+  max_tokens: number;
+  temperature?: number;
+  top_k?: number;
+  top_p?: number;
+  stop_sequences?: string[];
+  tokenizer?: string;
+}
+
+export interface AnthropicMessageResponse {
+  id: string;
+  model: string;
+  content: unknown;
+  usage?: Record<string, unknown>;
+}
+
+export interface AnthropicClient {
+  messages: {
+    create(request: AnthropicMessagesRequest): Promise<AnthropicMessageResponse>;
+  };
+}
+
+export interface AnthropicAdapterOptions {
+  client: AnthropicClient;
+  cache: DeterministicPromptExecutionCache;
+  deriveKey?: (request: AnthropicMessagesRequest) => CacheKeyComponents;
+}
+
+function defaultKey(request: AnthropicMessagesRequest): CacheKeyComponents {
+  const tokenizerSource = request.tokenizer ?? request.model;
+  const params = buildParams(request);
+  return {
+    modelHash: sha256(request.model),
+    tokenizerHash: sha256(tokenizerSource),
+    params,
+    toolsGraphHash: sha256(stableStringify(request.tools ?? [])),
+    promptHash: sha256(
+      stableStringify({
+        system: request.system ?? null,
+        messages: request.messages
+      })
+    )
+  };
+}
+
+function buildParams(request: AnthropicMessagesRequest): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    max_tokens: request.max_tokens
+  };
+  const candidate: Array<[keyof AnthropicMessagesRequest, string]> = [
+    ['temperature', 'temperature'],
+    ['top_k', 'top_k'],
+    ['top_p', 'top_p'],
+    ['stop_sequences', 'stop_sequences']
+  ];
+  for (const [key, alias] of candidate) {
+    const value = request[key];
+    if (value !== undefined) {
+      params[alias] = value;
+    }
+  }
+  return params;
+}
+
+export function createAnthropicMessagesAdapter(
+  options: AnthropicAdapterOptions
+): (request: AnthropicMessagesRequest) => Promise<AdapterResolution<AnthropicMessageResponse>> {
+  const derive = options.deriveKey ?? defaultKey;
+  return async (request: AnthropicMessagesRequest) => {
+    const key = derive(request);
+    const result = await options.cache.resolve(key, async () => {
+      const response = await options.client.messages.create(request);
+      return {
+        artifact: JSON.stringify(response),
+        metadata: {
+          adapter: 'anthropic.messages.create',
+          requestDigest: canonicalDigest(request)
+        }
+      };
+    });
+    const response = JSON.parse(result.artifact.toString('utf8')) as AnthropicMessageResponse;
+    if (result.type === 'hit') {
+      return {
+        response,
+        hit: true,
+        proof: result.proof,
+        entry: result.entry
+      };
+    }
+    return {
+      response,
+      hit: false,
+      trace: result.trace,
+      evictionProofs: result.evictionProofs,
+      entry: result.entry
+    };
+  };
+}

--- a/packages/dpec/src/adapters/openai.ts
+++ b/packages/dpec/src/adapters/openai.ts
@@ -1,0 +1,133 @@
+import { DeterministicPromptExecutionCache } from '../cache.js';
+import { canonicalDigest, sha256, stableStringify } from '../hash.js';
+import type { AdapterResolution, CacheKeyComponents } from '../types.js';
+
+export interface OpenAIChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: unknown;
+  name?: string;
+}
+
+export interface OpenAIChatToolDefinition {
+  type: string;
+  function?: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  };
+}
+
+export interface OpenAIChatCompletionRequest {
+  model: string;
+  messages: OpenAIChatMessage[];
+  tools?: OpenAIChatToolDefinition[];
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  stop?: string | string[];
+  seed?: number;
+  tokenizer?: string;
+  response_format?: Record<string, unknown>;
+}
+
+export interface OpenAIChatChoice {
+  index: number;
+  message: {
+    role: 'assistant' | 'tool';
+    content: unknown;
+    refusal?: unknown;
+  };
+  finish_reason: string | null;
+}
+
+export interface OpenAIChatCompletionResponse {
+  id: string;
+  created: number;
+  model: string;
+  choices: OpenAIChatChoice[];
+  usage?: Record<string, unknown>;
+}
+
+export interface OpenAIChatClient {
+  chat: {
+    completions: {
+      create(request: OpenAIChatCompletionRequest): Promise<OpenAIChatCompletionResponse>;
+    };
+  };
+}
+
+export interface OpenAIAdapterOptions {
+  client: OpenAIChatClient;
+  cache: DeterministicPromptExecutionCache;
+  deriveKey?: (request: OpenAIChatCompletionRequest) => CacheKeyComponents;
+}
+
+function defaultKey(request: OpenAIChatCompletionRequest): CacheKeyComponents {
+  const tokenizerSource = request.tokenizer ?? request.model;
+  const params = buildParams(request);
+  return {
+    modelHash: sha256(request.model),
+    tokenizerHash: sha256(tokenizerSource),
+    params,
+    toolsGraphHash: sha256(stableStringify(request.tools ?? [])),
+    promptHash: sha256(stableStringify(request.messages))
+  };
+}
+
+function buildParams(request: OpenAIChatCompletionRequest): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+  const candidate: Array<[keyof OpenAIChatCompletionRequest, string]> = [
+    ['temperature', 'temperature'],
+    ['top_p', 'top_p'],
+    ['max_tokens', 'max_tokens'],
+    ['frequency_penalty', 'frequency_penalty'],
+    ['presence_penalty', 'presence_penalty'],
+    ['stop', 'stop'],
+    ['seed', 'seed'],
+    ['response_format', 'response_format']
+  ];
+  for (const [key, alias] of candidate) {
+    const value = request[key];
+    if (value !== undefined) {
+      params[alias] = value;
+    }
+  }
+  return params;
+}
+
+export function createOpenAIChatAdapter(
+  options: OpenAIAdapterOptions
+): (request: OpenAIChatCompletionRequest) => Promise<AdapterResolution<OpenAIChatCompletionResponse>> {
+  const derive = options.deriveKey ?? defaultKey;
+  return async (request: OpenAIChatCompletionRequest) => {
+    const key = derive(request);
+    const result = await options.cache.resolve(key, async () => {
+      const response = await options.client.chat.completions.create(request);
+      return {
+        artifact: JSON.stringify(response),
+        metadata: {
+          adapter: 'openai.chat.completions',
+          requestDigest: canonicalDigest(request)
+        }
+      };
+    });
+    const response = JSON.parse(result.artifact.toString('utf8')) as OpenAIChatCompletionResponse;
+    if (result.type === 'hit') {
+      return {
+        response,
+        hit: true,
+        proof: result.proof,
+        entry: result.entry
+      };
+    }
+    return {
+      response,
+      hit: false,
+      trace: result.trace,
+      evictionProofs: result.evictionProofs,
+      entry: result.entry
+    };
+  };
+}

--- a/packages/dpec/src/cache.ts
+++ b/packages/dpec/src/cache.ts
@@ -1,0 +1,361 @@
+import { canonicalDigest, sha256, stableStringify } from './hash.js';
+import type {
+  CacheFetcher,
+  CacheHitProof,
+  CacheHitResult,
+  CacheKeyComponents,
+  CacheManifest,
+  CacheManifestEntry,
+  CacheMissResult,
+  CacheResolution,
+  EvictionProof,
+  MissFillTrace
+} from './types.js';
+import type { CacheArtifact, CacheFetcherResult } from './types.js';
+
+interface CacheEntry {
+  key: string;
+  canonicalKey: string;
+  components: CacheKeyComponents;
+  artifact: Buffer;
+  metadataDigest: string;
+  artifactDigest: string;
+  insertedAt: string;
+  lastAccessedAt: string;
+  hits: number;
+  sequence: number;
+  accessCounter: number;
+}
+
+export interface DeterministicPromptExecutionCacheOptions {
+  maxEntries?: number;
+  clock?: () => number;
+}
+
+const DEFAULT_MAX_ENTRIES = 256;
+
+function normalizeArtifact(artifact: CacheArtifact): Buffer {
+  if (artifact instanceof Uint8Array) {
+    return Buffer.from(artifact);
+  }
+  if (typeof artifact === 'string') {
+    return Buffer.from(artifact, 'utf8');
+  }
+  if (Buffer.isBuffer(artifact)) {
+    return Buffer.from(artifact);
+  }
+  return Buffer.from(stableStringify(artifact));
+}
+
+function canonicalKey(components: CacheKeyComponents): string {
+  return stableStringify({
+    modelHash: components.modelHash,
+    tokenizerHash: components.tokenizerHash,
+    params: components.params,
+    toolsGraphHash: components.toolsGraphHash,
+    promptHash: components.promptHash
+  });
+}
+
+function computeKey(components: CacheKeyComponents): string {
+  return sha256(canonicalKey(components));
+}
+
+function nowISO(clock: () => number): string {
+  return new Date(clock()).toISOString();
+}
+
+export class DeterministicPromptExecutionCache {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  private readonly traces: MissFillTrace[] = [];
+
+  private readonly options: Required<DeterministicPromptExecutionCacheOptions>;
+
+  private accessCounter = 0;
+
+  private sequence = 0;
+
+  constructor(options: DeterministicPromptExecutionCacheOptions = {}) {
+    this.options = {
+      maxEntries: options.maxEntries ?? DEFAULT_MAX_ENTRIES,
+      clock: options.clock ?? (() => Date.now())
+    };
+  }
+
+  async resolve(
+    components: CacheKeyComponents,
+    fetcher: CacheFetcher
+  ): Promise<CacheResolution> {
+    const key = computeKey(components);
+    const canonical = canonicalKey(components);
+    const existing = this.entries.get(key);
+
+    if (existing) {
+      existing.hits += 1;
+      existing.lastAccessedAt = nowISO(this.options.clock);
+      existing.accessCounter = ++this.accessCounter;
+      const entryManifest = this.toManifestEntry(existing);
+      const proof = this.buildHitProof(entryManifest);
+      return {
+        type: 'hit',
+        artifact: Buffer.from(existing.artifact),
+        proof,
+        entry: entryManifest
+      } satisfies CacheHitResult;
+    }
+
+    const fetched = await Promise.resolve(fetcher(components));
+    const normalized = normalizeArtifact(fetched.artifact);
+    const metadataDigest = canonicalDigest(fetched.metadata ?? {});
+    const artifactDigest = sha256(normalized);
+    const timestamp = nowISO(this.options.clock);
+    const entry: CacheEntry = {
+      key,
+      canonicalKey: canonical,
+      components: {
+        modelHash: components.modelHash,
+        tokenizerHash: components.tokenizerHash,
+        params: structuredClone(components.params),
+        toolsGraphHash: components.toolsGraphHash,
+        promptHash: components.promptHash
+      },
+      artifact: Buffer.from(normalized),
+      metadataDigest,
+      artifactDigest,
+      insertedAt: timestamp,
+      lastAccessedAt: timestamp,
+      hits: 1,
+      sequence: ++this.sequence,
+      accessCounter: ++this.accessCounter
+    };
+    this.entries.set(key, entry);
+
+    const trace = this.recordTrace(entry, fetched.artifact, fetched.metadata ?? {});
+    const evictionProofs = this.evictIfNeeded();
+    const manifestEntry = this.toManifestEntry(entry);
+
+    return {
+      type: 'miss',
+      artifact: Buffer.from(entry.artifact),
+      trace,
+      entry: manifestEntry,
+      evictionProofs
+    } satisfies CacheMissResult;
+  }
+
+  getTraces(): MissFillTrace[] {
+    return this.traces.map((trace) => ({
+      ...trace,
+      input: {
+        modelHash: trace.input.modelHash,
+        tokenizerHash: trace.input.tokenizerHash,
+        params: structuredClone(trace.input.params),
+        toolsGraphHash: trace.input.toolsGraphHash,
+        promptHash: trace.input.promptHash
+      }
+    }));
+  }
+
+  generateManifest(): CacheManifest {
+    const entries = Array.from(this.entries.values()).map((entry) => this.toManifestEntry(entry));
+    entries.sort((a, b) => a.key.localeCompare(b.key));
+    const digest = sha256(Buffer.from(stableStringify(entries)));
+    return {
+      createdAt: nowISO(this.options.clock),
+      digest,
+      entries
+    };
+  }
+
+  private toManifestEntry(entry: CacheEntry): CacheManifestEntry {
+    return {
+      key: entry.key,
+      canonicalKey: entry.canonicalKey,
+      artifactDigest: entry.artifactDigest,
+      insertedAt: entry.insertedAt,
+      lastAccessedAt: entry.lastAccessedAt,
+      hits: entry.hits,
+      sequence: entry.sequence,
+      accessCounter: entry.accessCounter,
+      metadataDigest: entry.metadataDigest
+    };
+  }
+
+  private buildHitProof(entry: CacheManifestEntry): CacheHitProof {
+    const manifestDigest = this.computeManifestDigestSnapshot();
+    const timestamp = nowISO(this.options.clock);
+    const payload = {
+      type: 'hit' as const,
+      key: entry.key,
+      artifactDigest: entry.artifactDigest,
+      manifestDigest,
+      hits: entry.hits,
+      sequence: entry.sequence,
+      timestamp
+    } satisfies Omit<CacheHitProof, 'eventDigest'>;
+    return {
+      ...payload,
+      eventDigest: sha256(Buffer.from(stableStringify(payload)))
+    };
+  }
+
+  private computeManifestDigestSnapshot(): string {
+    const entries = Array.from(this.entries.values())
+      .map((entry) => this.toManifestEntry(entry))
+      .sort((a, b) => a.key.localeCompare(b.key));
+    return sha256(Buffer.from(stableStringify(entries)));
+  }
+
+  private recordTrace(
+    entry: CacheEntry,
+    artifact: CacheFetcherResult['artifact'],
+    metadata: Record<string, unknown>
+  ): MissFillTrace {
+    const artifactBuffer = normalizeArtifact(artifact);
+    const input: CacheKeyComponents = {
+      modelHash: entry.components.modelHash,
+      tokenizerHash: entry.components.tokenizerHash,
+      params: structuredClone(entry.components.params),
+      toolsGraphHash: entry.components.toolsGraphHash,
+      promptHash: entry.components.promptHash
+    };
+    const payload = {
+      type: 'miss-fill' as const,
+      key: entry.key,
+      canonicalKey: entry.canonicalKey,
+      input,
+      artifactDigest: sha256(artifactBuffer),
+      artifactBase64: artifactBuffer.toString('base64'),
+      metadataDigest: canonicalDigest(metadata),
+      timestamp: nowISO(this.options.clock)
+    } satisfies Omit<MissFillTrace, 'eventDigest'>;
+    const trace: MissFillTrace = {
+      ...payload,
+      eventDigest: sha256(Buffer.from(stableStringify(payload)))
+    };
+    this.traces.push(trace);
+    return trace;
+  }
+
+  private evictIfNeeded(): EvictionProof[] {
+    const proofs: EvictionProof[] = [];
+    while (this.entries.size > this.options.maxEntries) {
+      const victim = this.selectEvictionCandidate();
+      if (!victim) {
+        break;
+      }
+      const survivors = Array.from(this.entries.values())
+        .filter((entry) => entry.key !== victim.key)
+        .map((entry) => ({ key: entry.key, accessCounter: entry.accessCounter }))
+        .sort((a, b) => a.accessCounter - b.accessCounter);
+      const payload = {
+        type: 'eviction' as const,
+        algorithm: 'LRU' as const,
+        timestamp: nowISO(this.options.clock),
+        victim: this.toManifestEntry(victim),
+        survivors
+      } satisfies Omit<EvictionProof, 'eventDigest'>;
+      const proof: EvictionProof = {
+        ...payload,
+        eventDigest: sha256(Buffer.from(stableStringify(payload)))
+      };
+      this.entries.delete(victim.key);
+      proofs.push(proof);
+    }
+    return proofs;
+  }
+
+  private selectEvictionCandidate(): CacheEntry | undefined {
+    let candidate: CacheEntry | undefined;
+    for (const entry of this.entries.values()) {
+      if (!candidate || entry.accessCounter < candidate.accessCounter) {
+        candidate = entry;
+      }
+    }
+    return candidate;
+  }
+
+  static verifyManifest(manifest: CacheManifest, reference?: CacheManifestEntry[]): boolean {
+    const sortedEntries = [...manifest.entries].sort((a, b) => a.key.localeCompare(b.key));
+    const digest = sha256(Buffer.from(stableStringify(sortedEntries)));
+    if (digest !== manifest.digest) {
+      return false;
+    }
+    if (!reference) {
+      return true;
+    }
+    const refSorted = [...reference].sort((a, b) => a.key.localeCompare(b.key));
+    return stableStringify(refSorted) === stableStringify(sortedEntries);
+  }
+
+  static verifyHitProof(proof: CacheHitProof, manifest: CacheManifest): boolean {
+    if (proof.type !== 'hit') {
+      return false;
+    }
+    if (manifest.digest !== proof.manifestDigest) {
+      return false;
+    }
+    const payload = {
+      type: proof.type,
+      key: proof.key,
+      artifactDigest: proof.artifactDigest,
+      manifestDigest: proof.manifestDigest,
+      hits: proof.hits,
+      sequence: proof.sequence,
+      timestamp: proof.timestamp
+    } satisfies Omit<CacheHitProof, 'eventDigest'>;
+    const canonical = stableStringify(payload);
+    if (sha256(Buffer.from(canonical)) !== proof.eventDigest) {
+      return false;
+    }
+    const entry = manifest.entries.find((item) => item.key === proof.key);
+    if (!entry) {
+      return false;
+    }
+    return (
+      entry.artifactDigest === proof.artifactDigest &&
+      entry.hits === proof.hits &&
+      entry.sequence === proof.sequence
+    );
+  }
+
+  static verifyEvictionProof(proof: EvictionProof): boolean {
+    if (proof.type !== 'eviction' || proof.algorithm !== 'LRU') {
+      return false;
+    }
+    const payload = {
+      type: proof.type,
+      algorithm: proof.algorithm,
+      timestamp: proof.timestamp,
+      victim: proof.victim,
+      survivors: proof.survivors
+    } satisfies Omit<EvictionProof, 'eventDigest'>;
+    const canonical = stableStringify(payload);
+    if (sha256(Buffer.from(canonical)) !== proof.eventDigest) {
+      return false;
+    }
+    for (const survivor of proof.survivors) {
+      if (survivor.accessCounter <= proof.victim.accessCounter) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static async replayTrace(
+    trace: MissFillTrace,
+    fetcher: CacheFetcher
+  ): Promise<boolean> {
+    const key = computeKey(trace.input);
+    if (key !== trace.key) {
+      return false;
+    }
+    const result = await Promise.resolve(fetcher(trace.input));
+    const artifactBuffer = normalizeArtifact(result.artifact);
+    const digest = sha256(artifactBuffer);
+    return digest === trace.artifactDigest;
+  }
+}
+
+export type { CacheResolution, CacheHitResult, CacheMissResult } from './types.js';

--- a/packages/dpec/src/hash.ts
+++ b/packages/dpec/src/hash.ts
@@ -1,0 +1,66 @@
+import { createHash } from 'crypto';
+
+export type JsonPrimitive = string | number | boolean | null;
+
+function canonicalize(value: unknown): string {
+  if (value === null) {
+    return 'null';
+  }
+  if (value === undefined) {
+    return 'undefined';
+  }
+  if (typeof value === 'number') {
+    if (Number.isNaN(value)) {
+      return 'NaN';
+    }
+    if (!Number.isFinite(value)) {
+      return value > 0 ? 'Infinity' : '-Infinity';
+    }
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'bigint') {
+    return `${value.toString()}n`;
+  }
+  if (typeof value === 'boolean' || typeof value === 'string') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalize(item)).join(',')}]`;
+  }
+  if (value instanceof Date) {
+    return `{"$date":${JSON.stringify(value.toISOString())}}`;
+  }
+  if (value instanceof Map) {
+    const entries = Array.from(value.entries()).sort(([a], [b]) =>
+      canonicalize(a).localeCompare(canonicalize(b))
+    );
+    return `{"$map":${canonicalize(entries)}}`;
+  }
+  if (value instanceof Set) {
+    const items = Array.from(value.values()).sort((a, b) =>
+      canonicalize(a).localeCompare(canonicalize(b))
+    );
+    return `{"$set":${canonicalize(items)}}`;
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, val]) => `${JSON.stringify(key)}:${canonicalize(val)}`);
+    return `{${entries.join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function stableStringify(value: unknown): string {
+  return canonicalize(value);
+}
+
+export function sha256(data: Buffer | string): string {
+  const buffer = typeof data === 'string' ? Buffer.from(data) : data;
+  return createHash('sha256').update(buffer).digest('hex');
+}
+
+export function canonicalDigest(value: unknown): string {
+  return sha256(Buffer.from(stableStringify(value)));
+}

--- a/packages/dpec/src/index.ts
+++ b/packages/dpec/src/index.ts
@@ -1,0 +1,28 @@
+export { DeterministicPromptExecutionCache, type DeterministicPromptExecutionCacheOptions } from './cache.js';
+export type {
+  CacheKeyComponents,
+  CacheResolution,
+  CacheHitResult,
+  CacheMissResult,
+  CacheManifest,
+  CacheManifestEntry,
+  CacheHitProof,
+  EvictionProof,
+  MissFillTrace,
+  AdapterResolution
+} from './types.js';
+export { stableStringify, canonicalDigest, sha256 } from './hash.js';
+export {
+  createOpenAIChatAdapter,
+  type OpenAIAdapterOptions,
+  type OpenAIChatCompletionRequest,
+  type OpenAIChatCompletionResponse,
+  type OpenAIChatClient
+} from './adapters/openai.js';
+export {
+  createAnthropicMessagesAdapter,
+  type AnthropicAdapterOptions,
+  type AnthropicMessagesRequest,
+  type AnthropicMessageResponse,
+  type AnthropicClient
+} from './adapters/anthropic.js';

--- a/packages/dpec/src/types.ts
+++ b/packages/dpec/src/types.ts
@@ -1,0 +1,94 @@
+export interface CacheKeyComponents {
+  modelHash: string;
+  tokenizerHash: string;
+  params: Record<string, unknown>;
+  toolsGraphHash: string;
+  promptHash: string;
+}
+
+export type CacheArtifact = Buffer | Uint8Array | string | Record<string, unknown> | Array<unknown>;
+
+export interface CacheFetcherResult {
+  artifact: CacheArtifact;
+  metadata?: Record<string, unknown>;
+}
+
+export type CacheFetcher = (
+  key: CacheKeyComponents
+) => Promise<CacheFetcherResult> | CacheFetcherResult;
+
+export interface CacheManifestEntry {
+  key: string;
+  canonicalKey: string;
+  artifactDigest: string;
+  insertedAt: string;
+  lastAccessedAt: string;
+  hits: number;
+  sequence: number;
+  accessCounter: number;
+  metadataDigest: string;
+}
+
+export interface CacheManifest {
+  createdAt: string;
+  digest: string;
+  entries: CacheManifestEntry[];
+}
+
+export interface CacheHitProof {
+  type: 'hit';
+  key: string;
+  artifactDigest: string;
+  manifestDigest: string;
+  timestamp: string;
+  hits: number;
+  sequence: number;
+  eventDigest: string;
+}
+
+export interface EvictionProof {
+  type: 'eviction';
+  algorithm: 'LRU';
+  timestamp: string;
+  victim: CacheManifestEntry;
+  survivors: Array<Pick<CacheManifestEntry, 'key' | 'accessCounter'>>;
+  eventDigest: string;
+}
+
+export interface MissFillTrace {
+  type: 'miss-fill';
+  key: string;
+  canonicalKey: string;
+  input: CacheKeyComponents;
+  artifactDigest: string;
+  artifactBase64: string;
+  metadataDigest: string;
+  timestamp: string;
+  eventDigest: string;
+}
+
+export interface CacheHitResult {
+  type: 'hit';
+  artifact: Buffer;
+  proof: CacheHitProof;
+  entry: CacheManifestEntry;
+}
+
+export interface CacheMissResult {
+  type: 'miss';
+  artifact: Buffer;
+  trace: MissFillTrace;
+  entry: CacheManifestEntry;
+  evictionProofs: EvictionProof[];
+}
+
+export type CacheResolution = CacheHitResult | CacheMissResult;
+
+export interface AdapterResolution<TResponse> {
+  response: TResponse;
+  hit: boolean;
+  proof?: CacheHitProof;
+  trace?: MissFillTrace;
+  evictionProofs?: EvictionProof[];
+  entry: CacheManifestEntry;
+}

--- a/packages/dpec/test/dpec.spec.ts
+++ b/packages/dpec/test/dpec.spec.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DeterministicPromptExecutionCache,
+  type CacheKeyComponents,
+  createOpenAIChatAdapter,
+  createAnthropicMessagesAdapter
+} from '../src/index.js';
+
+function buildKey(seed: string): CacheKeyComponents {
+  return {
+    modelHash: `model:${seed}`,
+    tokenizerHash: `tokenizer:${seed}`,
+    params: { temperature: 0.2, max_tokens: 64, seed },
+    toolsGraphHash: `tools:${seed}`,
+    promptHash: `prompt:${seed}`
+  };
+}
+
+describe('DeterministicPromptExecutionCache core', () => {
+  it('returns deterministic hits with attestable proofs', async () => {
+    let now = 0;
+    const cache = new DeterministicPromptExecutionCache({
+      maxEntries: 4,
+      clock: () => {
+        now += 1000;
+        return now;
+      }
+    });
+
+    const key = buildKey('alpha');
+    const fetcher = vi.fn(async () => ({ artifact: 'artifact-alpha' }));
+
+    const miss = await cache.resolve(key, fetcher);
+    expect(miss.type).toBe('miss');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    const hit = await cache.resolve(key, fetcher);
+    expect(hit.type).toBe('hit');
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    const manifest = cache.generateManifest();
+    expect(manifest.entries).toHaveLength(1);
+    expect(DeterministicPromptExecutionCache.verifyManifest(manifest)).toBe(true);
+    expect(DeterministicPromptExecutionCache.verifyHitProof(hit.proof, manifest)).toBe(true);
+    expect(Buffer.compare(miss.artifact, hit.artifact)).toBe(0);
+  });
+
+  it('produces verifiable eviction proofs and manifests', async () => {
+    let now = 0;
+    const cache = new DeterministicPromptExecutionCache({
+      maxEntries: 2,
+      clock: () => {
+        now += 1000;
+        return now;
+      }
+    });
+
+    const missA = await cache.resolve(buildKey('a'), async () => ({ artifact: 'A' }));
+    expect(missA.type).toBe('miss');
+    const missB = await cache.resolve(buildKey('b'), async () => ({ artifact: 'B' }));
+    expect(missB.evictionProofs).toHaveLength(0);
+    const missC = await cache.resolve(buildKey('c'), async () => ({ artifact: 'C' }));
+    expect(missC.evictionProofs.length).toBe(1);
+    expect(DeterministicPromptExecutionCache.verifyEvictionProof(missC.evictionProofs[0])).toBe(true);
+
+    const manifest = cache.generateManifest();
+    expect(DeterministicPromptExecutionCache.verifyManifest(manifest)).toBe(true);
+    expect(manifest.entries.map((e) => e.key).sort()).toEqual([
+      missB.entry.key,
+      missC.entry.key
+    ].sort());
+  });
+
+  it('replays miss-fill traces to yield byte-identical artifacts', async () => {
+    let now = 0;
+    const cache = new DeterministicPromptExecutionCache({
+      maxEntries: 3,
+      clock: () => {
+        now += 1000;
+        return now;
+      }
+    });
+
+    const miss = await cache.resolve(buildKey('trace'), async () => ({ artifact: 'TRACE-VALUE' }));
+    expect(miss.type).toBe('miss');
+    const ok = await DeterministicPromptExecutionCache.replayTrace(miss.trace, async () => ({
+      artifact: 'TRACE-VALUE'
+    }));
+    expect(ok).toBe(true);
+    const bad = await DeterministicPromptExecutionCache.replayTrace(miss.trace, async () => ({
+      artifact: 'DIFFERENT'
+    }));
+    expect(bad).toBe(false);
+  });
+});
+
+describe('Adapters', () => {
+  it('wraps OpenAI chat completions with deterministic caching', async () => {
+    let now = 0;
+    const cache = new DeterministicPromptExecutionCache({
+      maxEntries: 4,
+      clock: () => {
+        now += 1000;
+        return now;
+      }
+    });
+
+    const create = vi.fn(async () => ({
+      id: 'chatcmpl-1',
+      created: 1,
+      model: 'gpt-test',
+      choices: [
+        {
+          index: 0,
+          message: { role: 'assistant', content: 'hello' },
+          finish_reason: 'stop'
+        }
+      ]
+    }));
+
+    const client = {
+      chat: {
+        completions: {
+          create
+        }
+      }
+    };
+
+    const adapter = createOpenAIChatAdapter({ client, cache });
+    const request = {
+      model: 'gpt-test',
+      messages: [
+        { role: 'system', content: 'be terse' },
+        { role: 'user', content: 'hi' }
+      ],
+      temperature: 0,
+      max_tokens: 16
+    };
+
+    const miss = await adapter(request);
+    expect(miss.hit).toBe(false);
+    expect(create).toHaveBeenCalledTimes(1);
+    const hit = await adapter(request);
+    expect(hit.hit).toBe(true);
+    expect(create).toHaveBeenCalledTimes(1);
+    const manifest = cache.generateManifest();
+    expect(DeterministicPromptExecutionCache.verifyManifest(manifest)).toBe(true);
+    expect(hit.proof).toBeDefined();
+    expect(hit.proof && DeterministicPromptExecutionCache.verifyHitProof(hit.proof, manifest)).toBe(true);
+  });
+
+  it('wraps Anthropic messages with deterministic caching', async () => {
+    let now = 0;
+    const cache = new DeterministicPromptExecutionCache({
+      maxEntries: 4,
+      clock: () => {
+        now += 1000;
+        return now;
+      }
+    });
+
+    const create = vi.fn(async () => ({
+      id: 'msg-1',
+      model: 'claude-test',
+      content: [{ type: 'text', text: 'hello' }]
+    }));
+
+    const client = {
+      messages: {
+        create
+      }
+    };
+
+    const adapter = createAnthropicMessagesAdapter({ client, cache });
+    const request = {
+      model: 'claude-test',
+      messages: [{ role: 'user', content: 'hi there' }],
+      max_tokens: 20,
+      top_p: 0.9
+    };
+
+    const miss = await adapter(request);
+    expect(miss.hit).toBe(false);
+    expect(create).toHaveBeenCalledTimes(1);
+    const hit = await adapter(request);
+    expect(hit.hit).toBe(true);
+    expect(create).toHaveBeenCalledTimes(1);
+    const manifest = cache.generateManifest();
+    expect(DeterministicPromptExecutionCache.verifyManifest(manifest)).toBe(true);
+    expect(hit.proof).toBeDefined();
+    expect(hit.proof && DeterministicPromptExecutionCache.verifyHitProof(hit.proof, manifest)).toBe(true);
+  });
+});

--- a/packages/dpec/tsconfig.json
+++ b/packages/dpec/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- add the @summit/dpec package implementing the deterministic prompt execution cache with manifests, proofs, and trace replay helpers
- provide OpenAI and Anthropic adapters that derive cache keys from request payloads and return attestable cache hits
- cover the new behaviors with a Vitest suite verifying deterministic hits, eviction proofs, trace replay, and adapter integration

## Testing
- npm test (from packages/dpec)
- npm run build (from packages/dpec)

------
https://chatgpt.com/codex/tasks/task_e_68d780fe162883339a52385a841a9894