### PR TITLE
feat: add Go mpes runner with sandboxed multi-party evaluations

### DIFF
--- a/mpes/go.mod
+++ b/mpes/go.mod
@@ -1,0 +1,3 @@
+module github.com/summit/multi-party-eval/mpes
+
+go 1.20

--- a/mpes/policy.go
+++ b/mpes/policy.go
@@ -1,0 +1,48 @@
+package mpes
+
+import (
+	"fmt"
+	"sort"
+)
+
+// PolicyFirewall enforces capability walls between parties and the runner.
+type PolicyFirewall interface {
+	Enforce(partyID string, declared []Capability) error
+}
+
+// StaticPolicyFirewall enforces a static allowlist of capabilities per party.
+type StaticPolicyFirewall struct {
+	allowed map[string]map[Capability]struct{}
+}
+
+// NewStaticPolicyFirewall creates a policy firewall with the provided allowlists.
+func NewStaticPolicyFirewall(partyCapabilities map[string][]Capability) *StaticPolicyFirewall {
+	allowed := make(map[string]map[Capability]struct{}, len(partyCapabilities))
+	for party, caps := range partyCapabilities {
+		capSet := make(map[Capability]struct{}, len(caps))
+		for _, c := range caps {
+			capSet[c] = struct{}{}
+		}
+		allowed[party] = capSet
+	}
+	return &StaticPolicyFirewall{allowed: allowed}
+}
+
+// Enforce ensures the declared capabilities fall within the party's allowlist.
+func (s *StaticPolicyFirewall) Enforce(partyID string, declared []Capability) error {
+	allowed, ok := s.allowed[partyID]
+	if !ok {
+		return fmt.Errorf("party %s is not registered with the policy firewall", partyID)
+	}
+	unauthorized := make([]string, 0)
+	for _, capability := range declared {
+		if _, exists := allowed[capability]; !exists {
+			unauthorized = append(unauthorized, string(capability))
+		}
+	}
+	if len(unauthorized) > 0 {
+		sort.Strings(unauthorized)
+		return fmt.Errorf("party %s declared unauthorized capabilities: %v", partyID, unauthorized)
+	}
+	return nil
+}

--- a/mpes/runner.go
+++ b/mpes/runner.go
@@ -1,0 +1,101 @@
+package mpes
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Runner orchestrates sandboxed evaluation of submissions across multiple parties.
+type Runner struct {
+	tasks  []EvalTask
+	policy PolicyFirewall
+	signer *ScorecardSigner
+	clock  func() time.Time
+}
+
+// RunnerOption configures runner construction.
+type RunnerOption func(*Runner)
+
+// WithClock overrides the default time source (useful for testing).
+func WithClock(clock func() time.Time) RunnerOption {
+	return func(r *Runner) {
+		r.clock = clock
+	}
+}
+
+// NewRunner creates a runner with the provided tasks, policy firewall, and signer.
+func NewRunner(tasks []EvalTask, policy PolicyFirewall, signer *ScorecardSigner, opts ...RunnerOption) (*Runner, error) {
+	if len(tasks) == 0 {
+		return nil, fmt.Errorf("runner requires at least one task")
+	}
+	if policy == nil {
+		return nil, fmt.Errorf("runner requires a policy firewall")
+	}
+	if signer == nil {
+		return nil, fmt.Errorf("runner requires a scorecard signer")
+	}
+	runner := &Runner{
+		tasks:  append([]EvalTask(nil), tasks...),
+		policy: policy,
+		signer: signer,
+		clock:  time.Now,
+	}
+	for _, opt := range opts {
+		opt(runner)
+	}
+	return runner, nil
+}
+
+// Run executes the configured tasks for each submission in isolated sandboxes.
+func (r *Runner) Run(ctx context.Context, submissions []Submission) (map[string]Scorecard, error) {
+	if len(submissions) == 0 {
+		return map[string]Scorecard{}, nil
+	}
+
+	results := make(map[string]Scorecard)
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	errors := make(chan error, len(submissions))
+
+	for _, submission := range submissions {
+		submission := submission
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sandbox, err := newSandbox(submission.PartyID, r.policy)
+			if err != nil {
+				errors <- err
+				return
+			}
+			taskScores, err := sandbox.Execute(ctx, r.tasks, submission)
+			if err != nil {
+				errors <- err
+				return
+			}
+			scorecard := Scorecard{
+				PartyID:    submission.PartyID,
+				TaskScores: taskScores,
+				Metadata:   sandbox.Metadata(),
+				CreatedAt:  r.clock(),
+			}
+			if err := r.signer.SignScorecard(&scorecard); err != nil {
+				errors <- err
+				return
+			}
+			mu.Lock()
+			results[submission.PartyID] = scorecard
+			mu.Unlock()
+		}()
+	}
+
+	wg.Wait()
+	close(errors)
+	for err := range errors {
+		if err != nil {
+			return nil, err
+		}
+	}
+	return results, nil
+}

