### PR TITLE
feat: introduce policy backtest simulator engine and dashboard

### DIFF
--- a/pbs/README.md
+++ b/pbs/README.md
@@ -1,0 +1,50 @@
+# Policy Backtest Simulator (PBS)
+
+PBS replays historical trust-and-safety decisions under a new policy snapshot to quantify the impact of proposed changes. The Go engine performs deterministic re-adjudication, generates a signed backtest report, and emits a diff-friendly rollout recommendation. A companion TypeScript dashboard renders reports for rapid review.
+
+## Getting Started
+
+```bash
+cd pbs
+# run tests
+go test ./...
+
+# execute a backtest
+go run ./cmd/pbs \
+  --history testdata/history_sample.json \
+  --policy testdata/policy_hardened.json \
+  --report /tmp/report.json \
+  --recommendation /tmp/recommendation.txt \
+  --signing-key testdata/signing_key.json
+```
+
+The CLI prints paths for generated artifacts. Without `--report`/`--recommendation` it streams the recommendation to stdout.
+
+## Dashboard Generator
+
+The dashboard lives under `tools/pbs-dashboard`. After installing dependencies run:
+
+```bash
+cd tools/pbs-dashboard
+npm install
+npm run build
+npx tsx src/cli.ts --report ../../testdata/report_sample.json --out dist/dashboard.html
+```
+
+Pass `--recommendation` to include the rollout summary inside the page. The generated HTML is deterministic and suitable for artifact storage.
+
+## Determinism and Verification
+
+* Reports embed a deterministic `deterministic_run_id` derived from the policy digest, history digest, and engine version.
+* Engine tests cover deterministic reproduction, policy delta expectations, and signature integrity.
+* Golden recommendations prevent accidental drift in rollout guidance.
+
+## File Layout
+
+```
+pbs/
+  cmd/pbs            # CLI entrypoint
+  internal/pbs       # Engine, report builder, signing, recommendation helpers
+  testdata           # Fixtures for regression tests
+  tools/pbs-dashboard# TypeScript dashboard generator
+```

--- a/pbs/cmd/pbs/main.go
+++ b/pbs/cmd/pbs/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/summit/pbs/internal/pbs"
+)
+
+func main() {
+	historyPath := flag.String("history", "", "path to historical decisions JSON")
+	policyPath := flag.String("policy", "", "path to policy snapshot JSON")
+	reportPath := flag.String("report", "", "path to write the backtest report JSON")
+	recommendationPath := flag.String("recommendation", "", "path to write the rollout recommendation")
+	signingKeyPath := flag.String("signing-key", "", "path to signing key JSON (optional)")
+	flag.Parse()
+
+	if *historyPath == "" || *policyPath == "" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	history, historyDigest, err := pbs.LoadHistory(*historyPath)
+	if err != nil {
+		log.Fatalf("load history: %v", err)
+	}
+
+	policy, err := pbs.LoadPolicy(*policyPath)
+	if err != nil {
+		log.Fatalf("load policy: %v", err)
+	}
+
+	engine, err := pbs.NewEngine(policy)
+	if err != nil {
+		log.Fatalf("construct engine: %v", err)
+	}
+
+	summary, impacts, _ := engine.Run(history)
+	report := pbs.BuildReport(summary, impacts, policy, historyDigest)
+
+	if *signingKeyPath != "" {
+		key, err := pbs.LoadSigningKey(*signingKeyPath)
+		if err != nil {
+			log.Fatalf("load signing key: %v", err)
+		}
+		report, err = pbs.SignReport(report, key)
+		if err != nil {
+			log.Fatalf("sign report: %v", err)
+		}
+	}
+
+	if *reportPath != "" {
+		if err := pbs.WriteJSON(*reportPath, report); err != nil {
+			log.Fatalf("write report: %v", err)
+		}
+		fmt.Printf("wrote report to %s\n", *reportPath)
+	}
+
+	recommendation := pbs.BuildRecommendation(report)
+	if *recommendationPath != "" {
+		if err := pbs.WriteText(*recommendationPath, recommendation); err != nil {
+			log.Fatalf("write recommendation: %v", err)
+		}
+		fmt.Printf("wrote recommendation to %s\n", *recommendationPath)
+	}
+
+	if *reportPath == "" && *recommendationPath == "" {
+		fmt.Println(recommendation)
+	}
+}

--- a/pbs/go.mod
+++ b/pbs/go.mod
@@ -1,0 +1,3 @@
+module github.com/summit/pbs
+
+go 1.24.3

