### PR TITLE
feat: add consent state reconciler service

### DIFF
--- a/services/csr/README.md
+++ b/services/csr/README.md
@@ -1,0 +1,41 @@
+# Consent State Reconciler (CSR)
+
+CSR ingests consent records from CRM, mobile SDKs, and partner activity logs. It merges
+conflicting updates into a canonical consent graph with deterministic rule precedence and
+transparent proofs explaining each decision.
+
+## Key features
+
+- **Multi-source ingestion** via `/ingest`, supporting batch uploads with per-record proofs.
+- **Deterministic reconciliation** using source precedence (`crm` → `app_sdk` → `partner`),
+  recency, and lexical tiebreakers.
+- **Reconciliation proofs** that capture before/after graph snapshots and the winning rules
+  applied to each conflict.
+- **Diff and rollback APIs** (`/diff`, `/rollback`) for comparing snapshots and restoring any
+  previous consent state exactly.
+
+## Running locally
+
+```bash
+npm install
+npm run dev
+```
+
+### HTTP routes
+
+| Method | Path        | Description |
+| ------ | ----------- | ----------- |
+| GET    | `/healthz`  | Service health probe |
+| POST   | `/ingest`   | Accepts `{ records: ConsentRecord[] }` payloads and returns proofs with the new snapshot id |
+| GET    | `/diff`     | Computes differences between snapshots; supports `from`, `to`, and `userId` query params |
+| POST   | `/rollback` | Restores a prior snapshot via `{ snapshotId }` |
+| GET    | `/snapshots`| Lists all stored snapshots and their proofs |
+
+`ConsentRecord` payloads require `recordId`, `userId`, `consentType`, `status`, `source`, and
+ISO-8601 `timestamp`, with optional `channel` and metadata.
+
+## Testing
+
+```bash
+npm test
+```

--- a/services/csr/package.json
+++ b/services/csr/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@summit/csr",
+  "version": "0.1.0",
+  "description": "Consent State Reconciler service for cross-system consent merging",
+  "private": true,
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "lint": "eslint --ext .ts src",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.12.7",
+    "eslint": "^8.57.0",
+    "tsx": "^4.7.1",
+    "typescript": "^5.4.5",
+    "supertest": "^6.3.3",
+    "vitest": "^1.6.0"
+  }
+}

