### PR TITLE
feat: add immutable training run capsule toolkit

### DIFF
--- a/tools/itrc/README.md
+++ b/tools/itrc/README.md
@@ -1,0 +1,58 @@
+# Immutable Training Run Capsule (ITRC)
+
+ITRC packages machine-learning training or inference jobs into deterministic, signed
+capsules that can be replayed on demand.
+
+## Features
+
+- **Capsule packer** (`itrc pack`): embeds the environment lockfile, container image
+digest, dataset lineage identifiers, deterministic seeds, hardware hints, policy
+hashes, and expected artifact digests into a signed archive.
+- **Capsule verifier** (`itrc verify`): checks the signature and embedded lockfile to
+prevent tampering.
+- **Capsule runner** (`itrc run`): replays a capsule, captures stdout/stderr, and
+produces a signed run receipt containing artifact digests and metadata.
+- **Receipt verifier** (`itrc receipt-verify`): validates a receipt offline and compares
+artifacts in the workspace to the expected digests.
+
+All signatures use HMAC-SHA256 with a caller-supplied key. Tampering with either the
+capsule or the receipt yields deterministic verification failures.
+
+## Usage
+
+```bash
+python -m tools.itrc pack \
+  --capsule runs/fixture.itrc \
+  --name "mnist-fixture" \
+  --command "python train.py --epochs 1" \
+  --workdir /opt/jobs/mnist \
+  --env-lock /opt/jobs/mnist/poetry.lock \
+  --image-digest sha256:abc123... \
+  --dataset-lineage dataset:mnist:v1 \
+  --seed python=0 \
+  --hardware accelerator=nvidia-a100 \
+  --policy data-use=policy-v3 \
+  --artifact outputs/model.bin \
+  --key ./secrets/itrc.key \
+  --key-id ops-prod
+```
+
+Replay the capsule and emit a run receipt:
+
+```bash
+python -m tools.itrc run \
+  --capsule runs/fixture.itrc \
+  --key ./secrets/itrc.key \
+  --receipt receipts/fixture.json
+```
+
+Verify a receipt against the capsule offline:
+
+```bash
+python -m tools.itrc receipt-verify \
+  --capsule runs/fixture.itrc \
+  --receipt receipts/fixture.json \
+  --key ./secrets/itrc.key
+```
+
+See `python -m tools.itrc --help` for the complete command reference.

