### PR TITLE
feat: add query intent policy mapper service

### DIFF
--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -24,6 +24,7 @@ export default {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '^@tests/(.*)$': '<rootDir>/tests/$1',
+    '^(\\.{1,2}/.*)\\.js$': '$1',
   },
   transform: {
     '^.+\\.tsx?$': [

--- a/server/src/services/qic-pm/adapters/ppc-adapter.ts
+++ b/server/src/services/qic-pm/adapters/ppc-adapter.ts
@@ -1,0 +1,44 @@
+import type { PolicyDecisionResult, QueryContext } from '../types.js';
+import { QueryIntentPolicyMapper } from '../query-intent-policy-mapper.js';
+
+export interface PpcDirective {
+  pipeline: 'PPC';
+  action: PolicyDecisionResult['decision']['action'];
+  transforms: string[];
+  redactions: string[];
+  obligations: string[];
+  metadata: {
+    intent: PolicyDecisionResult['intent'];
+    confidence: number;
+    policyId: string;
+  };
+  explanation: PolicyDecisionResult['explanation'];
+}
+
+export interface PpcRequest {
+  query: string;
+  context?: QueryContext;
+}
+
+export const createPpcAdapter = (mapper: QueryIntentPolicyMapper) => ({
+  toDirective(request: PpcRequest): PpcDirective {
+    const result = mapper.evaluate(request.query, request.context ?? {});
+
+    return {
+      pipeline: 'PPC',
+      action: result.decision.action,
+      transforms: result.decision.transforms ? [...result.decision.transforms] : [],
+      redactions: result.decision.redactFields ? [...result.decision.redactFields] : [],
+      obligations: result.decision.obligations ? [...result.decision.obligations] : [],
+      metadata: {
+        intent: result.intent,
+        confidence: Number(result.confidence.toFixed(4)),
+        policyId: result.decision.policyId,
+      },
+      explanation: result.explanation.map((step) => ({
+        ...step,
+        details: step.details ? { ...step.details } : undefined,
+      })),
+    };
+  },
+});

--- a/server/src/services/qic-pm/adapters/rsr-adapter.ts
+++ b/server/src/services/qic-pm/adapters/rsr-adapter.ts
@@ -1,0 +1,47 @@
+import type { PolicyDecisionResult, QueryContext } from '../types.js';
+import { QueryIntentPolicyMapper } from '../query-intent-policy-mapper.js';
+
+export interface RsrRoutingRequest {
+  query: string;
+  context?: QueryContext;
+  correlationId?: string;
+}
+
+export interface RsrRoutingDecision {
+  router: 'RSR';
+  intent: PolicyDecisionResult['intent'];
+  confidence: number;
+  action: PolicyDecisionResult['decision']['action'];
+  allow: boolean;
+  explanation: PolicyDecisionResult['explanation'];
+  policy: PolicyDecisionResult['decision'];
+  correlationId?: string;
+}
+
+export const createRsrAdapter = (mapper: QueryIntentPolicyMapper) => ({
+  evaluate(request: RsrRoutingRequest): RsrRoutingDecision {
+    const context = request.context ?? {};
+    const result = mapper.evaluate(request.query, context);
+
+    const allow = result.decision.action === 'allow' || result.decision.action === 'transform';
+
+    return {
+      router: 'RSR',
+      intent: result.intent,
+      confidence: Number(result.confidence.toFixed(4)),
+      action: result.decision.action,
+      allow,
+      explanation: result.explanation.map((step) => ({
+        ...step,
+        details: step.details ? { ...step.details } : undefined,
+      })),
+      policy: {
+        ...result.decision,
+        obligations: result.decision.obligations ? [...result.decision.obligations] : undefined,
+        transforms: result.decision.transforms ? [...result.decision.transforms] : undefined,
+        redactFields: result.decision.redactFields ? [...result.decision.redactFields] : undefined,
+      },
+      correlationId: request.correlationId,
+    };
+  },
+});

--- a/server/src/services/qic-pm/config.ts
+++ b/server/src/services/qic-pm/config.ts
@@ -1,0 +1,147 @@
+import type {
+  PolicyDecision,
+  QueryIntent,
+} from './types.js';
+import type { ModelWeights } from './lightweight-model.js';
+
+export interface ThresholdConfig {
+  rulePriorityConfidence: number;
+  minimumConfidence: number;
+  lowConfidencePolicy: PolicyDecision;
+}
+
+export interface QueryIntentPolicyConfig {
+  intentPolicies: Record<QueryIntent, PolicyDecision> & { unknown: PolicyDecision };
+  defaultPolicy: PolicyDecision;
+  thresholds: ThresholdConfig;
+  cacheSize: number;
+  modelWeights: Record<QueryIntent, ModelWeights>;
+}
+
+export type QueryIntentPolicyConfigOptions = {
+  intentPolicies?: Partial<Record<QueryIntent, PolicyDecision> & { unknown: PolicyDecision }>;
+  defaultPolicy?: PolicyDecision;
+  thresholds?: Partial<ThresholdConfig>;
+  cacheSize?: number;
+  modelWeights?: Partial<Record<QueryIntent, Partial<ModelWeights>>>;
+};
+
+const buildPolicy = (policy: PolicyDecision): PolicyDecision => ({
+  ...policy,
+  obligations: policy.obligations ? [...policy.obligations] : undefined,
+  transforms: policy.transforms ? [...policy.transforms] : undefined,
+  redactFields: policy.redactFields ? [...policy.redactFields] : undefined,
+});
+
+export const defaultPolicyConfig: QueryIntentPolicyConfig = {
+  intentPolicies: {
+    analytics: buildPolicy({
+      action: 'allow',
+      policyId: 'policy-analytics-allow',
+      rationale: 'Analytics queries are permitted with routine monitoring.',
+      obligations: ['log_usage'],
+    }),
+    marketing: buildPolicy({
+      action: 'transform',
+      policyId: 'policy-marketing-transform',
+      rationale: 'Marketing queries require anonymization prior to sharing.',
+      transforms: ['mask_personal_data', 'aggregate_segments'],
+      obligations: ['record_transform'],
+    }),
+    support: buildPolicy({
+      action: 'allow',
+      policyId: 'policy-support-allow',
+      rationale: 'Support interactions are allowed with ticket logging.',
+      obligations: ['attach_case_id'],
+    }),
+    fraud: buildPolicy({
+      action: 'redact',
+      policyId: 'policy-fraud-redact',
+      rationale: 'Fraud investigations must redact customer PII before routing.',
+      obligations: ['notify_fraud_team'],
+      redactFields: ['account_number', 'ssn', 'routing_number'],
+    }),
+    research: buildPolicy({
+      action: 'transform',
+      policyId: 'policy-research-transform',
+      rationale: 'Research queries require de-identification and usage tracking.',
+      transforms: ['pseudonymize_entities'],
+      obligations: ['record_data_use'],
+    }),
+    unknown: buildPolicy({
+      action: 'redact',
+      policyId: 'policy-unknown-redact',
+      rationale: 'Unclassified queries default to redaction pending manual review.',
+      obligations: ['manual_review'],
+    }),
+  },
+  defaultPolicy: buildPolicy({
+    action: 'redact',
+    policyId: 'policy-default-redact',
+    rationale: 'Fallback policy to redact when mapping is unavailable.',
+    obligations: ['manual_review'],
+  }),
+  thresholds: {
+    rulePriorityConfidence: 0.82,
+    minimumConfidence: 0.55,
+    lowConfidencePolicy: buildPolicy({
+      action: 'redact',
+      policyId: 'policy-low-confidence',
+      rationale: 'Classifier confidence was below threshold; apply redaction.',
+      obligations: ['escalate_for_review'],
+    }),
+  },
+  cacheSize: 1000,
+  modelWeights: {} as Record<QueryIntent, ModelWeights>,
+};
+
+export const mergeConfig = (
+  base: QueryIntentPolicyConfig,
+  options: QueryIntentPolicyConfigOptions = {},
+  modelWeights: Record<QueryIntent, ModelWeights>,
+): QueryIntentPolicyConfig => {
+  const intentPolicies: QueryIntentPolicyConfig['intentPolicies'] = {
+    ...base.intentPolicies,
+    ...Object.fromEntries(
+      Object.entries(options.intentPolicies ?? {}).map(([intent, policy]) => [
+        intent as QueryIntent,
+        buildPolicy(policy as PolicyDecision),
+      ]),
+    ),
+  } as QueryIntentPolicyConfig['intentPolicies'];
+
+  const mergedThresholds: ThresholdConfig = {
+    ...base.thresholds,
+    ...options.thresholds,
+  };
+
+  const mergedModelWeights: Record<QueryIntent, ModelWeights> = {
+    ...modelWeights,
+  };
+
+  if (options.modelWeights) {
+    (Object.keys(options.modelWeights) as QueryIntent[]).forEach((intent) => {
+      const existing = mergedModelWeights[intent];
+      const override = options.modelWeights?.[intent];
+      if (!override) {
+        return;
+      }
+
+      mergedModelWeights[intent] = {
+        bias: override.bias ?? existing.bias,
+        tokens: {
+          ...existing.tokens,
+          ...(override.tokens ?? {}),
+        },
+      };
+    });
+  }
+
+  return {
+    intentPolicies,
+    defaultPolicy: options.defaultPolicy ? buildPolicy(options.defaultPolicy) : base.defaultPolicy,
+    thresholds: mergedThresholds,
+    cacheSize: options.cacheSize ?? base.cacheSize,
+    modelWeights: mergedModelWeights,
+  };
+};

--- a/server/src/services/qic-pm/index.ts
+++ b/server/src/services/qic-pm/index.ts
@@ -1,0 +1,7 @@
+export * from './types.js';
+export * from './rules.js';
+export * from './lightweight-model.js';
+export * from './config.js';
+export * from './query-intent-policy-mapper.js';
+export * from './adapters/rsr-adapter.js';
+export * from './adapters/ppc-adapter.js';

--- a/server/src/services/qic-pm/lightweight-model.ts
+++ b/server/src/services/qic-pm/lightweight-model.ts
@@ -1,0 +1,228 @@
+import type { ExplanationStep, QueryIntent } from './types.js';
+
+export interface ModelWeights {
+  bias: number;
+  tokens: Record<string, number>;
+}
+
+export interface ModelPrediction {
+  intent: QueryIntent;
+  confidence: number;
+  probabilities: Record<QueryIntent, number>;
+  explanation: ExplanationStep;
+}
+
+const SOFTMAX_FLOOR = 1e-6;
+
+const normalize = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+const buildFeatures = (query: string) => {
+  const tokens = normalize(query).split(' ').filter(Boolean);
+  const features = new Set<string>();
+
+  tokens.forEach((token) => features.add(token));
+
+  for (let i = 0; i < tokens.length - 1; i += 1) {
+    features.add(`${tokens[i]}_${tokens[i + 1]}`);
+  }
+
+  return { tokens, features };
+};
+
+export class LightweightIntentModel {
+  private readonly weights: Record<QueryIntent, ModelWeights>;
+
+  constructor(weights: Record<QueryIntent, ModelWeights>) {
+    this.weights = weights;
+  }
+
+  public predict(query: string): ModelPrediction {
+    const { features } = buildFeatures(query);
+
+    const scores = new Map<QueryIntent, number>();
+    let maxScore = Number.NEGATIVE_INFINITY;
+
+    (Object.keys(this.weights) as QueryIntent[]).forEach((intent) => {
+      const { bias, tokens } = this.weights[intent];
+      let score = bias;
+
+      features.forEach((feature) => {
+        const weight = tokens[feature];
+        if (weight) {
+          score += weight;
+        }
+      });
+
+      scores.set(intent, score);
+      maxScore = Math.max(maxScore, score);
+    });
+
+    const expScores = new Map<QueryIntent, number>();
+    let total = 0;
+
+    scores.forEach((score, intent) => {
+      const adjusted = Math.exp(score - maxScore);
+      expScores.set(intent, adjusted);
+      total += adjusted;
+    });
+
+    const probabilities: Record<QueryIntent, number> = {
+      analytics: SOFTMAX_FLOOR,
+      marketing: SOFTMAX_FLOOR,
+      support: SOFTMAX_FLOOR,
+      fraud: SOFTMAX_FLOOR,
+      research: SOFTMAX_FLOOR,
+      unknown: SOFTMAX_FLOOR,
+    };
+
+    expScores.forEach((value, intent) => {
+      probabilities[intent] = value / Math.max(total, SOFTMAX_FLOOR);
+    });
+
+    let bestIntent: QueryIntent = 'unknown';
+    let bestProbability = probabilities[bestIntent];
+
+    (Object.keys(probabilities) as QueryIntent[]).forEach((intent) => {
+      if (probabilities[intent] > bestProbability) {
+        bestIntent = intent;
+        bestProbability = probabilities[intent];
+      }
+    });
+
+    const activeFeatures = new Set(features);
+
+    const sortedContributions = Object.entries(this.weights[bestIntent]?.tokens ?? {})
+      .filter(([feature]) => activeFeatures.has(feature))
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 5)
+      .map(([feature, weight]) => ({ feature, weight }));
+
+    const explanation: ExplanationStep = {
+      stage: 'model',
+      intent: bestIntent,
+      confidence: Number(bestProbability.toFixed(4)),
+      description: `Lightweight model selected ${bestIntent} intent`,
+      details: {
+        scores: Object.fromEntries(scores),
+        topContributors: sortedContributions,
+      },
+    };
+
+    return {
+      intent: bestIntent,
+      confidence: bestProbability,
+      probabilities,
+      explanation,
+    };
+  }
+}
+
+export const defaultModelWeights: Record<QueryIntent, ModelWeights> = {
+  analytics: {
+    bias: -0.4,
+    tokens: {
+      metric: 1.1,
+      metrics: 1.0,
+      dashboard: 1.2,
+      dashboards: 1.0,
+      kpi: 1.05,
+      kpis: 1.0,
+      insight: 0.8,
+      insights: 0.8,
+      trend: 0.95,
+      trends: 0.9,
+      forecast: 0.85,
+      variance: 0.7,
+      report: 0.9,
+      reporting: 0.85,
+      'time_series': 0.8,
+      'region_performance': 0.75,
+    },
+  },
+  marketing: {
+    bias: -0.5,
+    tokens: {
+      campaign: 1.1,
+      campaigns: 1.0,
+      conversion: 1.05,
+      conversions: 1.05,
+      ctr: 0.9,
+      click: 0.8,
+      clicks: 0.8,
+      impression: 0.85,
+      impressions: 0.85,
+      retargeting: 0.95,
+      acquisition: 0.9,
+      funnel: 0.75,
+      lead: 0.9,
+      leads: 0.9,
+      nurture: 0.7,
+      'campaign_performance': 0.9,
+    },
+  },
+  support: {
+    bias: -0.3,
+    tokens: {
+      ticket: 1.1,
+      tickets: 1.05,
+      help: 0.9,
+      helpdesk: 1.0,
+      incident: 0.95,
+      outage: 0.95,
+      downtime: 0.9,
+      troubleshoot: 0.85,
+      troubleshooting: 0.85,
+      bug: 0.8,
+      error: 0.8,
+      escalation: 0.75,
+      customer: 0.6,
+      'service_request': 0.9,
+    },
+  },
+  fraud: {
+    bias: -0.55,
+    tokens: {
+      fraud: 1.3,
+      fraudulent: 1.25,
+      chargeback: 1.2,
+      chargebacks: 1.1,
+      laundering: 1.15,
+      aml: 1.05,
+      suspicious: 1.05,
+      alert: 0.7,
+      alerts: 0.7,
+      theft: 0.8,
+      takeover: 0.9,
+      'account_takeover': 1.1,
+      'stolen_card': 1.1,
+    },
+  },
+  research: {
+    bias: -0.35,
+    tokens: {
+      research: 1.2,
+      study: 1.1,
+      studies: 1.0,
+      hypothesis: 1.0,
+      survey: 0.95,
+      surveys: 0.95,
+      experiment: 0.9,
+      literature: 0.85,
+      publication: 0.85,
+      paper: 0.9,
+      academic: 0.9,
+      review: 0.7,
+      'peer_review': 0.9,
+      'experiment_design': 0.85,
+    },
+  },
+  unknown: {
+    bias: -0.2,
+    tokens: {},
+  },
+};

--- a/server/src/services/qic-pm/query-intent-policy-mapper.ts
+++ b/server/src/services/qic-pm/query-intent-policy-mapper.ts
@@ -1,0 +1,214 @@
+import { defaultRules, RuleEngine, type RuleDefinition } from './rules.js';
+import {
+  defaultModelWeights,
+  LightweightIntentModel,
+  type ModelPrediction,
+} from './lightweight-model.js';
+import {
+  defaultPolicyConfig,
+  mergeConfig,
+  type QueryIntentPolicyConfig,
+  type QueryIntentPolicyConfigOptions,
+} from './config.js';
+import type {
+  PolicyDecision,
+  PolicyDecisionResult,
+  QueryContext,
+  QueryIntent,
+} from './types.js';
+
+const stableStringify = (value: unknown): string => {
+  if (value === null || value === undefined) {
+    return 'null';
+  }
+
+  if (typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  }
+
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, val]) => `${JSON.stringify(key)}:${stableStringify(val)}`);
+
+  return `{${entries.join(',')}}`;
+};
+
+const cloneDecision = (decision: PolicyDecision): PolicyDecision => ({
+  ...decision,
+  obligations: decision.obligations ? [...decision.obligations] : undefined,
+  transforms: decision.transforms ? [...decision.transforms] : undefined,
+  redactFields: decision.redactFields ? [...decision.redactFields] : undefined,
+});
+
+const cloneExplanation = (explanation: PolicyDecisionResult['explanation']) =>
+  explanation.map((step) => ({
+    ...step,
+    details: step.details ? { ...step.details } : undefined,
+  }));
+
+const normalizeQuery = (query: string) =>
+  query
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+
+export interface EvaluateOptions {
+  context?: QueryContext;
+}
+
+export interface QueryIntentPolicyMapperOptions extends QueryIntentPolicyConfigOptions {
+  rules?: RuleDefinition[];
+}
+
+export class QueryIntentPolicyMapper {
+  private readonly ruleEngine: RuleEngine;
+
+  private readonly model: LightweightIntentModel;
+
+  private readonly config: QueryIntentPolicyConfig;
+
+  private readonly cache: Map<string, PolicyDecisionResult>;
+
+  constructor(options: QueryIntentPolicyMapperOptions = {}) {
+    const config = mergeConfig(defaultPolicyConfig, options, defaultModelWeights);
+
+    this.config = config;
+    this.ruleEngine = new RuleEngine(options.rules ?? defaultRules);
+    this.model = new LightweightIntentModel(config.modelWeights);
+    this.cache = new Map();
+  }
+
+  public evaluate(query: string, context: QueryContext = {}): PolicyDecisionResult {
+    const sanitizedQuery = normalizeQuery(query ?? '');
+    const cacheKey = `${sanitizedQuery}|${stableStringify(context)}`;
+
+    const cached = this.cache.get(cacheKey);
+    if (cached) {
+      return {
+        ...cached,
+        decision: cloneDecision(cached.decision),
+        explanation: cloneExplanation(cached.explanation),
+      };
+    }
+
+    const explanationSteps = [] as PolicyDecisionResult['explanation'];
+
+    let ruleMatch = null;
+    if (sanitizedQuery) {
+      ruleMatch = this.ruleEngine.evaluate(sanitizedQuery, context);
+      if (ruleMatch) {
+        explanationSteps.push(ruleMatch.explanation);
+      }
+    }
+
+    const modelResult: ModelPrediction | null = sanitizedQuery
+      ? this.model.predict(sanitizedQuery)
+      : null;
+
+    if (modelResult) {
+      explanationSteps.push(modelResult.explanation);
+    }
+
+    let intent: QueryIntent = modelResult?.intent ?? ruleMatch?.intent ?? 'unknown';
+    let confidence = modelResult?.confidence ?? 0;
+    const probabilities = modelResult?.probabilities ?? {
+      analytics: 0,
+      marketing: 0,
+      support: 0,
+      fraud: 0,
+      research: 0,
+      unknown: 1,
+    };
+
+    if (ruleMatch && modelResult) {
+      const modelSupport = modelResult.probabilities[ruleMatch.intent] ?? 0;
+      if (
+        ruleMatch.confidence >= this.config.thresholds.rulePriorityConfidence ||
+        modelSupport >= modelResult.confidence
+      ) {
+        intent = ruleMatch.intent;
+        confidence = Math.max(ruleMatch.confidence, modelSupport);
+        explanationSteps.push({
+          stage: 'rule',
+          intent,
+          confidence: Number(confidence.toFixed(4)),
+          description: `Rule ${ruleMatch.ruleId} prioritized intent ${intent}.`,
+          details: {
+            ruleId: ruleMatch.ruleId,
+            trigger: ruleMatch.trigger,
+            reason: 'rule-priority',
+          },
+        });
+      } else if (ruleMatch.intent !== modelResult.intent) {
+        explanationSteps.push({
+          stage: 'rule',
+          intent: ruleMatch.intent,
+          confidence: ruleMatch.confidence,
+          description: `Rule ${ruleMatch.ruleId} suggested ${ruleMatch.intent} but model favored ${modelResult.intent}.`,
+          details: {
+            ruleId: ruleMatch.ruleId,
+            trigger: ruleMatch.trigger,
+            reason: 'model-overrode-rule',
+          },
+        });
+      }
+    } else if (ruleMatch && !modelResult) {
+      intent = ruleMatch.intent;
+      confidence = ruleMatch.confidence;
+    }
+
+    if (!sanitizedQuery) {
+      intent = 'unknown';
+      confidence = 0;
+    }
+
+    let decision = cloneDecision(this.config.intentPolicies[intent] ?? this.config.defaultPolicy);
+    let policyReason: 'intent-match' | 'low-confidence' = 'intent-match';
+
+    if (confidence < this.config.thresholds.minimumConfidence) {
+      decision = cloneDecision(this.config.thresholds.lowConfidencePolicy);
+      policyReason = 'low-confidence';
+    }
+
+    explanationSteps.push({
+      stage: 'policy',
+      intent,
+      confidence: Number(confidence.toFixed(4)),
+      description: `Intent ${intent} mapped to ${decision.action} via policy ${decision.policyId}.`,
+      details: {
+        policyId: decision.policyId,
+        rationale: decision.rationale,
+        obligations: decision.obligations,
+        transforms: decision.transforms,
+        reason: policyReason,
+      },
+    });
+
+    const result: PolicyDecisionResult = {
+      intent,
+      confidence,
+      probabilities,
+      explanation: explanationSteps,
+      decision,
+    };
+
+    this.cache.set(cacheKey, {
+      ...result,
+      decision: cloneDecision(result.decision),
+      explanation: cloneExplanation(result.explanation),
+    });
+
+    if (this.cache.size > this.config.cacheSize) {
+      const firstKey = this.cache.keys().next().value;
+      if (firstKey) {
+        this.cache.delete(firstKey);
+      }
+    }
+
+    return result;
+  }
+}

