### PR TITLE
feat: add RTGH governance gate fuzzer

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility packages for Summit tooling."""

--- a/tools/rtgh/__init__.py
+++ b/tools/rtgh/__init__.py
@@ -1,0 +1,29 @@
+"""Red-Teamable Guard Harness (RTGH).
+
+This package provides a pluggable fuzzing harness that can exercise multiple
+categories of governance gates (RSR, PPC, MOCC, QPG, SRPL) through a unified
+interface.  It exposes the primary :class:`RTGHarness` along with helper data
+structures used to build payload grammars, constraint mutators, and reporting
+logic.
+"""
+
+from .config import FuzzConfig, SeededCanary
+from .grammar import PayloadGrammar
+from .mutators import ConstraintMutator, ProbabilityMutator
+from .adapters import GateAdapter, GateResult
+from .harness import RTGHarness
+from .report import FuzzReport, GateReport, BypassRecord
+
+__all__ = [
+    "FuzzConfig",
+    "SeededCanary",
+    "PayloadGrammar",
+    "ConstraintMutator",
+    "ProbabilityMutator",
+    "GateAdapter",
+    "GateResult",
+    "RTGHarness",
+    "FuzzReport",
+    "GateReport",
+    "BypassRecord",
+]

--- a/tools/rtgh/adapters.py
+++ b/tools/rtgh/adapters.py
@@ -1,0 +1,57 @@
+"""Adapters for interacting with governance gates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Protocol
+
+
+@dataclass
+class GateResult:
+    allowed: bool
+    severity: float
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_trace(self) -> Dict[str, Any]:
+        trace = {"allowed": self.allowed, "severity": self.severity}
+        if self.metadata:
+            trace["metadata"] = self.metadata
+        return trace
+
+
+class GateAdapter(Protocol):
+    """Protocol for pluggable gate adapters."""
+
+    name: str
+
+    def evaluate(self, payload: Any) -> GateResult:
+        """Return the evaluation result for *payload*."""
+
+    def trace_from(self, payload: Any, result: GateResult) -> Dict[str, Any]:
+        return {"gate": self.name, "payload": payload, "result": result.to_trace()}
+
+
+class InMemoryGateAdapter:
+    """Utility adapter for tests and dry-runs."""
+
+    def __init__(self, name: str, evaluator):
+        self.name = name
+        self._evaluator = evaluator
+        self._trace: List[Dict[str, Any]] = []
+
+    @property
+    def trace(self) -> List[Dict[str, Any]]:
+        return list(self._trace)
+
+    def evaluate(self, payload: Any) -> GateResult:  # type: ignore[override]
+        result = self._evaluator(payload)
+        if not isinstance(result, GateResult):
+            raise TypeError("Evaluator must return GateResult")
+        self._trace.append({"payload": payload, **result.to_trace()})
+        return result
+
+    def trace_from(self, payload: Any, result: GateResult) -> Dict[str, Any]:  # type: ignore[override]
+        return {"gate": self.name, "payload": payload, **result.to_trace()}
+
+
+__all__ = ["GateAdapter", "GateResult", "InMemoryGateAdapter"]

