### PR TITLE
feat: add semantic PII ontology mapper service

### DIFF
--- a/services/spom/README.md
+++ b/services/spom/README.md
@@ -1,0 +1,27 @@
+# Semantic PII Ontology Mapper (SPOM)
+
+SPOM maps schema fields to the platform's PII ontology. It blends high-signal
+rules with a lightweight embedding stub to assign sensitivity, category, and
+jurisdiction tags, emitting confidence scores and human-readable explanations.
+
+## Features
+
+- Deterministic rule engine that recognises naming patterns and sample values.
+- Embedding stub that estimates semantic similarity to ontology concepts.
+- Confidence scoring that fuses rule hits and semantic evidence.
+- Diff reporter that highlights tag changes across schema revisions.
+- FSR-PT plug-in that annotates registry schemas with ontology tags.
+
+## Usage
+
+```python
+from spom.mapper import SPOM, FieldObservation
+
+mapper = SPOM()
+fields = [
+    FieldObservation(name="email_address", sample_values=["user@example.com"]),
+]
+report = mapper.map_fields(fields)
+```
+
+See `tests/` for end-to-end examples with expected outputs.

--- a/services/spom/fsr-pt-plugin.ts
+++ b/services/spom/fsr-pt-plugin.ts
@@ -1,0 +1,57 @@
+/**
+ * FSR-PT plug-in that attaches SPOM ontology tags to registry schemas.
+ */
+
+export interface SchemaField {
+  name: string;
+  description?: string;
+  sampleValues?: string[];
+}
+
+export interface SpomMapping {
+  field: string;
+  tag: {
+    label: string;
+    category: string;
+    sensitivity: string;
+    jurisdictions: string[];
+  };
+  confidence: number;
+  explanations: string[];
+}
+
+export interface AnnotatedField extends SchemaField {
+  ontologyTag: SpomMapping["tag"] | null;
+  confidence: number;
+  explanations: string[];
+}
+
+export function annotateSchema(
+  schema: SchemaField[],
+  mappings: SpomMapping[],
+  threshold = 0.6,
+): AnnotatedField[] {
+  const index = new Map<string, SpomMapping>();
+  for (const mapping of mappings) {
+    index.set(mapping.field, mapping);
+  }
+
+  return schema.map((field) => {
+    const mapping = index.get(field.name);
+    if (!mapping || mapping.confidence < threshold) {
+      return {
+        ...field,
+        ontologyTag: null,
+        confidence: mapping?.confidence ?? 0,
+        explanations: mapping?.explanations ?? [],
+      };
+    }
+
+    return {
+      ...field,
+      ontologyTag: mapping.tag,
+      confidence: mapping.confidence,
+      explanations: mapping.explanations,
+    };
+  });
+}

--- a/services/spom/pyproject.toml
+++ b/services/spom/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "spom"
+version = "0.1.0"
+description = "Semantic PII Ontology Mapper"
+readme = "README.md"
+authors = [{name = "IntelGraph Team"}]
+requires-python = ">=3.11"
+dependencies = [
+  "pydantic>=2.8.0",
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest>=8.0.0",
+]
+
+[build-system]
+requires = ["setuptools>=65.0.0"]
+build-backend = "setuptools.build_meta"

--- a/services/spom/spom/__init__.py
+++ b/services/spom/spom/__init__.py
@@ -1,0 +1,15 @@
+"""Semantic PII Ontology Mapper package."""
+
+from .models import FieldObservation, MappingResult, OntologyTag, MappingReport
+from .mapper import SPOM
+from .diff import DiffReport, diff_reports
+
+__all__ = [
+    "FieldObservation",
+    "MappingResult",
+    "OntologyTag",
+    "MappingReport",
+    "SPOM",
+    "DiffReport",
+    "diff_reports",
+]