--- a/server/src/services/qic-pm/rules.ts
+++ b/server/src/services/qic-pm/rules.ts
@@ -1,0 +1,219 @@
+import type { ExplanationStep, QueryContext, QueryIntent } from './types.js';
+
+export interface RuleDefinition {
+  id: string;
+  intent: QueryIntent;
+  keywords?: string[];
+  phrases?: string[];
+  patterns?: RegExp[];
+  contextMatches?: { key: string; values: string[] }[];
+  confidence: number;
+}
+
+export interface RuleMatch {
+  intent: QueryIntent;
+  confidence: number;
+  ruleId: string;
+  trigger: string;
+  explanation: ExplanationStep;
+}
+
+const normalize = (value: string) => value.toLowerCase();
+
+const tokenize = (value: string) =>
+  normalize(value)
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .split(/\s+/)
+    .filter(Boolean);
+
+const ensureArray = (value?: string[]) => (value ? value.map(normalize) : []);
+
+const matchesContext = (
+  context: QueryContext | undefined,
+  contextMatches: RuleDefinition['contextMatches'],
+): boolean => {
+  if (!contextMatches || contextMatches.length === 0) {
+    return true;
+  }
+
+  if (!context) {
+    return false;
+  }
+
+  return contextMatches.every(({ key, values }) => {
+    const normalizedValues = values.map(normalize);
+    const ctxValue = context[key];
+
+    if (Array.isArray(ctxValue)) {
+      const ctxArray = ctxValue.map((item) => normalize(String(item)));
+      return normalizedValues.some((value) => ctxArray.includes(value));
+    }
+
+    if (typeof ctxValue === 'string') {
+      return normalizedValues.includes(normalize(ctxValue));
+    }
+
+    return false;
+  });
+};
+
+export class RuleEngine {
+  private readonly rules: RuleDefinition[];
+
+  constructor(rules: RuleDefinition[]) {
+    this.rules = rules;
+  }
+
+  public evaluate(query: string, context?: QueryContext): RuleMatch | null {
+    const normalizedQuery = normalize(query);
+    const tokens = tokenize(query);
+    const tokenSet = new Set(tokens);
+
+    let bestMatch: RuleMatch | null = null;
+
+    this.rules.forEach((rule, index) => {
+      if (!matchesContext(context, rule.contextMatches)) {
+        return;
+      }
+
+      const normalizedKeywords = ensureArray(rule.keywords);
+      const normalizedPhrases = ensureArray(rule.phrases);
+      const patterns = rule.patterns ?? [];
+
+      let trigger: string | null = null;
+
+      if (normalizedKeywords.length > 0) {
+        for (const keyword of normalizedKeywords) {
+          if (tokenSet.has(keyword)) {
+            trigger = keyword;
+            break;
+          }
+        }
+      }
+
+      if (!trigger && normalizedPhrases.length > 0) {
+        for (const phrase of normalizedPhrases) {
+          if (normalizedQuery.includes(phrase)) {
+            trigger = phrase;
+            break;
+          }
+        }
+      }
+
+      if (!trigger && patterns.length > 0) {
+        for (const pattern of patterns) {
+          if (pattern.test(query)) {
+            trigger = pattern.source;
+            break;
+          }
+        }
+      }
+
+      if (trigger) {
+        const explanation: ExplanationStep = {
+          stage: 'rule',
+          intent: rule.intent,
+          confidence: rule.confidence,
+          description: `Rule ${rule.id} matched on "${trigger}"`,
+          details: {
+            ruleId: rule.id,
+            trigger,
+            priority: index,
+          },
+        };
+
+        const match: RuleMatch = {
+          intent: rule.intent,
+          confidence: rule.confidence,
+          ruleId: rule.id,
+          trigger,
+          explanation,
+        };
+
+        if (!bestMatch) {
+          bestMatch = match;
+          return;
+        }
+
+        if (match.confidence > bestMatch.confidence) {
+          bestMatch = match;
+          return;
+        }
+
+        if (match.confidence === bestMatch.confidence && index < (bestMatch.explanation.details?.priority as number)) {
+          bestMatch = match;
+        }
+      }
+    });
+
+    return bestMatch;
+  }
+}
+
+export const defaultRules: RuleDefinition[] = [
+  {
+    id: 'fraud-high-signal',
+    intent: 'fraud',
+    keywords: ['fraud', 'chargeback', 'laundering', 'aml', 'stolen', 'synthetic', 'suspicious'],
+    phrases: ['account takeover', 'stolen card', 'suspicious wire'],
+    confidence: 0.97,
+  },
+  {
+    id: 'fraud-alert-context',
+    intent: 'fraud',
+    contextMatches: [{ key: 'channel', values: ['fraud', 'risk-desk', 'aml'] }],
+    confidence: 0.9,
+  },
+  {
+    id: 'support-ticket',
+    intent: 'support',
+    keywords: ['ticket', 'support', 'helpdesk', 'incident', 'outage', 'downtime'],
+    phrases: ['customer issue', 'need assistance', 'service request'],
+    confidence: 0.92,
+  },
+  {
+    id: 'support-channel',
+    intent: 'support',
+    contextMatches: [{ key: 'channel', values: ['support', 'helpdesk', 'csat'] }],
+    confidence: 0.86,
+  },
+  {
+    id: 'marketing-campaign',
+    intent: 'marketing',
+    keywords: ['campaign', 'conversion', 'click', 'impression', 'retargeting', 'acquisition'],
+    phrases: ['paid media', 'email blast', 'lead funnel'],
+    confidence: 0.91,
+  },
+  {
+    id: 'marketing-channel',
+    intent: 'marketing',
+    contextMatches: [{ key: 'channel', values: ['marketing', 'crm', 'adtech'] }],
+    confidence: 0.84,
+  },
+  {
+    id: 'analytics-dashboard',
+    intent: 'analytics',
+    keywords: ['metric', 'dashboard', 'trend', 'kpi', 'kpis', 'insight', 'reporting'],
+    phrases: ['time series', 'variance analysis', 'forecast model'],
+    confidence: 0.9,
+  },
+  {
+    id: 'analytics-role',
+    intent: 'analytics',
+    contextMatches: [{ key: 'userRole', values: ['analyst', 'bi-analyst', 'fp&a'] }],
+    confidence: 0.83,
+  },
+  {
+    id: 'research-project',
+    intent: 'research',
+    keywords: ['research', 'study', 'hypothesis', 'survey', 'publication', 'paper'],
+    phrases: ['peer review', 'literature review', 'experiment design'],
+    confidence: 0.88,
+  },
+  {
+    id: 'research-context',
+    intent: 'research',
+    contextMatches: [{ key: 'tags', values: ['research', 'academic', 'r&d'] }],
+    confidence: 0.82,
+  },
+];