--- a/mpes/runner_test.go
+++ b/mpes/runner_test.go
@@ -1,0 +1,194 @@
+package mpes
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+	"time"
+)
+
+type mutatingTask struct{}
+
+func (mutatingTask) Name() string { return "mutating" }
+
+func (mutatingTask) Evaluate(model ModelArtifact, data DataSlice) (Score, error) {
+	if len(model.Payload) > 0 {
+		model.Payload[0] = 'x'
+	}
+	if len(data.Records) > 0 && len(data.Records[0]) > 0 {
+		data.Records[0][0] = 'y'
+	}
+	evidenceModel := string(model.Payload)
+	evidenceData := ""
+	if len(data.Records) > 0 {
+		evidenceData = string(data.Records[0])
+	}
+	return Score{
+		Value:    float64(len(model.Payload) + len(data.Records)),
+		Evidence: "model=" + evidenceModel + ",data=" + evidenceData,
+	}, nil
+}
+
+type hashTask struct{}
+
+func (hashTask) Name() string { return "hash" }
+
+func (hashTask) Evaluate(model ModelArtifact, data DataSlice) (Score, error) {
+	hasher := sha256.New()
+	hasher.Write(model.Payload)
+	for _, record := range data.Records {
+		hasher.Write(record)
+	}
+	sum := hasher.Sum(nil)
+	value := binary.BigEndian.Uint64(sum[:8]) % 100000
+	return Score{
+		Value:    float64(value) / 100.0,
+		Evidence: hex.EncodeToString(sum),
+	}, nil
+}
+
+func fixedSigner(t *testing.T) *ScorecardSigner {
+	t.Helper()
+	seed := make([]byte, 32)
+	for i := range seed {
+		seed[i] = byte(i)
+	}
+	signer, err := NewScorecardSigner(seed)
+	if err != nil {
+		t.Fatalf("failed to create signer: %v", err)
+	}
+	return signer
+}
+
+func TestCrossPartyIsolation(t *testing.T) {
+	policy := NewStaticPolicyFirewall(map[string][]Capability{
+		"party-a": {Capability("compute")},
+		"party-b": {Capability("compute")},
+	})
+	runner, err := NewRunner([]EvalTask{mutatingTask{}}, policy, fixedSigner(t), WithClock(func() time.Time {
+		return time.Unix(100, 0)
+	}))
+	if err != nil {
+		t.Fatalf("failed to create runner: %v", err)
+	}
+
+	originalModelA := ModelArtifact{Name: "modelA", Capabilities: []Capability{"compute"}, Payload: []byte("AAAA")}
+	originalModelB := ModelArtifact{Name: "modelB", Capabilities: []Capability{"compute"}, Payload: []byte("BBBB")}
+	originalDataA := DataSlice{Name: "dataA", Records: [][]byte{[]byte("aaaa")}}
+	originalDataB := DataSlice{Name: "dataB", Records: [][]byte{[]byte("bbbb")}}
+
+	submissions := []Submission{
+		{PartyID: "party-a", Model: originalModelA, Data: originalDataA},
+		{PartyID: "party-b", Model: originalModelB, Data: originalDataB},
+	}
+
+	results, err := runner.Run(context.Background(), submissions)
+	if err != nil {
+		t.Fatalf("runner execution failed: %v", err)
+	}
+
+	if string(originalModelA.Payload) != "AAAA" {
+		t.Fatalf("modelA payload mutated outside sandbox: %s", originalModelA.Payload)
+	}
+	if string(originalModelB.Payload) != "BBBB" {
+		t.Fatalf("modelB payload mutated outside sandbox: %s", originalModelB.Payload)
+	}
+	if string(originalDataA.Records[0]) != "aaaa" {
+		t.Fatalf("dataA mutated outside sandbox: %s", originalDataA.Records[0])
+	}
+	if string(originalDataB.Records[0]) != "bbbb" {
+		t.Fatalf("dataB mutated outside sandbox: %s", originalDataB.Records[0])
+	}
+
+	evidenceA := results["party-a"].TaskScores["mutating"].Evidence
+	evidenceB := results["party-b"].TaskScores["mutating"].Evidence
+	if evidenceA == evidenceB {
+		t.Fatalf("evidence should be unique per party but matched: %s", evidenceA)
+	}
+	if len(results["party-a"].Metadata) == 0 || len(results["party-b"].Metadata) == 0 {
+		t.Fatalf("metadata missing sandbox details")
+	}
+}
+
+func TestIdenticalSubmissionsYieldIdenticalScores(t *testing.T) {
+	policy := NewStaticPolicyFirewall(map[string][]Capability{
+		"party-a": {Capability("compute")},
+		"party-b": {Capability("compute")},
+	})
+	runner, err := NewRunner([]EvalTask{hashTask{}}, policy, fixedSigner(t))
+	if err != nil {
+		t.Fatalf("failed to create runner: %v", err)
+	}
+
+	model := ModelArtifact{Name: "shared", Capabilities: []Capability{"compute"}, Payload: []byte("MODEL")}
+	data := DataSlice{Name: "shared-data", Records: [][]byte{[]byte("sample"), []byte("slice")}}
+
+	submissions := []Submission{
+		{PartyID: "party-a", Model: model, Data: data},
+		{PartyID: "party-b", Model: model, Data: data},
+	}
+
+	results, err := runner.Run(context.Background(), submissions)
+	if err != nil {
+		t.Fatalf("runner execution failed: %v", err)
+	}
+
+	scoreA := results["party-a"].TaskScores["hash"]
+	scoreB := results["party-b"].TaskScores["hash"]
+	if scoreA.Value != scoreB.Value {
+		t.Fatalf("expected identical score values, got %v and %v", scoreA.Value, scoreB.Value)
+	}
+	if scoreA.Evidence != scoreB.Evidence {
+		t.Fatalf("expected identical evidence, got %s and %s", scoreA.Evidence, scoreB.Evidence)
+	}
+}
+
+func TestScorecardsVerifyAndAreClean(t *testing.T) {
+	policy := NewStaticPolicyFirewall(map[string][]Capability{
+		"party-a": {Capability("compute")},
+		"party-b": {Capability("compute")},
+	})
+	signer := fixedSigner(t)
+	runner, err := NewRunner([]EvalTask{hashTask{}}, policy, signer, WithClock(func() time.Time {
+		return time.Unix(200, 0)
+	}))
+	if err != nil {
+		t.Fatalf("failed to create runner: %v", err)
+	}
+
+	modelA := ModelArtifact{Name: "shared", Capabilities: []Capability{"compute"}, Payload: []byte("MODEL-A")}
+	modelB := ModelArtifact{Name: "shared", Capabilities: []Capability{"compute"}, Payload: []byte("MODEL-B")}
+	dataA := DataSlice{Name: "shared-data", Records: [][]byte{[]byte("alpha")}}
+	dataB := DataSlice{Name: "shared-data", Records: [][]byte{[]byte("beta")}}
+
+	submissions := []Submission{
+		{PartyID: "party-a", Model: modelA, Data: dataA},
+		{PartyID: "party-b", Model: modelB, Data: dataB},
+	}
+
+	results, err := runner.Run(context.Background(), submissions)
+	if err != nil {
+		t.Fatalf("runner execution failed: %v", err)
+	}
+
+	for party, scorecard := range results {
+		verified, err := signer.VerifyScorecard(scorecard)
+		if err != nil {
+			t.Fatalf("verification errored for %s: %v", party, err)
+		}
+		if !verified {
+			t.Fatalf("scorecard signature failed for %s", party)
+		}
+		if got := scorecard.Metadata["party"]; got != party {
+			t.Fatalf("metadata party mismatch for %s: %s", party, got)
+		}
+		if _, ok := scorecard.Metadata["sandbox_id"]; !ok {
+			t.Fatalf("sandbox id missing for %s", party)
+		}
+		if len(scorecard.Metadata) != 2 {
+			t.Fatalf("expected only sandbox metadata for %s, got %#v", party, scorecard.Metadata)
+		}
+	}
+}