--- a/tools/itrc/__init__.py
+++ b/tools/itrc/__init__.py
@@ -1,0 +1,5 @@
+"""Immutable Training Run Capsule (ITRC) toolkit."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/tools/itrc/__main__.py
+++ b/tools/itrc/__main__.py
@@ -1,0 +1,6 @@
+"""Executable entry point for ``python -m tools.itrc``."""
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover - CLI bootstrap
+    raise SystemExit(main())

--- a/tools/itrc/capsule.py
+++ b/tools/itrc/capsule.py
@@ -1,0 +1,157 @@
+"""Capsule creation and verification utilities."""
+
+from __future__ import annotations
+
+import json
+import time
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from .signing import Signature, Signer, Verifier, signature_from_dict
+from .utils import Attachment, canonical_json, normalise_artifact_path, sha256_bytes, sha256_file
+
+
+SCHEMA = "itrc.capsule/1"
+
+
+@dataclass
+class Artifact:
+    path: str
+    sha256: str
+
+    def as_dict(self) -> Dict[str, str]:
+        return {"path": self.path, "sha256": self.sha256}
+
+
+@dataclass
+class Capsule:
+    manifest: Dict[str, Any]
+    signature: Signature
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "manifest": self.manifest,
+                "signature": self.signature.as_dict(),
+            },
+            sort_keys=True,
+            indent=2,
+        )
+
+    def payload_bytes(self) -> bytes:
+        return canonical_json(self.manifest)
+
+
+class CapsuleBuilder:
+    """Constructs capsules with deterministic metadata."""
+
+    def __init__(
+        self,
+        *,
+        name: str,
+        command: List[str],
+        working_dir: Path,
+        env: Dict[str, str],
+        container_image_digest: str,
+        env_lock_attachment: Attachment,
+        dataset_lineage_ids: List[str],
+        seeds: Dict[str, str],
+        hardware_hints: Dict[str, str],
+        policy_hashes: Dict[str, str],
+        artifacts: List[Artifact],
+        description: str | None = None,
+    ) -> None:
+        self._name = name
+        self._command = command
+        self._working_dir = working_dir
+        self._env = env
+        self._container_image_digest = container_image_digest
+        self._env_lock_attachment = env_lock_attachment
+        self._dataset_lineage_ids = dataset_lineage_ids
+        self._seeds = seeds
+        self._hardware_hints = hardware_hints
+        self._policy_hashes = policy_hashes
+        self._artifacts = artifacts
+        self._description = description
+
+    def build(self, signer: Signer) -> Capsule:
+        manifest = {
+            "schema": SCHEMA,
+            "name": self._name,
+            "description": self._description,
+            "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "command": self._command,
+            "working_dir": str(self._working_dir),
+            "environment": dict(sorted(self._env.items())),
+            "lineage": {
+                "container_image_digest": self._container_image_digest,
+                "dataset_lineage_ids": sorted(self._dataset_lineage_ids),
+                "policy_hashes": dict(sorted(self._policy_hashes.items())),
+                "seeds": dict(sorted(self._seeds.items())),
+                "hardware_hints": dict(sorted(self._hardware_hints.items())),
+            },
+            "inputs": {
+                "env_lockfile": {
+                    "path": self._env_lock_attachment.capsule_path,
+                    "sha256": self._env_lock_attachment.sha256,
+                    "source": str(self._env_lock_attachment.source_path),
+                }
+            },
+            "artifacts": [artifact.as_dict() for artifact in self._artifacts],
+        }
+        payload = canonical_json(manifest)
+        signature = signer.sign(payload)
+        return Capsule(manifest=manifest, signature=signature)
+
+
+def write_capsule(capsule: Capsule, attachments: Iterable[Attachment], destination: Path) -> None:
+    """Write *capsule* to *destination* alongside its attachments."""
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(destination, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        _write_zip_entry(archive, "capsule.json", capsule.to_json().encode("utf-8"))
+        for attachment in sorted(attachments, key=lambda att: att.capsule_path):
+            _write_zip_entry(archive, attachment.capsule_path, attachment.source_path.read_bytes())
+
+
+def load_capsule(path: Path, verifier: Verifier | None = None) -> Capsule:
+    """Load a capsule from *path* and verify it if a *verifier* is provided."""
+
+    with zipfile.ZipFile(path, "r") as archive:
+        with archive.open("capsule.json") as manifest_file:
+            data = json.loads(manifest_file.read().decode("utf-8"))
+    capsule = Capsule(manifest=data["manifest"], signature=signature_from_dict(data["signature"]))
+    if verifier is not None:
+        verifier.verify(capsule.payload_bytes(), capsule.signature)
+        _verify_attachments(path, capsule)
+    return capsule
+
+
+def _verify_attachments(path: Path, capsule: Capsule) -> None:
+    with zipfile.ZipFile(path, "r") as archive:
+        env_path = capsule.manifest["inputs"]["env_lockfile"]["path"]
+        expected_sha = capsule.manifest["inputs"]["env_lockfile"]["sha256"]
+        with archive.open(env_path) as env_file:
+            actual_sha = sha256_bytes(env_file.read())
+        if actual_sha != expected_sha:
+            raise ValueError("Embedded env lockfile does not match manifest digest")
+
+
+def _write_zip_entry(archive: zipfile.ZipFile, name: str, data: bytes) -> None:
+    info = zipfile.ZipInfo(filename=name)
+    info.date_time = (1980, 1, 1, 0, 0, 0)
+    info.compress_type = zipfile.ZIP_DEFLATED
+    archive.writestr(info, data)
+
+
+def prepare_artifacts(paths: List[str], base_dir: Path) -> List[Artifact]:
+    artifacts: List[Artifact] = []
+    for raw_path in sorted(paths):
+        normalized = normalise_artifact_path(raw_path, base_dir)
+        file_path = (base_dir / raw_path).resolve()
+        if not file_path.exists():
+            raise FileNotFoundError(f"Artifact path {raw_path} was not found under {base_dir}")
+        artifacts.append(Artifact(path=normalized, sha256=sha256_file(file_path)))
+    return artifacts

--- a/tools/itrc/cli.py
+++ b/tools/itrc/cli.py
@@ -1,0 +1,161 @@
+"""Command line interface for ITRC capsules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+from pathlib import Path
+from typing import List
+
+from .capsule import CapsuleBuilder, load_capsule, prepare_artifacts, write_capsule
+from .receipt import load_receipt, verify_receipt_artifacts
+from .runner import CapsuleReplayError, parse_env_overrides, run_capsule
+from .signing import Signer, Verifier
+from .utils import Attachment, load_key, parse_key_value
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        if args.subcommand == "pack":
+            return _cmd_pack(args)
+        if args.subcommand == "verify":
+            return _cmd_verify(args)
+        if args.subcommand == "run":
+            return _cmd_run(args)
+        if args.subcommand == "receipt-verify":
+            return _cmd_receipt_verify(args)
+    except CapsuleReplayError as exc:
+        parser.error(str(exc))
+    except Exception as exc:  # pragma: no cover - CLI guard rail
+        parser.error(str(exc))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="itrc", description="Immutable Training Run Capsule toolkit")
+    sub = parser.add_subparsers(dest="subcommand", required=True)
+
+    pack = sub.add_parser("pack", help="Build a signed capsule")
+    pack.add_argument("--capsule", required=True, help="Destination capsule file")
+    pack.add_argument("--name", required=True, help="Capsule name")
+    pack.add_argument("--command", dest="job_command", required=True, help="Command to execute (quoted)")
+    pack.add_argument("--workdir", default=str(Path.cwd()), help="Working directory of the job")
+    pack.add_argument("--env", action="append", default=[], help="Environment variable KEY=VALUE")
+    pack.add_argument("--env-lock", required=True, help="Environment lockfile to embed")
+    pack.add_argument("--image-digest", required=True, help="Container image digest")
+    pack.add_argument("--dataset-lineage", action="append", default=[], help="Dataset lineage identifier")
+    pack.add_argument("--seed", action="append", default=[], help="Deterministic seed KEY=VALUE")
+    pack.add_argument("--hardware", action="append", default=[], help="Hardware hint KEY=VALUE")
+    pack.add_argument("--policy", action="append", default=[], help="Policy hash KEY=VALUE")
+    pack.add_argument("--artifact", action="append", default=[], help="Expected artifact path")
+    pack.add_argument("--key", required=True, help="Signing key file")
+    pack.add_argument("--key-id", required=True, help="Identifier to embed for the signing key")
+    pack.add_argument("--description", help="Optional description for the capsule")
+
+    verify = sub.add_parser("verify", help="Verify capsule integrity")
+    verify.add_argument("--capsule", required=True)
+    verify.add_argument("--key", required=True)
+
+    run = sub.add_parser("run", help="Replay a capsule and emit a receipt")
+    run.add_argument("--capsule", required=True)
+    run.add_argument("--key", required=True)
+    run.add_argument("--key-id", help="Identifier used when signing the receipt (defaults to capsule key id)")
+    run.add_argument("--receipt", required=True, help="Receipt output path")
+    run.add_argument("--artifact-base", help="Directory to read artifacts from (defaults to working dir)")
+    run.add_argument("--workdir", help="Override working directory for the run")
+    run.add_argument("--env", action="append", default=[], help="Override environment variable KEY=VALUE")
+
+    receipt_verify = sub.add_parser("receipt-verify", help="Verify a receipt against a capsule")
+    receipt_verify.add_argument("--capsule", required=True)
+    receipt_verify.add_argument("--receipt", required=True)
+    receipt_verify.add_argument("--key", required=True)
+    receipt_verify.add_argument("--artifact-base", help="Directory where artifacts should be located for verification")
+
+    return parser
+
+
+def _cmd_pack(args: argparse.Namespace) -> int:
+    key = load_key(Path(args.key))
+    signer = Signer(key, args.key_id)
+    env_lock_attachment = Attachment.from_source(Path(args.env_lock))
+    working_dir = Path(args.workdir).resolve()
+
+    env_vars = parse_key_value(args.env)
+    seeds = parse_key_value(args.seed)
+    hardware_hints = parse_key_value(args.hardware)
+    policy_hashes = parse_key_value(args.policy)
+    dataset_lineage = sorted(set(args.dataset_lineage))
+
+    artifacts = prepare_artifacts(args.artifact, working_dir)
+
+    builder = CapsuleBuilder(
+        name=args.name,
+        command=shlex.split(args.job_command),
+        working_dir=working_dir,
+        env=env_vars,
+        container_image_digest=args.image_digest,
+        env_lock_attachment=env_lock_attachment,
+        dataset_lineage_ids=dataset_lineage,
+        seeds=seeds,
+        hardware_hints=hardware_hints,
+        policy_hashes=policy_hashes,
+        artifacts=artifacts,
+        description=args.description,
+    )
+    capsule = builder.build(signer)
+    write_capsule(capsule, [env_lock_attachment], Path(args.capsule))
+
+    print(json.dumps({"capsule": args.capsule, "artifacts": [a.path for a in artifacts]}, indent=2))
+    return 0
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    key = load_key(Path(args.key))
+    verifier = Verifier(key)
+    load_capsule(Path(args.capsule), verifier)
+    print(json.dumps({"verified": True, "capsule": args.capsule}))
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    key = load_key(Path(args.key))
+    env_overrides = parse_env_overrides(args.env)
+    receipt_path = Path(args.receipt)
+    artifact_base = Path(args.artifact_base).resolve() if args.artifact_base else None
+    workdir = Path(args.workdir).resolve() if args.workdir else None
+    run_capsule(
+        Path(args.capsule),
+        key=key,
+        key_id=args.key_id,
+        receipt_path=receipt_path,
+        artifact_base=artifact_base,
+        env_overrides=env_overrides,
+        workspace_override=workdir,
+    )
+    print(json.dumps({"receipt": str(receipt_path)}))
+    return 0
+
+
+def _cmd_receipt_verify(args: argparse.Namespace) -> int:
+    key = load_key(Path(args.key))
+    verifier = Verifier(key)
+    capsule = load_capsule(Path(args.capsule), verifier)
+    receipt = load_receipt(Path(args.receipt), verifier)
+
+    artifact_base = Path(args.artifact_base).resolve() if args.artifact_base else Path(capsule.manifest["working_dir"]).resolve()
+    verified = verify_receipt_artifacts(receipt, artifact_base)
+    print(
+        json.dumps(
+            {
+                "receipt": args.receipt,
+                "verified": all(item.expected_sha256 == item.actual_sha256 for item in verified),
+                "artifacts": [item.as_dict() for item in verified],
+            },
+            indent=2,
+        )
+    )
+    return 0