--- a/server/src/services/qic-pm/types.ts
+++ b/server/src/services/qic-pm/types.ts
@@ -1,0 +1,48 @@
+export type QueryIntent =
+  | 'analytics'
+  | 'marketing'
+  | 'support'
+  | 'fraud'
+  | 'research'
+  | 'unknown';
+
+export type PolicyAction = 'allow' | 'redact' | 'deny' | 'transform';
+
+export interface QueryContext {
+  channel?: string;
+  locale?: string;
+  tenantId?: string;
+  userRole?: string;
+  region?: string;
+  tags?: string[];
+  sensitivity?: 'low' | 'medium' | 'high';
+  [key: string]: unknown;
+}
+
+export interface ExplanationStep {
+  stage: 'rule' | 'model' | 'policy';
+  description: string;
+  intent: QueryIntent;
+  confidence?: number;
+  details?: Record<string, unknown>;
+}
+
+export interface ClassificationResult {
+  intent: QueryIntent;
+  confidence: number;
+  probabilities: Record<QueryIntent, number>;
+  explanation: ExplanationStep[];
+}
+
+export interface PolicyDecision {
+  action: PolicyAction;
+  policyId: string;
+  rationale: string;
+  obligations?: string[];
+  transforms?: string[];
+  redactFields?: string[];
+}
+
+export interface PolicyDecisionResult extends ClassificationResult {
+  decision: PolicyDecision;
+}

