### PR TITLE
feat: add attested dataset delivery network

### DIFF
--- a/services/addn/cmd/addn-server/main.go
+++ b/services/addn/cmd/addn-server/main.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"flag"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/summit/addn/internal/cache"
+	"github.com/summit/addn/pkg/addn"
+)
+
+type datasetUpload struct {
+	Dataset       string           `json:"dataset"`
+	Version       string           `json:"version"`
+	PolicyTags    []string         `json:"policyTags"`
+	ResidencyPins []string         `json:"residencyPins"`
+	Artifacts     []artifactUpload `json:"artifacts"`
+	IssuedAt      *time.Time       `json:"issuedAt,omitempty"`
+}
+
+type artifactUpload struct {
+	Name       string   `json:"name"`
+	Content    string   `json:"content"`
+	PolicyTags []string `json:"policyTags"`
+	Residency  string   `json:"residency"`
+}
+
+type revocationRequest struct {
+	Type   string `json:"type"`
+	Digest string `json:"digest"`
+	Reason string `json:"reason"`
+}
+
+func main() {
+	addr := flag.String("addr", ":8080", "address to bind")
+	ttl := flag.Duration("ttl", 10*time.Minute, "manifest ttl duration")
+	swr := flag.Duration("swr", 5*time.Minute, "stale-while-revalidate window")
+	flag.Parse()
+
+	edge, err := cache.NewEdgeCache(*ttl, *swr)
+	if err != nil {
+		log.Fatalf("failed to initialize cache: %v", err)
+	}
+
+	r := mux.NewRouter()
+	r.HandleFunc("/datasets", handleUpload(edge)).Methods(http.MethodPost)
+	r.HandleFunc("/datasets/{dataset}/{version}/manifest", handleManifest(edge)).Methods(http.MethodGet)
+	r.HandleFunc("/datasets/{dataset}/{version}/artifact/{artifact}", handleArtifact(edge)).Methods(http.MethodGet)
+	r.HandleFunc("/revocations", handleRevocations(edge)).Methods(http.MethodGet)
+	r.HandleFunc("/revocations", handleRevoke(edge)).Methods(http.MethodPost)
+
+	log.Printf("addn edge cache listening on %s", *addr)
+	if err := http.ListenAndServe(*addr, r); err != nil {
+		log.Fatalf("server exited: %v", err)
+	}
+}
+
+func handleUpload(edge *cache.EdgeCache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req datasetUpload
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		if len(req.Artifacts) == 0 {
+			http.Error(w, "artifacts required", http.StatusBadRequest)
+			return
+		}
+
+		inputs := make([]cache.ArtifactInput, 0, len(req.Artifacts))
+		for _, art := range req.Artifacts {
+			data, err := base64.StdEncoding.DecodeString(art.Content)
+			if err != nil {
+				http.Error(w, "invalid artifact content encoding", http.StatusBadRequest)
+				return
+			}
+			inputs = append(inputs, cache.ArtifactInput{
+				Name:       art.Name,
+				Content:    data,
+				PolicyTags: art.PolicyTags,
+				Residency:  art.Residency,
+			})
+		}
+
+		now := time.Now().UTC()
+		if req.IssuedAt != nil {
+			now = req.IssuedAt.UTC()
+		}
+
+		manifest, err := edge.AddDataset(cache.DatasetInput{
+			Dataset:       req.Dataset,
+			Version:       req.Version,
+			PolicyTags:    req.PolicyTags,
+			ResidencyPins: req.ResidencyPins,
+			Artifacts:     inputs,
+		}, now)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		writeJSON(w, http.StatusCreated, addn.ManifestResponse{
+			Manifest:    manifest,
+			Status:      "fresh",
+			Revocations: edge.RevocationList(),
+		})
+	}
+}
+
+func handleManifest(edge *cache.EdgeCache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		region := r.URL.Query().Get("region")
+		if region == "" {
+			http.Error(w, "region query parameter required", http.StatusBadRequest)
+			return
+		}
+
+		resp, err := edge.GetManifest(vars["dataset"], vars["version"], time.Now().UTC())
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if err := addn.VerifyResidency(resp.Manifest, region); err != nil {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
+
+		writeJSON(w, http.StatusOK, resp)
+	}
+}
+
+func handleArtifact(edge *cache.EdgeCache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		region := r.URL.Query().Get("region")
+		if region == "" {
+			http.Error(w, "region query parameter required", http.StatusBadRequest)
+			return
+		}
+
+		artifact, err := edge.GetArtifact(vars["dataset"], vars["version"], vars["artifact"], region)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("X-Artifact-Digest", artifact.Digest)
+		w.WriteHeader(http.StatusOK)
+		if _, err := w.Write(artifact.Content); err != nil {
+			log.Printf("error writing artifact: %v", err)
+		}
+	}
+}
+
+func handleRevocations(edge *cache.EdgeCache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, edge.RevocationList())
+	}
+}
+
+func handleRevoke(edge *cache.EdgeCache) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req revocationRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid payload", http.StatusBadRequest)
+			return
+		}
+		now := time.Now()
+		switch req.Type {
+		case "manifest":
+			edge.RevokeManifest(req.Digest, req.Reason, now)
+		case "artifact":
+			edge.RevokeArtifact(req.Digest, req.Reason, now)
+		default:
+			http.Error(w, "type must be manifest or artifact", http.StatusBadRequest)
+			return
+		}
+		writeJSON(w, http.StatusOK, edge.RevocationList())
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		log.Printf("failed to write json: %v", err)
+	}
+}

