### PR TITLE
feat: add federated attribution evaluator

### DIFF
--- a/services/fae/go/fae/aggregates.go
+++ b/services/fae/go/fae/aggregates.go
@@ -1,0 +1,47 @@
+package fae
+
+// CupedAggregate stores aggregated statistics required for CUPED uplift.
+type CupedAggregate struct {
+	N     int
+	SumY  float64
+	SumY2 float64
+	SumX  float64
+	SumX2 float64
+	SumXY float64
+}
+
+// MeanX returns the average covariate value.
+func (c CupedAggregate) MeanX() float64 {
+	if c.N == 0 {
+		return 0
+	}
+	return c.SumX / float64(c.N)
+}
+
+// MeanY returns the average outcome value.
+func (c CupedAggregate) MeanY() float64 {
+	if c.N == 0 {
+		return 0
+	}
+	return c.SumY / float64(c.N)
+}
+
+// Add merges a single observation into the aggregate.
+func (c *CupedAggregate) Add(y, x float64) {
+	c.N++
+	c.SumY += y
+	c.SumY2 += y * y
+	c.SumX += x
+	c.SumX2 += x * x
+	c.SumXY += x * y
+}
+
+// Merge combines two aggregates.
+func (c *CupedAggregate) Merge(other CupedAggregate) {
+	c.N += other.N
+	c.SumY += other.SumY
+	c.SumY2 += other.SumY2
+	c.SumX += other.SumX
+	c.SumX2 += other.SumX2
+	c.SumXY += other.SumXY
+}

--- a/services/fae/go/fae/attribution.go
+++ b/services/fae/go/fae/attribution.go
@@ -1,0 +1,103 @@
+package fae
+
+import "strings"
+
+// ShapleyAttribution allocates fractional credit to each channel.
+func ShapleyAttribution(pathConversions map[string]float64) map[string]float64 {
+	contributions := make(map[string]float64)
+	total := 0.0
+	for key, conversions := range pathConversions {
+		path := decodePath(key)
+		unique := uniqueChannels(path)
+		if len(unique) == 0 {
+			continue
+		}
+		weight := conversions / float64(len(unique))
+		for _, channel := range unique {
+			contributions[channel] += weight
+		}
+		total += conversions
+	}
+	if total == 0 {
+		return contributions
+	}
+	for channel, value := range contributions {
+		contributions[channel] = value / total
+	}
+	return contributions
+}
+
+func decodePath(key string) []string {
+	if key == "" {
+		return nil
+	}
+	return strings.Split(key, ">")
+}
+
+func uniqueChannels(path []string) []string {
+	seen := make(map[string]struct{})
+	ordered := make([]string, 0, len(path))
+	for _, channel := range path {
+		if _, ok := seen[channel]; ok {
+			continue
+		}
+		seen[channel] = struct{}{}
+		ordered = append(ordered, channel)
+	}
+	return ordered
+}
+
+// MarkovAttribution estimates removal effects similar to the Python implementation.
+func MarkovAttribution(pathConversions map[string]float64) map[string]float64 {
+	total := 0.0
+	for _, conversions := range pathConversions {
+		total += conversions
+	}
+	if total == 0 {
+		return map[string]float64{}
+	}
+	channels := make(map[string]struct{})
+	for key := range pathConversions {
+		for _, channel := range decodePath(key) {
+			channels[channel] = struct{}{}
+		}
+	}
+	removal := make(map[string]float64)
+	for channel := range channels {
+		affected := 0.0
+		for key, conversions := range pathConversions {
+			path := decodePath(key)
+			if contains(path, channel) {
+				affected += conversions
+			}
+		}
+		diff := affected / total
+		if diff < 0 {
+			diff = 0
+		}
+		removal[channel] = diff
+	}
+	effectSum := 0.0
+	for _, value := range removal {
+		effectSum += value
+	}
+	if effectSum == 0 {
+		for channel := range removal {
+			removal[channel] = 0
+		}
+		return removal
+	}
+	for channel, value := range removal {
+		removal[channel] = value / effectSum
+	}
+	return removal
+}
+
+func contains(path []string, target string) bool {
+	for _, channel := range path {
+		if channel == target {
+			return true
+		}
+	}
+	return false
+}