--- a/services/spom/spom/diff.py
+++ b/services/spom/spom/diff.py
@@ -1,0 +1,85 @@
+"""Diffing utilities for SPOM reports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+from .models import MappingReport, MappingResult
+
+
+@dataclass
+class DiffEntry:
+    field: str
+    from_tag: Optional[str]
+    to_tag: Optional[str]
+    from_confidence: float
+    to_confidence: float
+    explanation: str
+
+
+@dataclass
+class DiffReport:
+    dataset: str
+    changes: List[DiffEntry]
+
+    def as_dict(self) -> Dict[str, Dict[str, object]]:
+        return {
+            entry.field: {
+                "from": entry.from_tag,
+                "to": entry.to_tag,
+                "from_confidence": entry.from_confidence,
+                "to_confidence": entry.to_confidence,
+                "explanation": entry.explanation,
+            }
+            for entry in self.changes
+        }
+
+
+def diff_reports(before: MappingReport, after: MappingReport) -> DiffReport:
+    """Compute diff between two mapping reports."""
+
+    before_index = before.as_index()
+    after_index = after.as_index()
+    fields = set(before_index) | set(after_index)
+    changes: List[DiffEntry] = []
+
+    for field_name in sorted(fields):
+        previous: MappingResult | None = before_index.get(field_name)
+        current: MappingResult | None = after_index.get(field_name)
+
+        previous_tag = previous.tag.label if previous else None
+        current_tag = current.tag.label if current else None
+
+        if previous_tag == current_tag:
+            continue
+
+        explanation = _build_diff_explanation(previous, current)
+        changes.append(
+            DiffEntry(
+                field=field_name,
+                from_tag=previous_tag,
+                to_tag=current_tag,
+                from_confidence=previous.confidence if previous else 0.0,
+                to_confidence=current.confidence if current else 0.0,
+                explanation=explanation,
+            )
+        )
+
+    return DiffReport(dataset=after.dataset or before.dataset, changes=changes)
+
+
+def _build_diff_explanation(
+    previous: MappingResult | None, current: MappingResult | None
+) -> str:
+    if previous and current:
+        return (
+            "Tag changed from "
+            f"{previous.tag.summary()}"
+            f" to {current.tag.summary()}"
+        )
+    if previous and not current:
+        return "Field removed from dataset"
+    if current and not previous:
+        return "New field detected"
+    return "No change"

--- a/services/spom/spom/mapper.py
+++ b/services/spom/spom/mapper.py
@@ -1,0 +1,120 @@
+"""Core mapping engine for SPOM."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Iterable, List, Sequence
+
+from .ml import EmbeddingModel
+from .models import FieldObservation, MappingReport, MappingResult, OntologyTag
+from .rules import evaluate_rules
+
+
+SENSITIVITY_BY_CATEGORY: Dict[str, str] = {
+    "EMAIL": "medium",
+    "PHONE": "high",
+    "NAME": "medium",
+    "ADDRESS": "medium",
+    "IP": "medium",
+    "GOV_ID": "high",
+    "ACCESS_TOKEN": "critical",
+    "API_KEY": "critical",
+    "PAYMENT_HINTS": "high",
+}
+
+JURISDICTION_HINTS: Dict[str, List[str]] = {
+    "GOV_ID": ["us"],
+    "PAYMENT_HINTS": ["pci-dss"],
+}
+
+
+class SPOM:
+    """Semantic PII Ontology Mapper."""
+
+    def __init__(self, threshold: float = 0.6) -> None:
+        self.threshold = threshold
+        self.embedding = EmbeddingModel()
+
+    def map_fields(
+        self, fields: Sequence[FieldObservation], dataset: str | None = None
+    ) -> MappingReport:
+        dataset_name = dataset or (fields[0].dataset if fields else "unknown") or "unknown"
+        results: List[MappingResult] = []
+        for field in fields:
+            results.append(self._map_field(field))
+        return MappingReport(dataset=dataset_name, results=results)
+
+    def _map_field(self, field: FieldObservation) -> MappingResult:
+        matches = evaluate_rules(field)
+        scores: Dict[str, float] = defaultdict(float)
+        reasoning: Dict[str, List[str]] = defaultdict(list)
+        features: Dict[str, Dict[str, float]] = defaultdict(dict)
+
+        for match in matches:
+            scores[match.category] += match.weight
+            reasoning[match.category].append(f"Rule: {match.reason} (weight {match.weight:.2f})")
+            features[match.category][match.feature] = match.weight
+
+        text_for_embeddings = self._build_text(field)
+        candidates: Iterable[str]
+        if scores:
+            candidates = scores.keys()
+        else:
+            candidates = self.embedding.ontology_space.keys()
+        embed_category, embed_score = self.embedding.best_category(text_for_embeddings, candidates)
+        if embed_category:
+            scores[embed_category] += embed_score * 0.5
+            reasoning[embed_category].append(
+                f"Embedding similarity {embed_score:.2f} to {embed_category} keywords"
+            )
+            features[embed_category]["embedding"] = embed_score
+
+        if not scores:
+            fallback_tag = OntologyTag(
+                label="GENERAL_DATA",
+                category="GENERAL_DATA",
+                sensitivity="low",
+                jurisdictions=[],
+            )
+            return MappingResult(
+                field=field,
+                tag=fallback_tag,
+                confidence=0.0,
+                explanations=["No rules or embeddings matched"],
+                evidence={},
+            )
+
+        best_category = max(scores, key=scores.get)
+        confidence = min(1.0, scores[best_category])
+        explanations = reasoning[best_category]
+        evidence = {
+            "score": scores[best_category],
+            "features": features[best_category],
+        }
+
+        tag = self._build_tag(best_category, field)
+        return MappingResult(
+            field=field,
+            tag=tag,
+            confidence=confidence,
+            explanations=explanations,
+            evidence=evidence,
+        )
+
+    def _build_tag(self, category: str, field: FieldObservation) -> OntologyTag:
+        sensitivity = SENSITIVITY_BY_CATEGORY.get(category, "low")
+        jurisdictions = list(JURISDICTION_HINTS.get(category, []))
+        if category == "GOV_ID" and "ssn" in field.name.lower():
+            jurisdictions = ["us"]
+        if category == "ADDRESS" and "eu" in (field.description.lower() if field.description else ""):
+            jurisdictions.append("gdpr")
+        return OntologyTag(
+            label=category,
+            category=category,
+            sensitivity=sensitivity,
+            jurisdictions=jurisdictions,
+        )
+
+    def _build_text(self, field: FieldObservation) -> str:
+        samples = " ".join(field.sample_values[:3])
+        return " ".join(filter(None, [field.name, field.description, samples]))

