### PR TITLE
feat: introduce deterministic toolchain hasher CLI

### DIFF
--- a/ga-graphai/packages/dth/AGENTS.md
+++ b/ga-graphai/packages/dth/AGENTS.md
@@ -1,0 +1,4 @@
+- Deterministic Toolchain Hasher CLI package.
+- Use 2-space indentation for all JavaScript files.
+- Run `npm test` in this directory after making changes.
+- Document CLI usage updates in the package README.

--- a/ga-graphai/packages/dth/README.md
+++ b/ga-graphai/packages/dth/README.md
@@ -1,0 +1,98 @@
+# Deterministic Toolchain Hasher (DTH)
+
+`dth` computes stable identities for build and execution pipelines by fingerprinting the
+full toolchain (compilers, libraries, kernels, drivers) and the execution graph that
+uses them. The resulting pipeline IDs can be handed to cache registries such as
+DPEC and SPAR to guarantee deterministic cache hits across environments.
+
+## Installation
+
+```bash
+npm install
+```
+
+This package is managed via the `ga-graphai` workspace. Run `npm install` from the
+repository root to link workspace dependencies.
+
+## Usage
+
+```bash
+npx dth hash path/to/pipeline.manifest.yaml
+```
+
+### Commands
+
+#### `dth hash <manifest>`
+
+Computes a deterministic pipeline ID from the supplied manifest. Options:
+
+- `-a, --algorithm <algo>` — Hash algorithm (default `sha256`).
+- `-o, --output <file>` — Write the pipeline ID to a file instead of STDOUT.
+- `-r, --receipt <file>` — Emit a full pipeline receipt JSON to the given file.
+- `--pretty` — Pretty-print the receipt JSON output.
+
+#### `dth receipt <manifest>`
+
+Generates a structured receipt that includes the pipeline ID, component digests, and
+source manifest metadata. Options:
+
+- `-a, --algorithm <algo>` — Hash algorithm (default `sha256`).
+- `-o, --output <file>` — Where to write the receipt (defaults to STDOUT).
+- `--pretty` — Pretty-print the JSON output.
+
+#### `dth diff <left-receipt> <right-receipt>`
+
+Produces a human-readable explanation of the changes between two receipts.
+Options:
+
+- `-o, --output <file>` — Write the diff report to a file.
+- `--json` — Emit a machine-readable diff JSON instead of text.
+- `--fail-on-change` — Exit with status code `1` when differences are detected.
+
+## Manifest format
+
+The manifest describes the toolchain and execution graph. Supported formats are
+JSON, YAML, and TOML. A minimal example:
+
+```yaml
+name: example pipeline
+version: 1.0.0
+toolchain:
+  compilers:
+    - name: gcc
+      version: "12.2"
+      path: /usr/bin/gcc
+  libraries:
+    - name: glibc
+      version: "2.35"
+executionGraph:
+  nodes:
+    - id: preprocess
+      type: container
+      image: alpine:3.19
+      command: ./scripts/preprocess.sh
+  edges:
+    - from: preprocess
+      to: train
+      artifact: preprocessed-data
+metadata:
+  owner: ml-team
+```
+
+The CLI normalizes component ordering before hashing so manifests that describe the
+same toolchain yield identical IDs.
+
+## Receipts and registries
+
+Receipts embed per-component digests along with a canonical manifest hash. Caches
+and registries such as DPEC/SPAR can use these values to validate hits or explain
+mismatches via the diff command. The diff output highlights only altered
+components so you can quickly answer “why did this change?”.
+
+## Testing
+
+```bash
+npm test
+```
+
+The test suite relies on Node's built-in test runner to keep the toolchain light.

--- a/ga-graphai/packages/dth/package.json
+++ b/ga-graphai/packages/dth/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@ga-graphai/dth",
+  "version": "0.1.0",
+  "type": "module",
+  "bin": {
+    "dth": "./src/cli.js"
+  },
+  "exports": {
+    ".": "./src/index.js",
+    "./cli": "./src/cli.js"
+  },
+  "scripts": {
+    "test": "node --test tests/*.test.js"
+  },
+  "dependencies": {
+    "commander": "^12.1.0",
+    "js-yaml": "^4.1.0",
+    "toml": "^3.0.0"
+  }
+}