--- a/pbs/internal/pbs/engine.go
+++ b/pbs/internal/pbs/engine.go
@@ -1,0 +1,347 @@
+package pbs
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	engineVersion = "0.1.0"
+	schemaVersion = "2024-09-01"
+	defaultSource = "historical-log"
+	defaultRuleID = "__default__"
+)
+
+var allowedDecisions = map[string]struct{}{
+	"allow":     {},
+	"deny":      {},
+	"redact":    {},
+	"transform": {},
+}
+
+// Engine replays history under a provided policy snapshot.
+type Engine struct {
+	policy PolicySnapshot
+}
+
+// NewEngine constructs a new deterministic backtest engine.
+func NewEngine(policy PolicySnapshot) (*Engine, error) {
+	if err := validatePolicy(policy); err != nil {
+		return nil, err
+	}
+	return &Engine{policy: policy.Clone()}, nil
+}
+
+// Run executes the replay for the supplied history corpus.
+func (e *Engine) Run(history []HistoricalDecision) (Summary, []RuleImpact, []EvaluationResult) {
+	sorted := make([]HistoricalDecision, len(history))
+	copy(sorted, history)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].Timestamp == sorted[j].Timestamp {
+			return sorted[i].ID < sorted[j].ID
+		}
+		return sorted[i].Timestamp < sorted[j].Timestamp
+	})
+
+	var (
+		evaluations          = make([]EvaluationResult, 0, len(sorted))
+		ruleStats            = map[string]*ruleAccumulator{}
+		total                = len(sorted)
+		originalBlockCount   int
+		newBlockCount        int
+		originalLatencyTotal int
+		newLatencyTotal      int
+		canaryCatches        int
+	)
+
+	for _, decision := range sorted {
+		if _, ok := allowedDecisions[decision.Action]; !ok {
+			// Treat unknown decisions as allow to avoid inflating block deltas.
+			decision.Action = "allow"
+		}
+
+		originalLatencyTotal += decision.LatencyMS
+		if isBlocking(decision.Action) {
+			originalBlockCount++
+		}
+
+		result := e.evaluate(decision)
+
+		newLatencyTotal += result.NewLatency
+		if isBlocking(result.NewAction) {
+			newBlockCount++
+		}
+
+		if decision.Canary && decision.Action == "allow" && result.NewAction != "allow" {
+			canaryCatches++
+		}
+
+		eval := EvaluationResult{
+			DecisionID:      decision.ID,
+			OriginalAction:  decision.Action,
+			NewAction:       result.NewAction,
+			Canary:          decision.Canary,
+			OriginalLatency: decision.LatencyMS,
+			NewLatency:      result.NewLatency,
+			AppliedRuleID:   result.AppliedRuleID,
+		}
+		evaluations = append(evaluations, eval)
+
+		acc, ok := ruleStats[result.AppliedRuleID]
+		if !ok {
+			acc = &ruleAccumulator{}
+			ruleStats[result.AppliedRuleID] = acc
+		}
+		acc.matches++
+		acc.totalLatency += result.NewLatency
+		if !isBlocking(decision.Action) && isBlocking(result.NewAction) {
+			acc.blockEscalations++
+		}
+		if isBlocking(decision.Action) && !isBlocking(result.NewAction) {
+			acc.relaxations++
+		}
+		acc.resultingAction = result.NewAction
+	}
+
+	summary := buildSummary(total, originalBlockCount, newBlockCount, originalLatencyTotal, newLatencyTotal, canaryCatches)
+
+	impacts := make([]RuleImpact, 0, len(ruleStats))
+	ruleIDs := make([]string, 0, len(ruleStats))
+	for ruleID := range ruleStats {
+		ruleIDs = append(ruleIDs, ruleID)
+	}
+	sort.Strings(ruleIDs)
+	for _, ruleID := range ruleIDs {
+		acc := ruleStats[ruleID]
+		avgLatency := 0.0
+		if acc.matches > 0 {
+			avgLatency = round2(float64(acc.totalLatency) / float64(acc.matches))
+		}
+		impacts = append(impacts, RuleImpact{
+			RuleID:           ruleID,
+			Matches:          acc.matches,
+			BlockEscalations: acc.blockEscalations,
+			Relaxations:      acc.relaxations,
+			ResultingAction:  acc.resultingAction,
+			AverageLatency:   avgLatency,
+		})
+	}
+
+	return summary, impacts, evaluations
+}
+
+func (e *Engine) evaluate(decision HistoricalDecision) EvaluationResult {
+	appliedRuleID := defaultRuleID
+	action := e.policy.DefaultDecision
+	latency := decision.LatencyMS + e.policy.BaseLatencyMS
+
+	for _, rule := range e.policy.Rules {
+		if matches(rule.Match, decision.Attributes) {
+			appliedRuleID = rule.ID
+			if rule.Decision != "" {
+				action = rule.Decision
+			}
+			latency += rule.LatencyMS
+			break
+		}
+	}
+
+	if _, ok := allowedDecisions[action]; !ok {
+		action = "allow"
+	}
+
+	return EvaluationResult{
+		DecisionID:      decision.ID,
+		OriginalAction:  decision.Action,
+		NewAction:       action,
+		Canary:          decision.Canary,
+		OriginalLatency: decision.LatencyMS,
+		NewLatency:      latency,
+		AppliedRuleID:   appliedRuleID,
+	}
+}
+
+func matches(match map[string]string, attrs map[string]string) bool {
+	if len(match) == 0 {
+		return false
+	}
+	for key, expected := range match {
+		if actual, ok := attrs[key]; !ok || !strings.EqualFold(actual, expected) {
+			return false
+		}
+	}
+	return true
+}
+
+func isBlocking(action string) bool {
+	_, ok := allowedDecisions[action]
+	if !ok {
+		return false
+	}
+	return action != "allow"
+}
+
+func buildSummary(total, originalBlockCount, newBlockCount, originalLatencyTotal, newLatencyTotal, canaryCatches int) Summary {
+	if total == 0 {
+		return Summary{}
+	}
+
+	origBlockRate := float64(originalBlockCount) / float64(total)
+	newBlockRate := float64(newBlockCount) / float64(total)
+
+	origAvgLatency := float64(originalLatencyTotal) / float64(total)
+	newAvgLatency := float64(newLatencyTotal) / float64(total)
+
+	return Summary{
+		TotalDecisions:              total,
+		OriginalBlockRate:           round4(origBlockRate),
+		NewBlockRate:                round4(newBlockRate),
+		BlockRateDelta:              round4(newBlockRate - origBlockRate),
+		OriginalAverageLatencyMS:    round2(origAvgLatency),
+		NewAverageLatencyMS:         round2(newAvgLatency),
+		AverageLatencyDeltaMS:       round2(newAvgLatency - origAvgLatency),
+		FalseNegativeCanaryCatchers: canaryCatches,
+	}
+}
+
+func validatePolicy(policy PolicySnapshot) error {
+	if policy.Name == "" {
+		return errors.New("policy name is required")
+	}
+	if policy.Version == "" {
+		return errors.New("policy version is required")
+	}
+	if policy.DefaultDecision == "" {
+		policy.DefaultDecision = "allow"
+	}
+	if _, ok := allowedDecisions[policy.DefaultDecision]; !ok {
+		return fmt.Errorf("unsupported default decision: %s", policy.DefaultDecision)
+	}
+	seen := map[string]struct{}{}
+	for _, rule := range policy.Rules {
+		if rule.ID == "" {
+			return errors.New("policy rule id is required")
+		}
+		if _, ok := seen[rule.ID]; ok {
+			return fmt.Errorf("duplicate rule id %s", rule.ID)
+		}
+		seen[rule.ID] = struct{}{}
+		if rule.Decision != "" {
+			if _, ok := allowedDecisions[rule.Decision]; !ok {
+				return fmt.Errorf("unsupported decision %s in rule %s", rule.Decision, rule.ID)
+			}
+		}
+	}
+	return nil
+}
+
+func computeDigest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func round2(value float64) float64 {
+	return float64(int(value*100+0.5)) / 100
+}
+
+func round4(value float64) float64 {
+	return float64(int(value*10000+0.5)) / 10000
+}
+
+type ruleAccumulator struct {
+	matches          int
+	blockEscalations int
+	relaxations      int
+	totalLatency     int
+	resultingAction  string
+}
+
+// BuildReport assembles a canonical report payload.
+func BuildReport(summary Summary, impacts []RuleImpact, policy PolicySnapshot, historyDigest string) BacktestReport {
+	runID := computeRunID(policy, historyDigest)
+	sort.Slice(impacts, func(i, j int) bool {
+		return impacts[i].RuleID < impacts[j].RuleID
+	})
+	return BacktestReport{
+		SchemaVersion:      schemaVersion,
+		EngineVersion:      engineVersion,
+		DeterministicRunID: runID,
+		Policy: PolicyMetadata{
+			Name:    policy.Name,
+			Version: policy.Version,
+			Digest:  computePolicyDigest(policy),
+		},
+		Inputs: InputMetadata{
+			HistoryDigest:  historyDigest,
+			TotalDecisions: summary.TotalDecisions,
+			Source:         defaultSource,
+		},
+		Summary:     summary,
+		RuleImpacts: impacts,
+	}
+}
+
+func computeRunID(policy PolicySnapshot, historyDigest string) string {
+	builder := strings.Builder{}
+	builder.WriteString(policy.Name)
+	builder.WriteString(":")
+	builder.WriteString(policy.Version)
+	builder.WriteString(":")
+	builder.WriteString(computePolicyDigest(policy))
+	builder.WriteString(":")
+	builder.WriteString(historyDigest)
+	builder.WriteString(":")
+	builder.WriteString(engineVersion)
+	sum := sha256.Sum256([]byte(builder.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+func computePolicyDigest(policy PolicySnapshot) string {
+	builder := strings.Builder{}
+	builder.WriteString(policy.Name)
+	builder.WriteString(":")
+	builder.WriteString(policy.Version)
+	builder.WriteString(":")
+	builder.WriteString(strings.TrimSpace(policy.Description))
+	builder.WriteString(":")
+	builder.WriteString(policy.DefaultDecision)
+	builder.WriteString(":")
+	builder.WriteString(fmt.Sprintf("%d", policy.BaseLatencyMS))
+	ruleIDs := make([]string, 0, len(policy.Rules))
+	for _, rule := range policy.Rules {
+		builder.WriteString("|")
+		builder.WriteString(rule.ID)
+		builder.WriteString(":")
+		builder.WriteString(rule.Decision)
+		builder.WriteString(":")
+		builder.WriteString(fmt.Sprintf("%d", rule.LatencyMS))
+		keys := make([]string, 0, len(rule.Match))
+		for k := range rule.Match {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			builder.WriteString(":")
+			builder.WriteString(k)
+			builder.WriteString("=")
+			builder.WriteString(strings.ToLower(rule.Match[k]))
+		}
+		ruleIDs = append(ruleIDs, rule.ID)
+	}
+	sum := sha256.Sum256([]byte(builder.String()))
+	return hex.EncodeToString(sum[:])
+}
+
+// Replay orchestrates the full replay lifecycle given raw inputs.
+func Replay(history []HistoricalDecision, policy PolicySnapshot, historyDigest string) BacktestReport {
+	engine, err := NewEngine(policy)
+	if err != nil {
+		panic(err)
+	}
+	summary, impacts, _ := engine.Run(history)
+	return BuildReport(summary, impacts, policy, historyDigest)
+}

--- a/pbs/internal/pbs/engine_test.go
+++ b/pbs/internal/pbs/engine_test.go
@@ -1,0 +1,133 @@
+package pbs_test
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/summit/pbs/internal/pbs"
+)
+
+func fixturePath(t *testing.T, name string) string {
+	t.Helper()
+	return filepath.Join("..", "..", "testdata", name)
+}
+
+func mustLoadHistory(t *testing.T) ([]pbs.HistoricalDecision, string) {
+	t.Helper()
+	history, digest, err := pbs.LoadHistory(fixturePath(t, "history_sample.json"))
+	if err != nil {
+		t.Fatalf("load history: %v", err)
+	}
+	return history, digest
+}
+
+func mustLoadPolicy(t *testing.T, name string) pbs.PolicySnapshot {
+	t.Helper()
+	policy, err := pbs.LoadPolicy(fixturePath(t, name))
+	if err != nil {
+		t.Fatalf("load policy %s: %v", name, err)
+	}
+	return policy
+}
+
+func TestDeterministicReplay(t *testing.T) {
+	history, digest := mustLoadHistory(t)
+	policy := mustLoadPolicy(t, "policy_hardened.json")
+
+	engine, err := pbs.NewEngine(policy)
+	if err != nil {
+		t.Fatalf("new engine: %v", err)
+	}
+
+	summary1, impacts1, evals1 := engine.Run(history)
+	summary2, impacts2, evals2 := engine.Run(history)
+
+	if !reflect.DeepEqual(summary1, summary2) {
+		t.Fatalf("summary mismatch: %#v vs %#v", summary1, summary2)
+	}
+	if !reflect.DeepEqual(impacts1, impacts2) {
+		t.Fatalf("impacts mismatch: %#v vs %#v", impacts1, impacts2)
+	}
+	if !reflect.DeepEqual(evals1, evals2) {
+		t.Fatalf("evaluations mismatch")
+	}
+
+	report := pbs.BuildReport(summary1, impacts1, policy, digest)
+	if report.DeterministicRunID == "" {
+		t.Fatalf("run id should not be empty")
+	}
+}
+
+func TestPolicyChangeDelta(t *testing.T) {
+	history, digest := mustLoadHistory(t)
+
+	baseline := mustLoadPolicy(t, "policy_baseline.json")
+	hardened := mustLoadPolicy(t, "policy_hardened.json")
+
+	engineBaseline, err := pbs.NewEngine(baseline)
+	if err != nil {
+		t.Fatalf("baseline engine: %v", err)
+	}
+	baseSummary, _, _ := engineBaseline.Run(history)
+	if baseSummary.BlockRateDelta != 0 {
+		t.Fatalf("expected baseline block delta 0, got %v", baseSummary.BlockRateDelta)
+	}
+	if baseSummary.FalseNegativeCanaryCatchers != 0 {
+		t.Fatalf("expected no canary catches in baseline")
+	}
+
+	engineHardened, err := pbs.NewEngine(hardened)
+	if err != nil {
+		t.Fatalf("hardened engine: %v", err)
+	}
+	hardenedSummary, _, _ := engineHardened.Run(history)
+
+	if hardenedSummary.BlockRateDelta <= baseSummary.BlockRateDelta {
+		t.Fatalf("expected hardened block delta > baseline, got %v", hardenedSummary.BlockRateDelta)
+	}
+	if hardenedSummary.FalseNegativeCanaryCatchers != 1 {
+		t.Fatalf("expected hardened to catch 1 canary, got %d", hardenedSummary.FalseNegativeCanaryCatchers)
+	}
+
+	report := pbs.BuildReport(hardenedSummary, nil, hardened, digest)
+	rec := pbs.BuildRecommendation(report)
+
+	goldenPath := fixturePath(t, "recommendation_hardened.golden.txt")
+	golden, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden: %v", err)
+	}
+	if rec != string(golden) {
+		t.Fatalf("recommendation mismatch.\nwant:\n%s\n----\ngot:\n%s", string(golden), rec)
+	}
+}
+
+func TestReportSigning(t *testing.T) {
+	history, digest := mustLoadHistory(t)
+	policy := mustLoadPolicy(t, "policy_hardened.json")
+
+	engine, err := pbs.NewEngine(policy)
+	if err != nil {
+		t.Fatalf("engine: %v", err)
+	}
+	summary, impacts, _ := engine.Run(history)
+	report := pbs.BuildReport(summary, impacts, policy, digest)
+
+	key, err := pbs.LoadSigningKey(fixturePath(t, "signing_key.json"))
+	if err != nil {
+		t.Fatalf("load signing key: %v", err)
+	}
+	signed, err := pbs.SignReport(report, key)
+	if err != nil {
+		t.Fatalf("sign report: %v", err)
+	}
+	if len(signed.Signatures) != 1 {
+		t.Fatalf("expected 1 signature, got %d", len(signed.Signatures))
+	}
+	sig := signed.Signatures[0]
+	if sig.Digest == "" || sig.Signature == "" || sig.KeyID == "" {
+		t.Fatalf("signature missing fields: %#v", sig)
+	}
+}

--- a/pbs/internal/pbs/io.go
+++ b/pbs/internal/pbs/io.go
@@ -1,0 +1,63 @@
+package pbs
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+)
+
+// LoadHistory reads historical decisions from disk.
+func LoadHistory(path string) ([]HistoricalDecision, string, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("read history: %w", err)
+	}
+	var decisions []HistoricalDecision
+	if err := json.Unmarshal(raw, &decisions); err != nil {
+		return nil, "", fmt.Errorf("parse history: %w", err)
+	}
+	sort.SliceStable(decisions, func(i, j int) bool {
+		if decisions[i].Timestamp == decisions[j].Timestamp {
+			return decisions[i].ID < decisions[j].ID
+		}
+		return decisions[i].Timestamp < decisions[j].Timestamp
+	})
+	return decisions, computeDigest(raw), nil
+}
+
+// LoadPolicy loads a policy snapshot from disk.
+func LoadPolicy(path string) (PolicySnapshot, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return PolicySnapshot{}, fmt.Errorf("read policy: %w", err)
+	}
+	var snapshot PolicySnapshot
+	if err := json.Unmarshal(raw, &snapshot); err != nil {
+		return PolicySnapshot{}, fmt.Errorf("parse policy: %w", err)
+	}
+	if _, err := NewEngine(snapshot); err != nil {
+		return PolicySnapshot{}, err
+	}
+	return snapshot, nil
+}
+
+// WriteJSON writes indented JSON to the target path.
+func WriteJSON(path string, payload any) error {
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal json: %w", err)
+	}
+	return os.WriteFile(path, data, 0o644)
+}
+
+// WriteText writes text content to disk.
+func WriteText(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// ReadAll reads an io.Reader fully.
+func ReadAll(r io.Reader) ([]byte, error) {
+	return io.ReadAll(r)
+}

--- a/pbs/internal/pbs/recommendation.go
+++ b/pbs/internal/pbs/recommendation.go
@@ -1,0 +1,54 @@
+package pbs
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BuildRecommendation renders a diff-friendly rollout recommendation.
+func BuildRecommendation(report BacktestReport) string {
+	summary := report.Summary
+	verdict := "hold"
+	rationale := []string{}
+
+	blockDelta := summary.BlockRateDelta
+	latencyDelta := summary.AverageLatencyDeltaMS
+	canary := summary.FalseNegativeCanaryCatchers
+
+	if canary > 0 && blockDelta <= 0.02 {
+		verdict = "promote"
+		rationale = append(rationale, fmt.Sprintf("caught %d latent canaries", canary))
+		if blockDelta != 0 {
+			rationale = append(rationale, fmt.Sprintf("block-rate delta %+0.2f%%", blockDelta*100))
+		}
+	} else if blockDelta > 0.05 {
+		verdict = "hold"
+		rationale = append(rationale, fmt.Sprintf("block-rate delta %+0.2f%% exceeds limit", blockDelta*100))
+	} else if latencyDelta > 15 {
+		verdict = "hold"
+		rationale = append(rationale, fmt.Sprintf("average latency delta %+0.2fms", latencyDelta))
+	} else {
+		if blockDelta >= -0.01 {
+			verdict = "promote"
+		} else {
+			verdict = "observe"
+		}
+		rationale = append(rationale, fmt.Sprintf("block-rate delta %+0.2f%%", blockDelta*100))
+		rationale = append(rationale, fmt.Sprintf("latency delta %+0.2fms", latencyDelta))
+	}
+
+	builder := &strings.Builder{}
+	builder.WriteString("# PBS Rollout Recommendation\n")
+	builder.WriteString(fmt.Sprintf("verdict: %s\n", verdict))
+	builder.WriteString(fmt.Sprintf("policy_version: %s\n", report.Policy.Version))
+	builder.WriteString(fmt.Sprintf("run_id: %s\n", report.DeterministicRunID))
+	builder.WriteString("rationale:\n")
+	for _, line := range rationale {
+		builder.WriteString(fmt.Sprintf("  - %s\n", line))
+	}
+	builder.WriteString("metrics:\n")
+	builder.WriteString(fmt.Sprintf("  block_rate_delta: %+0.4f\n", blockDelta))
+	builder.WriteString(fmt.Sprintf("  latency_delta_ms: %+0.2f\n", latencyDelta))
+	builder.WriteString(fmt.Sprintf("  canary_catches: %d\n", canary))
+	return builder.String()
+}

--- a/pbs/internal/pbs/signing.go
+++ b/pbs/internal/pbs/signing.go
@@ -1,0 +1,72 @@
+package pbs
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// SigningKey represents an ed25519 keypair used for signing reports.
+type SigningKey struct {
+	KeyID      string `json:"key_id"`
+	PrivateKey string `json:"private_key"`
+}
+
+// LoadSigningKey loads a signing key from disk.
+func LoadSigningKey(path string) (SigningKey, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return SigningKey{}, fmt.Errorf("read signing key: %w", err)
+	}
+	var key SigningKey
+	if err := json.Unmarshal(raw, &key); err != nil {
+		return SigningKey{}, fmt.Errorf("parse signing key: %w", err)
+	}
+	if key.KeyID == "" {
+		return SigningKey{}, errors.New("signing key key_id is required")
+	}
+	if key.PrivateKey == "" {
+		return SigningKey{}, errors.New("signing key private_key is required")
+	}
+	return key, nil
+}
+
+// SignReport attaches a signature to the report using the provided key.
+func SignReport(report BacktestReport, key SigningKey) (BacktestReport, error) {
+	payload := report
+	payload.Signatures = nil
+
+	canonical, err := MarshalCanonicalJSON(payload)
+	if err != nil {
+		return report, fmt.Errorf("marshal canonical report: %w", err)
+	}
+	digest := computeDigest(canonical)
+
+	rawKey, err := base64.StdEncoding.DecodeString(key.PrivateKey)
+	if err != nil {
+		return report, fmt.Errorf("decode private key: %w", err)
+	}
+
+	var priv ed25519.PrivateKey
+	switch len(rawKey) {
+	case ed25519.PrivateKeySize:
+		priv = ed25519.PrivateKey(rawKey)
+	case ed25519.SeedSize:
+		priv = ed25519.NewKeyFromSeed(rawKey)
+	default:
+		return report, fmt.Errorf("unexpected private key length %d", len(rawKey))
+	}
+
+	signature := ed25519.Sign(priv, canonical)
+	sig := ReportSignature{
+		KeyID:     key.KeyID,
+		Algorithm: "ed25519",
+		Digest:    digest,
+		Signature: base64.StdEncoding.EncodeToString(signature),
+	}
+	report.Signatures = append(report.Signatures, sig)
+	return report, nil
+}