--- a/services/spom/spom/ml.py
+++ b/services/spom/spom/ml.py
@@ -1,0 +1,59 @@
+"""Lightweight embedding stub for semantic similarity."""
+
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from typing import Dict, Iterable, Tuple
+
+
+_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+
+
+class EmbeddingModel:
+    """Deterministic embedding stub used for scoring."""
+
+    def __init__(self) -> None:
+        self.ontology_space: Dict[str, Counter[str]] = {
+            "EMAIL": Counter({"email": 2, "mail": 1, "contact": 1, "inbox": 1}),
+            "PHONE": Counter({"phone": 2, "mobile": 1, "sms": 1, "dial": 1}),
+            "NAME": Counter({"name": 2, "fullname": 1, "first": 1, "last": 1}),
+            "ADDRESS": Counter({"address": 2, "street": 1, "city": 1, "postal": 1}),
+            "IP": Counter({"ip": 2, "address": 1, "network": 1, "client": 1}),
+            "GOV_ID": Counter({"government": 1, "id": 2, "ssn": 2, "passport": 1}),
+            "ACCESS_TOKEN": Counter({"token": 2, "session": 1, "auth": 1, "bearer": 1}),
+            "API_KEY": Counter({"api": 2, "key": 2, "secret": 1, "integration": 1}),
+            "PAYMENT_HINTS": Counter({"payment": 1, "card": 2, "iban": 1, "account": 1}),
+        }
+
+    def tokenize(self, text: str) -> Counter[str]:
+        tokens = _TOKEN_PATTERN.findall(text.lower())
+        return Counter(tokens)
+
+    def embed(self, text: str) -> Counter[str]:
+        return self.tokenize(text)
+
+    def similarity(self, text: str, category: str) -> float:
+        if category not in self.ontology_space:
+            return 0.0
+        a = self.embed(text)
+        b = self.ontology_space[category]
+        if not a or not b:
+            return 0.0
+        dot = sum(min(a[token], b[token]) for token in a.keys() & b.keys())
+        norm_a = math.sqrt(sum(v * v for v in a.values()))
+        norm_b = math.sqrt(sum(v * v for v in b.values()))
+        if norm_a == 0 or norm_b == 0:
+            return 0.0
+        return dot / (norm_a * norm_b)
+
+    def best_category(self, text: str, candidates: Iterable[str]) -> Tuple[str | None, float]:
+        best_category: str | None = None
+        best_score = 0.0
+        for category in candidates:
+            score = self.similarity(text, category)
+            if score > best_score:
+                best_category = category
+                best_score = score
+        return best_category, best_score