--- a/tools/rtgh/cli.py
+++ b/tools/rtgh/cli.py
@@ -1,0 +1,89 @@
+"""Command line entry point for RTGH."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from .config import FuzzConfig, SeededCanary
+from .grammar import PayloadGrammar, simple_dict_rule
+from .harness import RTGHarness
+from .mutators import ConstraintMutator
+
+
+def _load_config(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _load_adapters(import_path: str):
+    module_name, attr = import_path.rsplit(":", 1)
+    module = importlib.import_module(module_name)
+    adapters = getattr(module, attr)
+    if callable(adapters):
+        adapters = adapters()
+    return adapters
+
+
+def build_harness_from_config(config: Dict[str, Any]) -> RTGHarness:
+    grammar_rules = []
+    for rule in config.get("grammar", []):
+        grammar_rules.append(simple_dict_rule(rule["name"], rule["template"], rule.get("weight", 1)))
+    grammar = PayloadGrammar(grammar_rules)
+
+    mutators: List[ConstraintMutator] = []
+    config_mutators = config.get("mutators", [])
+    for mutator_config in config_mutators:
+        module_name, attr = mutator_config["callable"].rsplit(":", 1)
+        module = importlib.import_module(module_name)
+        factory = getattr(module, attr)
+        mutators.append(factory(**mutator_config.get("kwargs", {})))
+
+    seeded_canaries = [
+        SeededCanary(
+            gate=item["gate"],
+            payload=item["payload"],
+            severity=item.get("severity", 1.0),
+            metadata=item.get("metadata", {}),
+        )
+        for item in config.get("seeded_canaries", [])
+    ]
+
+    harness = RTGHarness(
+        adapters=_load_adapters(config["adapters"]),
+        grammar=grammar,
+        mutators=mutators,
+        config=FuzzConfig(
+            iterations=config.get("iterations", 128),
+            seed=config.get("seed", 0),
+            chained_seed=config.get("chained_seed"),
+            cross_gate_chance=config.get("cross_gate_chance", 0.35),
+            ci_mode=config.get("ci_mode", False),
+            seeded_canaries=seeded_canaries,
+        ),
+    )
+    return harness
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Red-Teamable Guard Harness")
+    parser.add_argument("config", type=Path, help="Path to RTGH JSON config")
+    parser.add_argument("--ci", action="store_true", help="Run in CI mode")
+    args = parser.parse_args(argv)
+
+    harness_config = _load_config(args.config)
+    if args.ci:
+        harness_config["ci_mode"] = True
+
+    harness = build_harness_from_config(harness_config)
+    report = harness.run()
+    output_path = Path(harness_config.get("output", "rtgh-report.json"))
+    output_path.write_bytes(report.to_bytes())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/rtgh/config.py
+++ b/tools/rtgh/config.py
@@ -1,0 +1,56 @@
+"""Configuration objects for the Red-Teamable Guard Harness (RTGH)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+
+@dataclass
+class SeededCanary:
+    """A deterministic payload expected to trigger a bypass.
+
+    Attributes
+    ----------
+    gate:
+        The canonical name of the target gate adapter.
+    payload:
+        Arbitrary payload delivered to the adapter.
+    severity:
+        The expected severity score contributed when the canary is bypassed.
+    metadata:
+        Optional additional information that will be propagated to reports.
+    """
+
+    gate: str
+    payload: Any
+    severity: float
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class FuzzConfig:
+    """Configuration controlling a fuzzing session."""
+
+    iterations: int = 128
+    seed: int = 0
+    chained_seed: Optional[int] = None
+    cross_gate_chance: float = 0.35
+    ci_mode: bool = False
+    seeded_canaries: Iterable[SeededCanary] = field(default_factory=list)
+    max_trace: int = 256
+    timeout_s: Optional[float] = None
+    score_weight: Callable[[float, float], float] = lambda bypass_rate, severity: bypass_rate
+
+    def build_rng_seeds(self) -> Dict[str, int]:
+        """Expose deterministic RNG seeds for sub-components."""
+
+        chained_seed = self.seed if self.chained_seed is None else self.chained_seed
+        return {
+            "payload": self.seed,
+            "mutation": self.seed ^ 0xDEADBEEF,
+            "chaining": chained_seed,
+        }
+
+
+DEFAULT_CONFIG = FuzzConfig()