--- a/services/fae/go/fae/cuped.go
+++ b/services/fae/go/fae/cuped.go
@@ -1,0 +1,62 @@
+package fae
+
+import "math"
+
+// CupedResult captures the adjusted uplift computation.
+type CupedResult struct {
+	Uplift                float64
+	TreatmentAdjustedMean float64
+	ControlAdjustedMean   float64
+	Theta                 float64
+	Variance              float64
+}
+
+func thetaAndMeanX(control CupedAggregate) (theta float64, meanX float64) {
+	if control.N == 0 {
+		return 0, 0
+	}
+	meanX = control.SumX / float64(control.N)
+	meanY := control.SumY / float64(control.N)
+	covXY := control.SumXY/float64(control.N) - meanX*meanY
+	varX := control.SumX2/float64(control.N) - meanX*meanX
+	if math.Abs(varX) < 1e-12 {
+		return 0, meanX
+	}
+	theta = covXY / varX
+	return theta, meanX
+}
+
+func adjustedMoments(agg CupedAggregate, theta, baselineMeanX float64) (meanZ, varZ float64) {
+	if agg.N == 0 {
+		return 0, 0
+	}
+	sumZ := agg.SumY - theta*(agg.SumX-float64(agg.N)*baselineMeanX)
+	sumZ2 := agg.SumY2 - 2*theta*(agg.SumXY-baselineMeanX*agg.SumY) + theta*theta*(agg.SumX2-2*baselineMeanX*agg.SumX+float64(agg.N)*baselineMeanX*baselineMeanX)
+	meanZ = sumZ / float64(agg.N)
+	varZ = sumZ2/float64(agg.N) - meanZ*meanZ
+	if varZ < 0 {
+		varZ = 0
+	}
+	return meanZ, varZ
+}
+
+// ComputeCupedUplift returns the CUPED uplift for the two aggregates.
+func ComputeCupedUplift(control, treatment CupedAggregate) CupedResult {
+	theta, meanX := thetaAndMeanX(control)
+	controlMean, controlVar := adjustedMoments(control, theta, meanX)
+	treatmentMean, treatmentVar := adjustedMoments(treatment, theta, meanX)
+	variance := 0.0
+	if control.N > 0 {
+		variance += controlVar / float64(control.N)
+	}
+	if treatment.N > 0 {
+		variance += treatmentVar / float64(treatment.N)
+	}
+	return CupedResult{
+		Uplift:                treatmentMean - controlMean,
+		TreatmentAdjustedMean: treatmentMean,
+		ControlAdjustedMean:   controlMean,
+		Theta:                 theta,
+		Variance:              variance,
+	}
+}

--- a/services/fae/go/fae/dp.go
+++ b/services/fae/go/fae/dp.go
@@ -1,0 +1,24 @@
+package fae
+
+import (
+	"math"
+	"math/rand"
+)
+
+// ApplyDPLaplace applies Laplace noise with deterministic seed for reproducibility.
+func ApplyDPLaplace(values []float64, epsilon, sensitivity float64, seed int64) []float64 {
+	if epsilon <= 0 {
+		copied := make([]float64, len(values))
+		copy(copied, values)
+		return copied
+	}
+	scale := sensitivity / epsilon
+	rng := rand.New(rand.NewSource(seed))
+	noisy := make([]float64, len(values))
+	for i, v := range values {
+		u := rng.Float64() - 0.5
+		noise := -scale * math.Copysign(math.Log(1-2*math.Abs(u)), u)
+		noisy[i] = v + noise
+	}
+	return noisy
+}