--- a/tools/itrc/receipt.py
+++ b/tools/itrc/receipt.py
@@ -1,0 +1,104 @@
+"""Receipt generation and verification."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .signing import Signature, Signer, Verifier, signature_from_dict
+from .utils import canonical_json, sha256_bytes, sha256_file, write_bytes_if_changed
+
+
+SCHEMA = "itrc.receipt/1"
+
+
+@dataclass
+class ReceiptArtifact:
+    path: str
+    expected_sha256: str
+    actual_sha256: str
+
+    def as_dict(self) -> Dict[str, str]:
+        return {
+            "path": self.path,
+            "expected_sha256": self.expected_sha256,
+            "actual_sha256": self.actual_sha256,
+            "match": self.expected_sha256 == self.actual_sha256,
+        }
+
+
+@dataclass
+class Receipt:
+    manifest: Dict[str, Any]
+    signature: Signature
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "manifest": self.manifest,
+                "signature": self.signature.as_dict(),
+            },
+            sort_keys=True,
+            indent=2,
+        )
+
+    def payload_bytes(self) -> bytes:
+        return canonical_json(self.manifest)
+
+    def write_to(self, path: Path) -> None:
+        write_bytes_if_changed(path, self.to_json().encode("utf-8"))
+
+
+def build_receipt(
+    *,
+    capsule_digest: str,
+    capsule_signature: Signature,
+    artifacts: List[ReceiptArtifact],
+    stdout: str,
+    stderr: str,
+    return_code: int,
+    duration_ms: int,
+    signer: Signer,
+) -> Receipt:
+    manifest = {
+        "schema": SCHEMA,
+        "capsule_digest": capsule_digest,
+        "capsule_signature": capsule_signature.as_dict(),
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "artifacts": [artifact.as_dict() for artifact in artifacts],
+        "return_code": return_code,
+        "duration_ms": duration_ms,
+        "logs": {
+            "stdout": stdout,
+            "stderr": stderr,
+            "combined_sha256": sha256_bytes((stdout + stderr).encode("utf-8")),
+        },
+    }
+    payload = canonical_json(manifest)
+    signature = signer.sign(payload)
+    return Receipt(manifest=manifest, signature=signature)
+
+
+def load_receipt(path: Path, verifier: Verifier | None = None) -> Receipt:
+    data = json.loads(path.read_text())
+    receipt = Receipt(manifest=data["manifest"], signature=signature_from_dict(data["signature"]))
+    if verifier is not None:
+        verifier.verify(receipt.payload_bytes(), receipt.signature)
+    return receipt
+
+
+def verify_receipt_artifacts(receipt: Receipt, base_dir: Path) -> List[ReceiptArtifact]:
+    verified: List[ReceiptArtifact] = []
+    for artifact in receipt.manifest.get("artifacts", []):
+        path = artifact["path"]
+        expected = artifact["expected_sha256"]
+        artifact_path = (base_dir / path).resolve()
+        if not artifact_path.exists():
+            actual = ""
+        else:
+            actual = sha256_file(artifact_path)
+        verified.append(ReceiptArtifact(path=path, expected_sha256=expected, actual_sha256=actual))
+    return verified

--- a/tools/itrc/runner.py
+++ b/tools/itrc/runner.py
@@ -1,0 +1,102 @@
+"""Capsule replay runner."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Dict, List
+
+from .capsule import load_capsule
+from .receipt import ReceiptArtifact, build_receipt
+from .signing import Signer, Verifier
+from .utils import parse_key_value, sha256_file
+
+
+class CapsuleReplayError(RuntimeError):
+    """Raised when a capsule cannot be replayed successfully."""
+
+
+def run_capsule(
+    capsule_path: Path,
+    *,
+    key: bytes,
+    key_id: str | None,
+    receipt_path: Path,
+    artifact_base: Path | None = None,
+    env_overrides: Dict[str, str] | None = None,
+    workspace_override: Path | None = None,
+) -> None:
+    """Replay *capsule_path* and write a signed receipt to *receipt_path*."""
+
+    verifier = Verifier(key)
+    capsule = load_capsule(capsule_path, verifier)
+
+    manifest = capsule.manifest
+    working_dir = Path(workspace_override or manifest["working_dir"]).resolve()
+    artifact_base = artifact_base or working_dir
+
+    command = manifest["command"]
+    if not isinstance(command, list) or not command:
+        raise CapsuleReplayError("Capsule manifest command must be a non-empty list")
+
+    environment = os.environ.copy()
+    environment.update(manifest.get("environment", {}))
+    if env_overrides:
+        environment.update(env_overrides)
+    for seed_key, seed_value in manifest.get("lineage", {}).get("seeds", {}).items():
+        environment.setdefault(f"ITRC_SEED_{seed_key.upper()}", str(seed_value))
+    environment.setdefault("PYTHONHASHSEED", manifest.get("lineage", {}).get("seeds", {}).get("python", "0"))
+
+    start = time.time()
+    try:
+        completed = subprocess.run(
+            command,
+            cwd=working_dir,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - environment specific
+        raise CapsuleReplayError(f"Failed to execute command {command[0]}: {exc}") from exc
+
+    duration_ms = int((time.time() - start) * 1000)
+
+    artifacts: List[ReceiptArtifact] = []
+    for artifact in manifest.get("artifacts", []):
+        path = artifact["path"]
+        expected = artifact["sha256"]
+        artifact_path = (artifact_base / path).resolve()
+        actual = sha256_file(artifact_path) if artifact_path.exists() else ""
+        artifacts.append(ReceiptArtifact(path=path, expected_sha256=expected, actual_sha256=actual))
+
+    mismatched = [artifact for artifact in artifacts if artifact.expected_sha256 != artifact.actual_sha256]
+    if mismatched:
+        mismatch_paths = ", ".join(artifact.path for artifact in mismatched)
+        raise CapsuleReplayError(f"Replay artifacts mismatched expected digests for: {mismatch_paths}")
+
+    signer = Signer(key, key_id or capsule.signature.key_id)
+    receipt = build_receipt(
+        capsule_digest=sha256_file(capsule_path),
+        capsule_signature=capsule.signature,
+        artifacts=artifacts,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        return_code=completed.returncode,
+        duration_ms=duration_ms,
+        signer=signer,
+    )
+    receipt.write_to(receipt_path)
+
+    if completed.returncode != 0:
+        raise CapsuleReplayError(
+            f"Capsule command exited with {completed.returncode}. Receipt captured at {receipt_path}"
+        )
+
+
+def parse_env_overrides(values: List[str] | None) -> Dict[str, str]:
+    if not values:
+        return {}
+    return parse_key_value(values)

--- a/tools/itrc/signing.py
+++ b/tools/itrc/signing.py
@@ -1,0 +1,69 @@
+"""Signing helpers for capsules and receipts."""
+
+from __future__ import annotations
+
+import base64
+import hmac
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Dict
+
+
+SIGNATURE_ALGORITHM = "HMAC-SHA256"
+
+
+@dataclass(frozen=True)
+class Signature:
+    algorithm: str
+    key_id: str
+    signature: str
+
+    def as_dict(self) -> Dict[str, str]:
+        return {
+            "algorithm": self.algorithm,
+            "key_id": self.key_id,
+            "signature": self.signature,
+        }
+
+
+class Signer:
+    """Utility that signs payloads and verifies signatures."""
+
+    def __init__(self, key: bytes, key_id: str) -> None:
+        if not key:
+            raise ValueError("Signing key must not be empty")
+        self._key = key
+        self._key_id = key_id
+
+    def sign(self, payload: bytes) -> Signature:
+        digest = hmac.new(self._key, payload, sha256).digest()
+        return Signature(algorithm=SIGNATURE_ALGORITHM, key_id=self._key_id, signature=base64.b64encode(digest).decode("ascii"))
+
+    def verify(self, payload: bytes, signature: Signature) -> None:
+        if signature.algorithm != SIGNATURE_ALGORITHM:
+            raise ValueError(f"Unsupported signature algorithm: {signature.algorithm}")
+        expected = hmac.new(self._key, payload, sha256).digest()
+        provided = base64.b64decode(signature.signature)
+        if not hmac.compare_digest(expected, provided):
+            raise ValueError("Signature verification failed")
+
+
+class Verifier:
+    """Verifier that shares its implementation with :class:`Signer`."""
+
+    def __init__(self, key: bytes) -> None:
+        if not key:
+            raise ValueError("Verification key must not be empty")
+        self._key = key
+
+    def verify(self, payload: bytes, signature: Signature) -> None:
+        if signature.algorithm != SIGNATURE_ALGORITHM:
+            raise ValueError(f"Unsupported signature algorithm: {signature.algorithm}")
+        expected = hmac.new(self._key, payload, sha256).digest()
+        provided = base64.b64decode(signature.signature)
+        if not hmac.compare_digest(expected, provided):
+            raise ValueError("Signature verification failed")
+
+
+def signature_from_dict(data: Dict[str, str]) -> Signature:
+    return Signature(algorithm=data["algorithm"], key_id=data["key_id"], signature=data["signature"])

--- a/tools/itrc/utils.py
+++ b/tools/itrc/utils.py
@@ -1,0 +1,114 @@
+"""Utility helpers for ITRC tooling."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+
+def sha256_bytes(data: bytes) -> str:
+    """Return the hexadecimal SHA256 digest for *data*."""
+    digest = hashlib.sha256()
+    digest.update(data)
+    return digest.hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    """Return the hexadecimal SHA256 digest for the file at *path*."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_json(data: Any) -> bytes:
+    """Return the canonical JSON representation of *data* as UTF-8 bytes."""
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+
+
+def load_key(path: Path) -> bytes:
+    """Load a signing or verification key from *path*.
+
+    Blank lines and surrounding whitespace are ignored, and the contents may be
+    provided either in raw binary form or as base64 encoded text.
+    """
+
+    data = path.read_bytes()
+    if not data:
+        raise ValueError(f"Signing key at {path} is empty")
+    if any(byte > 127 for byte in data):
+        return data
+    stripped = data.strip().splitlines()
+    if not stripped:
+        raise ValueError(f"Signing key at {path} contained no usable data")
+    if len(stripped) == 1:
+        maybe = stripped[0].strip()
+        try:
+            return base64.b64decode(maybe, validate=True)
+        except Exception:
+            return maybe
+    return b"".join(line.strip() for line in stripped)
+
+
+@dataclass(frozen=True)
+class Attachment:
+    """Represents a file embedded inside a capsule."""
+
+    capsule_path: str
+    source_path: Path
+    sha256: str
+
+    @classmethod
+    def from_source(cls, source: Path, capsule_path: str | None = None) -> "Attachment":
+        source = source.resolve()
+        if not source.exists():
+            raise FileNotFoundError(f"Attachment source {source} not found")
+        digest = sha256_file(source)
+        capsule_rel = capsule_path or source.name
+        return cls(capsule_path=f"attachments/{capsule_rel}", source_path=source, sha256=digest)
+
+
+def ensure_directory(path: Path) -> None:
+    """Create *path* and all parents if they do not exist."""
+
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def write_bytes_if_changed(path: Path, data: bytes) -> None:
+    """Write *data* to *path* if its current contents differ."""
+
+    if path.exists() and path.read_bytes() == data:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+
+
+def parse_key_value(items: list[str]) -> Dict[str, str]:
+    """Convert KEY=VALUE strings into a dictionary."""
+
+    result: Dict[str, str] = {}
+    for item in items:
+        if "=" not in item:
+            raise ValueError(f"Expected KEY=VALUE formatted input, received: {item}")
+        key, value = item.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise ValueError(f"Invalid empty key in pair: {item}")
+        result[key] = value
+    return result
+
+
+def normalise_artifact_path(path: str, base_dir: Path) -> str:
+    """Return a canonical relative path for *path* from *base_dir*."""
+
+    resolved = (base_dir / path).resolve()
+    try:
+        return str(resolved.relative_to(base_dir.resolve()))
+    except ValueError:
+        return resolved.name


### PR DESCRIPTION
## Summary
- add an ITRC command line toolkit for building, verifying, and replaying signed training capsules
- implement capsule packing, deterministic replay with artifact checks, and receipt signing/verification utilities
- document the workflow for packaging runs and validating run receipts

## Testing
- python -m tools.itrc --help
- python -m tools.itrc pack --capsule tmp/itrc_test/run.itrc --name test --command "python -c 'print(42)'" --workdir tmp/itrc_test --env-lock tmp/itrc_test/env.lock --image-digest sha256:testdigest --dataset-lineage dataset:1 --seed python=0 --hardware accelerator=cpu --policy data=policy1 --artifact model.bin --key tmp/itrc_test/key.bin --key-id test-key
- python -m tools.itrc run --capsule tmp/itrc_test/run.itrc --key tmp/itrc_test/key.bin --receipt tmp/itrc_test/receipt.json
- python -m tools.itrc receipt-verify --capsule tmp/itrc_test/run.itrc --receipt tmp/itrc_test/receipt.json --key tmp/itrc_test/key.bin

------
https://chatgpt.com/codex/tasks/task_e_68d7818605dc833390f8e821a3402232