--- a/services/addn/cmd/addn-verifier/main.go
+++ b/services/addn/cmd/addn-verifier/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/summit/addn/pkg/addn"
+)
+
+func main() {
+	manifestPath := flag.String("manifest", "", "path to manifest response json")
+	artifactDir := flag.String("artifacts", "", "directory containing artifacts to verify")
+	region := flag.String("region", "", "region to enforce residency pins")
+	flag.Parse()
+
+	if *manifestPath == "" {
+		log.Fatal("--manifest is required")
+	}
+
+	data, err := os.ReadFile(*manifestPath)
+	if err != nil {
+		log.Fatalf("read manifest: %v", err)
+	}
+
+	var resp addn.ManifestResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		log.Fatalf("decode manifest: %v", err)
+	}
+
+	if err := addn.VerifyManifest(resp, time.Now().UTC(), *region); err != nil {
+		log.Fatalf("manifest verification failed: %v", err)
+	}
+
+	if *artifactDir != "" {
+		if err := verifyArtifacts(resp, *artifactDir); err != nil {
+			log.Fatalf("artifact verification failed: %v", err)
+		}
+	}
+
+	fmt.Println("ADDN verification successful")
+}
+
+func verifyArtifacts(resp addn.ManifestResponse, dir string) error {
+	for _, art := range resp.Manifest.Artifacts {
+		path := filepath.Join(dir, art.Name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("read artifact %s: %w", art.Name, err)
+		}
+		digest := sha256.Sum256(data)
+		if hex.EncodeToString(digest[:]) != art.Digest {
+			return fmt.Errorf("digest mismatch for %s", art.Name)
+		}
+	}
+	return nil
+}

--- a/services/addn/go.mod
+++ b/services/addn/go.mod
@@ -1,0 +1,5 @@
+module github.com/summit/addn
+
+go 1.21
+
+require github.com/gorilla/mux v1.8.1