--- a/tools/rtgh/grammar.py
+++ b/tools/rtgh/grammar.py
@@ -1,0 +1,81 @@
+"""Payload grammar helpers."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Sequence
+
+
+GeneratorFunc = Callable[["RandomLike"], Any]
+
+
+class RandomLike:
+    """Protocol subset for deterministic randomness."""
+
+    def choice(self, seq: Sequence[Any]) -> Any:
+        raise NotImplementedError
+
+    def random(self) -> float:
+        raise NotImplementedError
+
+    def randint(self, a: int, b: int) -> int:
+        raise NotImplementedError
+
+    def choices(
+        self, population: Sequence[Any], weights: Sequence[int] | None = None, k: int = 1
+    ) -> List[Any]:
+        raise NotImplementedError
+
+
+@dataclass
+class GrammarRule:
+    name: str
+    generator: GeneratorFunc
+    weight: int = 1
+
+
+@dataclass
+class PayloadGrammar:
+    """Composable payload grammar using weighted production rules."""
+
+    rules: Iterable[GrammarRule]
+    default_rule: GrammarRule | None = None
+
+    def __post_init__(self) -> None:
+        self._rules: List[GrammarRule] = list(self.rules)
+        if self.default_rule:
+            self._rules.append(self.default_rule)
+        if not self._rules:
+            raise ValueError("At least one grammar rule is required")
+        self._weights = [max(1, rule.weight) for rule in self._rules]
+
+    def generate(self, rng: RandomLike) -> Any:
+        rule = rng.choices(self._rules, weights=self._weights, k=1)[0]
+        payload = rule.generator(rng)
+        return copy.deepcopy(payload)
+
+    def extend(self, *rules: GrammarRule) -> "PayloadGrammar":
+        return PayloadGrammar([*self._rules, *rules])
+
+
+def simple_dict_rule(name: str, template: Dict[str, Any], weight: int = 1) -> GrammarRule:
+    def _generator(rng: RandomLike) -> Dict[str, Any]:
+        payload = {}
+        for key, value in template.items():
+            if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+                payload[key] = rng.choice(list(value))
+            elif callable(value):
+                payload[key] = value(rng)
+            else:
+                payload[key] = value
+        return payload
+
+    return GrammarRule(name=name, generator=_generator, weight=weight)
+
+
+__all__ = [
+    "GrammarRule",
+    "PayloadGrammar",
+    "simple_dict_rule",
+]

--- a/tools/rtgh/harness.py
+++ b/tools/rtgh/harness.py
@@ -1,0 +1,140 @@
+"""Main fuzzing harness for RTGH."""
+
+from __future__ import annotations
+
+import copy
+import random
+import time
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, MutableMapping, Sequence
+
+from .adapters import GateAdapter
+from .config import FuzzConfig
+from .grammar import PayloadGrammar
+from .mutators import ConstraintMutator
+from .report import BypassRecord, FuzzReport, GateReport
+
+
+@dataclass
+class FuzzState:
+    rng_payload: random.Random
+    rng_mutation: random.Random
+    rng_chaining: random.Random
+    bypass_payloads: MutableMapping[str, List[Dict[str, Any]]]
+
+
+class RTGHarness:
+    """Red-Teamable Guard Harness for governance gate fuzzing."""
+
+    def __init__(
+        self,
+        adapters: Sequence[GateAdapter],
+        grammar: PayloadGrammar,
+        mutators: Iterable[ConstraintMutator] | None = None,
+        config: FuzzConfig | None = None,
+    ) -> None:
+        if not adapters:
+            raise ValueError("At least one gate adapter is required")
+        self.adapters = list(adapters)
+        self.grammar = grammar
+        self.mutators = list(mutators or [])
+        self.config = config or FuzzConfig()
+
+    def _build_state(self) -> FuzzState:
+        seeds = self.config.build_rng_seeds()
+        return FuzzState(
+            rng_payload=random.Random(seeds["payload"]),
+            rng_mutation=random.Random(seeds["mutation"]),
+            rng_chaining=random.Random(seeds["chaining"]),
+            bypass_payloads=defaultdict(list),
+        )
+
+    def _apply_mutators(self, payload: Any, state: FuzzState) -> Any:
+        result = payload
+        for mutator in self.mutators:
+            result = mutator(result, state.rng_mutation)
+        return result
+
+    def _maybe_chain(self, payload: Any, state: FuzzState) -> Any:
+        if not state.bypass_payloads:
+            return payload
+        if state.rng_chaining.random() > self.config.cross_gate_chance:
+            return payload
+        donor_gate = state.rng_chaining.choice(list(state.bypass_payloads))
+        donor_payload = state.rng_chaining.choice(state.bypass_payloads[donor_gate])
+        if isinstance(payload, dict) and isinstance(donor_payload, dict):
+            chained = dict(payload)
+            chained.update({f"{donor_gate}_signal": copy.deepcopy(donor_payload)})
+            return chained
+        return copy.deepcopy(donor_payload)
+
+    def _run_canaries(self, state: FuzzState, reports: Dict[str, GateReport]) -> None:
+        for canary in self.config.seeded_canaries:
+            matching = [adapter for adapter in self.adapters if adapter.name == canary.gate]
+            if not matching:
+                continue
+            adapter = matching[0]
+            trace = []
+            result = adapter.evaluate(canary.payload)
+            trace.append(adapter.trace_from(canary.payload, result))
+            if result.allowed:
+                bypass = BypassRecord(
+                    gate=adapter.name,
+                    payload=canary.payload,
+                    severity=canary.severity,
+                    trace=trace,
+                    metadata={"canary": True, **canary.metadata},
+                )
+                reports[adapter.name].bypasses.append(bypass)
+                state.bypass_payloads[adapter.name].append(copy.deepcopy(canary.payload))
+            reports[adapter.name].total_cases += 1
+
+    def run(self) -> FuzzReport:
+        state = self._build_state()
+        gate_reports: Dict[str, GateReport] = {
+            adapter.name: GateReport(gate=adapter.name, total_cases=0)
+            for adapter in self.adapters
+        }
+
+        self._run_canaries(state, gate_reports)
+
+        start_time = time.monotonic()
+        for _ in range(self.config.iterations):
+            payload = self.grammar.generate(state.rng_payload)
+            payload = self._apply_mutators(payload, state)
+            payload = self._maybe_chain(payload, state)
+
+            for adapter in self.adapters:
+                trace: List[Dict[str, Any]] = []
+                result = adapter.evaluate(payload)
+                trace_entry = adapter.trace_from(payload, result)
+                trace.append(trace_entry)
+                gate_report = gate_reports[adapter.name]
+                gate_report.total_cases += 1
+                if result.allowed:
+                    bypass = BypassRecord(
+                        gate=adapter.name,
+                        payload=payload,
+                        severity=result.severity,
+                        trace=trace,
+                        metadata={"canary": False},
+                    )
+                    gate_report.bypasses.append(bypass)
+                    state.bypass_payloads[adapter.name].append(copy.deepcopy(payload))
+
+            if self.config.timeout_s is not None and (time.monotonic() - start_time) > self.config.timeout_s:
+                break
+
+        for report in gate_reports.values():
+            report.bypasses.sort(key=lambda record: (-record.severity, repr(record.payload)))
+
+        return FuzzReport(
+            seed=self.config.seed,
+            ci_mode=self.config.ci_mode,
+            gate_reports=[gate_reports[adapter.name] for adapter in self.adapters],
+            metadata={"iterations": self.config.iterations},
+        )
+
+
+__all__ = ["RTGHarness"]

--- a/tools/rtgh/mutators.py
+++ b/tools/rtgh/mutators.py
@@ -1,0 +1,66 @@
+"""Constraint-aware mutation helpers."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List
+
+from .grammar import RandomLike
+
+
+MutatorFunc = Callable[[Any, RandomLike], Any]
+
+
+@dataclass
+class ConstraintMutator:
+    """Encapsulates a mutation that respects pre-conditions."""
+
+    name: str
+    mutate: MutatorFunc
+    condition: Callable[[Any], bool] | None = None
+
+    def __call__(self, payload: Any, rng: RandomLike) -> Any:
+        candidate = copy.deepcopy(payload)
+        if self.condition and not self.condition(candidate):
+            return candidate
+        return self.mutate(candidate, rng)
+
+
+@dataclass
+class ProbabilityMutator(ConstraintMutator):
+    """Constraint mutator that fires based on a probability threshold."""
+
+    probability: float = 0.5
+
+    def __call__(self, payload: Any, rng: RandomLike) -> Any:  # type: ignore[override]
+        candidate = copy.deepcopy(payload)
+        if self.condition and not self.condition(candidate):
+            return candidate
+        if rng.random() <= self.probability:
+            return self.mutate(candidate, rng)
+        return candidate
+
+
+def field_flip_mutator(field: str, choices: Iterable[Any], name: str | None = None) -> ProbabilityMutator:
+    def _mutate(payload: Dict[str, Any], rng: RandomLike) -> Dict[str, Any]:
+        payload[field] = rng.choice(list(choices))
+        return payload
+
+    return ProbabilityMutator(name=name or f"flip-{field}", mutate=_mutate)
+
+
+def inject_flag_mutator(field: str, value: Any, name: str | None = None) -> ProbabilityMutator:
+    def _mutate(payload: Dict[str, Any], rng: RandomLike) -> Dict[str, Any]:
+        payload[field] = value
+        return payload
+
+    return ProbabilityMutator(name=name or f"inject-{field}", mutate=_mutate)
+
+
+__all__ = [
+    "ConstraintMutator",
+    "ProbabilityMutator",
+    "field_flip_mutator",
+    "inject_flag_mutator",
+]