--- a/pbs/internal/pbs/types.go
+++ b/pbs/internal/pbs/types.go
@@ -1,0 +1,133 @@
+package pbs
+
+import "encoding/json"
+
+// HistoricalDecision represents a previously adjudicated request or event.
+type HistoricalDecision struct {
+	ID            string            `json:"id"`
+	Timestamp     string            `json:"timestamp"`
+	Actor         string            `json:"actor"`
+	Action        string            `json:"action"`
+	Attributes    map[string]string `json:"attributes"`
+	Canary        bool              `json:"canary"`
+	LatencyMS     int               `json:"latency_ms"`
+	PayloadHash   string            `json:"payload_hash"`
+	PolicyVersion string            `json:"policy_version"`
+}
+
+// PolicySnapshot models the rules used when replaying history.
+type PolicySnapshot struct {
+	Name            string       `json:"name"`
+	Version         string       `json:"version"`
+	Description     string       `json:"description"`
+	DefaultDecision string       `json:"default_decision"`
+	BaseLatencyMS   int          `json:"base_latency_ms"`
+	Rules           []PolicyRule `json:"rules"`
+}
+
+// PolicyRule is evaluated in declaration order until the first match.
+type PolicyRule struct {
+	ID          string            `json:"id"`
+	Description string            `json:"description"`
+	Match       map[string]string `json:"match"`
+	Decision    string            `json:"decision"`
+	LatencyMS   int               `json:"latency_ms"`
+}
+
+// EvaluationResult captures the outcome of replaying a single decision.
+type EvaluationResult struct {
+	DecisionID      string
+	OriginalAction  string
+	NewAction       string
+	Canary          bool
+	OriginalLatency int
+	NewLatency      int
+	AppliedRuleID   string
+}
+
+// Summary aggregates headline metrics from the backtest run.
+type Summary struct {
+	TotalDecisions              int     `json:"total_decisions"`
+	OriginalBlockRate           float64 `json:"original_block_rate"`
+	NewBlockRate                float64 `json:"new_block_rate"`
+	BlockRateDelta              float64 `json:"block_rate_delta"`
+	OriginalAverageLatencyMS    float64 `json:"original_average_latency_ms"`
+	NewAverageLatencyMS         float64 `json:"new_average_latency_ms"`
+	AverageLatencyDeltaMS       float64 `json:"average_latency_delta_ms"`
+	FalseNegativeCanaryCatchers int     `json:"false_negative_canary_catchers"`
+}
+
+// RuleImpact details how a policy rule affected the replay.
+type RuleImpact struct {
+	RuleID           string  `json:"rule_id"`
+	Matches          int     `json:"matches"`
+	BlockEscalations int     `json:"block_escalations"`
+	Relaxations      int     `json:"relaxations"`
+	ResultingAction  string  `json:"resulting_action"`
+	AverageLatency   float64 `json:"average_latency_ms"`
+}
+
+// BacktestReport is the canonical output emitted by the engine.
+type BacktestReport struct {
+	SchemaVersion      string            `json:"schema_version"`
+	EngineVersion      string            `json:"engine_version"`
+	DeterministicRunID string            `json:"deterministic_run_id"`
+	Policy             PolicyMetadata    `json:"policy"`
+	Inputs             InputMetadata     `json:"inputs"`
+	Summary            Summary           `json:"summary"`
+	RuleImpacts        []RuleImpact      `json:"rule_impacts"`
+	Signatures         []ReportSignature `json:"signatures,omitempty"`
+}
+
+// PolicyMetadata documents the snapshot used for the replay.
+type PolicyMetadata struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+	Digest  string `json:"digest"`
+}
+
+// InputMetadata documents the history corpus being replayed.
+type InputMetadata struct {
+	HistoryDigest  string `json:"history_digest"`
+	TotalDecisions int    `json:"total_decisions"`
+	Source         string `json:"source"`
+}
+
+// ReportSignature cryptographically authenticates the report payload.
+type ReportSignature struct {
+	KeyID     string `json:"key_id"`
+	Algorithm string `json:"algorithm"`
+	Digest    string `json:"digest"`
+	Signature string `json:"signature"`
+}
+
+// Clone returns a deep copy of the policy snapshot.
+func (p PolicySnapshot) Clone() PolicySnapshot {
+	dup := p
+	if len(p.Rules) > 0 {
+		dup.Rules = make([]PolicyRule, len(p.Rules))
+		copy(dup.Rules, p.Rules)
+		for i, rule := range p.Rules {
+			if len(rule.Match) == 0 {
+				continue
+			}
+			dupMatch := make(map[string]string, len(rule.Match))
+			for k, v := range rule.Match {
+				dupMatch[k] = v
+			}
+			dup.Rules[i].Match = dupMatch
+		}
+	}
+	return dup
+}
+
+// MarshalCanonicalJSON encodes a value using deterministic ordering.
+func MarshalCanonicalJSON(v any) ([]byte, error) {
+	buf, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	// encoding/json is deterministic for structs without map fields. Callers
+	// should avoid maps or pre-process them into sorted slices.
+	return buf, nil
+}