--- a/ga-graphai/packages/dth/src/cli.js
+++ b/ga-graphai/packages/dth/src/cli.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { Command } from 'commander';
+import { createRequire } from 'module';
+import { buildReceipt } from './receipt.js';
+import { diffReceipts, formatReceiptDiff } from './diff.js';
+import { loadManifest } from './manifest.js';
+import { computePipelineIdentity } from './hash.js';
+
+const require = createRequire(import.meta.url);
+const { version } = require('../package.json');
+
+function writeFileIfPath(targetPath, content) {
+  if (!targetPath) {
+    return;
+  }
+  const resolved = path.resolve(targetPath);
+  fs.mkdirSync(path.dirname(resolved), { recursive: true });
+  fs.writeFileSync(resolved, content);
+}
+
+function stringifyJSON(data, pretty) {
+  return pretty ? `${JSON.stringify(data, null, 2)}\n` : `${JSON.stringify(data)}\n`;
+}
+
+function handleHash(manifestPath, options) {
+  try {
+    const manifestInfo = loadManifest(manifestPath);
+    const identity = computePipelineIdentity(manifestInfo.manifest, {
+      algorithm: options.algorithm
+    });
+    if (options.receipt) {
+      const receipt = buildReceipt({
+        manifest: manifestInfo.manifest,
+        manifestPath: manifestInfo.path,
+        manifestFormat: manifestInfo.format,
+        manifestRawHash: manifestInfo.rawHash,
+        normalized: identity.normalized,
+        componentDigests: identity.componentDigests,
+        canonicalManifestHash: identity.canonicalManifestHash,
+        pipelineId: identity.id,
+        algorithm: identity.algorithm,
+        stats: manifestInfo.stats
+      });
+      writeFileIfPath(options.receipt, stringifyJSON(receipt, options.pretty));
+    }
+    const output = `${identity.id}\n`;
+    if (options.output) {
+      writeFileIfPath(options.output, output);
+    } else {
+      process.stdout.write(output);
+    }
+  } catch (error) {
+    process.stderr.write(`dth hash failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+function handleReceipt(manifestPath, options) {
+  try {
+    const manifestInfo = loadManifest(manifestPath);
+    const identity = computePipelineIdentity(manifestInfo.manifest, {
+      algorithm: options.algorithm
+    });
+    const receipt = buildReceipt({
+      manifest: manifestInfo.manifest,
+      manifestPath: manifestInfo.path,
+      manifestFormat: manifestInfo.format,
+      manifestRawHash: manifestInfo.rawHash,
+      normalized: identity.normalized,
+      componentDigests: identity.componentDigests,
+      canonicalManifestHash: identity.canonicalManifestHash,
+      pipelineId: identity.id,
+      algorithm: identity.algorithm,
+      stats: manifestInfo.stats
+    });
+    const serialized = stringifyJSON(receipt, options.pretty);
+    if (options.output) {
+      writeFileIfPath(options.output, serialized);
+    } else {
+      process.stdout.write(serialized);
+    }
+  } catch (error) {
+    process.stderr.write(`dth receipt failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+function readReceipt(receiptPath) {
+  const resolved = path.resolve(receiptPath);
+  const raw = fs.readFileSync(resolved, 'utf8');
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse receipt at ${resolved}: ${error.message}`);
+  }
+}
+
+function handleDiff(leftPath, rightPath, options) {
+  try {
+    const left = readReceipt(leftPath);
+    const right = readReceipt(rightPath);
+    const diff = diffReceipts(left, right);
+    let output;
+    if (options.json) {
+      output = stringifyJSON(diff, options.pretty);
+    } else {
+      output = `${formatReceiptDiff(diff)}\n`;
+    }
+    if (options.output) {
+      writeFileIfPath(options.output, output);
+    } else {
+      process.stdout.write(output);
+    }
+    if (options.failOnChange && diff.hasDifferences) {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    process.stderr.write(`dth diff failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+const program = new Command();
+program.name('dth').description('Deterministic Toolchain Hasher').version(version);
+
+program
+  .command('hash')
+  .argument('<manifest>', 'Path to the manifest file (JSON, YAML, TOML)')
+  .description('Compute a deterministic pipeline ID for the given manifest')
+  .option('-a, --algorithm <algorithm>', 'Hash algorithm to use', 'sha256')
+  .option('-o, --output <file>', 'Write the pipeline ID to a file')
+  .option('-r, --receipt <file>', 'Write a pipeline receipt to a file')
+  .option('--pretty', 'Pretty-print receipt JSON output', false)
+  .action((manifestPath, options) => handleHash(manifestPath, options));
+
+program
+  .command('receipt')
+  .argument('<manifest>', 'Path to the manifest file (JSON, YAML, TOML)')
+  .description('Generate a deterministic receipt for the manifest')
+  .option('-a, --algorithm <algorithm>', 'Hash algorithm to use', 'sha256')
+  .option('-o, --output <file>', 'Write the receipt to a file')
+  .option('--pretty', 'Pretty-print the JSON output', false)
+  .action((manifestPath, options) => handleReceipt(manifestPath, options));
+
+program
+  .command('diff')
+  .argument('<left>', 'Path to the baseline receipt JSON file')
+  .argument('<right>', 'Path to the comparison receipt JSON file')
+  .description('Explain the differences between two pipeline receipts')
+  .option('-o, --output <file>', 'Write the diff report to a file')
+  .option('--json', 'Emit the diff as machine-readable JSON', false)
+  .option('--pretty', 'Pretty-print JSON output', false)
+  .option('--fail-on-change', 'Exit with status code 1 if differences are detected', false)
+  .action((left, right, options) => handleDiff(left, right, options));
+
+program.showHelpAfterError();
+program.parseAsync(process.argv);

--- a/ga-graphai/packages/dth/src/diff.js
+++ b/ga-graphai/packages/dth/src/diff.js
@@ -1,0 +1,235 @@
+import { GRAPH_SORT_HINTS, TOOLCHAIN_SORT_HINTS, canonicalJSONStringify, deepEqual, isPlainObject, normalizeValue } from './hash.js';
+
+function makeItemKey(item, hints) {
+  if (isPlainObject(item)) {
+    for (const hint of hints) {
+      if (item[hint] !== undefined) {
+        return `${hint}:${item[hint]}`;
+      }
+    }
+  }
+  return canonicalJSONStringify(item);
+}
+
+function diffList(leftList = [], rightList = [], hints = []) {
+  const leftMap = new Map();
+  const rightMap = new Map();
+  for (const item of leftList || []) {
+    const normalized = normalizeValue(item);
+    const key = makeItemKey(normalized, hints);
+    leftMap.set(key, normalized);
+  }
+  for (const item of rightList || []) {
+    const normalized = normalizeValue(item);
+    const key = makeItemKey(normalized, hints);
+    rightMap.set(key, normalized);
+  }
+  const keys = new Set([...leftMap.keys(), ...rightMap.keys()]);
+  const changes = [];
+  for (const key of keys) {
+    const left = leftMap.get(key);
+    const right = rightMap.get(key);
+    if (left && !right) {
+      changes.push({ type: 'removed', key, left });
+      continue;
+    }
+    if (!left && right) {
+      changes.push({ type: 'added', key, right });
+      continue;
+    }
+    if (left && right && !deepEqual(left, right)) {
+      changes.push({ type: 'changed', key, left, right, diff: diffNested(left, right) });
+    }
+  }
+  return changes;
+}
+
+function diffNested(left, right, basePath = []) {
+  if (deepEqual(left, right)) {
+    return [];
+  }
+  if (Array.isArray(left) && Array.isArray(right)) {
+    const length = Math.max(left.length, right.length);
+    const changes = [];
+    for (let index = 0; index < length; index += 1) {
+      const nextPath = [...basePath, `[${index}]`];
+      if (index >= left.length) {
+        changes.push({ type: 'added', path: nextPath.join(''), right: right[index] });
+      } else if (index >= right.length) {
+        changes.push({ type: 'removed', path: nextPath.join(''), left: left[index] });
+      } else {
+        changes.push(...diffNested(left[index], right[index], nextPath));
+      }
+    }
+    return changes;
+  }
+  if (isPlainObject(left) && isPlainObject(right)) {
+    const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+    const changes = [];
+    for (const key of [...keys].sort()) {
+      const nextPath = [...basePath, basePath.length === 0 ? key : `.${key}`];
+      if (!(key in right)) {
+        changes.push({ type: 'removed', path: nextPath.join(''), left: left[key] });
+      } else if (!(key in left)) {
+        changes.push({ type: 'added', path: nextPath.join(''), right: right[key] });
+      } else {
+        changes.push(...diffNested(left[key], right[key], nextPath));
+      }
+    }
+    return changes;
+  }
+  if (left === undefined) {
+    return [{ type: 'added', path: basePath.join(''), right }];
+  }
+  if (right === undefined) {
+    return [{ type: 'removed', path: basePath.join(''), left }];
+  }
+  return [{ type: 'changed', path: basePath.join(''), left, right }];
+}
+
+function diffToolchain(leftToolchain = {}, rightToolchain = {}) {
+  const sections = new Set([...Object.keys(leftToolchain), ...Object.keys(rightToolchain)]);
+  const changes = [];
+  for (const section of sections) {
+    const hints = TOOLCHAIN_SORT_HINTS[section] || ['id', 'name', 'version'];
+    const left = leftToolchain[section] || [];
+    const right = rightToolchain[section] || [];
+    if (Array.isArray(left) || Array.isArray(right)) {
+      const listChanges = diffList(left, right, hints);
+      for (const change of listChanges) {
+        changes.push({ ...change, section });
+      }
+      continue;
+    }
+    const objectChanges = diffNested(left, right, [section]);
+    for (const change of objectChanges) {
+      changes.push({ ...change, section });
+    }
+  }
+  return changes;
+}
+
+function diffExecutionGraph(leftGraph = {}, rightGraph = {}) {
+  const sections = new Set([...Object.keys(leftGraph), ...Object.keys(rightGraph)]);
+  const changes = [];
+  for (const section of sections) {
+    const hints = GRAPH_SORT_HINTS[section] || ['id', 'name'];
+    const left = leftGraph[section] || [];
+    const right = rightGraph[section] || [];
+    if (Array.isArray(left) || Array.isArray(right)) {
+      const listChanges = diffList(left, right, hints);
+      for (const change of listChanges) {
+        changes.push({ ...change, section });
+      }
+      continue;
+    }
+    const objectChanges = diffNested(left, right, [section]);
+    for (const change of objectChanges) {
+      changes.push({ ...change, section });
+    }
+  }
+  return changes;
+}
+
+function diffDigests(leftDigests = {}, rightDigests = {}) {
+  const changes = [];
+  const keys = new Set([...Object.keys(leftDigests), ...Object.keys(rightDigests)]);
+  for (const key of keys) {
+    const left = leftDigests[key];
+    const right = rightDigests[key];
+    if (isPlainObject(left) && isPlainObject(right)) {
+      if (!deepEqual(left, right)) {
+        changes.push({ key, type: 'changed', left, right });
+      }
+      continue;
+    }
+    if (left !== right) {
+      const changeType = left === undefined ? 'added' : right === undefined ? 'removed' : 'changed';
+      changes.push({ key, type: changeType, left, right });
+    }
+  }
+  return changes;
+}
+
+function diffReceipts(left, right) {
+  const leftId = left?.pipeline?.id;
+  const rightId = right?.pipeline?.id;
+  const pipelineIdChanged = leftId !== rightId;
+  const toolchainChanges = diffToolchain(left?.toolchain, right?.toolchain);
+  const executionGraphChanges = diffExecutionGraph(left?.executionGraph, right?.executionGraph);
+  const metadataChanges = diffNested(left?.metadata || {}, right?.metadata || {}, ['metadata']);
+  const environmentChanges = diffNested(left?.environment || {}, right?.environment || {}, ['environment']);
+  const parameterChanges = diffNested(left?.parameters || {}, right?.parameters || {}, ['parameters']);
+  const lineageChanges = diffNested(left?.lineage || {}, right?.lineage || {}, ['lineage']);
+  const digestChanges = diffDigests(left?.digests || {}, right?.digests || {});
+  const hasDifferences =
+    pipelineIdChanged ||
+    toolchainChanges.length > 0 ||
+    executionGraphChanges.length > 0 ||
+    metadataChanges.length > 0 ||
+    environmentChanges.length > 0 ||
+    parameterChanges.length > 0 ||
+    lineageChanges.length > 0 ||
+    digestChanges.length > 0;
+  return {
+    pipeline: { left: leftId, right: rightId, changed: pipelineIdChanged },
+    toolchain: toolchainChanges,
+    executionGraph: executionGraphChanges,
+    metadata: metadataChanges,
+    environment: environmentChanges,
+    parameters: parameterChanges,
+    lineage: lineageChanges,
+    digests: digestChanges,
+    hasDifferences
+  };
+}
+
+function formatListChange(change) {
+  if (change.type === 'added') {
+    return `+ ${change.section || 'item'} ${change.key}`;
+  }
+  if (change.type === 'removed') {
+    return `- ${change.section || 'item'} ${change.key}`;
+  }
+  return `~ ${change.section || 'item'} ${change.key}`;
+}
+
+function formatReceiptDiff(diff, { includeSections = ['toolchain', 'executionGraph', 'metadata', 'environment', 'parameters', 'lineage'] } = {}) {
+  if (!diff.hasDifferences) {
+    return 'No differences detected. Receipts describe the same pipeline.';
+  }
+  const lines = [];
+  if (diff.pipeline.changed) {
+    lines.push(`Pipeline ID changed: ${diff.pipeline.left || '<none>'} -> ${diff.pipeline.right || '<none>'}`);
+  } else {
+    lines.push(`Pipeline ID unchanged: ${diff.pipeline.left || '<none>'}`);
+  }
+  if (diff.digests.length > 0) {
+    lines.push('Digest changes:');
+    for (const change of diff.digests) {
+      lines.push(`  - ${change.key}: ${change.left || '<none>'} -> ${change.right || '<none>'}`);
+    }
+  }
+  for (const section of includeSections) {
+    const sectionChanges = diff[section];
+    if (!sectionChanges || sectionChanges.length === 0) {
+      continue;
+    }
+    lines.push(`${section[0].toUpperCase()}${section.slice(1)} changes:`);
+    for (const change of sectionChanges) {
+      if ('key' in change) {
+        lines.push(`  ${formatListChange(change)}`);
+        if (change.type === 'changed' && change.diff?.length) {
+          for (const nested of change.diff) {
+            lines.push(`    • ${nested.path || change.key}: ${JSON.stringify(nested.left)} -> ${JSON.stringify(nested.right)}`);
+          }
+        }
+      } else {
+        lines.push(`  ${change.type === 'added' ? '+' : change.type === 'removed' ? '-' : '~'} ${change.path}: ${JSON.stringify(change.left)} -> ${JSON.stringify(change.right)}`);
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
+export { diffReceipts, formatReceiptDiff };

--- a/ga-graphai/packages/dth/src/hash.js
+++ b/ga-graphai/packages/dth/src/hash.js
@@ -1,0 +1,253 @@
+import { createHash } from 'node:crypto';
+import { isDeepStrictEqual } from 'node:util';
+
+const TOOLCHAIN_SORT_HINTS = {
+  compilers: ['id', 'name', 'version', 'path'],
+  libraries: ['id', 'name', 'version', 'path'],
+  kernels: ['id', 'name', 'version', 'image', 'path'],
+  drivers: ['id', 'name', 'version'],
+  runtimes: ['id', 'name', 'version'],
+  cuda: ['version', 'driver'],
+  frameworks: ['id', 'name', 'version'],
+  plugins: ['id', 'name', 'version']
+};
+
+const GRAPH_SORT_HINTS = {
+  nodes: ['id', 'name'],
+  edges: ['id', 'from', 'to', 'artifact'],
+  stages: ['id', 'name']
+};
+
+const FIELDS_TO_DROP = new Set(['pipelineId', 'pipeline_id', 'hash', 'hashes', 'receipt', 'receipts']);
+
+function isPlainObject(value) {
+  return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function normalizeValue(value) {
+  if (Array.isArray(value)) {
+    const array = [];
+    for (const entry of value) {
+      const normalized = normalizeValue(entry);
+      if (normalized !== undefined) {
+        array.push(normalized);
+      }
+    }
+    return array;
+  }
+  if (isPlainObject(value)) {
+    const entries = [];
+    for (const [key, val] of Object.entries(value)) {
+      if (FIELDS_TO_DROP.has(key)) {
+        continue;
+      }
+      const normalized = normalizeValue(val);
+      if (normalized !== undefined) {
+        entries.push([key, normalized]);
+      }
+    }
+    entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const result = {};
+    for (const [key, val] of entries) {
+      result[key] = val;
+    }
+    return result;
+  }
+  if (value === undefined) {
+    return undefined;
+  }
+  return value;
+}
+
+function inferSortHints(section, hintsMap) {
+  if (Array.isArray(section) && section.length > 0) {
+    return ['id', 'name', 'key'];
+  }
+  return hintsMap || [];
+}
+
+function makeSortKey(item, hints) {
+  if (isPlainObject(item)) {
+    for (const hint of hints) {
+      if (item[hint] !== undefined) {
+        return String(item[hint]);
+      }
+    }
+  }
+  return JSON.stringify(item);
+}
+
+function sortArray(value, hints = []) {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const normalized = value
+    .map((item) => normalizeValue(item))
+    .filter((item) => item !== undefined);
+  const uniqueHints = hints.length > 0 ? hints : inferSortHints(normalized, hints);
+  normalized.sort((left, right) => {
+    const leftKey = makeSortKey(left, uniqueHints);
+    const rightKey = makeSortKey(right, uniqueHints);
+    if (leftKey < rightKey) {
+      return -1;
+    }
+    if (leftKey > rightKey) {
+      return 1;
+    }
+    return 0;
+  });
+  return normalized;
+}
+
+function normalizeToolchain(toolchain) {
+  const normalized = {};
+  for (const [key, value] of Object.entries(toolchain)) {
+    if (Array.isArray(value)) {
+      const hints = TOOLCHAIN_SORT_HINTS[key] || ['id', 'name', 'version'];
+      normalized[key] = sortArray(value, hints);
+      continue;
+    }
+    if (isPlainObject(value)) {
+      normalized[key] = normalizeValue(value);
+      continue;
+    }
+    if (value !== undefined) {
+      normalized[key] = value;
+    }
+  }
+  return normalized;
+}
+
+function normalizeExecutionGraph(graph) {
+  const normalized = {};
+  for (const [key, value] of Object.entries(graph)) {
+    if (Array.isArray(value)) {
+      const hints = GRAPH_SORT_HINTS[key] || ['id', 'name'];
+      if (key === 'edges') {
+        normalized[key] = sortArray(
+          value.map((edge) => {
+            const normalEdge = normalizeValue(edge);
+            if (isPlainObject(normalEdge)) {
+              const canonical = { ...normalEdge };
+              if (canonical.from !== undefined && canonical.to !== undefined) {
+                canonical._edgeKey = `${canonical.from}->${canonical.to}`;
+              }
+              return canonical;
+            }
+            return normalEdge;
+          }),
+          ['_edgeKey', ...hints]
+        ).map((edge) => {
+          if (isPlainObject(edge)) {
+            const { _edgeKey, ...rest } = edge;
+            return rest;
+          }
+          return edge;
+        });
+        continue;
+      }
+      normalized[key] = sortArray(value, hints);
+      continue;
+    }
+    if (isPlainObject(value)) {
+      normalized[key] = normalizeValue(value);
+      continue;
+    }
+    if (value !== undefined) {
+      normalized[key] = value;
+    }
+  }
+  return normalized;
+}
+
+function canonicalJSONStringify(value) {
+  if (value === null) {
+    return 'null';
+  }
+  if (typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => canonicalJSONStringify(entry)).join(',')}]`;
+  }
+  const entries = Object.entries(value || {}).sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries
+    .map(([key, val]) => `${JSON.stringify(key)}:${canonicalJSONStringify(val)}`)
+    .join(',')}}`;
+}
+
+function computeDigest(value, algorithm) {
+  const hash = createHash(algorithm);
+  hash.update(canonicalJSONStringify(value));
+  return hash.digest('hex');
+}
+
+function normalizeManifest(manifest) {
+  const base = isPlainObject(manifest) ? manifest : {};
+  const normalized = normalizeValue(base) || {};
+  if (normalized.toolchain && isPlainObject(normalized.toolchain)) {
+    normalized.toolchain = normalizeToolchain(normalized.toolchain);
+  }
+  if (normalized.executionGraph && isPlainObject(normalized.executionGraph)) {
+    normalized.executionGraph = normalizeExecutionGraph(normalized.executionGraph);
+  }
+  if (Array.isArray(normalized.tags)) {
+    normalized.tags = [...normalized.tags].sort();
+  }
+  return normalized;
+}
+
+function deepEqual(left, right) {
+  return isDeepStrictEqual(left, right);
+}
+
+function computeComponentDigests(normalized, algorithm) {
+  const sections = {
+    toolchain: normalized.toolchain || {},
+    executionGraph: normalized.executionGraph || {},
+    metadata: normalized.metadata || {},
+    environment: normalized.environment || {},
+    parameters: normalized.parameters || {},
+    lineage: normalized.lineage || {}
+  };
+  const digests = {};
+  for (const [key, value] of Object.entries(sections)) {
+    digests[key] = computeDigest(value, algorithm);
+  }
+  return digests;
+}
+
+function computePipelineIdentity(manifest, options = {}) {
+  const algorithm = options.algorithm || 'sha256';
+  const normalized = normalizeManifest(manifest);
+  const canonical = canonicalJSONStringify(normalized);
+  const hash = createHash(algorithm);
+  hash.update(canonical);
+  const pipelineId = hash.digest('hex');
+  const componentDigests = computeComponentDigests(normalized, algorithm);
+  const canonicalManifestHash = computeDigest(normalized, 'sha256');
+  return {
+    id: pipelineId,
+    algorithm,
+    normalized,
+    canonical,
+    canonicalManifestHash,
+    componentDigests
+  };
+}
+
+export {
+  GRAPH_SORT_HINTS,
+  TOOLCHAIN_SORT_HINTS,
+  canonicalJSONStringify,
+  computeComponentDigests,
+  computeDigest,
+  computePipelineIdentity,
+  deepEqual,
+  isPlainObject,
+  normalizeExecutionGraph,
+  normalizeManifest,
+  normalizeToolchain,
+  normalizeValue,
+  sortArray
+};

--- a/ga-graphai/packages/dth/src/index.js
+++ b/ga-graphai/packages/dth/src/index.js
@@ -1,0 +1,13 @@
+export { loadManifest, parseManifestString } from './manifest.js';
+export {
+  canonicalJSONStringify,
+  computeComponentDigests,
+  computeDigest,
+  computePipelineIdentity,
+  normalizeExecutionGraph,
+  normalizeManifest,
+  normalizeToolchain,
+  normalizeValue
+} from './hash.js';
+export { buildReceipt } from './receipt.js';
+export { diffReceipts, formatReceiptDiff } from './diff.js';

--- a/ga-graphai/packages/dth/src/manifest.js
+++ b/ga-graphai/packages/dth/src/manifest.js
@@ -1,0 +1,68 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import yaml from 'js-yaml';
+import toml from 'toml';
+
+const EXTENSION_FORMAT = {
+  '.json': 'json',
+  '.yaml': 'yaml',
+  '.yml': 'yaml',
+  '.toml': 'toml'
+};
+
+const PARSERS = {
+  json: (content) => JSON.parse(content),
+  yaml: (content) => yaml.load(content),
+  toml: (content) => toml.parse(content)
+};
+
+function parseManifestString(raw, preferredFormat) {
+  const attempts = preferredFormat ? [preferredFormat, 'json', 'yaml', 'toml'] : ['json', 'yaml', 'toml'];
+  const tried = new Set();
+  for (const format of attempts) {
+    if (!PARSERS[format] || tried.has(format)) {
+      continue;
+    }
+    tried.add(format);
+    try {
+      const manifest = PARSERS[format](raw);
+      if (manifest && typeof manifest === 'object') {
+        return { manifest, format };
+      }
+      throw new Error(`Manifest parser for ${format} returned non-object data.`);
+    } catch (error) {
+      if (format === preferredFormat) {
+        continue;
+      }
+      if (attempts.at(-1) === format) {
+        throw error;
+      }
+    }
+  }
+  throw new Error('Unable to parse manifest. Supported formats: JSON, YAML, TOML.');
+}
+
+function loadManifest(manifestPath) {
+  const resolvedPath = path.resolve(manifestPath);
+  const raw = fs.readFileSync(resolvedPath, 'utf8');
+  const extension = path.extname(resolvedPath).toLowerCase();
+  const preferredFormat = EXTENSION_FORMAT[extension];
+  const { manifest, format } = parseManifestString(raw, preferredFormat);
+  if (!manifest || typeof manifest !== 'object') {
+    throw new Error('Manifest did not produce an object.');
+  }
+  const stats = fs.statSync(resolvedPath);
+  const rawHash = createHash('sha256').update(raw).digest('hex');
+  return {
+    manifest,
+    raw,
+    format,
+    preferredFormat,
+    path: resolvedPath,
+    stats,
+    rawHash
+  };
+}
+
+export { loadManifest, parseManifestString };

--- a/ga-graphai/packages/dth/src/receipt.js
+++ b/ga-graphai/packages/dth/src/receipt.js
@@ -1,0 +1,114 @@
+import path from 'node:path';
+import { canonicalJSONStringify } from './hash.js';
+
+function countToolchainComponents(toolchain = {}) {
+  const counts = {};
+  let total = 0;
+  for (const [key, value] of Object.entries(toolchain)) {
+    if (Array.isArray(value)) {
+      counts[key] = value.length;
+      total += value.length;
+    }
+  }
+  return { counts, total };
+}
+
+function summarizeExecutionGraph(graph = {}) {
+  const nodes = Array.isArray(graph.nodes) ? graph.nodes.length : 0;
+  const edges = Array.isArray(graph.edges) ? graph.edges.length : 0;
+  const stages = Array.isArray(graph.stages) ? graph.stages.length : 0;
+  return { nodes, edges, stages };
+}
+
+function pruneEmpty(value) {
+  if (Array.isArray(value)) {
+    const array = value
+      .map((entry) => pruneEmpty(entry))
+      .filter((entry) => entry !== undefined);
+    return array.length > 0 ? array : undefined;
+  }
+  if (value && typeof value === 'object') {
+    const entries = Object.entries(value)
+      .map(([key, val]) => [key, pruneEmpty(val)])
+      .filter(([, val]) => val !== undefined);
+    if (entries.length === 0) {
+      return undefined;
+    }
+    const result = {};
+    for (const [key, val] of entries) {
+      result[key] = val;
+    }
+    return result;
+  }
+  if (value === null || value === undefined) {
+    return undefined;
+  }
+  return value;
+}
+
+function buildReceipt({
+  manifest,
+  manifestPath,
+  manifestFormat,
+  manifestRawHash,
+  normalized,
+  componentDigests,
+  canonicalManifestHash,
+  pipelineId,
+  algorithm,
+  stats
+}) {
+  const computedAt = new Date().toISOString();
+  const toolchain = normalized.toolchain || {};
+  const executionGraph = normalized.executionGraph || {};
+  const { counts, total } = countToolchainComponents(toolchain);
+  const graphSummary = summarizeExecutionGraph(executionGraph);
+  const summary = {
+    toolchain: {
+      total,
+      byType: counts
+    },
+    executionGraph: graphSummary
+  };
+  const digests = {
+    algorithm,
+    pipeline: pipelineId,
+    canonicalManifest: canonicalManifestHash,
+    rawManifest: manifestRawHash,
+    components: componentDigests
+  };
+  const source = pruneEmpty({
+    manifestPath: manifestPath ? path.resolve(manifestPath) : undefined,
+    format: manifestFormat,
+    bytes: stats?.size,
+    modifiedAt: stats?.mtime ? stats.mtime.toISOString() : undefined
+  });
+  const integrations = {
+    dpec: { pipelineId },
+    spar: { pipelineId }
+  };
+  const receipt = pruneEmpty({
+    schemaVersion: 'dth-receipt/v1',
+    computedAt,
+    pipeline: pruneEmpty({
+      id: pipelineId,
+      name: normalized.name || manifest?.name,
+      version: manifest?.version,
+      description: manifest?.description
+    }),
+    summary,
+    toolchain,
+    executionGraph,
+    metadata: normalized.metadata,
+    environment: normalized.environment,
+    parameters: normalized.parameters,
+    lineage: normalized.lineage,
+    digests,
+    source,
+    integrations,
+    canonicalManifest: canonicalJSONStringify(normalized)
+  });
+  return receipt;
+}
+
+export { buildReceipt };

--- a/ga-graphai/packages/dth/tests/hash.test.js
+++ b/ga-graphai/packages/dth/tests/hash.test.js
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { buildReceipt, computePipelineIdentity, diffReceipts, formatReceiptDiff } from '../src/index.js';
+
+const baseManifest = {
+  name: 'sample pipeline',
+  version: '1.0.0',
+  toolchain: {
+    compilers: [
+      { name: 'gcc', version: '12.2', path: '/usr/bin/gcc' },
+      { name: 'nvcc', version: '12.3', path: '/usr/local/cuda/bin/nvcc' }
+    ],
+    libraries: [
+      { name: 'cublas', version: '12.3' },
+      { name: 'glibc', version: '2.35' }
+    ],
+    cuda: { version: '12.3', driver: '535.86' },
+    drivers: [{ name: 'nvidia', version: '535.86' }]
+  },
+  executionGraph: {
+    nodes: [
+      { id: 'preprocess', type: 'container', image: 'alpine:3.19' },
+      { id: 'train', type: 'container', image: 'pytorch:2.3' }
+    ],
+    edges: [
+      { from: 'preprocess', to: 'train', artifact: 'dataset' }
+    ]
+  },
+  metadata: {
+    owner: 'ml-team'
+  }
+};
+
+function makeReceipt(manifest, rawSeed) {
+  const identity = computePipelineIdentity(manifest);
+  const manifestRawHash = createHash('sha256').update(rawSeed).digest('hex');
+  return {
+    identity,
+    receipt: buildReceipt({
+      manifest,
+      manifestPath: '/tmp/manifest.yaml',
+      manifestFormat: 'yaml',
+      manifestRawHash,
+      normalized: identity.normalized,
+      componentDigests: identity.componentDigests,
+      canonicalManifestHash: identity.canonicalManifestHash,
+      pipelineId: identity.id,
+      algorithm: identity.algorithm,
+      stats: { size: rawSeed.length, mtime: new Date('2024-01-01T00:00:00Z') }
+    })
+  };
+}
+
+test('stable pipeline ID for equivalent manifests', () => {
+  const shuffledManifest = {
+    ...baseManifest,
+    toolchain: {
+      ...baseManifest.toolchain,
+      compilers: [...baseManifest.toolchain.compilers].reverse(),
+      libraries: [...baseManifest.toolchain.libraries].reverse()
+    },
+    executionGraph: {
+      ...baseManifest.executionGraph,
+      nodes: [...baseManifest.executionGraph.nodes].reverse()
+    }
+  };
+  const first = computePipelineIdentity(baseManifest);
+  const second = computePipelineIdentity(shuffledManifest);
+  assert.equal(first.id, second.id, 'IDs should be identical for equivalent manifests');
+  assert.deepEqual(first.normalized, second.normalized);
+});
+
+test('receipt integrates with registry-friendly metadata', () => {
+  const { identity, receipt } = makeReceipt(baseManifest, 'manifest-a');
+  assert.equal(receipt.pipeline.id, identity.id);
+  assert.ok(receipt.integrations.dpec.pipelineId);
+  assert.ok(receipt.integrations.spar.pipelineId);
+  assert.equal(receipt.summary.toolchain.byType.compilers, 2);
+  assert.equal(receipt.summary.executionGraph.nodes, 2);
+});
+
+test('diff pinpoints toolchain and graph changes', () => {
+  const { receipt: baselineReceipt } = makeReceipt(baseManifest, 'manifest-b');
+  const updatedManifest = JSON.parse(JSON.stringify(baseManifest));
+  updatedManifest.toolchain.libraries[0].version = '12.4';
+  updatedManifest.executionGraph.nodes.push({ id: 'evaluate', type: 'container', image: 'alpine:3.19' });
+  updatedManifest.executionGraph.edges.push({ from: 'train', to: 'evaluate', artifact: 'model' });
+  const { receipt: updatedReceipt } = makeReceipt(updatedManifest, 'manifest-c');
+  const diff = diffReceipts(baselineReceipt, updatedReceipt);
+  assert.ok(diff.hasDifferences, 'diff should detect changes');
+  const libraryChange = diff.toolchain.find((change) => change.section === 'libraries' && change.type === 'changed');
+  assert.ok(libraryChange, 'library change should be reported');
+  const addedNode = diff.executionGraph.find((change) => change.section === 'nodes' && change.type === 'added');
+  assert.ok(addedNode, 'new node should be detected');
+  const report = formatReceiptDiff(diff);
+  assert.match(report, /Pipeline ID changed/);
+  assert.match(report, /libraries/);
+  assert.match(report, /nodes/);
+});
+
+test('diff reports no differences for identical receipts', () => {
+  const { receipt: firstReceipt } = makeReceipt(baseManifest, 'manifest-d');
+  const { receipt: secondReceipt } = makeReceipt(baseManifest, 'manifest-d');
+  const diff = diffReceipts(firstReceipt, secondReceipt);
+  assert.equal(diff.hasDifferences, false);
+  const report = formatReceiptDiff(diff);
+  assert.match(report, /No differences detected/);
+});


### PR DESCRIPTION
## Summary
- add the new @ga-graphai/dth workspace package that provides the Deterministic Toolchain Hasher CLI
- compute stable pipeline identities, emit cache-ready receipts, and surface component-level diffs
- cover hashing and diff behavior with node-based tests

## Testing
- npm test (within packages/dth)


------
https://chatgpt.com/codex/tasks/task_e_68d78d79aab88333a95996a6af382236