### PR TITLE
feat: launch Topicality Collective marketing microsites

### DIFF
--- a/web/brands/companyos.html
+++ b/web/brands/companyos.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CompanyOS | Composable Operating System for Teams</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script defer src="../script.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-layout">
+        <a class="brand" href="../index.html">
+          <span class="brand-mark">OS</span>
+          <span class="brand-text">CompanyOS</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="sr-only">Toggle navigation</span>
+          ☰
+        </button>
+        <nav id="primary-navigation" class="site-nav">
+          <ul class="brand-nav">
+            <li><a href="./topicality-co.html">Topicality.co</a></li>
+            <li><a href="./topicality-llc.html">Topicality LLC</a></li>
+            <li><a href="./koshchei.html">Koshchei</a></li>
+            <li><a href="./stribog.html">Stribog</a></li>
+            <li><a href="./summit-co.html">Summit Co</a></li>
+            <li><a href="./summi7.html">Summi7</a></li>
+            <li><a href="./intelgraph.html">IntelGraph</a></li>
+            <li><a href="./mc.html">MC</a></li>
+            <li><a href="./companyos.html">CompanyOS</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero brand-hero brand-companyos">
+        <div class="container hero-content">
+          <div class="hero-copy">
+            <a class="brand-breadcrumb" href="../index.html">← Back to the collective</a>
+            <h1>The operating system for adaptive organizations</h1>
+            <p>
+              CompanyOS connects strategy, execution, and learning into a single composable platform.
+              Align teams, automate workflows, and measure impact across the Topicality ecosystem.
+            </p>
+            <div class="brand-badges">
+              <span class="brand-badge">Composable workflows</span>
+              <span class="brand-badge">Telemetry-driven</span>
+              <span class="brand-badge">Human-in-the-loop</span>
+            </div>
+            <div class="hero-actions">
+              <a class="button primary" href="#modules">Explore modules</a>
+              <a class="button ghost" href="../index.html#contact">Request access</a>
+            </div>
+          </div>
+          <div class="hero-card">
+            <h2>Why CompanyOS</h2>
+            <ul class="pill-list">
+              <li>Playbook automation</li>
+              <li>Copilot integration</li>
+              <li>Observability baked in</li>
+              <li>Enterprise security</li>
+            </ul>
+            <p class="hero-card-footnote">
+              CompanyOS powers transformation initiatives led by Summit Co, Summi7 experience
+              design, and IntelGraph intelligence workflows.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="container brand-overview">
+          <article>
+            <h2>Unified command</h2>
+            <p>
+              The platform orchestrates OKRs, projects, automation, and knowledge in one place. We
+              combine governance, collaboration, and AI assistance so leaders can pivot quickly
+              without sacrificing control.
+            </p>
+            <p>
+              CompanyOS natively integrates with the collective’s capabilities—IntelGraph data,
+              Stribog infrastructure, Koshchei security, and MC coaching—to keep every team aligned.
+            </p>
+          </article>
+          <aside>
+            <h3>Implementation waves</h3>
+            <ul class="detail-list">
+              <li>
+                <strong>Activate</strong>
+                Rapid configuration of workspaces, role models, and telemetry pipelines
+              </li>
+              <li>
+                <strong>Automate</strong>
+                Build automated playbooks, Summi7 copilots, and IntelGraph triggers
+              </li>
+              <li>
+                <strong>Amplify</strong>
+                Scale to partner ecosystems with governance guardrails and analytics
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section id="modules" class="section">
+        <div class="container">
+          <h2>Platform modules</h2>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Mission Control</h3>
+              <p>
+                Align strategy and execution with live dashboards, dependency mapping, and automated
+                check-ins.
+              </p>
+              <ul>
+                <li>Goal-to-work item linkage</li>
+                <li>Program health scoring</li>
+                <li>Scenario planning with IntelGraph data</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Copilot Studio</h3>
+              <p>
+                Deploy Summi7-designed copilots at scale with governance, telemetry, and human
+                supervision.
+              </p>
+              <ul>
+                <li>Role-based access policies</li>
+                <li>Prompt lifecycle management</li>
+                <li>Continuous learning loops</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Operational Automation</h3>
+              <p>
+                Automate repetitive workflows using low-code builders, Summit Co playbooks, and
+                integration libraries.
+              </p>
+              <ul>
+                <li>Cross-system orchestration</li>
+                <li>Compliance-aware automation</li>
+                <li>Audit-ready reporting</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--dark">
+        <div class="container cta-panel">
+          <div>
+            <h2>Compose your operating system</h2>
+            <p>
+              Partner with CompanyOS to align leaders, teams, and technology under a unified
+              operating model.
+            </p>
+          </div>
+          <div>
+            <a class="button primary" href="../index.html#contact">Request onboarding</a>
+            <p style="margin-top: 1rem; color: rgba(248, 250, 252, 0.75);">
+              Available as a managed service through Summit Co or direct license with Topicality LLC.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer brand-footer">
+      <div class="container footer-layout">
+        <div>
+          <span class="brand-foot">© <span id="current-year"></span> CompanyOS</span>
+          <p>The composable operating system of the Topicality Collective.</p>
+        </div>
+        <nav aria-label="Footer navigation">
+          <ul>
+            <li><a href="../index.html#brands">Brands</a></li>
+            <li><a href="../index.html#solutions">Solutions</a></li>
+            <li><a href="../index.html#insights">Insights</a></li>
+            <li><a href="../index.html#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/web/brands/intelgraph.html
+++ b/web/brands/intelgraph.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>IntelGraph | Intelligence Fusion Platform</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script defer src="../script.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-layout">
+        <a class="brand" href="../index.html">
+          <span class="brand-mark">IG</span>
+          <span class="brand-text">IntelGraph</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="sr-only">Toggle navigation</span>
+          ☰
+        </button>
+        <nav id="primary-navigation" class="site-nav">
+          <ul class="brand-nav">
+            <li><a href="./topicality-co.html">Topicality.co</a></li>
+            <li><a href="./topicality-llc.html">Topicality LLC</a></li>
+            <li><a href="./koshchei.html">Koshchei</a></li>
+            <li><a href="./stribog.html">Stribog</a></li>
+            <li><a href="./summit-co.html">Summit Co</a></li>
+            <li><a href="./summi7.html">Summi7</a></li>
+            <li><a href="./intelgraph.html">IntelGraph</a></li>
+            <li><a href="./mc.html">MC</a></li>
+            <li><a href="./companyos.html">CompanyOS</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero brand-hero brand-intelgraph">
+        <div class="container hero-content">
+          <div class="hero-copy">
+            <a class="brand-breadcrumb" href="../index.html">← Back to the collective</a>
+            <h1>The intelligence fusion engine for decisive action</h1>
+            <p>
+              IntelGraph unifies data from OSINT, proprietary sensors, and partner networks into a
+              living knowledge graph that powers investigations, decision support, and autonomous
+              operations.
+            </p>
+            <div class="brand-badges">
+              <span class="brand-badge">Knowledge graph</span>
+              <span class="brand-badge">AI analytics</span>
+              <span class="brand-badge">Mission workflows</span>
+            </div>
+            <div class="hero-actions">
+              <a class="button primary" href="#capabilities">Explore capabilities</a>
+              <a class="button ghost" href="../index.html#contact">Request a demo</a>
+            </div>
+          </div>
+          <div class="hero-card">
+            <h2>Platform highlights</h2>
+            <ul class="pill-list">
+              <li>Real-time ingest</li>
+              <li>Graph analytics</li>
+              <li>Investigation playbooks</li>
+              <li>Secure collaboration</li>
+            </ul>
+            <p class="hero-card-footnote">
+              IntelGraph is co-developed with analysts, operators, and mission owners to deliver
+              insight that is explainable, auditable, and actionable.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="container brand-overview">
+          <article>
+            <h2>Mission-ready platform</h2>
+            <p>
+              IntelGraph integrates with the broader Topicality ecosystem—Koshchei counter-ops,
+              Stribog infrastructure, Summi7 UX, and CompanyOS automation—to create a living digital
+              twin of your mission.
+            </p>
+            <p>
+              We provide secure environments, fine-grained access controls, and compliance tooling to
+              support public sector, enterprise, and coalition deployments.
+            </p>
+          </article>
+          <aside>
+            <h3>Deployment tiers</h3>
+            <ul class="detail-list">
+              <li>
+                <strong>IntelGraph Core</strong>
+                Rapid SaaS onboarding with curated data packs and analyst workspaces
+              </li>
+              <li>
+                <strong>IntelGraph Sovereign</strong>
+                Dedicated, sovereign-controlled regions with Stribog infrastructure and custom SLAs
+              </li>
+              <li>
+                <strong>IntelGraph Embedded</strong>
+                Edge-deployable package with offline sync for contested operations
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section id="capabilities" class="section">
+        <div class="container">
+          <h2>Platform capabilities</h2>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Signal Fusion Engine</h3>
+              <p>
+                Ingests structured and unstructured data at scale, applies entity resolution, and
+                links signals across time, geography, and intent.
+              </p>
+              <ul>
+                <li>Automated tradecraft templates</li>
+                <li>Live confidence scoring</li>
+                <li>AI-assisted anomaly detection</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Mission Workflows</h3>
+              <p>
+                Configurable workspaces for investigations, crisis response, and executive briefings
+                with audit-ready trails.
+              </p>
+              <ul>
+                <li>Collaborative timeline builder</li>
+                <li>Embedded Summi7 copilots</li>
+                <li>Secure document and media vault</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Decision Support Layer</h3>
+              <p>
+                Scenario planning and risk forecasting fused with Summit Co transformation playbooks
+                to drive confident decisions.
+              </p>
+              <ul>
+                <li>Dynamic dashboards</li>
+                <li>What-if simulations</li>
+                <li>Automated briefing generation</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--dark">
+        <div class="container cta-panel">
+          <div>
+            <h2>See IntelGraph in action</h2>
+            <p>
+              Request a guided demonstration featuring your data sources and mission scenarios.
+              IntelGraph teams will tailor the experience to your needs.
+            </p>
+          </div>
+          <div>
+            <a class="button primary" href="../index.html#contact">Book a private demo</a>
+            <p style="margin-top: 1rem; color: rgba(248, 250, 252, 0.75);">
+              Optionally include Summi7 design and Koshchei security advisors for full lifecycle
+              planning.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer brand-footer">
+      <div class="container footer-layout">
+        <div>
+          <span class="brand-foot">© <span id="current-year"></span> IntelGraph</span>
+          <p>The intelligence fusion platform of the Topicality Collective.</p>
+        </div>
+        <nav aria-label="Footer navigation">
+          <ul>
+            <li><a href="../index.html#brands">Brands</a></li>
+            <li><a href="../index.html#solutions">Solutions</a></li>
+            <li><a href="../index.html#insights">Insights</a></li>
+            <li><a href="../index.html#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/web/brands/koshchei.html
+++ b/web/brands/koshchei.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Koshchei | Counter-Operations & Resilience Lab</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script defer src="../script.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-layout">
+        <a class="brand" href="../index.html">
+          <span class="brand-mark">K</span>
+          <span class="brand-text">Koshchei</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="sr-only">Toggle navigation</span>
+          ☰
+        </button>
+        <nav id="primary-navigation" class="site-nav">
+          <ul class="brand-nav">
+            <li><a href="./topicality-co.html">Topicality.co</a></li>
+            <li><a href="./topicality-llc.html">Topicality LLC</a></li>
+            <li><a href="./koshchei.html">Koshchei</a></li>
+            <li><a href="./stribog.html">Stribog</a></li>
+            <li><a href="./summit-co.html">Summit Co</a></li>
+            <li><a href="./summi7.html">Summi7</a></li>
+            <li><a href="./intelgraph.html">IntelGraph</a></li>
+            <li><a href="./mc.html">MC</a></li>
+            <li><a href="./companyos.html">CompanyOS</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero brand-hero brand-koshchei">
+        <div class="container hero-content">
+          <div class="hero-copy">
+            <a class="brand-breadcrumb" href="../index.html">← Back to the collective</a>
+            <h1>Red team mastery engineered for contested domains</h1>
+            <p>
+              Koshchei is the counter-operations laboratory for the collective. We design, test, and
+              deploy advanced adversary simulations, deception detection, and resilience hardening
+              for national security and critical infrastructure partners.
+            </p>
+            <div class="brand-badges">
+              <span class="brand-badge">Adversary emulation</span>
+              <span class="brand-badge">Cognitive security</span>
+              <span class="brand-badge">Mission resilience</span>
+            </div>
+            <div class="hero-actions">
+              <a class="button primary" href="#arsenal">Review the arsenal</a>
+              <a class="button ghost" href="../index.html#contact">Schedule a threat workshop</a>
+            </div>
+          </div>
+          <div class="hero-card">
+            <h2>Defense elevation</h2>
+            <ul class="pill-list">
+              <li>Zero-day hunt cells</li>
+              <li>Psyops countermeasures</li>
+              <li>Red/blue/purple teaming</li>
+              <li>Resilience scoring</li>
+            </ul>
+            <p class="hero-card-footnote">
+              Every campaign is co-designed with your security leadership, with live telemetry fed
+              into IntelGraph for cross-mission intelligence.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="container brand-overview">
+          <article>
+            <h2>Operating philosophy</h2>
+            <p>
+              Resilience is earned by understanding the adversary's incentives. Koshchei builds
+              bespoke threat models that fuse cyber, cognitive, and physical vectors, then pressure
+              tests systems until vulnerabilities are exposed and remediated.
+            </p>
+            <p>
+              We partner with mission owners across defense, energy, finance, and emerging tech to
+              build response playbooks that are resilient under stress and legally defensible.
+            </p>
+          </article>
+          <aside>
+            <h3>Mission statistics</h3>
+            <ul class="detail-list">
+              <li>
+                <strong>Global coverage</strong>
+                4 continents, 20+ cross-border engagements annually
+              </li>
+              <li>
+                <strong>Specializations</strong>
+                OT/ICS, hybrid warfare, influence operations, secure communications
+              </li>
+              <li>
+                <strong>Integration</strong>
+                Seamless tie-ins with Stribog infrastructure and IntelGraph intelligence layers
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section id="arsenal" class="section">
+        <div class="container">
+          <h2>Koshchei arsenal</h2>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Mythos Range</h3>
+              <p>
+                Continuous adversary emulation environment replicating state and non-state threat
+                actors to evaluate cyber and human countermeasures.
+              </p>
+              <ul>
+                <li>Full-spectrum attack chains</li>
+                <li>Customizable rules of engagement</li>
+                <li>Real-time executive dashboards</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Counter-Psyops Cell</h3>
+              <p>
+                Rapid detection and neutralization of influence operations through narrative
+                tracking, payload attribution, and response frameworks.
+              </p>
+              <ul>
+                <li>Influence pattern recognition</li>
+                <li>Cross-platform signal ingestion</li>
+                <li>Proactive narrative defense</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Resilience Forge</h3>
+              <p>
+                Collaborative sessions aligning engineering, communications, and leadership on
+                hardening priorities with measurable impact.
+              </p>
+              <ul>
+                <li>Attack surface baselining</li>
+                <li>Remediation sprints</li>
+                <li>Executive-grade reporting</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--dark">
+        <div class="container cta-panel">
+          <div>
+            <h2>Test your resilience under live fire</h2>
+            <p>
+              Engage Koshchei to simulate your most likely adversaries and reveal blind spots before
+              they do.
+            </p>
+          </div>
+          <div>
+            <a class="button primary" href="../index.html#contact">Request an engagement</a>
+            <p style="margin-top: 1rem; color: rgba(248, 250, 252, 0.75);">
+              Secure coordination protocols available upon request; clearance-ready teams on call.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer brand-footer">
+      <div class="container footer-layout">
+        <div>
+          <span class="brand-foot">© <span id="current-year"></span> Koshchei</span>
+          <p>Counter-operations excellence within the Topicality Collective.</p>
+        </div>
+        <nav aria-label="Footer navigation">
+          <ul>
+            <li><a href="../index.html#brands">Brands</a></li>
+            <li><a href="../index.html#solutions">Solutions</a></li>
+            <li><a href="../index.html#insights">Insights</a></li>
+            <li><a href="../index.html#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/web/brands/mc.html
+++ b/web/brands/mc.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MC | Mastery Collective for Leadership & Operations</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script defer src="../script.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-layout">
+        <a class="brand" href="../index.html">
+          <span class="brand-mark">MC</span>
+          <span class="brand-text">Mastery Collective</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="sr-only">Toggle navigation</span>
+          ☰
+        </button>
+        <nav id="primary-navigation" class="site-nav">
+          <ul class="brand-nav">
+            <li><a href="./topicality-co.html">Topicality.co</a></li>
+            <li><a href="./topicality-llc.html">Topicality LLC</a></li>
+            <li><a href="./koshchei.html">Koshchei</a></li>
+            <li><a href="./stribog.html">Stribog</a></li>
+            <li><a href="./summit-co.html">Summit Co</a></li>
+            <li><a href="./summi7.html">Summi7</a></li>
+            <li><a href="./intelgraph.html">IntelGraph</a></li>
+            <li><a href="./mc.html">MC</a></li>
+            <li><a href="./companyos.html">CompanyOS</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero brand-hero brand-mc">
+        <div class="container hero-content">
+          <div class="hero-copy">
+            <a class="brand-breadcrumb" href="../index.html">← Back to the collective</a>
+            <h1>Executive mastery for modern command centers</h1>
+            <p>
+              MC coaches leaders, operators, and boards through high-stakes environments. We craft
+              playbooks, training, and command center experiences that deliver calm amid complexity.
+            </p>
+            <div class="brand-badges">
+              <span class="brand-badge">Executive coaching</span>
+              <span class="brand-badge">Mission rehearsals</span>
+              <span class="brand-badge">Command centers</span>
+            </div>
+            <div class="hero-actions">
+              <a class="button primary" href="#programs">Review programs</a>
+              <a class="button ghost" href="../index.html#contact">Plan a mastery session</a>
+            </div>
+          </div>
+          <div class="hero-card">
+            <h2>Core services</h2>
+            <ul class="pill-list">
+              <li>Leadership guilds</li>
+              <li>Scenario rehearsals</li>
+              <li>Decision theater design</li>
+              <li>Organizational coaching</li>
+            </ul>
+            <p class="hero-card-footnote">
+              MC integrates insights from the entire collective, ensuring leaders can leverage
+              intelligence, infrastructure, and automation with confidence.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="container brand-overview">
+          <article>
+            <h2>What we deliver</h2>
+            <p>
+              From boardrooms to tactical operations centers, MC equips teams with the mental models,
+              rituals, and tools to navigate volatility. We facilitate alignment across technology,
+              talent, and mission objectives.
+            </p>
+            <p>
+              MC is the human layer of the collective—translating advanced platforms into
+              high-performing teams.
+            </p>
+          </article>
+          <aside>
+            <h3>Guild offerings</h3>
+            <ul class="detail-list">
+              <li>
+                <strong>Executive guild</strong>
+                Peer coaching, leadership diagnostics, and strategic advising
+              </li>
+              <li>
+                <strong>Operations guild</strong>
+                Command center design, rehearsal choreography, and decision support workflows
+              </li>
+              <li>
+                <strong>Crisis guild</strong>
+                Scenario planning, war-room facilitation, and resilience storytelling
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section id="programs" class="section">
+        <div class="container">
+          <h2>Programs</h2>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Command Center Blueprint</h3>
+              <p>
+                Design and launch mission control environments that synthesize IntelGraph data,
+                CompanyOS automation, and Stribog infrastructure for real-time insight.
+              </p>
+              <ul>
+                <li>Human-centered space planning</li>
+                <li>Technology integration roadmap</li>
+                <li>Scenario rehearsal kits</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Executive Resilience Lab</h3>
+              <p>
+                Immersive workshops preparing leadership teams to communicate, decide, and lead during
+                disruption.
+              </p>
+              <ul>
+                <li>Media and stakeholder simulations</li>
+                <li>Decision heuristics training</li>
+                <li>Personal resilience coaching</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Operator Mastery Pathways</h3>
+              <p>
+                Role-based development for analysts, responders, and operations staff with Summi7
+                learning experiences and CompanyOS instrumentation.
+              </p>
+              <ul>
+                <li>Competency mapping</li>
+                <li>Hands-on labs</li>
+                <li>Performance telemetry dashboards</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--dark">
+        <div class="container cta-panel">
+          <div>
+            <h2>Unlock your command advantage</h2>
+            <p>
+              Engage MC to design leadership programs and command centers tailored to your mission.
+            </p>
+          </div>
+          <div>
+            <a class="button primary" href="../index.html#contact">Request a mastery consult</a>
+            <p style="margin-top: 1rem; color: rgba(248, 250, 252, 0.75);">
+              Confidential engagements available for public and private sector leaders.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer brand-footer">
+      <div class="container footer-layout">
+        <div>
+          <span class="brand-foot">© <span id="current-year"></span> Mastery Collective</span>
+          <p>Leadership excellence from the Topicality Collective.</p>
+        </div>
+        <nav aria-label="Footer navigation">
+          <ul>
+            <li><a href="../index.html#brands">Brands</a></li>
+            <li><a href="../index.html#solutions">Solutions</a></li>
+            <li><a href="../index.html#insights">Insights</a></li>
+            <li><a href="../index.html#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/web/brands/stribog.html
+++ b/web/brands/stribog.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Stribog | Sovereign Cloud & Edge Infrastructure</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script defer src="../script.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-layout">
+        <a class="brand" href="../index.html">
+          <span class="brand-mark">S</span>
+          <span class="brand-text">Stribog</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="sr-only">Toggle navigation</span>
+          ☰
+        </button>
+        <nav id="primary-navigation" class="site-nav">
+          <ul class="brand-nav">
+            <li><a href="./topicality-co.html">Topicality.co</a></li>
+            <li><a href="./topicality-llc.html">Topicality LLC</a></li>
+            <li><a href="./koshchei.html">Koshchei</a></li>
+            <li><a href="./stribog.html">Stribog</a></li>
+            <li><a href="./summit-co.html">Summit Co</a></li>
+            <li><a href="./summi7.html">Summi7</a></li>
+            <li><a href="./intelgraph.html">IntelGraph</a></li>
+            <li><a href="./mc.html">MC</a></li>
+            <li><a href="./companyos.html">CompanyOS</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero brand-hero brand-stribog">
+        <div class="container hero-content">
+          <div class="hero-copy">
+            <a class="brand-breadcrumb" href="../index.html">← Back to the collective</a>
+            <h1>Sovereign cloud built for austere environments</h1>
+            <p>
+              Stribog engineers distributed, climate-resilient infrastructure that keeps missions
+              online—from alpine command posts to maritime operations and emerging markets.
+            </p>
+            <div class="brand-badges">
+              <span class="brand-badge">Edge-to-cloud</span>
+              <span class="brand-badge">Zero-trust architecture</span>
+              <span class="brand-badge">Sovereign compliance</span>
+            </div>
+            <div class="hero-actions">
+              <a class="button primary" href="#platforms">Survey platforms</a>
+              <a class="button ghost" href="../index.html#contact">Plan a deployment</a>
+            </div>
+          </div>
+          <div class="hero-card">
+            <h2>Infrastructure stack</h2>
+            <ul class="pill-list">
+              <li>Modular data centers</li>
+              <li>Hardened networking</li>
+              <li>Continuous observability</li>
+              <li>Autonomous recovery</li>
+            </ul>
+            <p class="hero-card-footnote">
+              Designed with Koshchei counter-operations experts to ensure resilience against both
+              physical and cyber attack surfaces.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="container brand-overview">
+          <article>
+            <h2>Field-proven delivery</h2>
+            <p>
+              Our engineers design, deploy, and operate sovereign-grade cloud regions and forward
+              edge enclaves. Stribog solutions interoperate with national infrastructure, partner
+              coalitions, and contested environments where connectivity and supply chains are at
+              risk.
+            </p>
+            <p>
+              We combine ruggedized hardware, mesh networking, and remote orchestration with a
+              relentless focus on mission assurance and compliance.
+            </p>
+          </article>
+          <aside>
+            <h3>Deployment options</h3>
+            <ul class="detail-list">
+              <li>
+                <strong>TerraPods</strong>
+                Rapidly deployable modular data centers with integrated power and cooling
+              </li>
+              <li>
+                <strong>SkyMesh</strong>
+                High-availability aerial and satellite relay network with self-healing routes
+              </li>
+              <li>
+                <strong>HarborEdge</strong>
+                Maritime-grade compute stacks for offshore, naval, and logistics operations
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section id="platforms" class="section">
+        <div class="container">
+          <h2>Stribog platforms</h2>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Boreal Cloud</h3>
+              <p>
+                Sovereign cloud platform offering secure compute, storage, and AI workloads with
+                data residency guarantees and automated compliance reporting.
+              </p>
+              <ul>
+                <li>Multi-domain isolation</li>
+                <li>Hardware attestation pipeline</li>
+                <li>Integrated observability fabric</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Outpost Signal</h3>
+              <p>
+                Edge orchestration system enabling disconnected or denied environments to run
+                mission software with autonomous sync to headquarters.
+              </p>
+              <ul>
+                <li>Mesh-aware deployment engine</li>
+                <li>Bandwidth-optimized replication</li>
+                <li>Disaster recovery in minutes</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Shieldline</h3>
+              <p>
+                Managed defense service combining Stribog infrastructure with Koshchei threat
+                hunting and IntelGraph telemetry for end-to-end protection.
+              </p>
+              <ul>
+                <li>24/7 mission operations center</li>
+                <li>Joint threat-hunting teams</li>
+                <li>Executive resilience reporting</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--dark">
+        <div class="container cta-panel">
+          <div>
+            <h2>Architect for contested environments</h2>
+            <p>
+              Work with Stribog to design infrastructure that thrives when networks are degraded and
+              stakes are highest.
+            </p>
+          </div>
+          <div>
+            <a class="button primary" href="../index.html#contact">Coordinate a design session</a>
+            <p style="margin-top: 1rem; color: rgba(248, 250, 252, 0.75);">
+              Joint workshops available with Koshchei and Summit Co for holistic mission planning.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer brand-footer">
+      <div class="container footer-layout">
+        <div>
+          <span class="brand-foot">© <span id="current-year"></span> Stribog</span>
+          <p>Resilient infrastructure for the Topicality Collective.</p>
+        </div>
+        <nav aria-label="Footer navigation">
+          <ul>
+            <li><a href="../index.html#brands">Brands</a></li>
+            <li><a href="../index.html#solutions">Solutions</a></li>
+            <li><a href="../index.html#insights">Insights</a></li>
+            <li><a href="../index.html#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/web/brands/summi7.html
+++ b/web/brands/summi7.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Summi7 | Human-Centered Copilot Design Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script defer src="../script.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-layout">
+        <a class="brand" href="../index.html">
+          <span class="brand-mark">Ξ</span>
+          <span class="brand-text">Summi7</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="sr-only">Toggle navigation</span>
+          ☰
+        </button>
+        <nav id="primary-navigation" class="site-nav">
+          <ul class="brand-nav">
+            <li><a href="./topicality-co.html">Topicality.co</a></li>
+            <li><a href="./topicality-llc.html">Topicality LLC</a></li>
+            <li><a href="./koshchei.html">Koshchei</a></li>
+            <li><a href="./stribog.html">Stribog</a></li>
+            <li><a href="./summit-co.html">Summit Co</a></li>
+            <li><a href="./summi7.html">Summi7</a></li>
+            <li><a href="./intelgraph.html">IntelGraph</a></li>
+            <li><a href="./mc.html">MC</a></li>
+            <li><a href="./companyos.html">CompanyOS</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero brand-hero brand-summi7">
+        <div class="container hero-content">
+          <div class="hero-copy">
+            <a class="brand-breadcrumb" href="../index.html">← Back to the collective</a>
+            <h1>Copilots designed for trust, precision, and speed</h1>
+            <p>
+              Summi7 crafts human-in-the-loop AI experiences that empower decision-makers, analysts,
+              and operators. We blend ethnographic research, systems thinking, and rapid prototyping
+              to launch copilots people love.
+            </p>
+            <div class="brand-badges">
+              <span class="brand-badge">Human-centered AI</span>
+              <span class="brand-badge">UX research</span>
+              <span class="brand-badge">Copilot orchestration</span>
+            </div>
+            <div class="hero-actions">
+              <a class="button primary" href="#studio">Tour the studio</a>
+              <a class="button ghost" href="../index.html#contact">Launch a copilot</a>
+            </div>
+          </div>
+          <div class="hero-card">
+            <h2>Design tenets</h2>
+            <ul class="pill-list">
+              <li>Transparent intelligence</li>
+              <li>Human override pathways</li>
+              <li>Adaptive personalization</li>
+              <li>Mission-grade guardrails</li>
+            </ul>
+            <p class="hero-card-footnote">
+              Summi7 works closely with CompanyOS and IntelGraph teams to deliver copilots that are
+              explainable, compliant, and continuously improving.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="container brand-overview">
+          <article>
+            <h2>Studio capabilities</h2>
+            <p>
+              We field interdisciplinary squads—researchers, strategists, designers, prompt
+              engineers, and creative technologists—who embed with your teams to understand the
+              mission and co-design AI assistance that augments human strengths.
+            </p>
+            <p>
+              Our approach is grounded in measurable trust, ethical AI principles, and continuous
+              improvement loops informed by telemetry.
+            </p>
+          </article>
+          <aside>
+            <h3>Engagement blueprint</h3>
+            <ul class="detail-list">
+              <li>
+                <strong>Discovery</strong>
+                Field research, workflow mapping, and opportunity framing
+              </li>
+              <li>
+                <strong>Design &amp; validation</strong>
+                Prototyping, usability labs, policy and compliance reviews
+              </li>
+              <li>
+                <strong>Launch &amp; evolution</strong>
+                Copilot deployment, training, and performance tuning with CompanyOS telemetry
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section id="studio" class="section">
+        <div class="container">
+          <h2>Studio programs</h2>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Executive Copilot Lab</h3>
+              <p>
+                Build bespoke copilots for leadership teams that integrate strategic intelligence,
+                financial signals, and operational telemetry.
+              </p>
+              <ul>
+                <li>Confidential discovery sessions</li>
+                <li>Persona-driven design</li>
+                <li>Governance and controls</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Analyst Augmentation</h3>
+              <p>
+                Pair IntelGraph data models with Summi7 workflows to accelerate investigations,
+                reporting, and scenario planning.
+              </p>
+              <ul>
+                <li>Prompt engineering sprints</li>
+                <li>Explainable recommendations</li>
+                <li>Embedded analyst feedback loops</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Field Operations Assist</h3>
+              <p>
+                Deliver responsive copilots to teams in the field via Stribog edge infrastructure and
+                secure communications.
+              </p>
+              <ul>
+                <li>Offline-first design</li>
+                <li>Context-aware responses</li>
+                <li>Mission-critical UI systems</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--dark">
+        <div class="container cta-panel">
+          <div>
+            <h2>Prototype your copilot with Summi7</h2>
+            <p>
+              Engage the studio for a rapid concept sprint. We co-create, test, and deliver a pilot
+              experience in under six weeks.
+            </p>
+          </div>
+          <div>
+            <a class="button primary" href="../index.html#contact">Start a concept sprint</a>
+            <p style="margin-top: 1rem; color: rgba(248, 250, 252, 0.75);">
+              Integrations with CompanyOS, IntelGraph, and Summit Co available from day one.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer brand-footer">
+      <div class="container footer-layout">
+        <div>
+          <span class="brand-foot">© <span id="current-year"></span> Summi7</span>
+          <p>Human-centered AI experiences from the Topicality Collective.</p>
+        </div>
+        <nav aria-label="Footer navigation">
+          <ul>
+            <li><a href="../index.html#brands">Brands</a></li>
+            <li><a href="../index.html#solutions">Solutions</a></li>
+            <li><a href="../index.html#insights">Insights</a></li>
+            <li><a href="../index.html#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/web/brands/summit-co.html
+++ b/web/brands/summit-co.html
@@ -1,0 +1,193 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Summit Co | Transformation & Mission Delivery Partners</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script defer src="../script.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-layout">
+        <a class="brand" href="../index.html">
+          <span class="brand-mark">Σ</span>
+          <span class="brand-text">Summit Co</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="sr-only">Toggle navigation</span>
+          ☰
+        </button>
+        <nav id="primary-navigation" class="site-nav">
+          <ul class="brand-nav">
+            <li><a href="./topicality-co.html">Topicality.co</a></li>
+            <li><a href="./topicality-llc.html">Topicality LLC</a></li>
+            <li><a href="./koshchei.html">Koshchei</a></li>
+            <li><a href="./stribog.html">Stribog</a></li>
+            <li><a href="./summit-co.html">Summit Co</a></li>
+            <li><a href="./summi7.html">Summi7</a></li>
+            <li><a href="./intelgraph.html">IntelGraph</a></li>
+            <li><a href="./mc.html">MC</a></li>
+            <li><a href="./companyos.html">CompanyOS</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero brand-hero brand-summit-co">
+        <div class="container hero-content">
+          <div class="hero-copy">
+            <a class="brand-breadcrumb" href="../index.html">← Back to the collective</a>
+            <h1>Transformation partners for complex missions</h1>
+            <p>
+              Summit Co activates cross-functional teams to modernize operating models, scale digital
+              products, and guide missions through the summit of change.
+            </p>
+            <div class="brand-badges">
+              <span class="brand-badge">Operating model design</span>
+              <span class="brand-badge">Program acceleration</span>
+              <span class="brand-badge">Executive enablement</span>
+            </div>
+            <div class="hero-actions">
+              <a class="button primary" href="#engagements">View engagement patterns</a>
+              <a class="button ghost" href="../index.html#contact">Book a readiness review</a>
+            </div>
+          </div>
+          <div class="hero-card">
+            <h2>Transformation pillars</h2>
+            <ul class="pill-list">
+              <li>Strategy activation</li>
+              <li>Product &amp; platform delivery</li>
+              <li>Change enablement</li>
+              <li>Value realization</li>
+            </ul>
+            <p class="hero-card-footnote">
+              Summit Co assembles integrated squads from across the collective to tackle technology,
+              process, and culture in unison.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="container brand-overview">
+          <article>
+            <h2>Approach</h2>
+            <p>
+              We combine experience from enterprise transformations, startup scaling, and mission
+              critical operations. Every engagement begins with an immersion, followed by a jointly
+              authored ascent plan that sequences people, process, data, and technology milestones.
+            </p>
+            <p>
+              Summit Co leverages IntelGraph, CompanyOS, and Summi7 to embed data-driven decisioning
+              and human-centered experiences across the journey.
+            </p>
+          </article>
+          <aside>
+            <h3>Engagement cadence</h3>
+            <ul class="detail-list">
+              <li>
+                <strong>Discovery sprint</strong>
+                21-day diagnostic covering strategy, architecture, culture, and metrics
+              </li>
+              <li>
+                <strong>Transformation runway</strong>
+                90-day execution loops with integrated change management
+              </li>
+              <li>
+                <strong>Summit stewardship</strong>
+                Ongoing governance, portfolio management, and value tracking
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section id="engagements" class="section">
+        <div class="container">
+          <h2>Engagement patterns</h2>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Mission Operating System</h3>
+              <p>
+                Design and deploy an integrated operating model powered by CompanyOS and IntelGraph
+                for unified planning, execution, and intelligence.
+              </p>
+              <ul>
+                <li>Cross-functional fusion cells</li>
+                <li>Outcome-driven governance</li>
+                <li>Instrumentation from day one</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Digital Product Lift-Off</h3>
+              <p>
+                Launch or relaunch digital products with dedicated squads that cover discovery to
+                adoption, pairing Summi7 design with Summit Co delivery leadership.
+              </p>
+              <ul>
+                <li>Value hypothesis validation</li>
+                <li>Full-stack build-and-run teams</li>
+                <li>Customer success orchestration</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Enterprise Resilience Reset</h3>
+              <p>
+                Align technology, security, and culture to withstand volatility. Integrates Stribog
+                infrastructure and Koshchei countermeasures into operating rhythm.
+              </p>
+              <ul>
+                <li>Resilience posture assessment</li>
+                <li>Roadmap for modernization</li>
+                <li>Scenario-based playbooks</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--dark">
+        <div class="container cta-panel">
+          <div>
+            <h2>Climb higher with Summit Co</h2>
+            <p>
+              Schedule a readiness review to understand how Summit Co can assemble the right mix of
+              talent, tools, and governance for your mission.
+            </p>
+          </div>
+          <div>
+            <a class="button primary" href="../index.html#contact">Schedule readiness review</a>
+            <p style="margin-top: 1rem; color: rgba(248, 250, 252, 0.75);">
+              Executive briefings available virtually or onsite at collective hubs worldwide.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer brand-footer">
+      <div class="container footer-layout">
+        <div>
+          <span class="brand-foot">© <span id="current-year"></span> Summit Co</span>
+          <p>Transformation specialists within the Topicality Collective.</p>
+        </div>
+        <nav aria-label="Footer navigation">
+          <ul>
+            <li><a href="../index.html#brands">Brands</a></li>
+            <li><a href="../index.html#solutions">Solutions</a></li>
+            <li><a href="../index.html#insights">Insights</a></li>
+            <li><a href="../index.html#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/web/brands/topicality-co.html
+++ b/web/brands/topicality-co.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Topicality.co | Strategic Intelligence Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script defer src="../script.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-layout">
+        <a class="brand" href="../index.html">
+          <span class="brand-mark">T</span>
+          <span class="brand-text">Topicality.co</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="sr-only">Toggle navigation</span>
+          ☰
+        </button>
+        <nav id="primary-navigation" class="site-nav">
+          <ul class="brand-nav">
+            <li><a href="./topicality-co.html">Topicality.co</a></li>
+            <li><a href="./topicality-llc.html">Topicality LLC</a></li>
+            <li><a href="./koshchei.html">Koshchei</a></li>
+            <li><a href="./stribog.html">Stribog</a></li>
+            <li><a href="./summit-co.html">Summit Co</a></li>
+            <li><a href="./summi7.html">Summi7</a></li>
+            <li><a href="./intelgraph.html">IntelGraph</a></li>
+            <li><a href="./mc.html">MC</a></li>
+            <li><a href="./companyos.html">CompanyOS</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero brand-hero brand-topicality-co">
+        <div class="container hero-content">
+          <div class="hero-copy">
+            <a class="brand-breadcrumb" href="../index.html">← Back to the collective</a>
+            <h1>Strategic intelligence, captured with precision</h1>
+            <p>
+              Topicality.co distills complex geopolitical, market, and technological signals into
+              narratives leaders can trust. We blend human tradecraft with explainable analytics to
+              guide decisive action.
+            </p>
+            <div class="brand-badges">
+              <span class="brand-badge">Strategic advisory</span>
+              <span class="brand-badge">Signal fusion</span>
+              <span class="brand-badge">Executive briefings</span>
+            </div>
+            <div class="hero-actions">
+              <a class="button primary" href="#programs">Explore programs</a>
+              <a class="button ghost" href="../index.html#contact">Request a dossier</a>
+            </div>
+          </div>
+          <div class="hero-card">
+            <h2>Intelligence playbook</h2>
+            <ul class="pill-list">
+              <li>Horizon scanning</li>
+              <li>Counter-influence insights</li>
+              <li>Scenario wargaming</li>
+              <li>Leadership labs</li>
+            </ul>
+            <p class="hero-card-footnote">
+              Every deliverable passes through dual analyst review, AI-assisted validation, and
+              stakeholder calibration to keep teams aligned on the stakes.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="container brand-overview">
+          <article>
+            <h2>Operating thesis</h2>
+            <p>
+              The velocity of change across industries demands briefing cycles that move in days—not
+              quarters. Topicality.co activates embedded analysts, access-controlled data pipelines,
+              and AI summarization to surface actionable intelligence that is always contextualized
+              for the decision at hand.
+            </p>
+            <p>
+              Our teams specialize in synthesizing multi-domain signals, aligning with executive
+              cadence, and co-creating narratives that travel well across boards, agencies, and
+              partner alliances.
+            </p>
+          </article>
+          <aside>
+            <h3>Engagement details</h3>
+            <ul class="detail-list">
+              <li>
+                <strong>Audience</strong>
+                C-suite, mission leaders, venture partners, policy strategists
+              </li>
+              <li>
+                <strong>Outputs</strong>
+                Weekly situation reports, dynamic dashboards, rapid-response flash briefs
+              </li>
+              <li>
+                <strong>Access</strong>
+                Secure portal, encrypted delivery, on-call analyst access
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section id="programs" class="section">
+        <div class="container">
+          <h2>Signature programs</h2>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Atlas Briefings</h3>
+              <p>
+                A rapid intelligence cycle delivering curated daily and weekly briefs tailored to
+                your executive lens, with direct analyst collaboration.
+              </p>
+              <ul>
+                <li>Geopolitical and market fusion</li>
+                <li>Annotated decision points</li>
+                <li>Escalation pathways with subject-matter experts</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Black Channel Monitoring</h3>
+              <p>
+                Persistent collection across dark web, alternative, and influence networks to spot
+                shifts before they reach public channels.
+              </p>
+              <ul>
+                <li>Source credibility scoring</li>
+                <li>Automated narrative tracking</li>
+                <li>Actionable countermeasure recommendations</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Executive Immersion Labs</h3>
+              <p>
+                Immersive sessions pairing leadership teams with analysts, futurists, and
+                strategists to pressure-test scenarios and stress resilience.
+              </p>
+              <ul>
+                <li>Interactive wargaming</li>
+                <li>High-fidelity scenario simulation</li>
+                <li>Leadership readiness scorecards</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--dark">
+        <div class="container cta-panel">
+          <div>
+            <h2>Secure your next strategic move</h2>
+            <p>
+              Connect with a lead analyst to scope the intelligence you need. We mobilize within 72
+              hours for qualified missions.
+            </p>
+          </div>
+          <div>
+            <a class="button primary" href="../index.html#contact">Contact the collective</a>
+            <p style="margin-top: 1rem; color: rgba(248, 250, 252, 0.75);">
+              Prefer encrypted comms? Request a signal in your inquiry and we will initiate via your
+              preferred channel.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer brand-footer">
+      <div class="container footer-layout">
+        <div>
+          <span class="brand-foot">© <span id="current-year"></span> Topicality.co</span>
+          <p>Part of the Topicality Collective. Intelligence without compromise.</p>
+        </div>
+        <nav aria-label="Footer navigation">
+          <ul>
+            <li><a href="../index.html#brands">Brands</a></li>
+            <li><a href="../index.html#solutions">Solutions</a></li>
+            <li><a href="../index.html#insights">Insights</a></li>
+            <li><a href="../index.html#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/web/brands/topicality-llc.html
+++ b/web/brands/topicality-llc.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Topicality LLC | Collective Governance & Operations</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="../styles.css" />
+    <script defer src="../script.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-layout">
+        <a class="brand" href="../index.html">
+          <span class="brand-mark">T</span>
+          <span class="brand-text">Topicality LLC</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="sr-only">Toggle navigation</span>
+          ☰
+        </button>
+        <nav id="primary-navigation" class="site-nav">
+          <ul class="brand-nav">
+            <li><a href="./topicality-co.html">Topicality.co</a></li>
+            <li><a href="./topicality-llc.html">Topicality LLC</a></li>
+            <li><a href="./koshchei.html">Koshchei</a></li>
+            <li><a href="./stribog.html">Stribog</a></li>
+            <li><a href="./summit-co.html">Summit Co</a></li>
+            <li><a href="./summi7.html">Summi7</a></li>
+            <li><a href="./intelgraph.html">IntelGraph</a></li>
+            <li><a href="./mc.html">MC</a></li>
+            <li><a href="./companyos.html">CompanyOS</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero brand-hero brand-topicality-llc">
+        <div class="container hero-content">
+          <div class="hero-copy">
+            <a class="brand-breadcrumb" href="../index.html">← Back to the collective</a>
+            <h1>The nerve center of the Topicality Collective</h1>
+            <p>
+              Topicality LLC orchestrates governance, capital strategy, risk, and talent for all
+              affiliated brands—ensuring every mission operates with precision, ethics, and
+              resilience.
+            </p>
+            <div class="brand-badges">
+              <span class="brand-badge">Governance</span>
+              <span class="brand-badge">Capital deployment</span>
+              <span class="brand-badge">Talent network</span>
+            </div>
+            <div class="hero-actions">
+              <a class="button primary" href="#frameworks">View operating framework</a>
+              <a class="button ghost" href="../index.html#contact">Connect with leadership</a>
+            </div>
+          </div>
+          <div class="hero-card">
+            <h2>Core mandates</h2>
+            <ul class="pill-list">
+              <li>Strategic governance</li>
+              <li>Mission assurance</li>
+              <li>Shared services</li>
+              <li>Growth capital</li>
+            </ul>
+            <p class="hero-card-footnote">
+              We build the infrastructure that lets portfolio leaders focus on innovation while
+              staying aligned to collective principles.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--light">
+        <div class="container brand-overview">
+          <article>
+            <h2>Collective stewardship</h2>
+            <p>
+              From legal architecture to commercial acceleration, Topicality LLC centralizes
+              critical back-office, compliance, and growth enablement capabilities. Shared service
+              pods embed within each venture to drive scale while preserving brand autonomy.
+            </p>
+            <p>
+              Our governance model balances rapid experimentation with rigorous oversight, ensuring
+              every engagement upholds security, ethics, and partner trust.
+            </p>
+          </article>
+          <aside>
+            <h3>Enterprise services</h3>
+            <ul class="detail-list">
+              <li>
+                <strong>Capital &amp; finance</strong>
+                Investment allocation, treasury operations, and performance telemetry
+              </li>
+              <li>
+                <strong>Risk &amp; compliance</strong>
+                Mission assurance cells, legal frameworks, global regulatory navigation
+              </li>
+              <li>
+                <strong>People systems</strong>
+                Executive recruiting, tradecraft guilds, professional development
+              </li>
+            </ul>
+          </aside>
+        </div>
+      </section>
+
+      <section id="frameworks" class="section">
+        <div class="container">
+          <h2>Operating frameworks</h2>
+          <div class="feature-grid">
+            <article class="feature-card">
+              <h3>Collective Operating Model</h3>
+              <p>
+                Blueprint aligning every brand to a shared cadence of planning, financial
+                discipline, and mission reporting while preserving innovation autonomy.
+              </p>
+              <ul>
+                <li>Quarterly strategy reviews</li>
+                <li>Unified KPI telemetry</li>
+                <li>Portfolio-wide risk scoring</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Fusion Services Guild</h3>
+              <p>
+                Cross-functional experts who deploy to ventures as needed—covering security, legal,
+                product, partnerships, and communications.
+              </p>
+              <ul>
+                <li>On-demand embedded squads</li>
+                <li>Reusable playbooks</li>
+                <li>Continuous capability maturation</li>
+              </ul>
+            </article>
+            <article class="feature-card">
+              <h3>Leadership Conclave</h3>
+              <p>
+                Monthly convening of brand executives to sync mission priorities, share insight, and
+                coordinate resource allocations.
+              </p>
+              <ul>
+                <li>Portfolio foresight briefings</li>
+                <li>Live risk tabletop exercises</li>
+                <li>Collective commitments tracker</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section section--dark">
+        <div class="container cta-panel">
+          <div>
+            <h2>Partner with the collective</h2>
+            <p>
+              Explore joint ventures, capital opportunities, or strategic partnerships with the
+              Topicality leadership team.
+            </p>
+          </div>
+          <div>
+            <a class="button primary" href="../index.html#contact">Start the conversation</a>
+            <p style="margin-top: 1rem; color: rgba(248, 250, 252, 0.75);">
+              NDA-backed discussions and secure data rooms available for qualified partners.
+            </p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer brand-footer">
+      <div class="container footer-layout">
+        <div>
+          <span class="brand-foot">© <span id="current-year"></span> Topicality LLC</span>
+          <p>Stewardship for the Topicality Collective portfolio.</p>
+        </div>
+        <nav aria-label="Footer navigation">
+          <ul>
+            <li><a href="../index.html#brands">Brands</a></li>
+            <li><a href="../index.html#solutions">Solutions</a></li>
+            <li><a href="../index.html#insights">Insights</a></li>
+            <li><a href="../index.html#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -1,2 +1,308 @@
-<link rel="preload" as="script" href="/static/app.js" integrity="sha384-..." crossorigin="anonymous" />
-<script src="/static/app.js" integrity="sha384-..." integrity="sha384-..." crossorigin="anonymous"></script>
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Topicality Collective | Intelligence-Led Digital Operations</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="./styles.css" />
+    <script defer src="./script.js"></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="container header-layout">
+        <a class="brand" href="./index.html">
+          <span class="brand-mark">T</span>
+          <span class="brand-text">Topicality Collective</span>
+        </a>
+        <button class="nav-toggle" aria-expanded="false" aria-controls="primary-navigation">
+          <span class="sr-only">Toggle navigation</span>
+          ☰
+        </button>
+        <nav id="primary-navigation" class="site-nav">
+          <ul>
+            <li><a href="#vision">Vision</a></li>
+            <li><a href="#brands">Brands</a></li>
+            <li><a href="#solutions">Solutions</a></li>
+            <li><a href="#insights">Insights</a></li>
+            <li><a href="#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="container hero-content">
+          <div class="hero-copy">
+            <p class="eyebrow">Intelligence-Led Digital Ventures</p>
+            <h1>The unified web presence for the Topicality Collective</h1>
+            <p>
+              Nine trailblazing brands building the future of decision intelligence, secure
+              infrastructure, collaborative operations, and adaptive product ecosystems.
+            </p>
+            <div class="hero-actions">
+              <a class="button primary" href="#brands">Explore the portfolio</a>
+              <a class="button ghost" href="#contact">Partner with us</a>
+            </div>
+          </div>
+          <div class="hero-card">
+            <h2>Operating Domains</h2>
+            <ul class="pill-list">
+              <li>Strategic Intelligence</li>
+              <li>Secure Collaboration</li>
+              <li>Adaptive Automation</li>
+              <li>Mission-Grade Infrastructure</li>
+            </ul>
+            <p class="hero-card-footnote">
+              The Topicality Collective combines human expertise with resilient platforms to help
+              leaders navigate volatility with confidence.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="vision" class="section section--light">
+        <div class="container two-column">
+          <div>
+            <h2>Why the collective exists</h2>
+            <p>
+              Topicality LLC is the holding organization for a connected ecosystem of ventures.
+              Each brand solves a critical component of modern digital operations—from intelligence
+              fusion and countermeasure engineering to cloud-scale orchestration and executive
+              control rooms. Together, they deliver a powerful toolkit for governments, enterprises,
+              and complex mission partners.
+            </p>
+          </div>
+          <div class="stat-grid">
+            <div>
+              <span class="stat">9</span>
+              <span class="label">Specialized brands</span>
+            </div>
+            <div>
+              <span class="stat">18+</span>
+              <span class="label">Sectors served</span>
+            </div>
+            <div>
+              <span class="stat">24/7</span>
+              <span class="label">Operational support</span>
+            </div>
+            <div>
+              <span class="stat">∞</span>
+              <span class="label">Adaptive scenarios</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section id="brands" class="section">
+        <div class="container">
+          <h2>Meet the portfolio</h2>
+          <p class="section-lead">
+            Navigate to dedicated microsites for deeper narratives, product catalogs, and
+            engagement pathways.
+          </p>
+          <div class="brand-grid">
+            <article class="brand-card">
+              <h3>Topicality.co</h3>
+              <p>Flagship hub for intelligence-led strategy, research, and collective services.</p>
+              <a class="text-link" href="./brands/topicality-co.html">Visit microsite →</a>
+            </article>
+            <article class="brand-card">
+              <h3>Topicality LLC</h3>
+              <p>Corporate backbone orchestrating governance, capital planning, and talent ops.</p>
+              <a class="text-link" href="./brands/topicality-llc.html">Visit microsite →</a>
+            </article>
+            <article class="brand-card">
+              <h3>Koshchei</h3>
+              <p>Counter-operations lab delivering advanced protection, red teaming, and resilience.</p>
+              <a class="text-link" href="./brands/koshchei.html">Visit microsite →</a>
+            </article>
+            <article class="brand-card">
+              <h3>Stribog</h3>
+              <p>Weatherized infrastructure and sovereign cloud systems for austere environments.</p>
+              <a class="text-link" href="./brands/stribog.html">Visit microsite →</a>
+            </article>
+            <article class="brand-card">
+              <h3>Summit Co</h3>
+              <p>Transformation partners guiding enterprises through adaptive operating models.</p>
+              <a class="text-link" href="./brands/summit-co.html">Visit microsite →</a>
+            </article>
+            <article class="brand-card">
+              <h3>Summi7</h3>
+              <p>AI-native design studio for human-in-the-loop copilots and mission interfaces.</p>
+              <a class="text-link" href="./brands/summi7.html">Visit microsite →</a>
+            </article>
+            <article class="brand-card">
+              <h3>IntelGraph</h3>
+              <p>Graph-powered intelligence platform fusing data, tradecraft, and automation.</p>
+              <a class="text-link" href="./brands/intelgraph.html">Visit microsite →</a>
+            </article>
+            <article class="brand-card">
+              <h3>MC</h3>
+              <p>Operational mastery guild providing executive coaching and command center design.</p>
+              <a class="text-link" href="./brands/mc.html">Visit microsite →</a>
+            </article>
+            <article class="brand-card">
+              <h3>CompanyOS</h3>
+              <p>Composable operating system aligning teams, playbooks, and growth telemetry.</p>
+              <a class="text-link" href="./brands/companyos.html">Visit microsite →</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="solutions" class="section section--light">
+        <div class="container">
+          <h2>Integrated solution frameworks</h2>
+          <div class="solutions-grid">
+            <article>
+              <h3>Intelligence Fusion</h3>
+              <p>
+                Combine open-source, classified, and proprietary signals into decisive intelligence
+                for operational leaders, leveraging IntelGraph analytics and MC tradecraft.
+              </p>
+              <ul>
+                <li>Adaptive threat modeling</li>
+                <li>High-velocity investigation workflows</li>
+                <li>Mission assurance dashboards</li>
+              </ul>
+            </article>
+            <article>
+              <h3>Autonomous Operations</h3>
+              <p>
+                Deploy resilient, human-supervised automation via CompanyOS, Summi7 copilots, and
+                Summit Co transformation patterns.
+              </p>
+              <ul>
+                <li>Executive control rooms</li>
+                <li>Process observability &amp; compliance</li>
+                <li>Rapid experimentation loops</li>
+              </ul>
+            </article>
+            <article>
+              <h3>Protective Countermeasures</h3>
+              <p>
+                Koshchei and Stribog deliver defense-grade adversary emulation, zero-trust cloud,
+                and sovereign infrastructure that endures contested conditions.
+              </p>
+              <ul>
+                <li>Continuous red teaming</li>
+                <li>Distributed resilience architecture</li>
+                <li>Telemetry-driven hardening</li>
+              </ul>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="insights" class="section">
+        <div class="container insights">
+          <div>
+            <h2>Latest insights</h2>
+            <p class="section-lead">
+              Perspectives from the collective on emerging threats, growth models, and collaborative
+              advantage.
+            </p>
+          </div>
+          <div class="insights-grid">
+            <article>
+              <h3>2026 Strategic Outlook</h3>
+              <p>
+                A joint assessment of geopolitical volatility, capital flows, and innovation pacing
+                across allied and contested regions.
+              </p>
+              <a class="text-link" href="#contact">Request the briefing →</a>
+            </article>
+            <article>
+              <h3>Designing Human-Supervised Autonomy</h3>
+              <p>
+                Summi7 and CompanyOS share a blueprint for pairing executives with trusted AI
+                copilots to accelerate secure decision cycles.
+              </p>
+              <a class="text-link" href="#contact">Join the workshop →</a>
+            </article>
+            <article>
+              <h3>Resilience in Contested Terrain</h3>
+              <p>
+                Koshchei and Stribog outline the patterns that allow critical missions to endure
+                denial-of-service, infrastructure collapse, and influence campaigns.
+              </p>
+              <a class="text-link" href="#contact">Get the playbook →</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section id="contact" class="section section--dark">
+        <div class="container contact">
+          <div>
+            <h2>Engage the collective</h2>
+            <p>
+              Reach out once to access every brand. We triage inquiries within 24 hours and form the
+              right fusion cell for your mission.
+            </p>
+          </div>
+          <form class="contact-form" aria-label="Contact the Topicality Collective">
+            <label for="name">Name</label>
+            <input id="name" name="name" type="text" placeholder="Jane Doe" required />
+
+            <label for="organization">Organization</label>
+            <input
+              id="organization"
+              name="organization"
+              type="text"
+              placeholder="Your company or agency"
+              required
+            />
+
+            <label for="email">Email</label>
+            <input id="email" name="email" type="email" placeholder="you@example.com" required />
+
+            <label for="interest">Primary interest</label>
+            <select id="interest" name="interest" required>
+              <option value="">Select an area</option>
+              <option value="intelligence">Intelligence fusion</option>
+              <option value="operations">Autonomous operations</option>
+              <option value="resilience">Protective countermeasures</option>
+              <option value="transformation">Transformation &amp; coaching</option>
+            </select>
+
+            <label for="message">Mission context</label>
+            <textarea
+              id="message"
+              name="message"
+              rows="4"
+              placeholder="Describe challenges, timelines, and required outcomes"
+              required
+            ></textarea>
+
+            <button type="submit" class="button primary">Submit inquiry</button>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-layout">
+        <div>
+          <span class="brand-foot">© <span id="current-year"></span> Topicality LLC</span>
+          <p>Unified ventures powering secure intelligence, resilient infrastructure, and growth.</p>
+        </div>
+        <nav aria-label="Footer navigation">
+          <ul>
+            <li><a href="#vision">About</a></li>
+            <li><a href="#solutions">Solutions</a></li>
+            <li><a href="#insights">Insights</a></li>
+            <li><a href="#contact">Contact</a></li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/web/script.js
+++ b/web/script.js
@@ -1,0 +1,46 @@
+const navToggle = document.querySelector('.nav-toggle');
+const nav = document.querySelector('#primary-navigation');
+const currentYearEl = document.querySelector('#current-year');
+
+if (currentYearEl) {
+  currentYearEl.textContent = new Date().getFullYear();
+}
+
+if (navToggle && nav) {
+  navToggle.addEventListener('click', () => {
+    const isExpanded = navToggle.getAttribute('aria-expanded') === 'true';
+    navToggle.setAttribute('aria-expanded', String(!isExpanded));
+    nav.classList.toggle('open');
+  });
+
+  nav.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      nav.classList.remove('open');
+      navToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
+}
+
+const contactForm = document.querySelector('.contact-form');
+
+if (contactForm) {
+  contactForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+
+    const formData = new FormData(contactForm);
+    const submission = Object.fromEntries(formData.entries());
+
+    console.table(submission);
+
+    const button = contactForm.querySelector('button[type="submit"]');
+    const originalText = button.textContent;
+    button.disabled = true;
+    button.textContent = 'Request received ✅';
+
+    setTimeout(() => {
+      button.disabled = false;
+      button.textContent = originalText;
+      contactForm.reset();
+    }, 2600);
+  });
+}

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,0 +1,616 @@
+:root {
+  --bg-dark: #06080f;
+  --bg-light: #f5f7fb;
+  --bg-hero: radial-gradient(circle at top left, #18213a, #05060c);
+  --bg-accent: linear-gradient(135deg, #3358ff, #5dd4ff);
+  --text-primary: #0d1321;
+  --text-secondary: #4a5568;
+  --text-inverse: #f8fafc;
+  --border-subtle: rgba(13, 19, 33, 0.08);
+  --shadow-soft: 0 18px 40px rgba(15, 23, 42, 0.15);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 10px;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--text-primary);
+  background: #ffffff;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(18px);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.header-layout {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.brand-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  background: var(--bg-accent);
+  color: var(--text-inverse);
+  font-weight: 700;
+  font-size: 1.25rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.brand-text {
+  font-size: 1.15rem;
+}
+
+.site-nav ul {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-weight: 500;
+}
+
+.site-nav a {
+  color: var(--text-secondary);
+  transition: color 160ms ease;
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  color: var(--text-primary);
+}
+
+.nav-toggle {
+  display: none;
+  background: transparent;
+  border: none;
+  font-size: 1.6rem;
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.hero {
+  background: var(--bg-hero);
+  color: var(--text-inverse);
+  padding: 7rem 0 6rem;
+}
+
+.brand-hero {
+  padding: 6rem 0 5rem;
+}
+
+.brand-topicality-co {
+  background: linear-gradient(135deg, #233972, #0b1124);
+}
+
+.brand-topicality-llc {
+  background: linear-gradient(135deg, #1c212c, #050607);
+}
+
+.brand-koshchei {
+  background: linear-gradient(135deg, #260b34, #06010f);
+}
+
+.brand-stribog {
+  background: linear-gradient(135deg, #00304a, #01131c);
+}
+
+.brand-summit-co {
+  background: linear-gradient(135deg, #1a2b35, #061923);
+}
+
+.brand-summi7 {
+  background: linear-gradient(135deg, #2c0c4f, #0c0314);
+}
+
+.brand-intelgraph {
+  background: linear-gradient(135deg, #11203c, #03060a);
+}
+
+.brand-mc {
+  background: linear-gradient(135deg, #201809, #070401);
+}
+
+.brand-companyos {
+  background: linear-gradient(135deg, #0d1932, #010205);
+}
+
+.hero-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: center;
+}
+
+.hero-copy h1 {
+  font-size: clamp(2.6rem, 4vw, 3.4rem);
+  line-height: 1.1;
+  margin-bottom: 1rem;
+}
+
+.hero-copy p {
+  color: rgba(248, 250, 252, 0.75);
+  max-width: 520px;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.6);
+  font-size: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 2rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  padding: 0.85rem 1.6rem;
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
+}
+
+.button.primary {
+  background: var(--bg-accent);
+  color: var(--text-inverse);
+  box-shadow: var(--shadow-soft);
+}
+
+.button.primary:hover,
+.button.primary:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 45px rgba(51, 88, 255, 0.28);
+}
+
+.button.ghost {
+  border: 1px solid rgba(248, 250, 252, 0.35);
+  color: var(--text-inverse);
+  background: transparent;
+}
+
+.hero-card {
+  background: rgba(9, 13, 24, 0.82);
+  padding: 2.5rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-card h2 {
+  margin-top: 0;
+  margin-bottom: 1.5rem;
+}
+
+.pill-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  padding: 0;
+  margin: 0 0 1.5rem;
+}
+
+.pill-list li {
+  background: rgba(93, 212, 255, 0.12);
+  border: 1px solid rgba(93, 212, 255, 0.32);
+  border-radius: 999px;
+  padding: 0.5rem 1.1rem;
+  font-weight: 500;
+}
+
+.pill-list li:nth-child(odd) {
+  background: rgba(51, 88, 255, 0.12);
+  border-color: rgba(51, 88, 255, 0.32);
+}
+
+.section {
+  padding: 6rem 0;
+}
+
+.section--light {
+  background: var(--bg-light);
+}
+
+.section--dark {
+  background: var(--bg-dark);
+  color: var(--text-inverse);
+}
+
+.section h2 {
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  margin-top: 0;
+}
+
+.section-lead {
+  color: var(--text-secondary);
+  max-width: 640px;
+}
+
+.section--dark .section-lead {
+  color: rgba(248, 250, 252, 0.75);
+}
+
+.two-column {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: start;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 2rem;
+}
+
+.stat {
+  display: block;
+  font-weight: 700;
+  font-size: 2.6rem;
+}
+
+.label {
+  color: var(--text-secondary);
+}
+
+.brand-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+  margin-top: 3rem;
+}
+
+.brand-card {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+  background: #ffffff;
+}
+
+.brand-card:hover,
+.brand-card:focus-within {
+  transform: translateY(-6px);
+  border-color: rgba(51, 88, 255, 0.4);
+  box-shadow: var(--shadow-soft);
+}
+
+.text-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: #3358ff;
+  margin-top: 1rem;
+}
+
+.solutions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.solutions-grid article {
+  background: #ffffff;
+  border-radius: var(--radius-md);
+  padding: 2.25rem;
+  border: 1px solid rgba(13, 19, 33, 0.08);
+  box-shadow: var(--shadow-soft);
+}
+
+.solutions-grid h3 {
+  margin-top: 0;
+}
+
+.insights {
+  display: grid;
+  gap: 2.5rem;
+}
+
+.insights-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 2rem;
+}
+
+.insights-grid article {
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  background: rgba(9, 13, 24, 0.04);
+  border: 1px solid rgba(9, 13, 24, 0.08);
+}
+
+.brand-breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: rgba(248, 250, 252, 0.7);
+  margin-bottom: 1.5rem;
+}
+
+.brand-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 1.5rem 0;
+}
+
+.brand-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.brand-overview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.brand-overview aside {
+  padding: 2rem;
+  border-radius: var(--radius-md);
+  background: #ffffff;
+  border: 1px solid var(--border-subtle);
+  box-shadow: var(--shadow-soft);
+}
+
+.detail-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.detail-list strong {
+  display: block;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+.feature-card {
+  background: #ffffff;
+  border-radius: var(--radius-md);
+  padding: 2.25rem;
+  border: 1px solid rgba(13, 19, 33, 0.08);
+  box-shadow: var(--shadow-soft);
+}
+
+.feature-card h3 {
+  margin-top: 0;
+}
+
+.impact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.impact-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-md);
+  padding: 1.75rem;
+}
+
+.cta-panel {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: center;
+  background: linear-gradient(135deg, rgba(51, 88, 255, 0.12), rgba(93, 212, 255, 0.12));
+  border: 1px solid rgba(51, 88, 255, 0.2);
+  border-radius: var(--radius-lg);
+  padding: 2.75rem;
+}
+
+.brand-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.brand-nav a {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid rgba(13, 19, 33, 0.12);
+  background: rgba(255, 255, 255, 0.6);
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.brand-nav a:hover,
+.brand-nav a:focus {
+  border-color: rgba(51, 88, 255, 0.4);
+  color: #3358ff;
+}
+
+.brand-footer {
+  background: #05060c;
+  color: rgba(248, 250, 252, 0.72);
+}
+
+.section--dark .contact {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 3rem;
+  align-items: start;
+}
+
+.contact-form {
+  display: grid;
+  gap: 1rem;
+}
+
+.contact-form input,
+.contact-form select,
+.contact-form textarea {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(6, 8, 15, 0.65);
+  color: var(--text-inverse);
+}
+
+.contact-form input::placeholder,
+.contact-form textarea::placeholder {
+  color: rgba(248, 250, 252, 0.5);
+}
+
+.contact-form button {
+  justify-self: start;
+}
+
+.site-footer {
+  background: #010206;
+  color: rgba(248, 250, 252, 0.72);
+  padding: 2.5rem 0;
+}
+
+.footer-layout {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.footer-layout ul {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.brand-foot {
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+@media (max-width: 840px) {
+  .nav-toggle {
+    display: inline-flex;
+  }
+
+  .site-nav {
+    position: fixed;
+    inset: 0 0 auto;
+    top: 68px;
+    background: rgba(255, 255, 255, 0.97);
+    padding: 1.5rem 2rem;
+    transform: translateY(-100%);
+    transition: transform 220ms ease;
+  }
+
+  .site-nav.open {
+    transform: translateY(0);
+  }
+
+  .site-nav ul {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1rem;
+  }
+
+  .hero {
+    padding-top: 6rem;
+  }
+}
+
+@media (max-width: 540px) {
+  .hero-card {
+    padding: 2rem;
+  }
+
+  .solutions-grid article,
+  .insights-grid article,
+  .brand-card {
+    padding: 1.75rem;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the placeholder summit web root with a full marketing landing page for the Topicality Collective portfolio and shared contact funnel
- add a reusable styling system and lightweight interactions for navigation toggles, live year stamping, and contact form acknowledgement
- publish dedicated microsites for Topicality.co, Topicality LLC, Koshchei, Stribog, Summit Co, Summi7, IntelGraph, MC, and CompanyOS with tailored messaging and calls to action

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d7842882048333a2f27325982affaa