--- a/pbs/testdata/history_sample.json
+++ b/pbs/testdata/history_sample.json
@@ -1,0 +1,72 @@
+[
+  {
+    "id": "evt-1",
+    "timestamp": "2024-08-01T00:00:00Z",
+    "actor": "user-1",
+    "action": "allow",
+    "attributes": {
+      "country": "US",
+      "content_type": "text"
+    },
+    "canary": false,
+    "latency_ms": 18,
+    "payload_hash": "hash-1",
+    "policy_version": "baseline"
+  },
+  {
+    "id": "evt-2",
+    "timestamp": "2024-08-01T00:00:01Z",
+    "actor": "user-2",
+    "action": "allow",
+    "attributes": {
+      "country": "RU",
+      "content_type": "image"
+    },
+    "canary": true,
+    "latency_ms": 20,
+    "payload_hash": "hash-2",
+    "policy_version": "baseline"
+  },
+  {
+    "id": "evt-3",
+    "timestamp": "2024-08-01T00:00:02Z",
+    "actor": "user-3",
+    "action": "redact",
+    "attributes": {
+      "country": "US",
+      "content_type": "payment"
+    },
+    "canary": false,
+    "latency_ms": 30,
+    "payload_hash": "hash-3",
+    "policy_version": "baseline"
+  },
+  {
+    "id": "evt-4",
+    "timestamp": "2024-08-01T00:00:03Z",
+    "actor": "user-4",
+    "action": "allow",
+    "attributes": {
+      "country": "BR",
+      "content_type": "text"
+    },
+    "canary": false,
+    "latency_ms": 15,
+    "payload_hash": "hash-4",
+    "policy_version": "baseline"
+  },
+  {
+    "id": "evt-5",
+    "timestamp": "2024-08-01T00:00:04Z",
+    "actor": "user-5",
+    "action": "transform",
+    "attributes": {
+      "country": "US",
+      "content_type": "image"
+    },
+    "canary": false,
+    "latency_ms": 24,
+    "payload_hash": "hash-5",
+    "policy_version": "baseline"
+  }
+]