--- a/server/src/tests/fixtures/qicPmFixtures.json
+++ b/server/src/tests/fixtures/qicPmFixtures.json
@@ -1,0 +1,50 @@
+[
+  {
+    "query": "Show me the revenue trend by region for last quarter and compare KPIs to forecast",
+    "context": { "channel": "analytics", "userRole": "analyst" },
+    "expectedIntent": "analytics",
+    "expectedAction": "allow"
+  },
+  {
+    "query": "Plan the next ABM campaign messaging for healthcare leads and measure conversion",
+    "context": { "channel": "marketing" },
+    "expectedIntent": "marketing",
+    "expectedAction": "transform"
+  },
+  {
+    "query": "Customer opened a ticket about login errors and the outage impacting onboarding",
+    "context": { "channel": "support" },
+    "expectedIntent": "support",
+    "expectedAction": "allow"
+  },
+  {
+    "query": "Investigate card fraud chargeback spike from EU merchants and escalate",
+    "context": { "channel": "fraud" },
+    "expectedIntent": "fraud",
+    "expectedAction": "redact"
+  },
+  {
+    "query": "Draft methodology for a longitudinal customer sentiment research study",
+    "context": { "tags": ["research", "insights"] },
+    "expectedIntent": "research",
+    "expectedAction": "transform"
+  },
+  {
+    "query": "Need assistance to resolve a high priority incident ticket for premium partners",
+    "context": { "channel": "helpdesk" },
+    "expectedIntent": "support",
+    "expectedAction": "allow"
+  },
+  {
+    "query": "What is the click through rate on last quarter nurture campaigns and lead funnel performance",
+    "context": { "channel": "crm" },
+    "expectedIntent": "marketing",
+    "expectedAction": "transform"
+  },
+  {
+    "query": "Aggregate exposure metrics for the risk desk accounts with suspicious transfers",
+    "context": { "channel": "risk-desk" },
+    "expectedIntent": "fraud",
+    "expectedAction": "redact"
+  }
+]