--- a/services/fae/go/fae/fae_test.go
+++ b/services/fae/go/fae/fae_test.go
@@ -1,0 +1,109 @@
+package fae
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func fixtureAggregates() (CupedAggregate, CupedAggregate, map[string]float64) {
+	control := CupedAggregate{
+		N:     1,
+		SumY:  1.2,
+		SumY2: 1.44,
+		SumX:  0.8,
+		SumX2: 0.64,
+		SumXY: 0.96,
+	}
+	treatment := CupedAggregate{
+		N:     1,
+		SumY:  1.6,
+		SumY2: 2.56,
+		SumX:  1.0,
+		SumX2: 1.0,
+		SumXY: 1.6,
+	}
+	paths := map[string]float64{
+		"email>search": 1,
+		"email>social": 1,
+	}
+	return control, treatment, paths
+}
+
+func TestCupedMatchesFixture(t *testing.T) {
+	control, treatment, _ := fixtureAggregates()
+	result := ComputeCupedUplift(control, treatment)
+	if result.Uplift <= 0 {
+		t.Fatalf("expected positive uplift, got %v", result.Uplift)
+	}
+}
+
+func TestAttributionSharesSumToOne(t *testing.T) {
+	_, _, paths := fixtureAggregates()
+	shapley := ShapleyAttribution(paths)
+	total := 0.0
+	for _, value := range shapley {
+		total += value
+	}
+	if total < 0.99 || total > 1.01 {
+		t.Fatalf("shapley share sum = %v", total)
+	}
+	markov := MarkovAttribution(paths)
+	total = 0.0
+	for _, value := range markov {
+		total += value
+	}
+	if total < 0.99 || total > 1.01 {
+		t.Fatalf("markov share sum = %v", total)
+	}
+}
+
+func TestDPNoiseDeterministic(t *testing.T) {
+	values := []float64{1, 2}
+	noisy := ApplyDPLaplace(values, 0.5, 1, 42)
+	noisy2 := ApplyDPLaplace(values, 0.5, 1, 42)
+	for i := range noisy {
+		if noisy[i] != noisy2[i] {
+			t.Fatalf("dp noise not deterministic")
+		}
+	}
+}
+
+func TestReportSignature(t *testing.T) {
+	payload := map[string]any{"uplift": 0.1}
+	secret := "secret"
+	report1, err := GenerateReport(payload, secret)
+	if err != nil {
+		t.Fatalf("generate report: %v", err)
+	}
+	report2, err := GenerateReport(payload, secret)
+	if err != nil {
+		t.Fatalf("generate report: %v", err)
+	}
+	if string(report1) != string(report2) {
+		t.Fatalf("reports differ: %s vs %s", report1, report2)
+	}
+	ok, err := VerifyReport(report1, secret)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected verification to succeed")
+	}
+	// mutate payload to ensure verification fails
+	var doc map[string]any
+	if err := json.Unmarshal(report1, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	doc["payload"].(map[string]any)["uplift"] = 0.2
+	tampered, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	ok, err = VerifyReport(tampered, secret)
+	if err != nil {
+		t.Fatalf("verify tampered: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected tampered report to fail")
+	}
+}

--- a/services/fae/go/fae/go.mod
+++ b/services/fae/go/fae/go.mod
@@ -1,0 +1,4 @@
+module summit/fae
+
+go 1.21
+