--- a/pbs/testdata/policy_baseline.json
+++ b/pbs/testdata/policy_baseline.json
@@ -1,0 +1,28 @@
+{
+  "name": "baseline-policy",
+  "version": "2024-08-01",
+  "description": "Baseline adjudication policy mirroring historical outcomes.",
+  "default_decision": "allow",
+  "base_latency_ms": 2,
+  "rules": [
+    {
+      "id": "rule-payment-redact",
+      "description": "Redact payment content regardless of country",
+      "match": {
+        "content_type": "payment"
+      },
+      "decision": "redact",
+      "latency_ms": 5
+    },
+    {
+      "id": "rule-us-image-transform",
+      "description": "Transform US image uploads",
+      "match": {
+        "content_type": "image",
+        "country": "US"
+      },
+      "decision": "transform",
+      "latency_ms": 3
+    }
+  ]
+}

--- a/pbs/testdata/policy_hardened.json
+++ b/pbs/testdata/policy_hardened.json
@@ -1,0 +1,37 @@
+{
+  "name": "baseline-policy",
+  "version": "2024-08-15",
+  "description": "Hardened snapshot catching RU canaries and bumping baseline latency.",
+  "default_decision": "allow",
+  "base_latency_ms": 3,
+  "rules": [
+    {
+      "id": "rule-ru-deny",
+      "description": "Block RU-originated submissions",
+      "match": {
+        "country": "RU"
+      },
+      "decision": "deny",
+      "latency_ms": 6
+    },
+    {
+      "id": "rule-payment-redact",
+      "description": "Redact payment content regardless of country",
+      "match": {
+        "content_type": "payment"
+      },
+      "decision": "redact",
+      "latency_ms": 5
+    },
+    {
+      "id": "rule-us-image-transform",
+      "description": "Transform US image uploads",
+      "match": {
+        "content_type": "image",
+        "country": "US"
+      },
+      "decision": "transform",
+      "latency_ms": 3
+    }
+  ]
+}