--- a/mpes/sandbox.go
+++ b/mpes/sandbox.go
@@ -1,0 +1,59 @@
+package mpes
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+// Sandbox represents an ephemeral execution environment for a party submission.
+type Sandbox struct {
+	id     string
+	party  string
+	policy PolicyFirewall
+}
+
+// newSandbox builds an isolated sandbox per submission.
+func newSandbox(partyID string, policy PolicyFirewall) (*Sandbox, error) {
+	buf := make([]byte, 8)
+	if _, err := rand.Read(buf); err != nil {
+		return nil, fmt.Errorf("failed to seed sandbox id: %w", err)
+	}
+	return &Sandbox{
+		id:     hex.EncodeToString(buf),
+		party:  partyID,
+		policy: policy,
+	}, nil
+}
+
+// Execute runs all tasks against the isolated copies of the submission artifacts.
+func (s *Sandbox) Execute(ctx context.Context, tasks []EvalTask, submission Submission) (map[string]Score, error) {
+	if err := s.policy.Enforce(submission.PartyID, submission.Model.Capabilities); err != nil {
+		return nil, err
+	}
+	safeModel := submission.Model.Clone()
+	safeData := submission.Data.Clone()
+	results := make(map[string]Score, len(tasks))
+	for _, task := range tasks {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		score, err := task.Evaluate(safeModel, safeData)
+		if err != nil {
+			return nil, fmt.Errorf("task %s failed in sandbox %s: %w", task.Name(), s.id, err)
+		}
+		results[task.Name()] = score
+	}
+	return results, nil
+}
+
+// Metadata returns sandbox details safe to share with the caller.
+func (s *Sandbox) Metadata() map[string]string {
+	return map[string]string{
+		"sandbox_id": s.id,
+		"party":      s.party,
+	}
+}