--- a/services/csr/src/app.ts
+++ b/services/csr/src/app.ts
@@ -1,0 +1,75 @@
+import express from "express";
+import ConsentStateReconciler from "./reconciler";
+import {
+  ConsentRecord,
+  DiffRequest,
+  IngestResult,
+  RollbackResult,
+} from "./types";
+
+export interface CreateAppOptions {
+  reconciler?: ConsentStateReconciler;
+}
+
+export function createApp(options: CreateAppOptions = {}) {
+  const reconciler = options.reconciler ?? new ConsentStateReconciler();
+  const app = express();
+  app.use(express.json({ limit: "1mb" }));
+
+  app.get("/healthz", (_req, res) => {
+    res.json({ status: "ok" });
+  });
+
+  app.post("/ingest", (req, res) => {
+    const payload = req.body as { records?: ConsentRecord[] };
+    if (!payload?.records || !Array.isArray(payload.records) || payload.records.length === 0) {
+      res.status(400).json({ error: "records array is required" });
+      return;
+    }
+
+    try {
+      const result: IngestResult = reconciler.ingest(payload.records);
+      res.status(201).json(result);
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  });
+
+  app.get("/diff", (req, res) => {
+    const diffRequest: DiffRequest = {
+      from: typeof req.query.from === "string" ? req.query.from : undefined,
+      to: typeof req.query.to === "string" ? req.query.to : undefined,
+      userId: typeof req.query.userId === "string" ? req.query.userId : undefined,
+    };
+
+    try {
+      const diff = reconciler.diff(diffRequest);
+      res.json(diff);
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  });
+
+  app.post("/rollback", (req, res) => {
+    const payload = req.body as { snapshotId?: string };
+    if (!payload?.snapshotId) {
+      res.status(400).json({ error: "snapshotId is required" });
+      return;
+    }
+
+    try {
+      const result: RollbackResult = reconciler.rollback(payload.snapshotId);
+      res.json(result);
+    } catch (error) {
+      res.status(400).json({ error: (error as Error).message });
+    }
+  });
+
+  app.get("/snapshots", (_req, res) => {
+    res.json({ snapshots: reconciler.listSnapshots() });
+  });
+
+  return { app, reconciler };
+}
+
+export type AppFactory = ReturnType<typeof createApp>;

--- a/services/csr/src/index.ts
+++ b/services/csr/src/index.ts
@@ -1,0 +1,10 @@
+import { createApp } from "./app";
+
+const { app } = createApp();
+
+const port = process.env.PORT ? Number.parseInt(process.env.PORT, 10) : 4102;
+
+app.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Consent State Reconciler service listening on port ${port}`);
+});

--- a/services/csr/src/reconciler.ts
+++ b/services/csr/src/reconciler.ts
@@ -1,0 +1,456 @@
+import { v4 as uuid } from "uuid";
+import {
+  AppliedRule,
+  ConsentRecord,
+  ConsentStateRecord,
+  DiffEntry,
+  DiffRequest,
+  DiffResponse,
+  GraphNode,
+  GraphSnapshot,
+  IngestResult,
+  ReconciliationProof,
+  RollbackResult,
+  Snapshot,
+  SourceSystem,
+} from "./types";
+
+const DEFAULT_SOURCE_PRECEDENCE: SourceSystem[] = ["crm", "app_sdk", "partner"];
+
+function makeKey(record: Pick<ConsentRecord, "userId" | "consentType" | "channel">) {
+  return [record.userId, record.consentType, record.channel ?? "*"]
+    .map((segment) => segment.trim())
+    .join(":");
+}
+
+function serialiseState(state: Map<string, ConsentStateRecord>): Record<string, ConsentStateRecord> {
+  const serialised: Record<string, ConsentStateRecord> = {};
+  for (const [key, value] of state.entries()) {
+    serialised[key] = { ...value, provenance: { ...value.provenance } };
+  }
+  return serialised;
+}
+
+function deserialiseState(state: Record<string, ConsentStateRecord>): Map<string, ConsentStateRecord> {
+  return new Map(
+    Object.entries(state).map(([key, value]) => [key, { ...value, provenance: { ...value.provenance } }]),
+  );
+}
+
+function precedenceRank(source: SourceSystem, precedence: SourceSystem[]): number {
+  const index = precedence.indexOf(source);
+  return index === -1 ? precedence.length : index;
+}
+
+function parseTimestamp(timestamp: string): number {
+  const value = Date.parse(timestamp);
+  if (Number.isNaN(value)) {
+    throw new Error(`Invalid timestamp provided: ${timestamp}`);
+  }
+  return value;
+}
+
+function buildGraphSnapshot(
+  userId: string,
+  consentType: string,
+  channel: string | undefined,
+  candidates: ConsentStateRecord[],
+  precedence: SourceSystem[],
+): GraphSnapshot {
+  const nodes: Map<string, GraphNode> = new Map();
+  const edges: GraphSnapshot["edges"] = [];
+
+  const userNodeId = `user:${userId}`;
+  const consentNodeId = `consent:${consentType}`;
+
+  nodes.set(userNodeId, {
+    id: userNodeId,
+    type: "user",
+    label: userId,
+  });
+  nodes.set(consentNodeId, {
+    id: consentNodeId,
+    type: "consent",
+    label: consentType,
+    data: channel ? { channel } : undefined,
+  });
+
+  for (const candidate of candidates) {
+    const sourceNodeId = `source:${candidate.source}`;
+    if (!nodes.has(sourceNodeId)) {
+      nodes.set(sourceNodeId, {
+        id: sourceNodeId,
+        type: "source",
+        label: candidate.source,
+      });
+    }
+
+    const recordNodeId = `record:${candidate.provenance.recordId}`;
+    nodes.set(recordNodeId, {
+      id: recordNodeId,
+      type: "record",
+      label: candidate.provenance.recordId,
+      data: {
+        status: candidate.status,
+        timestamp: candidate.timestamp,
+      },
+    });
+
+    edges.push({
+      from: userNodeId,
+      to: consentNodeId,
+      label: candidate.status,
+      data: {
+        source: candidate.source,
+        recordId: candidate.provenance.recordId,
+        timestamp: candidate.timestamp,
+      },
+    });
+    edges.push({
+      from: sourceNodeId,
+      to: recordNodeId,
+      label: "provided",
+      data: {
+        precedence: precedenceRank(candidate.source, precedence),
+      },
+    });
+  }
+
+  return {
+    nodes: Array.from(nodes.values()),
+    edges,
+  };
+}
+
+export class ConsentStateReconciler {
+  private state: Map<string, ConsentStateRecord>;
+
+  private processedRecordIds: Set<string>;
+
+  private snapshots: Snapshot[];
+
+  constructor(private readonly sourcePrecedence: SourceSystem[] = DEFAULT_SOURCE_PRECEDENCE) {
+    this.state = new Map();
+    this.processedRecordIds = new Set();
+    this.snapshots = [];
+    this.createSnapshot("initial", []);
+  }
+
+  public ingest(records: ConsentRecord[]): IngestResult {
+    if (!Array.isArray(records) || records.length === 0) {
+      throw new Error("At least one consent record must be provided for ingestion.");
+    }
+
+    const proofs: ReconciliationProof[] = [];
+
+    for (const record of records) {
+      const proof = this.processRecord(record);
+      proofs.push(proof);
+    }
+
+    const snapshot = this.createSnapshot("ingest", proofs);
+
+    return { snapshotId: snapshot.id, proofs };
+  }
+
+  public listSnapshots(): Snapshot[] {
+    return [...this.snapshots];
+  }
+
+  public getCurrentSnapshot(): Snapshot {
+    return this.snapshots[this.snapshots.length - 1];
+  }
+
+  public diff(request: DiffRequest): DiffResponse {
+    if (this.snapshots.length < 2 && !request.from) {
+      throw new Error("Not enough snapshots to compute a diff.");
+    }
+
+    const toSnapshot = request.to
+      ? this.findSnapshot(request.to)
+      : this.snapshots[this.snapshots.length - 1];
+
+    const fromSnapshot = request.from
+      ? this.findSnapshot(request.from)
+      : this.snapshots[this.snapshots.length - 2];
+
+    const filterUser = request.userId;
+
+    const differences: DiffEntry[] = [];
+    const seen = new Set<string>();
+
+    const fromEntries = Object.entries(fromSnapshot.state);
+    const toEntries = Object.entries(toSnapshot.state);
+
+    for (const [key, value] of fromEntries) {
+      if (filterUser && value.userId !== filterUser) {
+        continue;
+      }
+      seen.add(key);
+      const next = toSnapshot.state[key];
+      if (!next || JSON.stringify(next) !== JSON.stringify(value)) {
+        differences.push({
+          key,
+          userId: value.userId,
+          consentType: value.consentType,
+          channel: value.channel,
+          before: value,
+          after: next,
+        });
+      }
+    }
+
+    for (const [key, value] of toEntries) {
+      if (seen.has(key)) {
+        continue;
+      }
+      if (filterUser && value.userId !== filterUser) {
+        continue;
+      }
+      differences.push({
+        key,
+        userId: value.userId,
+        consentType: value.consentType,
+        channel: value.channel,
+        before: undefined,
+        after: value,
+      });
+    }
+
+    return {
+      fromSnapshot: fromSnapshot.id,
+      toSnapshot: toSnapshot.id,
+      differences,
+    };
+  }
+
+  public rollback(snapshotId: string): RollbackResult {
+    const snapshot = this.findSnapshot(snapshotId);
+    this.state = deserialiseState(snapshot.state);
+    this.processedRecordIds = new Set(snapshot.processedRecordIds);
+
+    const rollbackSnapshot = this.createSnapshot(`rollback:${snapshotId}`, []);
+
+    return {
+      restoredSnapshotId: rollbackSnapshot.id,
+      restoredFrom: snapshotId,
+    };
+  }
+
+  private processRecord(record: ConsentRecord): ReconciliationProof {
+    this.validateRecord(record);
+    const key = makeKey(record);
+    const appliedRules: AppliedRule[] = [];
+    const existing = this.state.get(key) ?? null;
+
+    if (this.processedRecordIds.has(record.recordId)) {
+      appliedRules.push({
+        rule: "DUPLICATE_RECORD",
+        description: `record ${record.recordId} was already processed and is ignored`,
+        winner: "none",
+      });
+
+      const graph = existing
+        ? buildGraphSnapshot(
+            record.userId,
+            record.consentType,
+            record.channel,
+            [existing],
+            this.sourcePrecedence,
+          )
+        : buildGraphSnapshot(
+            record.userId,
+            record.consentType,
+            record.channel,
+            [],
+            this.sourcePrecedence,
+          );
+
+      return {
+        recordId: record.recordId,
+        key,
+        userId: record.userId,
+        consentType: record.consentType,
+        channel: record.channel,
+        before: graph,
+        after: graph,
+        winningState: existing,
+        previousState: existing ?? undefined,
+        appliedRules,
+        changed: false,
+      };
+    }
+
+    const candidate: ConsentStateRecord = {
+      key,
+      userId: record.userId,
+      consentType: record.consentType,
+      channel: record.channel,
+      status: record.status,
+      source: record.source,
+      timestamp: record.timestamp,
+      provenance: {
+        recordId: record.recordId,
+        metadata: record.metadata ? { ...record.metadata } : undefined,
+      },
+    };
+
+    const beforeGraphCandidates = existing ? [existing, candidate] : [candidate];
+    const beforeGraph = buildGraphSnapshot(
+      record.userId,
+      record.consentType,
+      record.channel,
+      beforeGraphCandidates,
+      this.sourcePrecedence,
+    );
+
+    const { winner, changed, previousState } = this.resolve(existing, candidate, appliedRules);
+
+    if (winner && (changed || !existing)) {
+      this.state.set(key, winner);
+    }
+
+    this.processedRecordIds.add(record.recordId);
+
+    const afterState = this.state.get(key) ?? null;
+    const afterGraphCandidates = afterState ? [afterState] : [];
+    const afterGraph = buildGraphSnapshot(
+      record.userId,
+      record.consentType,
+      record.channel,
+      afterGraphCandidates,
+      this.sourcePrecedence,
+    );
+
+    return {
+      recordId: record.recordId,
+      key,
+      userId: record.userId,
+      consentType: record.consentType,
+      channel: record.channel,
+      before: beforeGraph,
+      after: afterGraph,
+      winningState: afterState,
+      previousState,
+      appliedRules,
+      changed,
+    };
+  }
+
+  private resolve(
+    existing: ConsentStateRecord | null,
+    candidate: ConsentStateRecord,
+    appliedRules: AppliedRule[],
+  ): { winner: ConsentStateRecord | null; changed: boolean; previousState?: ConsentStateRecord } {
+    if (!existing) {
+      appliedRules.push({
+        rule: "NO_PREVIOUS_STATE",
+        description: "no prior state existed; incoming record becomes the baseline",
+        winner: "incoming",
+      });
+      return { winner: candidate, changed: true };
+    }
+
+    let winner: "existing" | "incoming" = "existing";
+
+    const existingRank = precedenceRank(existing.source, this.sourcePrecedence);
+    const candidateRank = precedenceRank(candidate.source, this.sourcePrecedence);
+
+    if (candidateRank < existingRank) {
+      appliedRules.push({
+        rule: "SOURCE_PRECEDENCE",
+        description: `${candidate.source} outranks ${existing.source}`,
+        winner: "incoming",
+      });
+      winner = "incoming";
+    } else if (candidateRank > existingRank) {
+      appliedRules.push({
+        rule: "SOURCE_PRECEDENCE",
+        description: `${existing.source} outranks ${candidate.source}`,
+        winner: "existing",
+      });
+    } else {
+      const existingTime = parseTimestamp(existing.timestamp);
+      const candidateTime = parseTimestamp(candidate.timestamp);
+
+      if (candidateTime > existingTime) {
+        appliedRules.push({
+          rule: "RECENCY",
+          description: `incoming record is more recent (${candidate.timestamp} > ${existing.timestamp})`,
+          winner: "incoming",
+        });
+        winner = "incoming";
+      } else if (candidateTime < existingTime) {
+        appliedRules.push({
+          rule: "RECENCY",
+          description: `existing record is more recent (${existing.timestamp} >= ${candidate.timestamp})`,
+          winner: "existing",
+        });
+      } else {
+        const lexicalWinner = candidate.provenance.recordId.localeCompare(existing.provenance.recordId);
+        if (lexicalWinner > 0) {
+          appliedRules.push({
+            rule: "TIE_BREAKER",
+            description: `timestamps equal; higher lexical recordId ${candidate.provenance.recordId} wins`,
+            winner: "incoming",
+          });
+          winner = "incoming";
+        } else {
+          appliedRules.push({
+            rule: "TIE_BREAKER",
+            description: `timestamps equal; existing recordId ${existing.provenance.recordId} remains authoritative`,
+            winner: "existing",
+          });
+        }
+      }
+    }
+
+    if (winner === "existing") {
+      return { winner: existing, changed: false, previousState: existing };
+    }
+
+    return { winner: candidate, changed: true, previousState: existing };
+  }
+
+  private validateRecord(record: ConsentRecord) {
+    if (!record.recordId?.trim()) {
+      throw new Error("recordId is required");
+    }
+    if (!record.userId?.trim()) {
+      throw new Error("userId is required");
+    }
+    if (!record.consentType?.trim()) {
+      throw new Error("consentType is required");
+    }
+    if (!record.status?.trim()) {
+      throw new Error("status is required");
+    }
+    if (!record.source?.trim()) {
+      throw new Error("source is required");
+    }
+    parseTimestamp(record.timestamp);
+  }
+
+  private findSnapshot(id: string): Snapshot {
+    const snapshot = this.snapshots.find((entry) => entry.id === id);
+    if (!snapshot) {
+      throw new Error(`Snapshot ${id} was not found`);
+    }
+    return snapshot;
+  }
+
+  private createSnapshot(reason: string, proofs: ReconciliationProof[]): Snapshot {
+    const snapshot: Snapshot = {
+      id: uuid(),
+      createdAt: new Date().toISOString(),
+      reason,
+      state: serialiseState(this.state),
+      processedRecordIds: Array.from(this.processedRecordIds.values()),
+      proofs,
+    };
+    this.snapshots.push(snapshot);
+    return snapshot;
+  }
+}
+
+export default ConsentStateReconciler;

--- a/services/csr/src/types.ts
+++ b/services/csr/src/types.ts
@@ -1,0 +1,105 @@
+export type SourceSystem = "crm" | "app_sdk" | "partner" | (string & {});
+
+export interface ConsentRecord {
+  recordId: string;
+  source: SourceSystem;
+  userId: string;
+  consentType: string;
+  channel?: string;
+  status: string;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ConsentStateRecord {
+  key: string;
+  userId: string;
+  consentType: string;
+  channel?: string;
+  status: string;
+  source: SourceSystem;
+  timestamp: string;
+  provenance: {
+    recordId: string;
+    metadata?: Record<string, unknown>;
+  };
+}
+
+export interface GraphNode {
+  id: string;
+  type: "user" | "consent" | "source" | "record";
+  label: string;
+  data?: Record<string, unknown>;
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  label: string;
+  data?: Record<string, unknown>;
+}
+
+export interface GraphSnapshot {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+}
+
+export interface AppliedRule {
+  rule: string;
+  description: string;
+  winner?: "existing" | "incoming" | "none";
+}
+
+export interface ReconciliationProof {
+  recordId: string;
+  key: string;
+  userId: string;
+  consentType: string;
+  channel?: string;
+  before: GraphSnapshot;
+  after: GraphSnapshot;
+  winningState: ConsentStateRecord | null;
+  previousState?: ConsentStateRecord;
+  appliedRules: AppliedRule[];
+  changed: boolean;
+}
+
+export interface Snapshot {
+  id: string;
+  createdAt: string;
+  reason: string;
+  state: Record<string, ConsentStateRecord>;
+  processedRecordIds: string[];
+  proofs: ReconciliationProof[];
+}
+
+export interface DiffRequest {
+  from?: string;
+  to?: string;
+  userId?: string;
+}
+
+export interface DiffEntry {
+  key: string;
+  userId: string;
+  consentType: string;
+  channel?: string;
+  before?: ConsentStateRecord;
+  after?: ConsentStateRecord;
+}
+
+export interface DiffResponse {
+  fromSnapshot: string;
+  toSnapshot: string;
+  differences: DiffEntry[];
+}
+
+export interface IngestResult {
+  snapshotId: string;
+  proofs: ReconciliationProof[];
+}
+
+export interface RollbackResult {
+  restoredSnapshotId: string;
+  restoredFrom: string;
+}

--- a/services/csr/test/api.test.ts
+++ b/services/csr/test/api.test.ts
@@ -1,0 +1,42 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+import { createApp } from "../src/app";
+
+const record = {
+  recordId: "api-r-1",
+  userId: "api-user",
+  consentType: "sms",
+  status: "granted",
+  source: "crm",
+  timestamp: "2024-05-06T00:00:00Z",
+};
+
+describe("CSR HTTP API", () => {
+  it("ingests records, emits proofs, diff, and rollback", async () => {
+    const { app } = createApp();
+
+    const ingestResponse = await request(app)
+      .post("/ingest")
+      .send({ records: [record] })
+      .expect(201);
+
+    expect(ingestResponse.body.proofs[0].before.nodes.length).toBeGreaterThan(0);
+    expect(ingestResponse.body.proofs[0].after.nodes.length).toBeGreaterThan(0);
+    expect(ingestResponse.body.snapshotId).toBeTruthy();
+
+    const diffResponse = await request(app).get("/diff").expect(200);
+    expect(diffResponse.body.differences.length).toBeGreaterThan(0);
+
+    const rollbackResponse = await request(app)
+      .post("/rollback")
+      .send({ snapshotId: ingestResponse.body.snapshotId })
+      .expect(200);
+
+    expect(rollbackResponse.body.restoredFrom).toEqual(ingestResponse.body.snapshotId);
+
+    const snapshotsResponse = await request(app).get("/snapshots").expect(200);
+    const snapshotIds = snapshotsResponse.body.snapshots.map((snapshot: { id: string }) => snapshot.id);
+    expect(snapshotIds).toContain(ingestResponse.body.snapshotId);
+    expect(snapshotIds).toContain(rollbackResponse.body.restoredSnapshotId);
+  });
+});

--- a/services/csr/test/reconciler.test.ts
+++ b/services/csr/test/reconciler.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, beforeEach } from "vitest";
+import ConsentStateReconciler from "../src/reconciler";
+import { ConsentRecord } from "../src/types";
+
+const baseRecord = {
+  userId: "user-123",
+  consentType: "email_marketing",
+  channel: "email",
+};
+
+describe("ConsentStateReconciler", () => {
+  let reconciler: ConsentStateReconciler;
+
+  beforeEach(() => {
+    reconciler = new ConsentStateReconciler();
+  });
+
+  it("resolves conflicts using source precedence", () => {
+    const partnerRecord: ConsentRecord = {
+      ...baseRecord,
+      recordId: "r-1",
+      source: "partner",
+      status: "denied",
+      timestamp: "2024-05-01T00:00:00Z",
+    };
+
+    const crmRecord: ConsentRecord = {
+      ...baseRecord,
+      recordId: "r-2",
+      source: "crm",
+      status: "granted",
+      timestamp: "2024-05-01T01:00:00Z",
+    };
+
+    reconciler.ingest([partnerRecord]);
+    const result = reconciler.ingest([crmRecord]);
+
+    expect(result.proofs[0].winningState?.source).toEqual("crm");
+    expect(result.proofs[0].winningState?.status).toEqual("granted");
+    expect(
+      result.proofs[0].appliedRules.some(
+        (rule) => rule.rule === "SOURCE_PRECEDENCE" && rule.winner === "incoming",
+      ),
+    ).toBe(true);
+  });
+
+  it("uses recency when precedence ties", () => {
+    const oldRecord: ConsentRecord = {
+      ...baseRecord,
+      recordId: "r-3",
+      source: "app_sdk",
+      status: "denied",
+      timestamp: "2024-05-01T00:00:00Z",
+    };
+
+    const recentRecord: ConsentRecord = {
+      ...baseRecord,
+      recordId: "r-4",
+      source: "app_sdk",
+      status: "granted",
+      timestamp: "2024-05-02T00:00:00Z",
+    };
+
+    reconciler.ingest([oldRecord]);
+    const result = reconciler.ingest([recentRecord]);
+
+    expect(result.proofs[0].winningState?.status).toEqual("granted");
+    expect(result.proofs[0].changed).toBe(true);
+    expect(
+      result.proofs[0].appliedRules.some(
+        (rule) => rule.rule === "RECENCY" && rule.winner === "incoming",
+      ),
+    ).toBe(true);
+  });
+
+  it("ignores duplicate records deterministically", () => {
+    const record: ConsentRecord = {
+      ...baseRecord,
+      recordId: "r-5",
+      source: "crm",
+      status: "granted",
+      timestamp: "2024-05-03T00:00:00Z",
+    };
+
+    const first = reconciler.ingest([record]);
+    const second = reconciler.ingest([record]);
+
+    expect(first.proofs[0].changed).toBe(true);
+    expect(second.proofs[0].changed).toBe(false);
+    expect(
+      second.proofs[0].appliedRules.find((rule) => rule.rule === "DUPLICATE_RECORD")?.winner,
+    ).toEqual("none");
+  });
+
+  it("produces diff snapshots and supports rollback", () => {
+    const baselineRecord: ConsentRecord = {
+      ...baseRecord,
+      recordId: "r-6",
+      source: "crm",
+      status: "granted",
+      timestamp: "2024-05-04T00:00:00Z",
+    };
+
+    const updateRecord: ConsentRecord = {
+      ...baseRecord,
+      recordId: "r-7",
+      source: "crm",
+      status: "denied",
+      timestamp: "2024-05-05T00:00:00Z",
+    };
+
+    const baselineResult = reconciler.ingest([baselineRecord]);
+    const baselineSnapshotId = baselineResult.snapshotId;
+
+    reconciler.ingest([updateRecord]);
+
+    const diff = reconciler.diff({});
+
+    expect(diff.differences.length).toBeGreaterThan(0);
+
+    const rollbackResult = reconciler.rollback(baselineSnapshotId);
+    const current = reconciler.getCurrentSnapshot();
+    const targetSnapshot = reconciler
+      .listSnapshots()
+      .find((snapshot) => snapshot.id === baselineSnapshotId);
+
+    expect(rollbackResult.restoredFrom).toEqual(baselineSnapshotId);
+    expect(current.state).toEqual(targetSnapshot?.state);
+  });
+});

--- a/services/csr/tsconfig.json
+++ b/services/csr/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest/importMeta", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/services/csr/vitest.config.ts
+++ b/services/csr/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["test/**/*.test.ts"],
+    coverage: {
+      reporter: ["text", "json", "html"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add the consent state reconciler Node/TS service for reconciling CRM, SDK, and partner consent updates
- expose ingestion, diff, snapshot, and rollback APIs that emit reconciliation proofs with before/after graphs
- cover the reconciler and HTTP surfaces with Vitest suites and document usage in a dedicated README

## Testing
- npm test (services/csr)


------
https://chatgpt.com/codex/tasks/task_e_68d781cac6d0833380dbdaeb005e7e63