--- a/pbs/testdata/recommendation_hardened.golden.txt
+++ b/pbs/testdata/recommendation_hardened.golden.txt
@@ -1,0 +1,10 @@
+# PBS Rollout Recommendation
+verdict: hold
+policy_version: 2024-08-15
+run_id: a1722d1fd487acec2c982a635d3de0f807fe99c9b00ee98228c56829c91b4e0e
+rationale:
+  - block-rate delta +20.00% exceeds limit
+metrics:
+  block_rate_delta: +0.2000
+  latency_delta_ms: +5.80
+  canary_catches: 1

--- a/pbs/testdata/recommendation_sample.txt
+++ b/pbs/testdata/recommendation_sample.txt
@@ -1,0 +1,11 @@
+# PBS Rollout Recommendation
+verdict: hold
+policy_version: 2024-08-15
+run_id: a1722d1fd487acec2c982a635d3de0f807fe99c9b00ee98228c56829c91b4e0e
+rationale:
+  - block-rate delta +20.00% exceeds limit
+metrics:
+  block_rate_delta: +0.2000
+  latency_delta_ms: +5.80
+  canary_catches: 1
+

--- a/pbs/testdata/report_sample.json
+++ b/pbs/testdata/report_sample.json
@@ -1,0 +1,67 @@
+{
+  "schema_version": "2024-09-01",
+  "engine_version": "0.1.0",
+  "deterministic_run_id": "a1722d1fd487acec2c982a635d3de0f807fe99c9b00ee98228c56829c91b4e0e",
+  "policy": {
+    "name": "baseline-policy",
+    "version": "2024-08-15",
+    "digest": "27d7201862a820bd7c75197810956a6d2870b6a07e109258d3481d04acb09a0b"
+  },
+  "inputs": {
+    "history_digest": "eb1c39a396d249b81c017ba14464f178859221f93a4d89a6aba244ff218c551a",
+    "total_decisions": 5,
+    "source": "historical-log"
+  },
+  "summary": {
+    "total_decisions": 5,
+    "original_block_rate": 0.4,
+    "new_block_rate": 0.6,
+    "block_rate_delta": 0.2,
+    "original_average_latency_ms": 21.4,
+    "new_average_latency_ms": 27.2,
+    "average_latency_delta_ms": 5.8,
+    "false_negative_canary_catchers": 1
+  },
+  "rule_impacts": [
+    {
+      "rule_id": "__default__",
+      "matches": 2,
+      "block_escalations": 0,
+      "relaxations": 0,
+      "resulting_action": "allow",
+      "average_latency_ms": 19.5
+    },
+    {
+      "rule_id": "rule-payment-redact",
+      "matches": 1,
+      "block_escalations": 0,
+      "relaxations": 0,
+      "resulting_action": "redact",
+      "average_latency_ms": 38
+    },
+    {
+      "rule_id": "rule-ru-deny",
+      "matches": 1,
+      "block_escalations": 1,
+      "relaxations": 0,
+      "resulting_action": "deny",
+      "average_latency_ms": 29
+    },
+    {
+      "rule_id": "rule-us-image-transform",
+      "matches": 1,
+      "block_escalations": 0,
+      "relaxations": 0,
+      "resulting_action": "transform",
+      "average_latency_ms": 30
+    }
+  ],
+  "signatures": [
+    {
+      "key_id": "local-dev",
+      "algorithm": "ed25519",
+      "digest": "eb528ef40d025b3a40ffc2df9401679f278f9039ae0cf7dee013cda4b534f97c",
+      "signature": "nqnmxfI79qUE5sVMOua7mAm+J5BFBZfUGhdvVZCzwB91qRp9s91EwltJx3HSFs4DOgp8bDQBuu0pJ/BmUT2uBQ=="
+    }
+  ]
+}