--- a/services/addn/go.sum
+++ b/services/addn/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/services/addn/internal/cache/cache.go
+++ b/services/addn/internal/cache/cache.go
@@ -1,0 +1,269 @@
+package cache
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/summit/addn/pkg/addn"
+)
+
+// EdgeCache stores datasets and generates manifests with attestation metadata.
+type EdgeCache struct {
+	mu          sync.RWMutex
+	datasets    map[string]*datasetRecord
+	revocations addn.RevocationList
+	originKey   ed25519.PrivateKey
+	originPub   ed25519.PublicKey
+	edgeKey     ed25519.PrivateKey
+	edgePub     ed25519.PublicKey
+	ttl         time.Duration
+	stale       time.Duration
+}
+
+type datasetRecord struct {
+	manifest  addn.Manifest
+	artifacts map[string]artifactRecord
+}
+
+type artifactRecord struct {
+	manifest addn.ManifestArtifact
+	content  []byte
+}
+
+// ArtifactInput captures the data used to seed an artifact into the cache.
+type ArtifactInput struct {
+	Name       string
+	Content    []byte
+	PolicyTags []string
+	Residency  string
+}
+
+// DatasetInput describes a dataset version upload request.
+type DatasetInput struct {
+	Dataset       string
+	Version       string
+	PolicyTags    []string
+	ResidencyPins []string
+	Artifacts     []ArtifactInput
+}
+
+// NewEdgeCache constructs a new in-memory edge cache instance.
+func NewEdgeCache(ttl, stale time.Duration) (*EdgeCache, error) {
+	originPub, originKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+	edgePub, edgeKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EdgeCache{
+		datasets: make(map[string]*datasetRecord),
+		revocations: addn.RevocationList{
+			Version:   1,
+			UpdatedAt: time.Now().UTC(),
+			Manifests: make(map[string]addn.Revocation),
+			Artifacts: make(map[string]addn.Revocation),
+		},
+		originKey: originKey,
+		originPub: originPub,
+		edgeKey:   edgeKey,
+		edgePub:   edgePub,
+		ttl:       ttl,
+		stale:     stale,
+	}, nil
+}
+
+func datasetKey(dataset, version string) string {
+	return fmt.Sprintf("%s::%s", dataset, version)
+}
+
+// AddDataset seeds or replaces a dataset version within the cache.
+func (c *EdgeCache) AddDataset(input DatasetInput, now time.Time) (addn.Manifest, error) {
+	if input.Dataset == "" || input.Version == "" {
+		return addn.Manifest{}, fmt.Errorf("dataset and version are required")
+	}
+	if len(input.Artifacts) == 0 {
+		return addn.Manifest{}, fmt.Errorf("at least one artifact required")
+	}
+
+	issuedAt := now.UTC()
+	validUntil := issuedAt.Add(c.ttl)
+
+	manifestArtifacts := make([]addn.ManifestArtifact, 0, len(input.Artifacts))
+	artifactRecords := make(map[string]artifactRecord, len(input.Artifacts))
+
+	for _, art := range input.Artifacts {
+		if art.Name == "" {
+			return addn.Manifest{}, fmt.Errorf("artifact name required")
+		}
+		digest := sha256.Sum256(art.Content)
+		digestHex := fmt.Sprintf("%x", digest[:])
+		manifestArtifact := addn.ManifestArtifact{
+			Name:       art.Name,
+			Digest:     digestHex,
+			Size:       len(art.Content),
+			PolicyTags: append([]string(nil), art.PolicyTags...),
+			Residency:  art.Residency,
+			EdgeURL:    fmt.Sprintf("/datasets/%s/%s/artifact/%s", input.Dataset, input.Version, art.Name),
+		}
+		manifestArtifacts = append(manifestArtifacts, manifestArtifact)
+		artifactRecords[art.Name] = artifactRecord{manifest: manifestArtifact, content: append([]byte(nil), art.Content...)}
+	}
+
+	manifest := addn.Manifest{
+		Dataset:                     input.Dataset,
+		Version:                     input.Version,
+		IssuedAt:                    issuedAt,
+		ValidUntil:                  validUntil,
+		StaleWhileRevalidateSeconds: int64(c.stale.Seconds()),
+		PolicyTags:                  append([]string(nil), input.PolicyTags...),
+		ResidencyPins:               append([]string(nil), input.ResidencyPins...),
+		Artifacts:                   manifestArtifacts,
+	}
+
+	digest, err := addn.ComputeManifestDigest(manifest)
+	if err != nil {
+		return addn.Manifest{}, err
+	}
+	manifest.ManifestDigest = digest
+
+	originSig := ed25519.Sign(c.originKey, []byte(digest))
+	edgeMsg := append([]byte(digest), originSig...)
+	edgeSig := ed25519.Sign(c.edgeKey, edgeMsg)
+
+	manifest.ProofChain = addn.ProofChain{Steps: []addn.ProofStep{
+		{
+			Authority: "origin",
+			PublicKey: base64.StdEncoding.EncodeToString(c.originPub),
+			Signature: base64.StdEncoding.EncodeToString(originSig),
+		},
+		{
+			Authority: "edge",
+			PublicKey: base64.StdEncoding.EncodeToString(c.edgePub),
+			Signature: base64.StdEncoding.EncodeToString(edgeSig),
+		},
+	}}
+
+	record := &datasetRecord{
+		manifest:  manifest,
+		artifacts: artifactRecords,
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.datasets[datasetKey(input.Dataset, input.Version)] = record
+
+	return manifest, nil
+}
+
+// GetManifest returns the stored manifest response for a dataset version.
+func (c *EdgeCache) GetManifest(dataset, version string, now time.Time) (addn.ManifestResponse, error) {
+	c.mu.RLock()
+	record, ok := c.datasets[datasetKey(dataset, version)]
+	revocations := cloneRevocations(c.revocations)
+	c.mu.RUnlock()
+	if !ok {
+		return addn.ManifestResponse{}, fmt.Errorf("dataset version not found")
+	}
+
+	manifest := record.manifest
+	status := "fresh"
+	if now.After(manifest.ValidUntil) {
+		if now.After(manifest.ValidUntil.Add(c.stale)) {
+			return addn.ManifestResponse{}, addn.ErrManifestExpired
+		}
+		status = "stale"
+	}
+
+	if _, revoked := revocations.Manifests[manifest.ManifestDigest]; revoked {
+		return addn.ManifestResponse{}, addn.ErrManifestRevoked
+	}
+
+	manifestCopy := manifest
+	manifestCopy.Artifacts = append([]addn.ManifestArtifact(nil), manifest.Artifacts...)
+
+	return addn.ManifestResponse{
+		Manifest:    manifestCopy,
+		Status:      status,
+		Revocations: revocations,
+	}, nil
+}
+
+// GetArtifact returns an artifact payload enforcing residency and revocations.
+func (c *EdgeCache) GetArtifact(dataset, version, artifactName, region string) (addn.ArtifactEnvelope, error) {
+	c.mu.RLock()
+	record, ok := c.datasets[datasetKey(dataset, version)]
+	revocations := cloneRevocations(c.revocations)
+	c.mu.RUnlock()
+	if !ok {
+		return addn.ArtifactEnvelope{}, fmt.Errorf("dataset version not found")
+	}
+
+	artifact, ok := record.artifacts[artifactName]
+	if !ok {
+		return addn.ArtifactEnvelope{}, fmt.Errorf("artifact not found")
+	}
+
+	if _, revoked := revocations.Artifacts[artifact.manifest.Digest]; revoked {
+		return addn.ArtifactEnvelope{}, addn.ErrArtifactRevoked
+	}
+
+	if err := addn.VerifyResidency(record.manifest, region); err != nil {
+		return addn.ArtifactEnvelope{}, err
+	}
+
+	return addn.ArtifactEnvelope{
+		Name:      artifact.manifest.Name,
+		Digest:    artifact.manifest.Digest,
+		Content:   append([]byte(nil), artifact.content...),
+		Residency: artifact.manifest.Residency,
+	}, nil
+}
+
+// RevokeManifest marks a manifest digest as revoked.
+func (c *EdgeCache) RevokeManifest(digest, reason string, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.revocations.Manifests[digest] = addn.Revocation{Reason: reason, RevokedAt: now.UTC()}
+	c.revocations.Version++
+	c.revocations.UpdatedAt = now.UTC()
+}
+
+// RevokeArtifact marks an artifact digest as revoked.
+func (c *EdgeCache) RevokeArtifact(digest, reason string, now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.revocations.Artifacts[digest] = addn.Revocation{Reason: reason, RevokedAt: now.UTC()}
+	c.revocations.Version++
+	c.revocations.UpdatedAt = now.UTC()
+}
+
+// RevocationList returns a copy of the current revocation data.
+func (c *EdgeCache) RevocationList() addn.RevocationList {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return cloneRevocations(c.revocations)
+}
+
+func cloneRevocations(src addn.RevocationList) addn.RevocationList {
+	copyList := addn.RevocationList{
+		Version:   src.Version,
+		UpdatedAt: src.UpdatedAt,
+		Manifests: make(map[string]addn.Revocation, len(src.Manifests)),
+		Artifacts: make(map[string]addn.Revocation, len(src.Artifacts)),
+	}
+	for k, v := range src.Manifests {
+		copyList.Manifests[k] = v
+	}
+	for k, v := range src.Artifacts {
+		copyList.Artifacts[k] = v
+	}
+	return copyList
+}

--- a/services/addn/internal/cache/cache_test.go
+++ b/services/addn/internal/cache/cache_test.go
@@ -1,0 +1,132 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/summit/addn/pkg/addn"
+)
+
+func TestEdgeCacheManifestLifecycle(t *testing.T) {
+	edge, err := NewEdgeCache(2*time.Minute, time.Minute)
+	if err != nil {
+		t.Fatalf("new edge cache: %v", err)
+	}
+
+	now := time.Now().UTC()
+	_, err = edge.AddDataset(DatasetInput{
+		Dataset:       "features",
+		Version:       "2024-10-01",
+		PolicyTags:    []string{"p0", "confidential"},
+		ResidencyPins: []string{"us-east"},
+		Artifacts: []ArtifactInput{{
+			Name:       "features.json",
+			Content:    []byte(`{"a":1}`),
+			PolicyTags: []string{"row-level"},
+			Residency:  "us-east",
+		}},
+	}, now)
+	if err != nil {
+		t.Fatalf("add dataset: %v", err)
+	}
+
+	resp, err := edge.GetManifest("features", "2024-10-01", now)
+	if err != nil {
+		t.Fatalf("get manifest: %v", err)
+	}
+	if resp.Status != "fresh" {
+		t.Fatalf("expected fresh status, got %s", resp.Status)
+	}
+
+	if err := addn.VerifyManifest(resp, now, "us-east"); err != nil {
+		t.Fatalf("verify manifest: %v", err)
+	}
+
+	respAgain, err := edge.GetManifest("features", "2024-10-01", now.Add(30*time.Second))
+	if err != nil {
+		t.Fatalf("get manifest again: %v", err)
+	}
+	if respAgain.Manifest.ManifestDigest != resp.Manifest.ManifestDigest {
+		t.Fatalf("manifest digests changed for identical manifest")
+	}
+}
+
+func TestEdgeCacheResidencyAndRevocation(t *testing.T) {
+	edge, err := NewEdgeCache(time.Minute, time.Minute)
+	if err != nil {
+		t.Fatalf("new edge cache: %v", err)
+	}
+
+	now := time.Now()
+	manifest, err := edge.AddDataset(DatasetInput{
+		Dataset:       "dataset",
+		Version:       "v1",
+		PolicyTags:    []string{"pii"},
+		ResidencyPins: []string{"eu-central"},
+		Artifacts: []ArtifactInput{{
+			Name:      "data.bin",
+			Content:   []byte{1, 2, 3},
+			Residency: "eu-central",
+		}},
+	}, now)
+	if err != nil {
+		t.Fatalf("add dataset: %v", err)
+	}
+
+	if _, err := edge.GetArtifact("dataset", "v1", "data.bin", "us-east"); err == nil {
+		t.Fatalf("expected residency violation")
+	}
+
+	resp, err := edge.GetManifest("dataset", "v1", now)
+	if err != nil {
+		t.Fatalf("manifest fetch: %v", err)
+	}
+
+	edge.RevokeArtifact(manifest.Artifacts[0].Digest, "compromised", now.Add(time.Second))
+	if _, err := edge.GetArtifact("dataset", "v1", "data.bin", "eu-central"); err == nil {
+		t.Fatalf("expected revoked artifact error")
+	}
+
+	edge.RevokeManifest(manifest.ManifestDigest, "stale", now.Add(2*time.Second))
+	if _, err := edge.GetManifest("dataset", "v1", now.Add(3*time.Second)); err == nil {
+		t.Fatalf("expected revoked manifest error")
+	}
+
+	if err := addn.VerifyManifest(resp, now, "eu-central"); err != nil {
+		t.Fatalf("verify manifest pre-revocation should succeed: %v", err)
+	}
+}
+
+func TestEdgeCacheStaleWhileRevalidate(t *testing.T) {
+	edge, err := NewEdgeCache(2*time.Second, 4*time.Second)
+	if err != nil {
+		t.Fatalf("new edge cache: %v", err)
+	}
+
+	now := time.Now()
+	_, err = edge.AddDataset(DatasetInput{
+		Dataset:       "signals",
+		Version:       "001",
+		ResidencyPins: []string{"ap-south"},
+		Artifacts: []ArtifactInput{{
+			Name:      "signals.json",
+			Content:   []byte(`[]`),
+			Residency: "ap-south",
+		}},
+	}, now)
+	if err != nil {
+		t.Fatalf("add dataset: %v", err)
+	}
+
+	resp, err := edge.GetManifest("signals", "001", now.Add(3*time.Second))
+	if err != nil {
+		t.Fatalf("expected stale manifest within SWR window: %v", err)
+	}
+	if resp.Status != "stale" {
+		t.Fatalf("expected stale status, got %s", resp.Status)
+	}
+
+	if _, err := edge.GetManifest("signals", "001", now.Add(7*time.Second)); err == nil {
+		t.Fatalf("expected manifest expiration beyond SWR window")
+	}
+}

