### PR TITLE
feat: add csrs retention simulator

### DIFF
--- a/client/src/features/csrs/__tests__/CsrsTimeline.test.tsx
+++ b/client/src/features/csrs/__tests__/CsrsTimeline.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, within } from '@testing-library/react';
+import fs from 'node:fs';
+import path from 'node:path';
+import React from 'react';
+
+import CsrsTimeline from '../components/CsrsTimeline';
+import type { RetentionPlan } from '../types';
+
+function loadPlanFixture(): RetentionPlan {
+  const fixturePath = path.resolve(
+    __dirname,
+    '../../../../../python/tests/fixtures/csrs_golden_plan.json'
+  );
+  const content = fs.readFileSync(fixturePath, 'utf-8');
+  return JSON.parse(content) as RetentionPlan;
+}
+
+const planFixture = loadPlanFixture();
+
+describe('CsrsTimeline', () => {
+  it('renders timeline rows with risk highlights', () => {
+    render(<CsrsTimeline plan={planFixture} />);
+
+    expect(screen.getByRole('heading', { name: /consent-scoped retention simulator/i })).toBeVisible();
+
+    const timelineTable = screen.getByRole('table', { name: /per-purpose deletion horizons/i });
+    const rows = within(timelineTable).getAllByRole('row');
+    const fraudRow = rows.find((row) => {
+      const utils = within(row);
+      return utils.queryByText('accounts_core') && utils.queryByText('fraud_detection');
+    });
+    expect(fraudRow).not.toBeUndefined();
+    expect(fraudRow).toHaveAttribute('data-risk', 'breach');
+    expect(within(fraudRow as HTMLTableRowElement).getByText('2023-12-28')).toBeVisible();
+  });
+
+  it('lists downstream dependency impacts', () => {
+    render(<CsrsTimeline plan={planFixture} />);
+
+    const dependencyTable = screen.getByRole('table', { name: /downstream artifact impacts/i });
+    expect(within(dependencyTable).getByText('fraud_features_v4')).toBeVisible();
+    expect(within(dependencyTable).getByText(/eligible for deletion 33 days earlier/i)).toBeVisible();
+  });
+});