--- a/mpes/signing.go
+++ b/mpes/signing.go
@@ -1,0 +1,72 @@
+package mpes
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"fmt"
+)
+
+// ScorecardSigner handles signing and verifying party scorecards.
+type ScorecardSigner struct {
+	publicKey  ed25519.PublicKey
+	privateKey ed25519.PrivateKey
+}
+
+// NewScorecardSigner generates a signer from the provided seed. If seed is nil a random key is created.
+func NewScorecardSigner(seed []byte) (*ScorecardSigner, error) {
+	if seed != nil {
+		if len(seed) != ed25519.SeedSize {
+			return nil, fmt.Errorf("seed must be %d bytes", ed25519.SeedSize)
+		}
+		privateKey := ed25519.NewKeyFromSeed(seed)
+		publicKey := privateKey.Public().(ed25519.PublicKey)
+		return &ScorecardSigner{publicKey: publicKey, privateKey: privateKey}, nil
+	}
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate ed25519 key: %w", err)
+	}
+	return &ScorecardSigner{publicKey: publicKey, privateKey: privateKey}, nil
+}
+
+// PublicKey returns the signer's public key for verification.
+func (s *ScorecardSigner) PublicKey() ed25519.PublicKey {
+	return append(ed25519.PublicKey(nil), s.publicKey...)
+}
+
+// SignScorecard calculates the signature over the canonical payload.
+func (s *ScorecardSigner) SignScorecard(scorecard *Scorecard) error {
+	payload, err := scorecardPayload(scorecard)
+	if err != nil {
+		return err
+	}
+	scorecard.Signature = ed25519.Sign(s.privateKey, payload)
+	return nil
+}
+
+// VerifyScorecard ensures the signature matches the provided scorecard.
+func (s *ScorecardSigner) VerifyScorecard(scorecard Scorecard) (bool, error) {
+	payload, err := scorecardPayload(&scorecard)
+	if err != nil {
+		return false, err
+	}
+	if len(scorecard.Signature) == 0 {
+		return false, fmt.Errorf("scorecard signature missing")
+	}
+	return ed25519.Verify(s.publicKey, payload, scorecard.Signature), nil
+}
+
+func scorecardPayload(scorecard *Scorecard) ([]byte, error) {
+	clone := scorecard.CloneWithoutSignature()
+	return json.Marshal(struct {
+		PartyID   string            `json:"party_id"`
+		Scores    map[string]Score  `json:"scores"`
+		Metadata  map[string]string `json:"metadata,omitempty"`
+		CreatedAt int64             `json:"created_at_unix"`
+	}{
+		PartyID:   clone.PartyID,
+		Scores:    clone.TaskScores,
+		Metadata:  clone.Metadata,
+		CreatedAt: clone.CreatedAt.UnixNano(),
+	})
+}