--- a/services/addn/pkg/addn/types.go
+++ b/services/addn/pkg/addn/types.go
@@ -1,0 +1,68 @@
+package addn
+
+import "time"
+
+// ManifestArtifact describes an individual artifact that belongs to a dataset version.
+type ManifestArtifact struct {
+	Name       string   `json:"name"`
+	Digest     string   `json:"digest"`
+	Size       int      `json:"size"`
+	PolicyTags []string `json:"policyTags"`
+	Residency  string   `json:"residency"`
+	EdgeURL    string   `json:"edgeUrl"`
+}
+
+// ProofStep is a single signature in the proof chain from origin to edge.
+type ProofStep struct {
+	Authority string `json:"authority"`
+	PublicKey string `json:"publicKey"`
+	Signature string `json:"signature"`
+}
+
+// ProofChain is an ordered set of signatures that attests the manifest.
+type ProofChain struct {
+	Steps []ProofStep `json:"steps"`
+}
+
+// Manifest encapsulates the deterministic dataset metadata that clients verify.
+type Manifest struct {
+	Dataset                     string             `json:"dataset"`
+	Version                     string             `json:"version"`
+	IssuedAt                    time.Time          `json:"issuedAt"`
+	ValidUntil                  time.Time          `json:"validUntil"`
+	StaleWhileRevalidateSeconds int64              `json:"staleWhileRevalidateSeconds"`
+	PolicyTags                  []string           `json:"policyTags"`
+	ResidencyPins               []string           `json:"residencyPins"`
+	Artifacts                   []ManifestArtifact `json:"artifacts"`
+	ManifestDigest              string             `json:"manifestDigest"`
+	ProofChain                  ProofChain         `json:"proofChain"`
+}
+
+// ManifestResponse is emitted by the edge service and consumed by clients.
+type ManifestResponse struct {
+	Manifest    Manifest       `json:"manifest"`
+	Status      string         `json:"status"`
+	Revocations RevocationList `json:"revocations"`
+}
+
+// Revocation captures a revoked manifest or artifact digest.
+type Revocation struct {
+	Reason    string    `json:"reason"`
+	RevokedAt time.Time `json:"revokedAt"`
+}
+
+// RevocationList contains the active revocations from origin and edge.
+type RevocationList struct {
+	Version   int                   `json:"version"`
+	UpdatedAt time.Time             `json:"updatedAt"`
+	Manifests map[string]Revocation `json:"manifests"`
+	Artifacts map[string]Revocation `json:"artifacts"`
+}
+
+// ArtifactEnvelope is returned when fetching artifact content from the edge.
+type ArtifactEnvelope struct {
+	Name      string `json:"name"`
+	Digest    string `json:"digest"`
+	Content   []byte `json:"content"`
+	Residency string `json:"residency"`
+}