--- a/services/spom/spom/models.py
+++ b/services/spom/spom/models.py
@@ -1,0 +1,78 @@
+"""Shared models for SPOM."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class FieldObservation(BaseModel):
+    """Represents a schema field observed in a dataset."""
+
+    name: str
+    data_type: str = "string"
+    description: str = ""
+    sample_values: List[str] = Field(default_factory=list, alias="sampleValues")
+    constraints: Dict[str, Any] = Field(default_factory=dict)
+    dataset: Optional[str] = None
+
+    @field_validator("sample_values", mode="before")
+    @classmethod
+    def _coerce_values(cls, value: Any) -> List[str]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return [str(v) for v in value]
+        return [str(value)]
+
+    model_config = {
+        "populate_by_name": True,
+        "str_strip_whitespace": True,
+    }
+
+
+class OntologyTag(BaseModel):
+    """Represents a PII ontology tag."""
+
+    label: str
+    category: str
+    sensitivity: str
+    jurisdictions: List[str] = Field(default_factory=list)
+
+    def summary(self) -> str:
+        jurisdictions = ", ".join(self.jurisdictions) if self.jurisdictions else "global"
+        return f"{self.category} ({self.sensitivity}, {jurisdictions})"
+
+
+class MappingResult(BaseModel):
+    """Mapping outcome for a single field."""
+
+    field: FieldObservation
+    tag: OntologyTag
+    confidence: float
+    explanations: List[str]
+    evidence: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("confidence")
+    @classmethod
+    def _clamp_confidence(cls, value: float) -> float:
+        return max(0.0, min(1.0, value))
+
+    def concise_explanation(self) -> str:
+        return "; ".join(self.explanations)
+
+
+class MappingReport(BaseModel):
+    """Collection of mapping results for a dataset."""
+
+    dataset: str
+    generated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    results: List[MappingResult]
+
+    def as_index(self) -> Dict[str, MappingResult]:
+        return {result.field.name: result for result in self.results}
+
+    def top_hits(self, threshold: float = 0.6) -> List[MappingResult]:
+        return [result for result in self.results if result.confidence >= threshold]

--- a/services/spom/spom/rules.py
+++ b/services/spom/spom/rules.py
@@ -1,0 +1,129 @@
+"""Rule engine definitions for SPOM."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .models import FieldObservation
+
+
+@dataclass
+class RuleMatch:
+    """Represents a single rule contribution."""
+
+    category: str
+    weight: float
+    reason: str
+    feature: str
+
+
+@dataclass
+class Rule:
+    """Rule definition."""
+
+    pattern: re.Pattern[str]
+    category: str
+    weight: float
+    reason: str
+    feature: str
+
+    def evaluate(self, value: str) -> RuleMatch | None:
+        if not value:
+            return None
+        if self.pattern.search(value):
+            return RuleMatch(
+                category=self.category,
+                weight=self.weight,
+                reason=self.reason,
+                feature=self.feature,
+            )
+        return None
+
+
+NAME_RULES: List[Rule] = [
+    Rule(re.compile(r"email"), "EMAIL", 0.7, "Field name contains 'email'", "name"),
+    Rule(re.compile(r"phone|mobile"), "PHONE", 0.7, "Field name references phone", "name"),
+    Rule(re.compile(r"ip(_)?address|client_ip|signup_ip"), "IP", 0.65, "Field name references IP address", "name"),
+    Rule(re.compile(r"ssn|social[_\s]?security"), "GOV_ID", 0.8, "Field name references Social Security", "name"),
+    Rule(re.compile(r"passport|driver"), "GOV_ID", 0.65, "Field name references government ID", "name"),
+    Rule(re.compile(r"name"), "NAME", 0.55, "Field name references personal name", "name"),
+    Rule(re.compile(r"address|street|city"), "ADDRESS", 0.55, "Field name references address", "name"),
+    Rule(re.compile(r"token|jwt|session"), "ACCESS_TOKEN", 0.75, "Field name references token", "name"),
+    Rule(re.compile(r"api[_-]?key|client[_-]?secret"), "API_KEY", 0.75, "Field name references API key", "name"),
+    Rule(re.compile(r"card|payment|iban"), "PAYMENT_HINTS", 0.6, "Field name references payment", "name"),
+]
+
+VALUE_RULES: List[Rule] = [
+    Rule(re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$"), "EMAIL", 0.7, "Sample value looks like an email", "sample"),
+    Rule(
+        re.compile(r"^(\+?\d{1,3}[\s-]?)?(\(?\d{3}\)?[\s-]?)?\d{3}[\s-]?\d{4}$"),
+        "PHONE",
+        0.7,
+        "Sample value looks like a phone number",
+        "sample",
+    ),
+    Rule(
+        re.compile(r"^(\d{3}-\d{2}-\d{4}|\d{9})$"),
+        "GOV_ID",
+        0.75,
+        "Sample value looks like a Social Security Number",
+        "sample",
+    ),
+    Rule(
+        re.compile(r"^((25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(25[0-5]|2[0-4]\d|[01]?\d\d?)$"),
+        "IP",
+        0.7,
+        "Sample value looks like an IPv4 address",
+        "sample",
+    ),
+    Rule(
+        re.compile(r"^[0-9]{4} ?(?:[0-9]{4} ?){2,3}[0-9]{4}$"),
+        "PAYMENT_HINTS",
+        0.75,
+        "Sample value looks like a payment card number",
+        "sample",
+    ),
+]
+
+DESCRIPTION_RULES: List[Rule] = [
+    Rule(re.compile(r"email"), "EMAIL", 0.5, "Description references email", "description"),
+    Rule(re.compile(r"phone|sms|contact"), "PHONE", 0.45, "Description references phone", "description"),
+    Rule(re.compile(r"address"), "ADDRESS", 0.45, "Description references address", "description"),
+    Rule(re.compile(r"name"), "NAME", 0.4, "Description references personal name", "description"),
+    Rule(re.compile(r"government|compliance|id"), "GOV_ID", 0.55, "Description references government ID", "description"),
+]
+
+
+def evaluate_rules(field: FieldObservation) -> List[RuleMatch]:
+    """Evaluate all rules against a field."""
+
+    matches: List[RuleMatch] = []
+    lowered_name = field.name.lower()
+    for rule in NAME_RULES:
+        match = rule.evaluate(lowered_name)
+        if match:
+            matches.append(match)
+
+    lowered_description = field.description.lower()
+    for rule in DESCRIPTION_RULES:
+        match = rule.evaluate(lowered_description)
+        if match:
+            matches.append(match)
+
+    for value in field.sample_values:
+        lowered_value = value.lower()
+        for rule in VALUE_RULES:
+            match = rule.evaluate(lowered_value)
+            if match:
+                matches.append(match)
+                break
+
+    return matches
+
+
+def summarise_matches(matches: Iterable[RuleMatch]) -> List[str]:
+    """Return human-readable text for rule matches."""
+
+    return [match.reason for match in matches]

--- a/services/spom/tests/conftest.py
+++ b/services/spom/tests/conftest.py
@@ -1,0 +1,8 @@
+"""Pytest configuration for SPOM tests."""
+
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))