--- a/pbs/testdata/signing_key.json
+++ b/pbs/testdata/signing_key.json
@@ -1,0 +1,4 @@
+{
+  "key_id": "local-dev",
+  "private_key": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
+}

--- a/pbs/tools/pbs-dashboard/package.json
+++ b/pbs/tools/pbs-dashboard/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@summit/pbs-dashboard",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Static dashboard generator for PBS backtest reports",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/cli.js"
+  },
+  "dependencies": {
+    "commander": "^11.1.0",
+    "fs-extra": "^11.2.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.2",
+    "tslib": "^2.6.2",
+    "tsx": "^4.7.1",
+    "typescript": "^5.4.0"
+  }
+}

--- a/pbs/tools/pbs-dashboard/src/cli.ts
+++ b/pbs/tools/pbs-dashboard/src/cli.ts
@@ -1,0 +1,47 @@
+import { Command } from "commander";
+import fs from "fs-extra";
+import path from "node:path";
+import { renderDashboard } from "./generator";
+import { reportSchema } from "./types";
+
+const program = new Command();
+
+program
+  .name("pbs-dashboard")
+  .description("Generate a static HTML dashboard for PBS backtest reports")
+  .requiredOption("-r, --report <path>", "path to the backtest report JSON")
+  .option("-o, --out <path>", "where to write the dashboard HTML", "dist/dashboard.html")
+  .option("-R, --recommendation <path>", "optional rollout recommendation to embed");
+
+program.parse(process.argv);
+
+interface Options {
+  report: string;
+  out: string;
+  recommendation?: string;
+}
+
+async function main(options: Options) {
+  const reportPath = path.resolve(options.report);
+  const reportJson = await fs.readFile(reportPath, "utf-8");
+  const report = reportSchema.parse(JSON.parse(reportJson));
+
+  let recommendation: string | undefined;
+  if (options.recommendation) {
+    const recPath = path.resolve(options.recommendation);
+    recommendation = await fs.readFile(recPath, "utf-8");
+  }
+
+  const html = renderDashboard(report, recommendation);
+  const outPath = path.resolve(options.out);
+  await fs.ensureDir(path.dirname(outPath));
+  await fs.writeFile(outPath, html, "utf-8");
+  // eslint-disable-next-line no-console
+  console.log(`Dashboard written to ${outPath}`);
+}
+
+main(program.opts<Options>()).catch((error) => {
+  // eslint-disable-next-line no-console
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/pbs/tools/pbs-dashboard/src/generator.ts
+++ b/pbs/tools/pbs-dashboard/src/generator.ts
@@ -1,0 +1,178 @@
+import { Report, RuleImpact, Summary } from "./types";
+
+const numberFormatter = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+const percentFormatter = new Intl.NumberFormat("en-US", {
+  style: "percent",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function renderSummary(summary: Summary): string {
+  const blockDelta = percentFormatter.format(summary.block_rate_delta);
+  const originalBlock = percentFormatter.format(summary.original_block_rate);
+  const newBlock = percentFormatter.format(summary.new_block_rate);
+
+  return `
+    <section class="summary">
+      <div class="card">
+        <h3>Total Decisions</h3>
+        <p>${summary.total_decisions.toLocaleString("en-US")}</p>
+      </div>
+      <div class="card">
+        <h3>Block Rate</h3>
+        <p>${originalBlock} → ${newBlock}</p>
+      </div>
+      <div class="card">
+        <h3>Block Delta</h3>
+        <p class="delta">${blockDelta}</p>
+      </div>
+      <div class="card">
+        <h3>Latency Δ</h3>
+        <p>${numberFormatter.format(summary.average_latency_delta_ms)} ms</p>
+      </div>
+      <div class="card">
+        <h3>Canary Catches</h3>
+        <p>${summary.false_negative_canary_catchers}</p>
+      </div>
+    </section>
+  `;
+}
+
+function renderRuleImpacts(impacts: RuleImpact[]): string {
+  if (impacts.length === 0) {
+    return `<p>No rule impacts recorded.</p>`;
+  }
+  const rows = impacts
+    .map((impact) => {
+      return `
+        <tr>
+          <td><code>${impact.rule_id}</code></td>
+          <td>${impact.matches}</td>
+          <td>${impact.block_escalations}</td>
+          <td>${impact.relaxations}</td>
+          <td>${impact.resulting_action}</td>
+          <td>${numberFormatter.format(impact.average_latency_ms)}</td>
+        </tr>
+      `;
+    })
+    .join("\n");
+
+  return `
+    <table class="impacts">
+      <thead>
+        <tr>
+          <th>Rule</th>
+          <th>Matches</th>
+          <th>Escalations</th>
+          <th>Relaxations</th>
+          <th>Result Action</th>
+          <th>Avg Latency (ms)</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${rows}
+      </tbody>
+    </table>
+  `;
+}
+
+function renderSignatures(report: Report): string {
+  if (!report.signatures || report.signatures.length === 0) {
+    return "";
+  }
+  const rows = report.signatures
+    .map(
+      (signature) => `
+        <tr>
+          <td>${signature.key_id}</td>
+          <td>${signature.algorithm}</td>
+          <td><code>${signature.digest}</code></td>
+          <td><code>${signature.signature}</code></td>
+        </tr>
+      `,
+    )
+    .join("\n");
+  return `
+    <section>
+      <h2>Signatures</h2>
+      <table class="signatures">
+        <thead>
+          <tr>
+            <th>Key</th>
+            <th>Algorithm</th>
+            <th>Digest</th>
+            <th>Signature</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${rows}
+        </tbody>
+      </table>
+    </section>
+  `;
+}
+
+function escapeHTML(input: string): string {
+  return input
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+export function renderDashboard(report: Report, recommendation?: string): string {
+  const summary = renderSummary(report.summary);
+  const impacts = renderRuleImpacts(report.rule_impacts);
+  const signatures = renderSignatures(report);
+  const recommendationBlock = recommendation
+    ? `<section class="recommendation"><h2>Rollout Recommendation</h2><pre>${escapeHTML(
+        recommendation,
+      )}</pre></section>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>PBS Report: ${report.policy.name} (${report.policy.version})</title>
+    <style>
+      body { font-family: "Inter", system-ui, sans-serif; margin: 2rem; background: #0f172a; color: #f8fafc; }
+      h1, h2, h3 { color: #38bdf8; }
+      .summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 2rem; }
+      .card { background: rgba(15, 23, 42, 0.8); padding: 1rem 1.25rem; border-radius: 0.75rem; box-shadow: 0 8px 24px rgba(15, 23, 42, 0.45); }
+      .card h3 { margin-top: 0; font-size: 0.95rem; letter-spacing: 0.05em; text-transform: uppercase; opacity: 0.75; }
+      .card p { margin: 0.25rem 0 0; font-size: 1.4rem; font-weight: 600; }
+      .card .delta { color: #fbbf24; }
+      table { width: 100%; border-collapse: collapse; margin-top: 1rem; }
+      th { text-align: left; font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.06em; opacity: 0.75; }
+      td, th { padding: 0.75rem 0.5rem; border-bottom: 1px solid rgba(148, 163, 184, 0.2); }
+      code { font-family: "Source Code Pro", monospace; }
+      pre { background: rgba(15, 23, 42, 0.9); padding: 1rem; border-radius: 0.75rem; overflow-x: auto; }
+      .recommendation { margin-top: 2rem; }
+      .meta { display: flex; gap: 2rem; flex-wrap: wrap; font-size: 0.9rem; opacity: 0.85; }
+      .meta span { display: inline-flex; align-items: center; gap: 0.5rem; }
+      footer { margin-top: 3rem; font-size: 0.75rem; opacity: 0.6; }
+    </style>
+  </head>
+  <body>
+    <h1>Policy Backtest Report</h1>
+    <div class="meta">
+      <span><strong>Policy:</strong> ${report.policy.name} (${report.policy.version})</span>
+      <span><strong>Run ID:</strong> <code>${report.deterministic_run_id}</code></span>
+      <span><strong>History digest:</strong> <code>${report.inputs.history_digest}</code></span>
+      <span><strong>Engine:</strong> v${report.engine_version}</span>
+    </div>
+    ${summary}
+    <section>
+      <h2>Rule Impact Overview</h2>
+      ${impacts}
+    </section>
+    ${recommendationBlock}
+    ${signatures}
+    <footer>Generated by @summit/pbs-dashboard</footer>
+  </body>
+</html>`;
+}

--- a/pbs/tools/pbs-dashboard/src/types.ts
+++ b/pbs/tools/pbs-dashboard/src/types.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+export const summarySchema = z.object({
+  total_decisions: z.number(),
+  original_block_rate: z.number(),
+  new_block_rate: z.number(),
+  block_rate_delta: z.number(),
+  original_average_latency_ms: z.number(),
+  new_average_latency_ms: z.number(),
+  average_latency_delta_ms: z.number(),
+  false_negative_canary_catchers: z.number(),
+});
+
+export const ruleImpactSchema = z.object({
+  rule_id: z.string(),
+  matches: z.number(),
+  block_escalations: z.number(),
+  relaxations: z.number(),
+  resulting_action: z.string(),
+  average_latency_ms: z.number(),
+});
+
+export const reportSchema = z.object({
+  schema_version: z.string(),
+  engine_version: z.string(),
+  deterministic_run_id: z.string(),
+  policy: z.object({
+    name: z.string(),
+    version: z.string(),
+    digest: z.string(),
+  }),
+  inputs: z.object({
+    history_digest: z.string(),
+    total_decisions: z.number(),
+    source: z.string(),
+  }),
+  summary: summarySchema,
+  rule_impacts: z.array(ruleImpactSchema),
+  signatures: z
+    .array(
+      z.object({
+        key_id: z.string(),
+        algorithm: z.string(),
+        digest: z.string(),
+        signature: z.string(),
+      })
+    )
+    .optional(),
+});
+
+export type Report = z.infer<typeof reportSchema>;
+export type Summary = z.infer<typeof summarySchema>;
+export type RuleImpact = z.infer<typeof ruleImpactSchema>;

--- a/pbs/tools/pbs-dashboard/tsconfig.json
+++ b/pbs/tools/pbs-dashboard/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "target": "ES2022",
+    "moduleResolution": "Bundler",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "typeRoots": ["./node_modules/@types"],
+    "allowImportingTsExtensions": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
+}


### PR DESCRIPTION
## Summary
- add a Go-based PBS engine to deterministically replay historical policy decisions, compute impact deltas, and sign reports
- provide sample fixtures, golden recommendations, and a CLI entrypoint for producing reproducible backtest artifacts
- scaffold a TypeScript dashboard generator for rendering PBS reports and rollout guidance

## Testing
- go test ./...
- (cd pbs/tools/pbs-dashboard && npm run build)

------
https://chatgpt.com/codex/tasks/task_e_68d781283c308333adc64ea52ea9267d