--- a/tools/rtgh/report.py
+++ b/tools/rtgh/report.py
@@ -1,0 +1,83 @@
+"""Report primitives for RTGH."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List
+
+
+@dataclass
+class BypassRecord:
+    gate: str
+    payload: Any
+    severity: float
+    trace: List[Dict[str, Any]]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class GateReport:
+    gate: str
+    total_cases: int
+    bypasses: List[BypassRecord] = field(default_factory=list)
+
+    @property
+    def bypass_rate(self) -> float:
+        if self.total_cases == 0:
+            return 0.0
+        return len(self.bypasses) / float(self.total_cases)
+
+    @property
+    def average_severity(self) -> float:
+        if not self.bypasses:
+            return 0.0
+        return sum(record.severity for record in self.bypasses) / len(self.bypasses)
+
+    def unified_score(self) -> float:
+        return self.bypass_rate * self.average_severity
+
+
+@dataclass
+class FuzzReport:
+    seed: int
+    ci_mode: bool
+    gate_reports: List[GateReport]
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        gate_dicts = []
+        for gate_report in self.gate_reports:
+            gate_dicts.append(
+                {
+                    "gate": gate_report.gate,
+                    "total": gate_report.total_cases,
+                    "bypass_rate": gate_report.bypass_rate,
+                    "average_severity": gate_report.average_severity,
+                    "score": gate_report.unified_score(),
+                    "bypasses": [
+                        {
+                            "payload": record.payload,
+                            "severity": record.severity,
+                            "trace": record.trace,
+                            "metadata": record.metadata,
+                        }
+                        for record in gate_report.bypasses
+                    ],
+                }
+            )
+        return {
+            "seed": self.seed,
+            "ci_mode": self.ci_mode,
+            "metadata": self.metadata,
+            "gates": gate_dicts,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+    def to_bytes(self) -> bytes:
+        return self.to_json().encode("utf-8")
+
+
+__all__ = ["FuzzReport", "GateReport", "BypassRecord"]

--- a/tools/rtgh/tests/test_harness.py
+++ b/tools/rtgh/tests/test_harness.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.rtgh import (
+    FuzzConfig,
+    PayloadGrammar,
+    RTGHarness,
+    SeededCanary,
+)
+from tools.rtgh.adapters import GateResult, InMemoryGateAdapter
+from tools.rtgh.grammar import GrammarRule
+from tools.rtgh.mutators import field_flip_mutator, inject_flag_mutator
+
+
+@pytest.fixture
+def sample_adapters():
+    def rsr(payload):
+        if payload.get("action") == "grant" and payload.get("role") == "admin":
+            return GateResult(True, 0.9, {"reason": "privilege escalation"})
+        return GateResult(False, 0.0)
+
+    def qpg(payload):
+        if payload.get("quota", 0) > 5 and payload.get("region") == "restricted":
+            return GateResult(True, 0.6, {"reason": "quota override"})
+        return GateResult(False, 0.0)
+
+    return [
+        InMemoryGateAdapter("RSR", rsr),
+        InMemoryGateAdapter("QPG", qpg),
+    ]
+
+
+def build_grammar():
+    rules = [
+        GrammarRule(
+            name="baseline",
+            generator=lambda rng: {
+                "action": rng.choice(["audit", "grant", "revoke"]),
+                "role": rng.choice(["user", "auditor", "admin"]),
+                "quota": rng.randint(0, 10),
+                "region": rng.choice(["open", "restricted"]),
+            },
+            weight=4,
+        ),
+        GrammarRule(
+            name="elevate",
+            generator=lambda rng: {"action": "grant", "role": "user", "quota": rng.randint(0, 3), "region": "open"},
+            weight=1,
+        ),
+    ]
+    return PayloadGrammar(rules)
+
+
+def test_seeded_bypass_produces_stable_scores(sample_adapters):
+    grammar = build_grammar()
+    mutators = [
+        inject_flag_mutator("role", "admin", name="force-admin"),
+        field_flip_mutator("region", ["restricted", "open"], name="flip-region"),
+    ]
+
+    config = FuzzConfig(
+        iterations=32,
+        seed=1337,
+        ci_mode=False,
+        seeded_canaries=[
+            SeededCanary(gate="RSR", payload={"action": "grant", "role": "admin"}, severity=0.9),
+        ],
+    )
+
+    harness = RTGHarness(sample_adapters, grammar, mutators, config)
+    report = harness.run()
+
+    rsr_report = next(g for g in report.gate_reports if g.gate == "RSR")
+    assert rsr_report.bypass_rate > 0
+    assert rsr_report.average_severity > 0
+    assert pytest.approx(rsr_report.unified_score(), rel=1e-6) == rsr_report.unified_score()
+    assert any(record.metadata.get("canary") for record in rsr_report.bypasses)
+
+    rerun_report = RTGHarness(sample_adapters, grammar, mutators, config).run()
+    assert report.to_bytes() == rerun_report.to_bytes()
+
+
+def test_adapters_record_full_traces(sample_adapters):
+    grammar = build_grammar()
+    config = FuzzConfig(iterations=4, seed=7)
+    harness = RTGHarness(sample_adapters, grammar, [], config)
+    report = harness.run()
+
+    bypass_records = [record for gate in report.gate_reports for record in gate.bypasses]
+    if bypass_records:
+        trace = bypass_records[0].trace
+        assert trace, "trace should contain at least one entry"
+        assert trace[0]["gate"] in {adapter.name for adapter in sample_adapters}
+        assert "payload" in trace[0]
+
+
+def test_ci_mode_generates_stable_output(sample_adapters):
+    grammar = build_grammar()
+    config = FuzzConfig(iterations=8, seed=2024, ci_mode=True)
+    harness = RTGHarness(sample_adapters, grammar, [], config)
+    first = harness.run().to_bytes()
+    second = RTGHarness(sample_adapters, grammar, [], config).run().to_bytes()
+    assert first == second


### PR DESCRIPTION
## Summary
- add the Red-Teamable Guard Harness (RTGH) core with deterministic grammars, mutators, seeded canaries, and unified scoring
- expose a configurable CLI adapter loader for running RTGH with reproducible seeds and CI-friendly reporting
- cover RTGH with tests that verify seeded bypass discovery, trace capture, and byte-identical CI outputs

## Testing
- pytest tools/rtgh/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d7828ad5bc8333812a051870fa6063