--- a/server/src/tests/services/QueryIntentPolicyMapper.test.ts
+++ b/server/src/tests/services/QueryIntentPolicyMapper.test.ts
@@ -1,0 +1,97 @@
+import { QueryIntentPolicyMapper } from '../../services/qic-pm/query-intent-policy-mapper';
+import { createRsrAdapter } from '../../services/qic-pm/adapters/rsr-adapter';
+import { createPpcAdapter } from '../../services/qic-pm/adapters/ppc-adapter';
+import type { QueryIntent, PolicyAction } from '../../services/qic-pm/types';
+import fixtures from '../fixtures/qicPmFixtures.json';
+
+interface FixtureRow {
+  query: string;
+  context?: Record<string, unknown>;
+  expectedIntent: QueryIntent;
+  expectedAction: PolicyAction;
+}
+
+describe('QueryIntentPolicyMapper', () => {
+  const mapper = new QueryIntentPolicyMapper();
+
+  it('meets accuracy and precision targets on labeled fixtures', () => {
+    const rows = fixtures as FixtureRow[];
+
+    let correctIntent = 0;
+    let correctPolicyAction = 0;
+
+    rows.forEach((row) => {
+      const verdict = mapper.evaluate(row.query, row.context ?? {});
+
+      if (verdict.intent === row.expectedIntent) {
+        correctIntent += 1;
+      }
+
+      if (verdict.decision.action === row.expectedAction) {
+        correctPolicyAction += 1;
+      }
+
+      expect(verdict.explanation.length).toBeGreaterThan(0);
+      expect(Object.values(verdict.probabilities).reduce((sum, value) => sum + value, 0)).toBeCloseTo(1, 5);
+    });
+
+    const intentAccuracy = correctIntent / rows.length;
+    const mappingPrecision = correctPolicyAction / rows.length;
+
+    expect(intentAccuracy).toBeGreaterThanOrEqual(0.9);
+    expect(mappingPrecision).toBeGreaterThanOrEqual(0.9);
+  });
+
+  it('returns deterministic verdicts and explanations for identical inputs', () => {
+    const context = { channel: 'support', tenantId: 'tenant-123' };
+    const query = 'Need help with outage ticket for enterprise accounts';
+
+    const first = mapper.evaluate(query, context);
+    const second = mapper.evaluate(query, context);
+
+    expect(second).toEqual(first);
+    expect(second).not.toBe(first);
+    expect(second.explanation).toEqual(first.explanation);
+    expect(second.explanation).not.toBe(first.explanation);
+  });
+
+  describe('integration adapters', () => {
+    it('generates RSR-compatible routing decisions', () => {
+      const adapter = createRsrAdapter(mapper);
+      const request = {
+        query: 'Customer ticket escalation for login outage',
+        context: { channel: 'support' },
+        correlationId: 'corr-001',
+      };
+
+      const baseVerdict = mapper.evaluate(request.query, request.context ?? {});
+      const routingDecision = adapter.evaluate(request);
+
+      expect(routingDecision.router).toBe('RSR');
+      expect(routingDecision.intent).toBe(baseVerdict.intent);
+      expect(routingDecision.policy).toEqual(baseVerdict.decision);
+      expect(routingDecision.explanation).toEqual(baseVerdict.explanation);
+      expect(routingDecision.allow).toBe(true);
+      expect(routingDecision.correlationId).toBe('corr-001');
+    });
+
+    it('produces PPC directives with policy metadata and traces', () => {
+      const adapter = createPpcAdapter(mapper);
+      const request = {
+        query: 'Plan the next global campaign and compute conversion uplift',
+        context: { channel: 'marketing' },
+      };
+
+      const baseVerdict = mapper.evaluate(request.query, request.context ?? {});
+      const directive = adapter.toDirective(request);
+
+      expect(directive.pipeline).toBe('PPC');
+      expect(directive.metadata.intent).toBe(baseVerdict.intent);
+      expect(directive.metadata.policyId).toBe(baseVerdict.decision.policyId);
+      expect(directive.action).toBe(baseVerdict.decision.action);
+      expect(directive.explanation).toEqual(baseVerdict.explanation);
+      expect(directive.transforms).toEqual(baseVerdict.decision.transforms ?? []);
+      expect(directive.redactions).toEqual(baseVerdict.decision.redactFields ?? []);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a QIC-PM service that combines rule-based signals, a lightweight intent model, and policy mapping with deterministic caching and explanations
- expose reusable adapters for the RSR router and PPC pipeline plus fixtures for verifying accuracy targets
- tweak the Jest config so ts-jest can resolve ESM-style `.js` specifiers during tests and add focused coverage for the new service

## Testing
- npm test -- --config jest.config.js QueryIntentPolicyMapper

------
https://chatgpt.com/codex/tasks/task_e_68d78da2079883338e67f0697a2dc953