--- a/mpes/types.go
+++ b/mpes/types.go
@@ -1,0 +1,89 @@
+package mpes
+
+import "time"
+
+// Capability describes an action that a party's submission can request.
+type Capability string
+
+// ModelArtifact represents a submitted model along with its declared capabilities.
+type ModelArtifact struct {
+	Name         string
+	Version      string
+	Capabilities []Capability
+	Payload      []byte
+}
+
+// Clone produces a deep copy of the model artifact to ensure sandbox isolation.
+func (m ModelArtifact) Clone() ModelArtifact {
+	clone := ModelArtifact{
+		Name:         m.Name,
+		Version:      m.Version,
+		Capabilities: append([]Capability(nil), m.Capabilities...),
+		Payload:      append([]byte(nil), m.Payload...),
+	}
+	return clone
+}
+
+// DataSlice represents a dataset shard submitted for evaluation.
+type DataSlice struct {
+	Name    string
+	Records [][]byte
+}
+
+// Clone returns an isolated copy of the data slice.
+func (d DataSlice) Clone() DataSlice {
+	records := make([][]byte, len(d.Records))
+	for i, r := range d.Records {
+		records[i] = append([]byte(nil), r...)
+	}
+	return DataSlice{
+		Name:    d.Name,
+		Records: records,
+	}
+}
+
+// Submission ties a party to a model/data bundle for evaluation.
+type Submission struct {
+	PartyID string
+	Model   ModelArtifact
+	Data    DataSlice
+}
+
+// Score represents the outcome of running a task.
+type Score struct {
+	Value    float64
+	Evidence string
+}
+
+// EvalTask defines a pluggable evaluation job that can run inside a sandbox.
+type EvalTask interface {
+	Name() string
+	Evaluate(model ModelArtifact, data DataSlice) (Score, error)
+}
+
+// Scorecard captures the signed results for a particular party.
+type Scorecard struct {
+	PartyID    string
+	TaskScores map[string]Score
+	Metadata   map[string]string
+	CreatedAt  time.Time
+	Signature  []byte
+}
+
+// CloneWithoutSignature is useful for testing isolation of metadata.
+func (s Scorecard) CloneWithoutSignature() Scorecard {
+	copyScores := make(map[string]Score, len(s.TaskScores))
+	for k, v := range s.TaskScores {
+		copyScores[k] = v
+	}
+	copyMetadata := make(map[string]string, len(s.Metadata))
+	for k, v := range s.Metadata {
+		copyMetadata[k] = v
+	}
+	return Scorecard{
+		PartyID:    s.PartyID,
+		TaskScores: copyScores,
+		Metadata:   copyMetadata,
+		CreatedAt:  s.CreatedAt,
+	}
+}


### PR DESCRIPTION
## Summary
- add a Go-based mpes runner that orchestrates per-party sandboxes, applies policy firewalls, and signs results
- provide static capability allowlists and scorecard signer utilities for enclave-style evaluations
- cover cross-party isolation, deterministic scoring, and scorecard verification with unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68d78d5e72748333b201cb69362a6282