--- a/services/spom/tests/test_diff.py
+++ b/services/spom/tests/test_diff.py
@@ -1,0 +1,29 @@
+"""Diffing behaviour for SPOM reports."""
+
+from spom.diff import diff_reports
+from spom.mapper import SPOM
+from spom.models import FieldObservation
+
+
+def test_diff_only_reports_actual_tag_changes():
+    mapper = SPOM()
+    dataset_v1 = [
+        FieldObservation(name="contact_value", sample_values=["+1-202-555-0172"]),
+        FieldObservation(name="email_address", sample_values=["user@example.com"]),
+    ]
+    dataset_v2 = [
+        FieldObservation(name="contact_value", sample_values=["person@example.com"]),
+        FieldObservation(name="email_address", sample_values=["user@example.com"]),
+    ]
+
+    report_v1 = mapper.map_fields(dataset_v1, dataset="v1")
+    report_v2 = mapper.map_fields(dataset_v2, dataset="v2")
+
+    diff = diff_reports(report_v1, report_v2)
+
+    assert len(diff.changes) == 1
+    change = diff.changes[0]
+    assert change.field == "contact_value"
+    assert change.from_tag == "PHONE"
+    assert change.to_tag == "EMAIL"
+    assert "Tag changed" in change.explanation

--- a/services/spom/tests/test_mapper.py
+++ b/services/spom/tests/test_mapper.py
@@ -1,0 +1,89 @@
+"""Tests for the SPOM mapper."""
+
+from spom.mapper import SPOM
+from spom.models import FieldObservation
+
+
+def build_seed_dataset():
+    return [
+        FieldObservation(
+            name="email_address",
+            description="Primary contact email",
+            sample_values=["analyst@example.com"],
+        ),
+        FieldObservation(
+            name="customer_phone",
+            description="SMS contact",
+            sample_values=["+1-202-555-0172"],
+        ),
+        FieldObservation(
+            name="customer_name",
+            description="Full name",
+            sample_values=["Alex Doe"],
+        ),
+        FieldObservation(
+            name="shipping_address",
+            description="EU shipping address",
+            sample_values=["123 Market St"],
+        ),
+        FieldObservation(
+            name="signup_ip",
+            description="Client IP",
+            sample_values=["192.168.1.10"],
+        ),
+        FieldObservation(
+            name="ssn",
+            description="US Social Security Number",
+            sample_values=["123-45-6789"],
+        ),
+        FieldObservation(
+            name="session_token",
+            description="Auth session token",
+            sample_values=["eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"],
+        ),
+        FieldObservation(
+            name="api_key",
+            description="Integration key",
+            sample_values=["sk_live_12345"],
+        ),
+        FieldObservation(
+            name="card_number_hint",
+            description="Card hash",
+            sample_values=["4242424242424242"],
+        ),
+    ]
+
+
+def test_seed_dataset_maps_with_high_confidence():
+    mapper = SPOM()
+    report = mapper.map_fields(build_seed_dataset(), dataset="seed")
+
+    results = {result.field.name: result for result in report.results}
+
+    assert results["email_address"].tag.category == "EMAIL"
+    assert results["email_address"].confidence >= 0.8
+    assert any("Rule:" in step for step in results["email_address"].explanations)
+
+    assert results["customer_phone"].tag.category == "PHONE"
+    assert results["customer_phone"].confidence >= 0.7
+
+    assert results["ssn"].tag.category == "GOV_ID"
+    assert results["ssn"].confidence >= 0.8
+    assert "us" in results["ssn"].tag.jurisdictions
+
+    assert results["shipping_address"].tag.category == "ADDRESS"
+    assert "gdpr" in results["shipping_address"].tag.jurisdictions
+
+    assert results["card_number_hint"].tag.category == "PAYMENT_HINTS"
+    assert results["card_number_hint"].confidence >= 0.7
+
+
+def test_explanations_include_rules_and_embeddings():
+    mapper = SPOM()
+    [email_field] = [FieldObservation(name="user_email", sample_values=["user@example.com"])]
+    result = mapper.map_fields([email_field], dataset="seed").results[0]
+
+    assert any(step.startswith("Rule:") for step in result.explanations)
+    assert any("Embedding similarity" in step for step in result.explanations)
+
+


### PR DESCRIPTION
## Summary
- add the SPOM python package that maps schema fields to ontology tags using rules plus a stub embedding model and produces diff reports
- provide an FSR-PT annotateSchema plugin for surfacing SPOM confidences and explanations in the registry
- cover seeded dataset mapping, explanation content, and diff stability with new pytest suites

## Testing
- pytest services/spom/tests


------
https://chatgpt.com/codex/tasks/task_e_68d7814d4578833382be6856c56413bc