--- a/services/fae/go/fae/report.go
+++ b/services/fae/go/fae/report.go
@@ -1,0 +1,58 @@
+package fae
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/json"
+)
+
+// GenerateReport generates a deterministic JSON document with a signature.
+func GenerateReport(payload any, secret string) ([]byte, error) {
+	canonical, err := canonicalJSON(map[string]any{"payload": payload})
+	if err != nil {
+		return nil, err
+	}
+	sig := hmac.New(sha256.New, []byte(secret))
+	sig.Write(canonical)
+	signature := sig.Sum(nil)
+	report, err := canonicalJSON(map[string]any{
+		"payload":   payload,
+		"signature": encodeHex(signature),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return report, nil
+}
+
+// VerifyReport verifies the signature against the secret.
+func VerifyReport(report []byte, secret string) (bool, error) {
+	var document map[string]any
+	if err := json.Unmarshal(report, &document); err != nil {
+		return false, err
+	}
+	signature, _ := document["signature"].(string)
+	payload := map[string]any{"payload": document["payload"]}
+	canonical, err := canonicalJSON(payload)
+	if err != nil {
+		return false, err
+	}
+	sig := hmac.New(sha256.New, []byte(secret))
+	sig.Write(canonical)
+	expected := encodeHex(sig.Sum(nil))
+	return hmac.Equal([]byte(signature), []byte(expected)), nil
+}
+
+func canonicalJSON(payload any) ([]byte, error) {
+	return json.Marshal(payload)
+}
+
+func encodeHex(data []byte) string {
+	const hexdigits = "0123456789abcdef"
+	dst := make([]byte, len(data)*2)
+	for i, b := range data {
+		dst[i*2] = hexdigits[b>>4]
+		dst[i*2+1] = hexdigits[b&0x0f]
+	}
+	return string(dst)
+}

--- a/services/fae/python/fae/__init__.py
+++ b/services/fae/python/fae/__init__.py
@@ -1,0 +1,27 @@
+"""Federated Attribution Evaluator (FAE).
+
+This package exposes utilities for computing privacy-aware uplift and
+attribution metrics on securely aggregated datasets.
+"""
+
+from .aggregates import CupedAggregate, SecureAggregatedMetrics, SecureAggregator
+from .uplift import compute_cuped_uplift
+from .attribution import shapley_attribution, markov_attribution
+from .dp import apply_dp_noise
+from .cohort import slice_metrics
+from .bias import run_bias_checks
+from .report import generate_report, verify_report
+
+__all__ = [
+    "CupedAggregate",
+    "SecureAggregatedMetrics",
+    "SecureAggregator",
+    "compute_cuped_uplift",
+    "shapley_attribution",
+    "markov_attribution",
+    "apply_dp_noise",
+    "slice_metrics",
+    "run_bias_checks",
+    "generate_report",
+    "verify_report",
+]

--- a/services/fae/python/fae/aggregates.py
+++ b/services/fae/python/fae/aggregates.py
@@ -1,0 +1,143 @@
+"""Secure aggregation utilities for FAE."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple
+
+CohortKey = Tuple[Tuple[str, str], ...]
+Path = Tuple[str, ...]
+
+
+def _normalize_cohort(cohort: Optional[Mapping[str, str]]) -> CohortKey:
+    if not cohort:
+        return ()
+    return tuple(sorted((str(k), str(v)) for k, v in cohort.items()))
+
+
+@dataclass
+class CupedAggregate:
+    """Aggregated statistics required for CUPED uplift."""
+
+    n: int = 0
+    sum_y: float = 0.0
+    sum_y2: float = 0.0
+    sum_x: float = 0.0
+    sum_x2: float = 0.0
+    sum_xy: float = 0.0
+
+    def add(self, y: float, x: float) -> None:
+        self.n += 1
+        self.sum_y += y
+        self.sum_y2 += y * y
+        self.sum_x += x
+        self.sum_x2 += x * x
+        self.sum_xy += x * y
+
+    def merge(self, other: "CupedAggregate") -> None:
+        self.n += other.n
+        self.sum_y += other.sum_y
+        self.sum_y2 += other.sum_y2
+        self.sum_x += other.sum_x
+        self.sum_x2 += other.sum_x2
+        self.sum_xy += other.sum_xy
+
+    @property
+    def mean_y(self) -> float:
+        return self.sum_y / self.n if self.n else 0.0
+
+    @property
+    def mean_x(self) -> float:
+        return self.sum_x / self.n if self.n else 0.0
+
+
+@dataclass
+class SecureAggregatedMetrics:
+    """Securely aggregated metrics for a cohort."""
+
+    cohort: CohortKey
+    control: CupedAggregate = field(default_factory=CupedAggregate)
+    treatment: CupedAggregate = field(default_factory=CupedAggregate)
+    path_conversions: MutableMapping[Path, float] = field(default_factory=dict)
+    metadata: MutableMapping[str, Any] = field(default_factory=dict)
+
+    def copy(self) -> "SecureAggregatedMetrics":
+        clone = SecureAggregatedMetrics(cohort=self.cohort)
+        clone.control = CupedAggregate(
+            self.control.n,
+            self.control.sum_y,
+            self.control.sum_y2,
+            self.control.sum_x,
+            self.control.sum_x2,
+            self.control.sum_xy,
+        )
+        clone.treatment = CupedAggregate(
+            self.treatment.n,
+            self.treatment.sum_y,
+            self.treatment.sum_y2,
+            self.treatment.sum_x,
+            self.treatment.sum_x2,
+            self.treatment.sum_xy,
+        )
+        clone.path_conversions = dict(self.path_conversions)
+        clone.metadata = dict(self.metadata)
+        return clone
+
+
+class SecureAggregator:
+    """Creates secure aggregates from raw event data."""
+
+    def __init__(self, metrics: Mapping[CohortKey, SecureAggregatedMetrics]):
+        self._metrics = dict(metrics)
+
+    @property
+    def metrics(self) -> Mapping[CohortKey, SecureAggregatedMetrics]:
+        return self._metrics
+
+    @classmethod
+    def from_events(
+        cls,
+        events: Iterable[Mapping[str, Any]],
+        cohort_keys: Optional[Iterable[str]] = None,
+    ) -> "SecureAggregator":
+        metrics: Dict[CohortKey, SecureAggregatedMetrics] = {}
+        keys: Optional[List[str]] = list(cohort_keys) if cohort_keys else None
+
+        for event in events:
+            cohort_data = event.get("cohort", {})
+            cohort = (
+                _normalize_cohort({k: cohort_data.get(k, "undefined") for k in keys})
+                if keys
+                else _normalize_cohort(cohort_data)
+            )
+            record = metrics.setdefault(cohort, SecureAggregatedMetrics(cohort))
+
+            group = str(event.get("group", "control")).lower()
+            y = float(event.get("outcome", 0.0))
+            x = float(event.get("covariate", 0.0))
+            if group == "treatment":
+                record.treatment.add(y, x)
+            else:
+                record.control.add(y, x)
+
+            path = tuple(event.get("path", ()))
+            if path:
+                record.path_conversions[path] = record.path_conversions.get(path, 0.0) + float(
+                    event.get("conversions", 1.0)
+                )
+
+        return cls(metrics)
+
+    def combine(self, other: "SecureAggregator") -> "SecureAggregator":
+        merged: Dict[CohortKey, SecureAggregatedMetrics] = {
+            key: metric.copy() for key, metric in self._metrics.items()
+        }
+        for cohort, metric in other.metrics.items():
+            target = merged.setdefault(cohort, SecureAggregatedMetrics(cohort)).copy()
+            target.control.merge(metric.control)
+            target.treatment.merge(metric.treatment)
+            for path, value in metric.path_conversions.items():
+                target.path_conversions[path] = target.path_conversions.get(path, 0.0) + value
+            merged[cohort] = target
+        return SecureAggregator(merged)
+

--- a/services/fae/python/fae/attribution.py
+++ b/services/fae/python/fae/attribution.py
@@ -1,0 +1,49 @@
+"""Attribution strategies for securely aggregated paths."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Mapping, Tuple
+
+Path = Tuple[str, ...]
+
+
+def shapley_attribution(path_conversions: Mapping[Path, float]) -> Dict[str, float]:
+    contributions: Dict[str, float] = defaultdict(float)
+    total = 0.0
+    for path, conversions in path_conversions.items():
+        unique = []
+        for channel in path:
+            if channel not in unique:
+                unique.append(channel)
+        if not unique:
+            continue
+        weight = conversions / len(unique)
+        for channel in unique:
+            contributions[channel] += weight
+        total += conversions
+    if total <= 0:
+        return dict(contributions)
+    return {channel: value / total for channel, value in contributions.items()}
+
+
+def markov_attribution(path_conversions: Mapping[Path, float]) -> Dict[str, float]:
+    total = sum(path_conversions.values())
+    if total <= 0:
+        return {}
+
+    removal_effects: Dict[str, float] = defaultdict(float)
+    channels = set(channel for path in path_conversions for channel in path)
+
+    for channel in channels:
+        affected = sum(
+            conversions for path, conversions in path_conversions.items() if channel in path
+        )
+        removal_effect = affected / total
+        removal_effects[channel] = max(removal_effect, 0.0)
+
+    effect_sum = sum(removal_effects.values())
+    if effect_sum == 0:
+        return {channel: 0.0 for channel in removal_effects}
+    return {channel: effect / effect_sum for channel, effect in removal_effects.items()}
+

--- a/services/fae/python/fae/bias.py
+++ b/services/fae/python/fae/bias.py
@@ -1,0 +1,45 @@
+"""Bias and health checks for aggregated experiments."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Mapping
+
+from .aggregates import CohortKey, SecureAggregatedMetrics
+
+
+@dataclass
+class BiasSignal:
+    name: str
+    value: float
+    threshold: float
+    passes: bool
+
+
+def _sample_ratio_test(control_n: int, treatment_n: int) -> BiasSignal:
+    total = control_n + treatment_n
+    if total == 0:
+        return BiasSignal("sample_ratio", 0.0, 3.0, True)
+    expected = total / 2
+    z = (control_n - expected) / math.sqrt(total / 4)
+    return BiasSignal("sample_ratio", abs(z), 3.0, abs(z) <= 3.0)
+
+
+def _covariate_shift(metric: SecureAggregatedMetrics) -> BiasSignal:
+    control_mean = metric.control.mean_x
+    treatment_mean = metric.treatment.mean_x
+    diff = treatment_mean - control_mean
+    return BiasSignal("covariate_shift", diff, 0.1, abs(diff) <= 0.1)
+
+
+def run_bias_checks(metrics: Mapping[CohortKey, SecureAggregatedMetrics]):
+    results = {}
+    for cohort, metric in metrics.items():
+        signals = [
+            _sample_ratio_test(metric.control.n, metric.treatment.n),
+            _covariate_shift(metric),
+        ]
+        results[cohort] = signals
+    return results
+

--- a/services/fae/python/fae/cohort.py
+++ b/services/fae/python/fae/cohort.py
@@ -1,0 +1,20 @@
+"""Cohort slicing helpers."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from .aggregates import CohortKey, SecureAggregatedMetrics
+
+
+def slice_metrics(
+    metrics: Mapping[CohortKey, SecureAggregatedMetrics],
+    filters: Mapping[str, str],
+):
+    selected = {}
+    for cohort, metric in metrics.items():
+        cohort_dict = dict(cohort)
+        if all(cohort_dict.get(key) == value for key, value in filters.items()):
+            selected[cohort] = metric
+    return selected
+

--- a/services/fae/python/fae/dp.py
+++ b/services/fae/python/fae/dp.py
@@ -1,0 +1,33 @@
+"""Differential privacy helpers."""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import MutableSequence, Sequence
+
+
+def laplace_noise(scale: float, rng: random.Random) -> float:
+    if scale <= 0:
+        return 0.0
+    u = rng.random() - 0.5
+    return -scale * math.copysign(math.log(1 - 2 * abs(u)), u)
+
+
+def apply_dp_noise(
+    values: Sequence[float],
+    epsilon: float,
+    sensitivity: float = 1.0,
+    seed: int = 0,
+) -> Sequence[float]:
+    """Applies Laplace noise to a sequence deterministically for tests."""
+
+    if epsilon <= 0:
+        return list(values)
+    scale = sensitivity / epsilon
+    rng = random.Random(seed)
+    noised: MutableSequence[float] = []  # type: ignore[assignment]
+    for value in values:
+        noised.append(float(value) + laplace_noise(scale, rng))
+    return noised
+

--- a/services/fae/python/fae/report.py
+++ b/services/fae/python/fae/report.py
@@ -1,0 +1,40 @@
+"""Signed evaluation report generation."""
+
+from __future__ import annotations
+
+import hmac
+import json
+from dataclasses import asdict, is_dataclass
+from hashlib import sha256
+from typing import Any, Mapping, Sequence
+
+
+def _serialize(obj: Any) -> Any:
+    if is_dataclass(obj):
+        return {k: _serialize(v) for k, v in asdict(obj).items()}
+    if isinstance(obj, Mapping):
+        return {str(k): _serialize(v) for k, v in sorted(obj.items())}
+    if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+        return [_serialize(v) for v in obj]
+    return obj
+
+
+def _canonical_json(payload: Mapping[str, Any]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def generate_report(payload: Mapping[str, Any], secret: str) -> bytes:
+    serialized = _serialize(payload)
+    canonical = _canonical_json({"payload": serialized})
+    signature = hmac.new(secret.encode("utf-8"), canonical, sha256).hexdigest()
+    return _canonical_json({"payload": serialized, "signature": signature})
+
+
+def verify_report(report_bytes: bytes, secret: str) -> bool:
+    document = json.loads(report_bytes.decode("utf-8"))
+    signature = document.get("signature", "")
+    payload = {"payload": document.get("payload")}
+    canonical = _canonical_json(payload)
+    expected = hmac.new(secret.encode("utf-8"), canonical, sha256).hexdigest()
+    return hmac.compare_digest(signature, expected)
+

--- a/services/fae/python/fae/uplift.py
+++ b/services/fae/python/fae/uplift.py
@@ -1,0 +1,63 @@
+"""CUPED uplift estimation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from .aggregates import CupedAggregate
+
+
+@dataclass
+class CupedResult:
+    uplift: float
+    treatment_adjusted_mean: float
+    control_adjusted_mean: float
+    theta: float
+    variance: float
+
+
+def _theta_and_mean_x(control: CupedAggregate) -> Dict[str, float]:
+    if control.n == 0:
+        return {"theta": 0.0, "mean_x": 0.0}
+    mean_x = control.sum_x / control.n
+    mean_y = control.sum_y / control.n
+    cov_xy = control.sum_xy / control.n - mean_x * mean_y
+    var_x = control.sum_x2 / control.n - mean_x * mean_x
+    theta = cov_xy / var_x if var_x > 1e-12 else 0.0
+    return {"theta": theta, "mean_x": mean_x}
+
+
+def _adjusted_moments(agg: CupedAggregate, theta: float, baseline_mean_x: float):
+    if agg.n == 0:
+        return 0.0, 0.0
+    sum_z = agg.sum_y - theta * (agg.sum_x - agg.n * baseline_mean_x)
+    sum_z2 = (
+        agg.sum_y2
+        - 2 * theta * (agg.sum_xy - baseline_mean_x * agg.sum_y)
+        + theta**2
+        * (agg.sum_x2 - 2 * baseline_mean_x * agg.sum_x + agg.n * baseline_mean_x**2)
+    )
+    mean_z = sum_z / agg.n
+    var_z = sum_z2 / agg.n - mean_z**2
+    return mean_z, max(var_z, 0.0)
+
+
+def compute_cuped_uplift(control: CupedAggregate, treatment: CupedAggregate) -> CupedResult:
+    params = _theta_and_mean_x(control)
+    theta = params["theta"]
+    baseline_mean_x = params["mean_x"]
+    control_mean, control_var = _adjusted_moments(control, theta, baseline_mean_x)
+    treat_mean, treat_var = _adjusted_moments(treatment, theta, baseline_mean_x)
+    uplift = treat_mean - control_mean
+    variance = (control_var / control.n if control.n else 0.0) + (
+        treat_var / treatment.n if treatment.n else 0.0
+    )
+    return CupedResult(
+        uplift=uplift,
+        treatment_adjusted_mean=treat_mean,
+        control_adjusted_mean=control_mean,
+        theta=theta,
+        variance=variance,
+    )
+

--- a/services/fae/tests/test_fae.py
+++ b/services/fae/tests/test_fae.py
@@ -1,0 +1,150 @@
+from math import isclose
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "python"))
+
+import pytest
+
+from fae import (
+    SecureAggregator,
+    apply_dp_noise,
+    compute_cuped_uplift,
+    generate_report,
+    markov_attribution,
+    run_bias_checks,
+    shapley_attribution,
+    slice_metrics,
+    verify_report,
+)
+
+
+RAW_EVENTS = [
+    {
+        "user": 1,
+        "group": "control",
+        "outcome": 1.2,
+        "covariate": 0.8,
+        "path": ["email", "search"],
+        "cohort": {"region": "na", "segment": "a"},
+    },
+    {
+        "user": 2,
+        "group": "treatment",
+        "outcome": 1.6,
+        "covariate": 1.0,
+        "path": ["email", "social"],
+        "cohort": {"region": "na", "segment": "a"},
+    },
+    {
+        "user": 3,
+        "group": "treatment",
+        "outcome": 0.4,
+        "covariate": 0.6,
+        "path": ["search"],
+        "cohort": {"region": "eu", "segment": "b"},
+    },
+    {
+        "user": 4,
+        "group": "control",
+        "outcome": 0.7,
+        "covariate": 0.9,
+        "path": ["social", "search"],
+        "cohort": {"region": "eu", "segment": "b"},
+    },
+]
+
+
+@pytest.fixture(scope="module")
+def aggregator():
+    return SecureAggregator.from_events(RAW_EVENTS)
+
+
+def _direct_cuped(events):
+    control = [e for e in events if e["group"] == "control"]
+    treatment = [e for e in events if e["group"] == "treatment"]
+
+    def stats(records):
+        n = len(records)
+        sum_y = sum(r["outcome"] for r in records)
+        sum_y2 = sum(r["outcome"] ** 2 for r in records)
+        sum_x = sum(r["covariate"] for r in records)
+        sum_x2 = sum(r["covariate"] ** 2 for r in records)
+        sum_xy = sum(r["covariate"] * r["outcome"] for r in records)
+        return n, sum_y, sum_y2, sum_x, sum_x2, sum_xy
+
+    sc = stats(control)
+    st = stats(treatment)
+
+    from fae.aggregates import CupedAggregate
+
+    control_agg = CupedAggregate(*sc)
+    treatment_agg = CupedAggregate(*st)
+    return compute_cuped_uplift(control_agg, treatment_agg)
+
+
+def test_cuped_matches_baseline(aggregator):
+    cohort_metrics = next(
+        iter(slice_metrics(aggregator.metrics, {"region": "na", "segment": "a"}).values())
+    )
+    result = compute_cuped_uplift(cohort_metrics.control, cohort_metrics.treatment)
+    baseline = _direct_cuped(RAW_EVENTS[:2])  # first cohort (region=na, segment=a)
+    assert isclose(result.uplift, baseline.uplift, rel_tol=1e-6, abs_tol=1e-6)
+
+
+def test_shapley_and_markov_match_raw_counts(aggregator):
+    cohort_metrics = next(
+        iter(slice_metrics(aggregator.metrics, {"region": "na", "segment": "a"}).values())
+    )
+    aggregated = cohort_metrics.path_conversions
+    raw_counts = {}
+    for event in RAW_EVENTS[:2]:
+        path = tuple(event["path"])
+        raw_counts[path] = raw_counts.get(path, 0.0) + 1.0
+    assert shapley_attribution(aggregated) == pytest.approx(
+        shapley_attribution(raw_counts), rel=1e-6
+    )
+    assert markov_attribution(aggregated) == pytest.approx(
+        markov_attribution(raw_counts), rel=1e-6
+    )
+
+
+def test_dp_noise_changes_results_predictably(aggregator):
+    cohort_metrics = next(
+        iter(slice_metrics(aggregator.metrics, {"region": "na", "segment": "a"}).values())
+    )
+    values = [
+        cohort_metrics.control.sum_y,
+        cohort_metrics.treatment.sum_y,
+    ]
+    noisy = apply_dp_noise(values, epsilon=0.5, seed=42)
+    assert noisy != pytest.approx(values)
+    assert noisy == pytest.approx(
+        apply_dp_noise(values, epsilon=0.5, seed=42), rel=1e-9
+    )
+
+
+def test_reports_are_deterministic(aggregator):
+    cohort_metrics = next(
+        iter(slice_metrics(aggregator.metrics, {"region": "na", "segment": "a"}).values())
+    )
+    payload = {
+        "uplift": compute_cuped_uplift(cohort_metrics.control, cohort_metrics.treatment),
+        "shapley": shapley_attribution(cohort_metrics.path_conversions),
+        "markov": markov_attribution(cohort_metrics.path_conversions),
+        "bias": run_bias_checks({cohort_metrics.cohort: cohort_metrics}),
+    }
+    secret = "fae-secret"
+    report1 = generate_report(payload, secret)
+    report2 = generate_report(payload, secret)
+    assert report1 == report2
+    assert verify_report(report1, secret)
+
+
+def test_cohort_slice(aggregator):
+    sliced = slice_metrics(aggregator.metrics, {"region": "na"})
+    assert len(sliced) == 1
+    cohort = next(iter(sliced.values()))
+    expected = tuple(sorted((("region", "na"), ("segment", "a"))))
+    assert cohort.cohort == expected
+


### PR DESCRIPTION
## Summary
- add a Python FAE package with secure aggregates, CUPED uplift, attribution, bias checks, and signed reports
- implement a Go toolkit mirroring CUPED, attribution, DP noise, and deterministic report signing
- add Python and Go fixtures/tests to validate baseline parity, DP behavior, and reproducible reports

## Testing
- pytest services/fae/tests/test_fae.py
- (cd services/fae/go/fae && go test ./...)


------
https://chatgpt.com/codex/tasks/task_e_68d7819dcab88333a41f068e71283786