--- a/client/src/features/csrs/components/CsrsTimeline.tsx
+++ b/client/src/features/csrs/components/CsrsTimeline.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+
+import { buildDependencyRows, buildTimelineRows } from '../dataTransforms';
+import type { RetentionPlan } from '../types';
+
+export interface CsrsTimelineProps {
+  plan: RetentionPlan;
+}
+
+const srOnlyStyle: React.CSSProperties = {
+  border: 0,
+  clip: 'rect(0 0 0 0)',
+  height: '1px',
+  margin: '-1px',
+  overflow: 'hidden',
+  padding: 0,
+  position: 'absolute',
+  width: '1px',
+};
+
+export const CsrsTimeline: React.FC<CsrsTimelineProps> = ({ plan }) => {
+  const timelineRows = buildTimelineRows(plan);
+  const dependencyRows = buildDependencyRows(plan);
+
+  return (
+    <div aria-label="Consent-Scoped Retention Simulator">
+      <header>
+        <h2>Consent-Scoped Retention Simulator</h2>
+        <p>
+          Generated at <strong>{plan.generated_at}</strong> with late write slip{' '}
+          <strong>{plan.clock_shift.late_write_slip_days}d</strong> and backfill window{' '}
+          <strong>{plan.clock_shift.backfill_days}d</strong>.
+        </p>
+      </header>
+
+      <section aria-label="Retention timelines">
+        <h3>Per-purpose deletion horizons</h3>
+        <table>
+          <caption className="sr-only" style={srOnlyStyle}>
+            Per-purpose deletion horizons
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">Dataset</th>
+              <th scope="col">Purpose</th>
+              <th scope="col">Baseline</th>
+              <th scope="col">Late writes</th>
+              <th scope="col">Backfill</th>
+              <th scope="col">Risk</th>
+              <th scope="col">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {timelineRows.map((row) => (
+              <tr key={`${row.dataset}-${row.purpose}`} data-risk={row.riskLevel}>
+                <td>{row.dataset}</td>
+                <td>{row.purpose}</td>
+                <td>{row.baselineHorizon}</td>
+                <td>{row.lateWriteHorizon}</td>
+                <td>{row.backfillHorizon}</td>
+                <td>{formatRiskLabel(row.riskLevel)}</td>
+                <td>{row.blockers.join(', ') || 'None'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section aria-label="Dependent artifacts">
+        <h3>Downstream artifact impacts</h3>
+        <table>
+          <caption className="sr-only" style={srOnlyStyle}>
+            Downstream artifact impacts
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">Dataset</th>
+              <th scope="col">Artifact</th>
+              <th scope="col">Purpose</th>
+              <th scope="col">Type</th>
+              <th scope="col">Impact</th>
+              <th scope="col">Alignment Δ (days)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {dependencyRows.map((row) => (
+              <tr key={`${row.dataset}-${row.name}`}>
+                <td>{row.dataset}</td>
+                <td>{row.name}</td>
+                <td>{row.purpose}</td>
+                <td>{row.type}</td>
+                <td>{row.impact}</td>
+                <td>{row.alignmentDeltaDays}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+};
+
+function formatRiskLabel(level: 'ok' | 'elevated' | 'breach'): string {
+  switch (level) {
+    case 'breach':
+      return 'Breach';
+    case 'elevated':
+      return 'Elevated';
+    default:
+      return 'OK';
+  }
+}
+
+export default CsrsTimeline;

--- a/client/src/features/csrs/dataTransforms.ts
+++ b/client/src/features/csrs/dataTransforms.ts
@@ -1,0 +1,59 @@
+import type {
+  DependencyRow,
+  PurposeTimeline,
+  RetentionPlan,
+  TimelineRow,
+} from './types';
+
+const NEAR_BREACH_BUFFER_DAYS = 2;
+
+export function buildTimelineRows(plan: RetentionPlan): TimelineRow[] {
+  return plan.datasets.flatMap((dataset) =>
+    dataset.purposes.map((purpose) => ({
+      dataset: dataset.name,
+      purpose: purpose.purpose,
+      baselineHorizon: purpose.baseline_deletion_horizon,
+      lateWriteHorizon: purpose.late_write_horizon,
+      backfillHorizon: purpose.backfill_horizon,
+      riskLevel: determineRiskLevel(purpose),
+      blockers: formatRiskNotes(purpose),
+    }))
+  );
+}
+
+export function buildDependencyRows(plan: RetentionPlan): DependencyRow[] {
+  return plan.datasets.flatMap((dataset) =>
+    dataset.dependencies.map((dependency) => ({
+      dataset: dataset.name,
+      name: dependency.name,
+      purpose: dependency.purpose,
+      type: dependency.type,
+      impact: dependency.impact,
+      alignmentDeltaDays: dependency.alignment_delta_days,
+    }))
+  );
+}
+
+export function determineRiskLevel(purpose: PurposeTimeline): TimelineRow['riskLevel'] {
+  if (purpose.compliance_risk.some((entry) => entry.status === 'breach')) {
+    return 'breach';
+  }
+  if (
+    purpose.compliance_risk.some(
+      (entry) =>
+        entry.projected_shift_days > 0 &&
+        entry.allowed_days - entry.projected_shift_days <= NEAR_BREACH_BUFFER_DAYS
+    )
+  ) {
+    return 'elevated';
+  }
+  return 'ok';
+}
+
+function formatRiskNotes(purpose: PurposeTimeline): string[] {
+  return purpose.compliance_risk.map((entry) => {
+    const prefix = `${entry.type.replace('_', ' ')}: ${entry.status}`;
+    const delta = entry.delta_days === 0 ? '' : ` (${entry.delta_days > 0 ? '+' : ''}${entry.delta_days}d)`;
+    return `${prefix}${delta}`.trim();
+  });
+}

--- a/client/src/features/csrs/types.ts
+++ b/client/src/features/csrs/types.ts
@@ -1,0 +1,63 @@
+export interface ComplianceRiskEntry {
+  type: 'late_writes' | 'backfill';
+  status: 'ok' | 'breach';
+  allowed_days: number;
+  projected_shift_days: number;
+  delta_days: number;
+  projected_horizon: string;
+}
+
+export interface PurposeTimeline {
+  purpose: string;
+  retention_days: number;
+  baseline_deletion_horizon: string;
+  late_write_horizon: string;
+  backfill_horizon: string;
+  compliance_risk: ComplianceRiskEntry[];
+}
+
+export interface DependencyImpact {
+  name: string;
+  type: 'index' | 'feature' | string;
+  purpose: string;
+  retention_days: number;
+  latency_days: number;
+  deletion_horizon: string;
+  alignment_delta_days: number;
+  impact: string;
+}
+
+export interface DatasetPlan {
+  name: string;
+  last_arrival: string;
+  purposes: PurposeTimeline[];
+  dependencies: DependencyImpact[];
+}
+
+export interface RetentionPlan {
+  generated_at: string;
+  clock_shift: {
+    late_write_slip_days: number;
+    backfill_days: number;
+  };
+  datasets: DatasetPlan[];
+}
+
+export interface TimelineRow {
+  dataset: string;
+  purpose: string;
+  baselineHorizon: string;
+  lateWriteHorizon: string;
+  backfillHorizon: string;
+  riskLevel: 'ok' | 'elevated' | 'breach';
+  blockers: string[];
+}
+
+export interface DependencyRow {
+  dataset: string;
+  name: string;
+  purpose: string;
+  type: string;
+  impact: string;
+  alignmentDeltaDays: number;
+}

--- a/python/intelgraph_py/csrs/__init__.py
+++ b/python/intelgraph_py/csrs/__init__.py
@@ -1,0 +1,14 @@
+"""Consent-Scoped Retention Simulator (CSRS).
+
+This package exposes the RetentionPlanner used to model purpose-specific
+retention schedules and emit deterministic retention plan diffs.
+"""
+
+from .planner import RetentionPlanner, ClockShiftScenario
+from .diff import generate_signed_retention_diff
+
+__all__ = [
+    "RetentionPlanner",
+    "ClockShiftScenario",
+    "generate_signed_retention_diff",
+]

--- a/python/intelgraph_py/csrs/diff.py
+++ b/python/intelgraph_py/csrs/diff.py
@@ -1,0 +1,48 @@
+"""Utilities for producing deterministic retention plan diffs."""
+from __future__ import annotations
+
+import difflib
+import hmac
+import hashlib
+import json
+from typing import Any, Mapping
+
+_CANONICAL_SEPARATORS = (",", ":")
+
+
+def _canonical_json(payload: Mapping[str, Any]) -> str:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=_CANONICAL_SEPARATORS,
+        ensure_ascii=False,
+    )
+
+
+def generate_signed_retention_diff(
+    previous_plan: Mapping[str, Any] | None,
+    proposed_plan: Mapping[str, Any],
+    signing_key: str,
+) -> Mapping[str, str]:
+    """Return a deterministic diff and signature for a plan update."""
+
+    previous_serialized = _canonical_json(previous_plan or {})
+    proposed_serialized = _canonical_json(proposed_plan)
+    diff = "\n".join(
+        difflib.unified_diff(
+            previous_serialized.splitlines(),
+            proposed_serialized.splitlines(),
+            fromfile="previous",
+            tofile="proposed",
+            lineterm="",
+        )
+    )
+    digest = hmac.new(signing_key.encode("utf-8"), diff.encode("utf-8"), hashlib.sha256)
+    return {
+        "diff": diff,
+        "signature": digest.hexdigest(),
+        "algorithm": "hmac-sha256",
+    }
+
+
+__all__ = ["generate_signed_retention_diff"]

--- a/python/intelgraph_py/csrs/models.py
+++ b/python/intelgraph_py/csrs/models.py
@@ -1,0 +1,142 @@
+"""Domain models for the Consent-Scoped Retention Simulator (CSRS)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Iterable, List, Mapping, Sequence
+
+ISO_8601 = "%Y-%m-%dT%H:%M:%S%z"
+DATE_ONLY = "%Y-%m-%d"
+
+
+@dataclass(frozen=True)
+class ClockShift:
+    """Represents clock drift scenarios that impact retention."""
+
+    late_write_slip_days: int = 0
+    backfill_days: int = 0
+
+    def to_dict(self) -> Mapping[str, int]:
+        return {
+            "late_write_slip_days": self.late_write_slip_days,
+            "backfill_days": self.backfill_days,
+        }
+
+
+@dataclass(frozen=True)
+class RetentionPurpose:
+    """Retention configuration for a single purpose."""
+
+    name: str
+    retention_days: int
+    allowed_late_write_days: int
+    allowed_backfill_days: int
+
+    def horizon(self, reference: datetime) -> datetime:
+        return reference - timedelta(days=self.retention_days)
+
+
+@dataclass(frozen=True)
+class DependentArtifact:
+    """Represents downstream artifacts derived from a dataset."""
+
+    name: str
+    artifact_type: str
+    purpose: str
+    retention_days: int
+    latency_days: int
+
+    def horizon(self, reference: datetime) -> datetime:
+        return reference - timedelta(days=self.retention_days)
+
+
+@dataclass(frozen=True)
+class Dataset:
+    """Dataset participating in retention planning."""
+
+    name: str
+    last_arrival: datetime
+    purposes: Sequence[RetentionPurpose] = field(default_factory=list)
+    dependencies: Sequence[DependentArtifact] = field(default_factory=list)
+
+    @staticmethod
+    def from_dict(payload: Mapping[str, object]) -> "Dataset":
+        last_arrival = _parse_datetime(payload["last_arrival"])
+        purposes = [
+            RetentionPurpose(
+                name=item["purpose"],
+                retention_days=int(item["retention_days"]),
+                allowed_late_write_days=int(item["allowed_late_write_days"]),
+                allowed_backfill_days=int(item["allowed_backfill_days"]),
+            )
+            for item in payload.get("purposes", [])
+        ]
+        dependencies = [
+            DependentArtifact(
+                name=item["name"],
+                artifact_type=item["type"],
+                purpose=item["purpose"],
+                retention_days=int(item["retention_days"]),
+                latency_days=int(item.get("latency_days", 0)),
+            )
+            for item in payload.get("dependencies", [])
+        ]
+        return Dataset(
+            name=str(payload["name"]),
+            last_arrival=last_arrival,
+            purposes=tuple(sorted(purposes, key=lambda p: p.name)),
+            dependencies=tuple(sorted(dependencies, key=lambda d: d.name)),
+        )
+
+    def to_dict(self) -> Mapping[str, object]:
+        return {
+            "name": self.name,
+            "last_arrival": self.last_arrival.strftime(ISO_8601),
+            "purposes": [
+                {
+                    "purpose": purpose.name,
+                    "retention_days": purpose.retention_days,
+                    "allowed_late_write_days": purpose.allowed_late_write_days,
+                    "allowed_backfill_days": purpose.allowed_backfill_days,
+                }
+                for purpose in self.purposes
+            ],
+            "dependencies": [
+                {
+                    "name": dep.name,
+                    "type": dep.artifact_type,
+                    "purpose": dep.purpose,
+                    "retention_days": dep.retention_days,
+                    "latency_days": dep.latency_days,
+                }
+                for dep in self.dependencies
+            ],
+        }
+
+
+def _parse_datetime(value: object) -> datetime:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(f"Invalid ISO timestamp: {value}") from exc
+    raise TypeError(f"Unsupported datetime representation: {value!r}")
+
+
+def serialize_date(value: datetime) -> str:
+    return value.strftime(DATE_ONLY)
+
+
+def serialize_datetime(value: datetime) -> str:
+    return value.strftime(ISO_8601)
+
+
+def ensure_datasets(payloads: Iterable[Mapping[str, object]]) -> List[Dataset]:
+    return [Dataset.from_dict(item) for item in payloads]

--- a/python/intelgraph_py/csrs/planner.py
+++ b/python/intelgraph_py/csrs/planner.py
@@ -1,0 +1,177 @@
+"""Core planning logic for the Consent-Scoped Retention Simulator (CSRS)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Iterable, List, Mapping, MutableMapping, Sequence
+
+from .models import (
+    ClockShift,
+    Dataset,
+    DependentArtifact,
+    RetentionPurpose,
+    ensure_datasets,
+    serialize_date,
+    serialize_datetime,
+)
+
+
+@dataclass(frozen=True)
+class ClockShiftScenario:
+    """Wrapper around :class:`ClockShift` to keep public API stable."""
+
+    late_write_slip_days: int = 0
+    backfill_days: int = 0
+
+    def to_clock_shift(self) -> ClockShift:
+        return ClockShift(
+            late_write_slip_days=int(self.late_write_slip_days),
+            backfill_days=int(self.backfill_days),
+        )
+
+    def to_dict(self) -> Mapping[str, int]:
+        return self.to_clock_shift().to_dict()
+
+
+class RetentionPlanner:
+    """Simulates dataset retention horizons and dependent artifact impacts."""
+
+    def __init__(
+        self,
+        reference_time: datetime | None = None,
+        clock_shift: ClockShiftScenario | None = None,
+    ) -> None:
+        if reference_time is None:
+            reference_time = datetime.now(tz=timezone.utc)
+        if reference_time.tzinfo is None:
+            reference_time = reference_time.replace(tzinfo=timezone.utc)
+        self._reference_time = reference_time
+        self._clock_shift = (clock_shift or ClockShiftScenario()).to_clock_shift()
+
+    @property
+    def reference_time(self) -> datetime:
+        return self._reference_time
+
+    @property
+    def clock_shift(self) -> ClockShift:
+        return self._clock_shift
+
+    def simulate(self, datasets: Iterable[Mapping[str, object]]) -> Mapping[str, object]:
+        materialized = ensure_datasets(datasets)
+        planned = [
+            self._simulate_dataset(dataset)
+            for dataset in sorted(materialized, key=lambda item: item.name)
+        ]
+        return {
+            "generated_at": serialize_datetime(self.reference_time),
+            "clock_shift": self.clock_shift.to_dict(),
+            "datasets": planned,
+        }
+
+    def _simulate_dataset(self, dataset: Dataset) -> Mapping[str, object]:
+        anchor = min(dataset.last_arrival, self.reference_time)
+        horizons: MutableMapping[str, datetime] = {}
+        purposes_output: List[Mapping[str, object]] = []
+        for purpose in dataset.purposes:
+            purpose_result = self._simulate_purpose(purpose, anchor)
+            horizons[purpose.name] = purpose_result["deletion_horizon_anchor"]
+            purposes_output.append(self._redact_anchor_fields(purpose_result))
+        impacts = [
+            self._summarize_dependency(dependency, horizons, anchor)
+            for dependency in dataset.dependencies
+        ]
+        impacts.sort(key=lambda item: (item["purpose"], item["name"]))
+        return {
+            "name": dataset.name,
+            "last_arrival": serialize_datetime(dataset.last_arrival),
+            "purposes": purposes_output,
+            "dependencies": impacts,
+        }
+
+    def _simulate_purpose(
+        self,
+        purpose: RetentionPurpose,
+        anchor: datetime,
+    ) -> MutableMapping[str, object]:
+        base_horizon = purpose.horizon(anchor)
+        late_write_horizon = base_horizon - timedelta(days=self.clock_shift.late_write_slip_days)
+        backfill_horizon = base_horizon - timedelta(days=self.clock_shift.backfill_days)
+        risk = [
+            self._risk_entry(
+                "late_writes",
+                purpose.allowed_late_write_days,
+                self.clock_shift.late_write_slip_days,
+                late_write_horizon,
+            ),
+            self._risk_entry(
+                "backfill",
+                purpose.allowed_backfill_days,
+                self.clock_shift.backfill_days,
+                backfill_horizon,
+            ),
+        ]
+        return {
+            "purpose": purpose.name,
+            "retention_days": purpose.retention_days,
+            "baseline_deletion_horizon": serialize_date(base_horizon),
+            "late_write_horizon": serialize_date(late_write_horizon),
+            "backfill_horizon": serialize_date(backfill_horizon),
+            "deletion_horizon_anchor": base_horizon,
+            "compliance_risk": risk,
+        }
+
+    def _risk_entry(
+        self,
+        risk_type: str,
+        allowed_days: int,
+        projected_shift: int,
+        horizon: datetime,
+    ) -> Mapping[str, object]:
+        delta = projected_shift - allowed_days
+        status = "breach" if delta > 0 else "ok"
+        return {
+            "type": risk_type,
+            "status": status,
+            "allowed_days": allowed_days,
+            "projected_shift_days": projected_shift,
+            "delta_days": delta,
+            "projected_horizon": serialize_date(horizon),
+        }
+
+    def _summarize_dependency(
+        self,
+        dependency: DependentArtifact,
+        horizons: Mapping[str, datetime],
+        anchor: datetime,
+    ) -> Mapping[str, object]:
+        dependency_anchor = anchor + timedelta(days=dependency.latency_days)
+        dependency_horizon = dependency.horizon(dependency_anchor)
+        dataset_horizon = horizons.get(
+            dependency.purpose,
+            min(horizons.values()) if horizons else dependency_horizon,
+        )
+        delta = int((dependency_horizon - dataset_horizon).days)
+        if delta > 0:
+            summary = f"extends deletion window by {delta} days"
+        elif delta < 0:
+            summary = f"eligible for deletion {abs(delta)} days earlier"
+        else:
+            summary = "aligned with dataset horizon"
+        return {
+            "name": dependency.name,
+            "type": dependency.artifact_type,
+            "purpose": dependency.purpose,
+            "retention_days": dependency.retention_days,
+            "latency_days": dependency.latency_days,
+            "deletion_horizon": serialize_date(dependency_horizon),
+            "alignment_delta_days": delta,
+            "impact": summary,
+        }
+
+    @staticmethod
+    def _redact_anchor_fields(purpose_payload: MutableMapping[str, object]) -> Mapping[str, object]:
+        # Consumers do not need the raw datetime anchor and removing it keeps
+        # serialized plans deterministic across timezones.
+        sanitized = dict(purpose_payload)
+        sanitized.pop("deletion_horizon_anchor", None)
+        return sanitized

--- a/python/tests/fixtures/csrs_golden_plan.json
+++ b/python/tests/fixtures/csrs_golden_plan.json
@@ -1,0 +1,165 @@
+{
+  "generated_at": "2025-01-01T00:00:00+0000",
+  "clock_shift": {
+    "late_write_slip_days": 4,
+    "backfill_days": 20
+  },
+  "datasets": [
+    {
+      "name": "accounts_core",
+      "last_arrival": "2024-12-31T18:00:00+0000",
+      "purposes": [
+        {
+          "purpose": "customer_support",
+          "retention_days": 180,
+          "baseline_deletion_horizon": "2024-07-04",
+          "late_write_horizon": "2024-06-30",
+          "backfill_horizon": "2024-06-14",
+          "compliance_risk": [
+            {
+              "type": "late_writes",
+              "status": "breach",
+              "allowed_days": 2,
+              "projected_shift_days": 4,
+              "delta_days": 2,
+              "projected_horizon": "2024-06-30"
+            },
+            {
+              "type": "backfill",
+              "status": "breach",
+              "allowed_days": 14,
+              "projected_shift_days": 20,
+              "delta_days": 6,
+              "projected_horizon": "2024-06-14"
+            }
+          ]
+        },
+        {
+          "purpose": "fraud_detection",
+          "retention_days": 365,
+          "baseline_deletion_horizon": "2024-01-01",
+          "late_write_horizon": "2023-12-28",
+          "backfill_horizon": "2023-12-12",
+          "compliance_risk": [
+            {
+              "type": "late_writes",
+              "status": "breach",
+              "allowed_days": 3,
+              "projected_shift_days": 4,
+              "delta_days": 1,
+              "projected_horizon": "2023-12-28"
+            },
+            {
+              "type": "backfill",
+              "status": "ok",
+              "allowed_days": 30,
+              "projected_shift_days": 20,
+              "delta_days": -10,
+              "projected_horizon": "2023-12-12"
+            }
+          ]
+        }
+      ],
+      "dependencies": [
+        {
+          "name": "customer_support_index",
+          "type": "index",
+          "purpose": "customer_support",
+          "retention_days": 150,
+          "latency_days": 1,
+          "deletion_horizon": "2024-08-04",
+          "alignment_delta_days": 31,
+          "impact": "extends deletion window by 31 days"
+        },
+        {
+          "name": "fraud_features_v4",
+          "type": "feature",
+          "purpose": "fraud_detection",
+          "retention_days": 400,
+          "latency_days": 2,
+          "deletion_horizon": "2023-11-29",
+          "alignment_delta_days": -33,
+          "impact": "eligible for deletion 33 days earlier"
+        }
+      ]
+    },
+    {
+      "name": "transactions_delta",
+      "last_arrival": "2024-12-30T06:00:00+0000",
+      "purposes": [
+        {
+          "purpose": "fraud_detection",
+          "retention_days": 540,
+          "baseline_deletion_horizon": "2023-07-09",
+          "late_write_horizon": "2023-07-05",
+          "backfill_horizon": "2023-06-19",
+          "compliance_risk": [
+            {
+              "type": "late_writes",
+              "status": "ok",
+              "allowed_days": 5,
+              "projected_shift_days": 4,
+              "delta_days": -1,
+              "projected_horizon": "2023-07-05"
+            },
+            {
+              "type": "backfill",
+              "status": "ok",
+              "allowed_days": 45,
+              "projected_shift_days": 20,
+              "delta_days": -25,
+              "projected_horizon": "2023-06-19"
+            }
+          ]
+        },
+        {
+          "purpose": "regulatory_reporting",
+          "retention_days": 730,
+          "baseline_deletion_horizon": "2022-12-31",
+          "late_write_horizon": "2022-12-27",
+          "backfill_horizon": "2022-12-11",
+          "compliance_risk": [
+            {
+              "type": "late_writes",
+              "status": "ok",
+              "allowed_days": 10,
+              "projected_shift_days": 4,
+              "delta_days": -6,
+              "projected_horizon": "2022-12-27"
+            },
+            {
+              "type": "backfill",
+              "status": "ok",
+              "allowed_days": 90,
+              "projected_shift_days": 20,
+              "delta_days": -70,
+              "projected_horizon": "2022-12-11"
+            }
+          ]
+        }
+      ],
+      "dependencies": [
+        {
+          "name": "fraud_scoring_index",
+          "type": "index",
+          "purpose": "fraud_detection",
+          "retention_days": 540,
+          "latency_days": 1,
+          "deletion_horizon": "2023-07-10",
+          "alignment_delta_days": 1,
+          "impact": "extends deletion window by 1 days"
+        },
+        {
+          "name": "reg_report_features",
+          "type": "feature",
+          "purpose": "regulatory_reporting",
+          "retention_days": 800,
+          "latency_days": 3,
+          "deletion_horizon": "2022-10-25",
+          "alignment_delta_days": -67,
+          "impact": "eligible for deletion 67 days earlier"
+        }
+      ]
+    }
+  ]
+}

--- a/python/tests/fixtures/csrs_input.json
+++ b/python/tests/fixtures/csrs_input.json
@@ -1,0 +1,77 @@
+{
+  "reference_time": "2025-01-01T00:00:00Z",
+  "clock_shift": {
+    "late_write_slip_days": 4,
+    "backfill_days": 20
+  },
+  "datasets": [
+    {
+      "name": "accounts_core",
+      "last_arrival": "2024-12-31T18:00:00Z",
+      "purposes": [
+        {
+          "purpose": "fraud_detection",
+          "retention_days": 365,
+          "allowed_late_write_days": 3,
+          "allowed_backfill_days": 30
+        },
+        {
+          "purpose": "customer_support",
+          "retention_days": 180,
+          "allowed_late_write_days": 2,
+          "allowed_backfill_days": 14
+        }
+      ],
+      "dependencies": [
+        {
+          "name": "fraud_features_v4",
+          "type": "feature",
+          "purpose": "fraud_detection",
+          "retention_days": 400,
+          "latency_days": 2
+        },
+        {
+          "name": "customer_support_index",
+          "type": "index",
+          "purpose": "customer_support",
+          "retention_days": 150,
+          "latency_days": 1
+        }
+      ]
+    },
+    {
+      "name": "transactions_delta",
+      "last_arrival": "2024-12-30T06:00:00Z",
+      "purposes": [
+        {
+          "purpose": "fraud_detection",
+          "retention_days": 540,
+          "allowed_late_write_days": 5,
+          "allowed_backfill_days": 45
+        },
+        {
+          "purpose": "regulatory_reporting",
+          "retention_days": 730,
+          "allowed_late_write_days": 10,
+          "allowed_backfill_days": 90
+        }
+      ],
+      "dependencies": [
+        {
+          "name": "fraud_scoring_index",
+          "type": "index",
+          "purpose": "fraud_detection",
+          "retention_days": 540,
+          "latency_days": 1
+        },
+        {
+          "name": "reg_report_features",
+          "type": "feature",
+          "purpose": "regulatory_reporting",
+          "retention_days": 800,
+          "latency_days": 3
+        }
+      ]
+    }
+  ]
+}

--- a/python/tests/test_csrs.py
+++ b/python/tests/test_csrs.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import datetime
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from intelgraph_py.csrs import (
+    ClockShiftScenario,
+    RetentionPlanner,
+    generate_signed_retention_diff,
+)
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((FIXTURE_DIR / name).read_text())
+
+
+def _planner_from_fixture(payload: dict) -> RetentionPlanner:
+    reference_time = datetime.fromisoformat(payload["reference_time"].replace("Z", "+00:00"))
+    return RetentionPlanner(
+        reference_time=reference_time,
+        clock_shift=ClockShiftScenario(**payload["clock_shift"]),
+    )
+
+
+@pytest.mark.parametrize(
+    "fixture_name, golden_name",
+    [("csrs_input.json", "csrs_golden_plan.json")],
+)
+def test_simulation_matches_golden_snapshot(fixture_name: str, golden_name: str) -> None:
+    fixture = _load_fixture(fixture_name)
+    golden = _load_fixture(golden_name)
+    planner = _planner_from_fixture(fixture)
+    plan = planner.simulate(fixture["datasets"])
+    assert plan == golden
+
+
+def test_dependencies_cover_all_expected_impacts() -> None:
+    fixture = _load_fixture("csrs_input.json")
+    planner = _planner_from_fixture(fixture)
+    plan = planner.simulate(fixture["datasets"])
+    flattened = [
+        dependency["name"]
+        for dataset in plan["datasets"]
+        for dependency in dataset["dependencies"]
+    ]
+    dependency_names = set(flattened)
+    expected = {
+        "fraud_features_v4",
+        "customer_support_index",
+        "fraud_scoring_index",
+        "reg_report_features",
+    }
+    assert expected.issubset(dependency_names)
+    # Ensure there are no duplicate dependencies accidentally dropped or merged.
+    assert len(flattened) == len(dependency_names)
+
+
+def test_retention_diff_is_deterministic() -> None:
+    golden = _load_fixture("csrs_golden_plan.json")
+    mutated = deepcopy(golden)
+    mutated["datasets"][0]["purposes"][0]["retention_days"] += 1
+    signing_key = "demo-secret"
+    first = generate_signed_retention_diff(golden, mutated, signing_key)
+    second = generate_signed_retention_diff(golden, mutated, signing_key)
+    assert first == second
+    # Changing the signing key must change the signature to ensure authenticity.
+    different_key = generate_signed_retention_diff(golden, mutated, "other-secret")
+    assert first["diff"] == different_key["diff"]
+    assert first["signature"] != different_key["signature"]


### PR DESCRIPTION
## Summary
- add a consent-scoped retention planner that models purpose timelines, dependency impacts, and produces signed plan diffs
- capture golden fixture coverage to guarantee deterministic horizons and dependency visibility
- introduce a CSRS timeline UI with timeline/dependency tables and unit tests

## Testing
- pytest python/tests/test_csrs.py
- npm run test:jest -- --config jest.config.ts CsrsTimeline.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d78d1c5dbc8333abfaa16039d83492