--- a/services/addn/pkg/addn/verify.go
+++ b/services/addn/pkg/addn/verify.go
@@ -1,0 +1,159 @@
+package addn
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"sort"
+	"time"
+)
+
+var (
+	// ErrManifestExpired indicates that the manifest is outside its SMaxAge+SWR window.
+	ErrManifestExpired = errors.New("manifest expired beyond stale-while-revalidate window")
+	// ErrManifestRevoked indicates the manifest digest was revoked.
+	ErrManifestRevoked = errors.New("manifest digest has been revoked")
+	// ErrArtifactRevoked indicates the artifact digest was revoked.
+	ErrArtifactRevoked = errors.New("artifact digest has been revoked")
+	// ErrResidencyViolation indicates a residency pin mismatch.
+	ErrResidencyViolation = errors.New("residency requirement violated")
+	// ErrProofInvalid indicates a signature failure.
+	ErrProofInvalid = errors.New("proof chain verification failed")
+)
+
+type manifestCanonical struct {
+	Dataset                     string             `json:"dataset"`
+	Version                     string             `json:"version"`
+	IssuedAt                    time.Time          `json:"issuedAt"`
+	ValidUntil                  time.Time          `json:"validUntil"`
+	StaleWhileRevalidateSeconds int64              `json:"staleWhileRevalidateSeconds"`
+	PolicyTags                  []string           `json:"policyTags"`
+	ResidencyPins               []string           `json:"residencyPins"`
+	Artifacts                   []ManifestArtifact `json:"artifacts"`
+}
+
+// ComputeManifestDigest calculates the canonical SHA-256 digest used for signing manifests.
+func ComputeManifestDigest(m Manifest) (string, error) {
+	canonical := manifestCanonical{
+		Dataset:                     m.Dataset,
+		Version:                     m.Version,
+		IssuedAt:                    m.IssuedAt.UTC(),
+		ValidUntil:                  m.ValidUntil.UTC(),
+		StaleWhileRevalidateSeconds: m.StaleWhileRevalidateSeconds,
+		PolicyTags:                  append([]string(nil), m.PolicyTags...),
+		ResidencyPins:               append([]string(nil), m.ResidencyPins...),
+		Artifacts:                   append([]ManifestArtifact(nil), m.Artifacts...),
+	}
+
+	sort.Strings(canonical.PolicyTags)
+	sort.Strings(canonical.ResidencyPins)
+	sort.Slice(canonical.Artifacts, func(i, j int) bool {
+		return canonical.Artifacts[i].Name < canonical.Artifacts[j].Name
+	})
+	for i := range canonical.Artifacts {
+		artifact := &canonical.Artifacts[i]
+		sort.Strings(artifact.PolicyTags)
+	}
+
+	payload, err := json.Marshal(canonical)
+	if err != nil {
+		return "", err
+	}
+
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+// VerifyManifest performs expiration, revocation, residency, and proof checks.
+func VerifyManifest(resp ManifestResponse, now time.Time, region string) error {
+	manifest := resp.Manifest
+	digest, err := ComputeManifestDigest(manifest)
+	if err != nil {
+		return err
+	}
+	if digest != manifest.ManifestDigest {
+		return ErrProofInvalid
+	}
+
+	if now.After(manifest.ValidUntil.Add(time.Duration(manifest.StaleWhileRevalidateSeconds) * time.Second)) {
+		return ErrManifestExpired
+	}
+
+	if resp.Revocations.Manifests != nil {
+		if _, ok := resp.Revocations.Manifests[manifest.ManifestDigest]; ok {
+			return ErrManifestRevoked
+		}
+	}
+
+	if err := verifyProofChain(manifest.ProofChain, digest); err != nil {
+		return err
+	}
+
+	if region != "" {
+		if err := VerifyResidency(manifest, region); err != nil {
+			return err
+		}
+	}
+
+	if resp.Revocations.Artifacts != nil {
+		for _, art := range manifest.Artifacts {
+			if _, revoked := resp.Revocations.Artifacts[art.Digest]; revoked {
+				return ErrArtifactRevoked
+			}
+		}
+	}
+
+	return nil
+}
+
+// VerifyResidency ensures the manifest allows serving the requested region.
+func VerifyResidency(manifest Manifest, region string) error {
+	allowed := false
+	for _, pin := range manifest.ResidencyPins {
+		if pin == region {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return ErrResidencyViolation
+	}
+
+	for _, art := range manifest.Artifacts {
+		if art.Residency != "" && art.Residency != region {
+			return ErrResidencyViolation
+		}
+	}
+	return nil
+}
+
+func verifyProofChain(chain ProofChain, digest string) error {
+	if len(chain.Steps) < 2 {
+		return ErrProofInvalid
+	}
+
+	expected := []byte(digest)
+	var prevSig []byte
+	for _, step := range chain.Steps {
+		sig, err := base64.StdEncoding.DecodeString(step.Signature)
+		if err != nil {
+			return err
+		}
+		pub, err := base64.StdEncoding.DecodeString(step.PublicKey)
+		if err != nil {
+			return err
+		}
+		if len(pub) != ed25519.PublicKeySize {
+			return ErrProofInvalid
+		}
+		if !ed25519.Verify(ed25519.PublicKey(pub), expected, sig) {
+			return ErrProofInvalid
+		}
+		prevSig = sig
+		expected = append([]byte(digest), prevSig...)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- stand up a new Go edge cache module that issues deterministic manifests with proof chains, residency pins, and revocation metadata
- expose HTTP endpoints for dataset ingestion, manifest retrieval with stale-while-revalidate handling, artifact delivery, and revocation management
- add a verifier CLI plus unit tests covering lifecycle, residency enforcement, and stale window logic

## Testing
- go test ./... -v

------
https://chatgpt.com/codex/tasks/task_e_68d785ba4b488333a9f2268a5ccebfb1