### PR TITLE
feat: add audit log succinctness proofs library

### DIFF
--- a/alsp/alsp_test.go
+++ b/alsp/alsp_test.go
@@ -1,0 +1,119 @@
+package alsp
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"time"
+)
+
+func TestProverVerifierAndReplay(t *testing.T) {
+	ctx := context.Background()
+	storage := NewInMemoryStorage()
+	prover, err := NewProver(ctx, storage, 2)
+	if err != nil {
+		t.Fatalf("unexpected error creating prover: %v", err)
+	}
+
+	// Populate two blocks with a deliberate index gap between them.
+	payload := bytes.Repeat([]byte("A"), 512)
+	for i := 0; i < 2; i++ {
+		_, err := prover.AppendEvent(ctx, time.Unix(0, int64(i)*int64(time.Millisecond)), payload)
+		if err != nil {
+			t.Fatalf("append event failed: %v", err)
+		}
+	}
+
+	// Create a gap before appending the next block.
+	prover.nextEventIndex = 5
+
+	for i := 0; i < 2; i++ {
+		_, err := prover.AppendEvent(ctx, time.Unix(0, int64(10+i)*int64(time.Millisecond)), payload)
+		if err != nil {
+			t.Fatalf("append event failed: %v", err)
+		}
+	}
+
+	if err := prover.Flush(ctx); err != nil {
+		t.Fatalf("flush failed: %v", err)
+	}
+
+	// Deterministic timing for proofs.
+	prover.clock = &fakeClock{
+		times: []time.Time{
+			time.Unix(0, 0), time.Unix(0, 1_000), // range
+			time.Unix(0, 2_000), time.Unix(0, 3_000), // event
+			time.Unix(0, 4_000), time.Unix(0, 5_000), // gap
+		},
+	}
+
+	rangeProof, err := prover.ProveRange(ctx, Range{Start: 0, End: 1})
+	if err != nil {
+		t.Fatalf("prove range failed: %v", err)
+	}
+	eventProof, err := prover.ProveEvent(ctx, 5)
+	if err != nil {
+		t.Fatalf("prove event failed: %v", err)
+	}
+	gapProof, err := prover.ProveGap(ctx, 2, 4)
+	if err != nil {
+		t.Fatalf("prove gap failed: %v", err)
+	}
+
+	verifier := NewVerifier(rangeProof.HeadDigest)
+	rangeResult, err := verifier.VerifyRange(rangeProof)
+	if err != nil {
+		t.Fatalf("verify range failed: %v", err)
+	}
+	if rangeResult.CoveredRange != (Range{Start: 0, End: 1}) {
+		t.Fatalf("unexpected range result: %+v", rangeResult.CoveredRange)
+	}
+
+	eventResult, err := verifier.VerifyEvent(eventProof)
+	if err != nil {
+		t.Fatalf("verify event failed: %v", err)
+	}
+	if eventResult.CoveredRange != (Range{Start: 5, End: 5}) {
+		t.Fatalf("unexpected event result: %+v", eventResult.CoveredRange)
+	}
+
+	gapResult, err := verifier.VerifyGap(gapProof)
+	if err != nil {
+		t.Fatalf("verify gap failed: %v", err)
+	}
+	if gapResult.CoveredRange != (Range{Start: 2, End: 4}) {
+		t.Fatalf("unexpected gap result: %+v", gapResult.CoveredRange)
+	}
+
+	replayer := NewReplayer(NewVerifier(rangeProof.HeadDigest))
+	outcomes, err := replayer.Replay([]ReplayEntry{
+		{RangeProof: &rangeProof},
+		{EventProof: &eventProof},
+		{GapProof: &gapProof},
+	})
+	if err != nil {
+		t.Fatalf("replay failed: %v", err)
+	}
+	if len(outcomes) != 3 {
+		t.Fatalf("unexpected replay outcomes: %d", len(outcomes))
+	}
+	for i, outcome := range outcomes {
+		if outcome.Err != nil {
+			t.Fatalf("outcome %d error: %v", i, outcome.Err)
+		}
+	}
+
+	report := prover.Metrics()
+	if report.CompressionRatio <= 1.0 {
+		t.Fatalf("expected compression ratio > 1, got %f", report.CompressionRatio)
+	}
+	if report.AvgRangeLatency != time.Microsecond {
+		t.Fatalf("unexpected range latency: %s", report.AvgRangeLatency)
+	}
+	if report.AvgEventLatency != time.Microsecond {
+		t.Fatalf("unexpected event latency: %s", report.AvgEventLatency)
+	}
+	if report.AvgGapLatency != time.Microsecond {
+		t.Fatalf("unexpected gap latency: %s", report.AvgGapLatency)
+	}
+}

--- a/alsp/block.go
+++ b/alsp/block.go
@@ -1,0 +1,62 @@
+package alsp
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"time"
+)
+
+// newBlock constructs a block for the supplied events.
+func newBlock(index uint64, prevDigest []byte, events []Event, createdAt time.Time) (Block, error) {
+	if len(events) == 0 {
+		return Block{}, nil
+	}
+
+	leaves := make([][]byte, len(events))
+	for i, e := range events {
+		leaves[i] = e.Digest()
+	}
+	merkleRoot, _ := buildMerkleTree(leaves)
+
+	digest := deriveBlockDigest(index, events[0].Index, events[len(events)-1].Index, prevDigest, merkleRoot)
+
+	return Block{
+		Index:      index,
+		StartIndex: events[0].Index,
+		EndIndex:   events[len(events)-1].Index,
+		CreatedAt:  createdAt.UTC(),
+		Events:     append([]Event(nil), events...),
+		MerkleRoot: merkleRoot,
+		Digest:     digest,
+		PrevDigest: append([]byte(nil), prevDigest...),
+	}, nil
+}
+
+func deriveBlockDigest(blockIndex, startIndex, endIndex uint64, prevDigest, merkleRoot []byte) []byte {
+	h := sha256.New()
+	h.Write([]byte("alsp.block"))
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, blockIndex)
+	h.Write(buf)
+	binary.BigEndian.PutUint64(buf, startIndex)
+	h.Write(buf)
+	binary.BigEndian.PutUint64(buf, endIndex)
+	h.Write(buf)
+	h.Write(merkleRoot)
+	h.Write(prevDigest)
+	return h.Sum(nil)
+}
+
+// ensureContinuity asserts that the next block correctly references the
+// previous digest and that indices form a contiguous run. This guard is part of
+// the verifier as well as the replay logic.
+func ensureContinuity(prev, next Block) bool {
+	if !bytes.Equal(next.PrevDigest, prev.Digest) {
+		return false
+	}
+	if next.StartIndex <= prev.EndIndex {
+		return false
+	}
+	return true
+}

--- a/alsp/clock.go
+++ b/alsp/clock.go
@@ -1,0 +1,29 @@
+package alsp
+
+import "time"
+
+type clock interface {
+	Now() time.Time
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time { return time.Now() }
+
+// fakeClock is exported in tests to provide deterministic durations.
+type fakeClock struct {
+	times []time.Time
+	idx   int
+}
+
+func (f *fakeClock) Now() time.Time {
+	if len(f.times) == 0 {
+		return time.Now()
+	}
+	if f.idx >= len(f.times) {
+		return f.times[len(f.times)-1]
+	}
+	t := f.times[f.idx]
+	f.idx++
+	return t
+}

--- a/alsp/errors.go
+++ b/alsp/errors.go
@@ -1,0 +1,12 @@
+package alsp
+
+import "errors"
+
+var (
+	ErrInvalidRange    = errors.New("alsp: invalid range")
+	ErrEventNotFound   = errors.New("alsp: event not found")
+	ErrBlockNotFound   = errors.New("alsp: block not found")
+	ErrInvalidProof    = errors.New("alsp: invalid proof")
+	ErrGapNotProvable  = errors.New("alsp: gap cannot be proven with current snapshot")
+	ErrInconsistentLog = errors.New("alsp: inconsistent block chain")
+)

--- a/alsp/go.mod
+++ b/alsp/go.mod
@@ -1,0 +1,3 @@
+module github.com/summit/alsp
+
+go 1.22

--- a/alsp/merkle.go
+++ b/alsp/merkle.go
@@ -1,0 +1,108 @@
+package alsp
+
+import (
+	"bytes"
+	"crypto/sha256"
+)
+
+type merkleNode struct {
+	hash []byte
+}
+
+// MerkleProof captures the sibling hashes necessary to verify the membership
+// of a leaf hash within a specific Merkle root.
+type MerkleProof struct {
+	LeafDigest     []byte   `json:"leafDigest"`
+	SiblingDigests [][]byte `json:"siblingDigests"`
+	PathBits       []byte   `json:"pathBits"`
+}
+
+// buildMerkleTree constructs a binary Merkle tree and returns the root hash
+// along with all intermediate layers used to extract proofs.
+func buildMerkleTree(leaves [][]byte) ([]byte, [][]merkleNode) {
+	if len(leaves) == 0 {
+		empty := sha256.Sum256([]byte("alsp.empty"))
+		return empty[:], [][]merkleNode{{{hash: empty[:]}}}
+	}
+
+	var layers [][]merkleNode
+	current := make([]merkleNode, len(leaves))
+	for i, leaf := range leaves {
+		digest := sha256.Sum256(append([]byte("leaf"), leaf...))
+		current[i] = merkleNode{hash: digest[:]}
+	}
+	layers = append(layers, current)
+
+	for len(current) > 1 {
+		var next []merkleNode
+		for i := 0; i < len(current); i += 2 {
+			if i+1 >= len(current) {
+				// Duplicate the last node if the level is odd.
+				next = append(next, merkleNode{hash: hashNode(current[i].hash, current[i].hash)})
+				continue
+			}
+			next = append(next, merkleNode{hash: hashNode(current[i].hash, current[i+1].hash)})
+		}
+		current = next
+		layers = append(layers, current)
+	}
+
+	return current[0].hash, layers
+}
+
+func hashNode(left, right []byte) []byte {
+	h := sha256.New()
+	h.Write([]byte("node"))
+	h.Write(left)
+	h.Write(right)
+	return h.Sum(nil)
+}
+
+func buildMerkleProof(leaves [][]byte, index int) MerkleProof {
+	_, layers := buildMerkleTree(leaves)
+	proof := MerkleProof{
+		LeafDigest: leaves[index],
+	}
+	var pathBits []byte
+	var siblings [][]byte
+
+	position := index
+	for level := 0; level < len(layers)-1; level++ {
+		layer := layers[level]
+		var siblingPos int
+		var bit byte
+		if position%2 == 0 {
+			// even index => sibling on the right
+			if position+1 < len(layer) {
+				siblingPos = position + 1
+			} else {
+				siblingPos = position
+			}
+			bit = 0
+		} else {
+			siblingPos = position - 1
+			bit = 1
+		}
+		siblings = append(siblings, layer[siblingPos].hash)
+		pathBits = append(pathBits, bit)
+		position /= 2
+	}
+	proof.SiblingDigests = siblings
+	proof.PathBits = pathBits
+	return proof
+}
+
+// verifyMerkleProof checks that the supplied proof resolves to the provided
+// root hash. The hashing strategy mirrors buildMerkleTree.
+func verifyMerkleProof(root []byte, proof MerkleProof) bool {
+	h := sha256.Sum256(append([]byte("leaf"), proof.LeafDigest...))
+	current := h[:]
+	for i, sibling := range proof.SiblingDigests {
+		if proof.PathBits[i] == 0 {
+			current = hashNode(current, sibling)
+		} else {
+			current = hashNode(sibling, current)
+		}
+	}
+	return bytes.Equal(current, root)
+}

--- a/alsp/metrics.go
+++ b/alsp/metrics.go
@@ -1,0 +1,81 @@
+package alsp
+
+import (
+	"sync"
+	"time"
+)
+
+// PerformanceMetrics aggregates compression statistics and latency samples.
+type PerformanceMetrics struct {
+	mu sync.Mutex
+
+	rawBytes        int
+	compressedBytes int
+
+	rangeSamples []time.Duration
+	eventSamples []time.Duration
+	gapSamples   []time.Duration
+}
+
+func (m *PerformanceMetrics) recordRaw(size int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rawBytes += size
+}
+
+func (m *PerformanceMetrics) recordCompressed(size int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.compressedBytes += size
+}
+
+func (m *PerformanceMetrics) recordRangeLatency(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rangeSamples = append(m.rangeSamples, d)
+}
+
+func (m *PerformanceMetrics) recordEventLatency(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.eventSamples = append(m.eventSamples, d)
+}
+
+func (m *PerformanceMetrics) recordGapLatency(d time.Duration) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.gapSamples = append(m.gapSamples, d)
+}
+
+// Report summarises the collected metrics. When there are no samples the report
+// defaults to zeroed values to keep consumers deterministic.
+type Report struct {
+	CompressionRatio float64       `json:"compressionRatio"`
+	AvgRangeLatency  time.Duration `json:"avgRangeLatency"`
+	AvgEventLatency  time.Duration `json:"avgEventLatency"`
+	AvgGapLatency    time.Duration `json:"avgGapLatency"`
+}
+
+func (m *PerformanceMetrics) Report() Report {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	report := Report{}
+	if m.compressedBytes > 0 {
+		report.CompressionRatio = float64(m.rawBytes) / float64(m.compressedBytes)
+	}
+	report.AvgRangeLatency = averageDuration(m.rangeSamples)
+	report.AvgEventLatency = averageDuration(m.eventSamples)
+	report.AvgGapLatency = averageDuration(m.gapSamples)
+	return report
+}
+
+func averageDuration(samples []time.Duration) time.Duration {
+	if len(samples) == 0 {
+		return 0
+	}
+	var total time.Duration
+	for _, sample := range samples {
+		total += sample
+	}
+	return total / time.Duration(len(samples))
+}

--- a/alsp/proofs.go
+++ b/alsp/proofs.go
@@ -1,0 +1,189 @@
+package alsp
+
+import "context"
+
+// BlockProof bundles a subset of events and their membership proofs for a
+// particular block.
+type BlockProof struct {
+	Header BlockHeader   `json:"header"`
+	Events []Event       `json:"events"`
+	Proofs []MerkleProof `json:"proofs"`
+}
+
+// RangeProof demonstrates that every event between Start and End is included in
+// the log and anchored to the supplied head digest.
+type RangeProof struct {
+	Query       Range        `json:"query"`
+	Blocks      []BlockProof `json:"blocks"`
+	StartAnchor []byte       `json:"startAnchor"`
+	HeadDigest  []byte       `json:"headDigest"`
+}
+
+// EventProof is a specialised proof that focuses on a single event.
+type EventProof struct {
+	Index      uint64     `json:"index"`
+	Event      Event      `json:"event"`
+	Block      BlockProof `json:"block"`
+	HeadDigest []byte     `json:"headDigest"`
+}
+
+// GapProof asserts that there are no events inside the provided window by
+// supplying consecutive block headers that fence off the gap.
+type GapProof struct {
+	Start      uint64      `json:"start"`
+	End        uint64      `json:"end"`
+	Left       BlockHeader `json:"left"`
+	Right      BlockHeader `json:"right"`
+	HeadDigest []byte      `json:"headDigest"`
+}
+
+// ProveRange builds an inclusion proof for the requested range.
+func (p *Prover) ProveRange(ctx context.Context, r Range) (RangeProof, error) {
+	startTime := p.clock.Now()
+	if err := r.Validate(); err != nil {
+		return RangeProof{}, err
+	}
+	blocks, err := p.allBlocks(ctx)
+	if err != nil {
+		return RangeProof{}, err
+	}
+	if len(blocks) == 0 {
+		return RangeProof{}, ErrBlockNotFound
+	}
+
+	var proofs []BlockProof
+	var seenStart, seenEnd bool
+	for _, block := range blocks {
+		if r.Start > block.EndIndex || r.End < block.StartIndex {
+			continue
+		}
+		bp := buildBlockProof(block, r)
+		if len(bp.Events) == 0 {
+			continue
+		}
+		proofs = append(proofs, bp)
+		if r.Start >= block.StartIndex && r.Start <= block.EndIndex {
+			seenStart = true
+		}
+		if r.End >= block.StartIndex && r.End <= block.EndIndex {
+			seenEnd = true
+		}
+	}
+	if len(proofs) == 0 {
+		return RangeProof{}, ErrInvalidProof
+	}
+	if !seenStart || !seenEnd {
+		return RangeProof{}, ErrEventNotFound
+	}
+	report := RangeProof{
+		Query:       r,
+		Blocks:      proofs,
+		HeadDigest:  append([]byte(nil), blocks[len(blocks)-1].Digest...),
+		StartAnchor: append([]byte(nil), proofs[0].Header.PrevDigest...),
+	}
+	p.metrics.recordRangeLatency(p.clock.Now().Sub(startTime))
+	return report, nil
+}
+
+// ProveEvent builds an inclusion proof for a single event index.
+func (p *Prover) ProveEvent(ctx context.Context, index uint64) (EventProof, error) {
+	startTime := p.clock.Now()
+	blocks, err := p.allBlocks(ctx)
+	if err != nil {
+		return EventProof{}, err
+	}
+	leavesRange := Range{Start: index, End: index}
+	for _, block := range blocks {
+		if index < block.StartIndex || index > block.EndIndex {
+			continue
+		}
+		bp := buildBlockProof(block, leavesRange)
+		if len(bp.Events) == 0 {
+			continue
+		}
+		proof := EventProof{
+			Index:      index,
+			Event:      bp.Events[0],
+			Block:      bp,
+			HeadDigest: append([]byte(nil), blocks[len(blocks)-1].Digest...),
+		}
+		p.metrics.recordEventLatency(p.clock.Now().Sub(startTime))
+		return proof, nil
+	}
+	return EventProof{}, ErrEventNotFound
+}
+
+// ProveGap constructs a gap proof that the interval [start,end] has no events.
+func (p *Prover) ProveGap(ctx context.Context, start, end uint64) (GapProof, error) {
+	startTime := p.clock.Now()
+	if end < start {
+		return GapProof{}, ErrInvalidRange
+	}
+	blocks, err := p.allBlocks(ctx)
+	if err != nil {
+		return GapProof{}, err
+	}
+	var left Block
+	var right Block
+	foundLeft := false
+	foundRight := false
+	for _, block := range blocks {
+		if block.EndIndex < start {
+			left = block
+			foundLeft = true
+			continue
+		}
+		if block.StartIndex > end {
+			right = block
+			foundRight = true
+			break
+		}
+	}
+	if !foundLeft || !foundRight {
+		return GapProof{}, ErrGapNotProvable
+	}
+	if right.Index != left.Index+1 {
+		return GapProof{}, ErrGapNotProvable
+	}
+	if !ensureContinuity(left, right) {
+		return GapProof{}, ErrInconsistentLog
+	}
+	proof := GapProof{
+		Start:      start,
+		End:        end,
+		Left:       left.Header(),
+		Right:      right.Header(),
+		HeadDigest: append([]byte(nil), blocks[len(blocks)-1].Digest...),
+	}
+	p.metrics.recordGapLatency(p.clock.Now().Sub(startTime))
+	return proof, nil
+}
+
+func buildBlockProof(block Block, r Range) BlockProof {
+	leaves := make([][]byte, len(block.Events))
+	for i, event := range block.Events {
+		leaves[i] = event.Digest()
+	}
+	var events []Event
+	var proofs []MerkleProof
+	for i, event := range block.Events {
+		if event.Index < r.Start || event.Index > r.End {
+			continue
+		}
+		events = append(events, event)
+		proofs = append(proofs, buildMerkleProof(leaves, i))
+	}
+	return BlockProof{
+		Header: block.Header(),
+		Events: events,
+		Proofs: proofs,
+	}
+}
+
+func (p *Prover) allBlocks(ctx context.Context) ([]Block, error) {
+	latest, err := p.storage.LatestBlock(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return p.storage.BlocksInRange(ctx, 0, latest.Index)
+}

--- a/alsp/prover.go
+++ b/alsp/prover.go
@@ -1,0 +1,100 @@
+package alsp
+
+import (
+	"context"
+	"time"
+)
+
+// Prover is responsible for compressing the append-only audit log into block
+// digests and constructing proofs for client queries.
+type Prover struct {
+	storage   Storage
+	blockSize int
+
+	pending []Event
+
+	metrics *PerformanceMetrics
+	clock   clock
+
+	nextEventIndex uint64
+	nextBlockIndex uint64
+	lastDigest     []byte
+}
+
+// NewProver initialises a prover instance that continues from the persisted
+// state when storage already contains blocks.
+func NewProver(ctx context.Context, storage Storage, blockSize int) (*Prover, error) {
+	if blockSize <= 0 {
+		blockSize = 128
+	}
+	p := &Prover{
+		storage:   storage,
+		blockSize: blockSize,
+		metrics:   &PerformanceMetrics{},
+		clock:     systemClock{},
+	}
+	if storage != nil {
+		block, err := storage.LatestBlock(ctx)
+		if err == nil {
+			p.lastDigest = append([]byte(nil), block.Digest...)
+			p.nextBlockIndex = block.Index + 1
+			p.nextEventIndex = block.EndIndex + 1
+		} else if err != ErrBlockNotFound {
+			return nil, err
+		}
+	}
+	return p, nil
+}
+
+// AppendEvent ingests a new audit entry and compresses it when a block is full.
+func (p *Prover) AppendEvent(ctx context.Context, timestamp time.Time, payload []byte) (Event, error) {
+	event := Event{
+		Index:     p.nextEventIndex,
+		Timestamp: timestamp.UTC(),
+		Payload:   append([]byte(nil), payload...),
+	}
+	p.pending = append(p.pending, event)
+	p.metrics.recordRaw(len(event.Payload))
+	p.nextEventIndex++
+
+	if len(p.pending) >= p.blockSize {
+		if err := p.flushPending(ctx); err != nil {
+			return Event{}, err
+		}
+	}
+	return event, nil
+}
+
+// Flush persists any pending events into a compressed block.
+func (p *Prover) Flush(ctx context.Context) error {
+	return p.flushPending(ctx)
+}
+
+func (p *Prover) flushPending(ctx context.Context) error {
+	if len(p.pending) == 0 {
+		return nil
+	}
+	block, err := newBlock(p.nextBlockIndex, p.lastDigest, p.pending, p.clock.Now())
+	if err != nil {
+		return err
+	}
+	if err := p.storage.SaveBlock(ctx, block); err != nil {
+		return err
+	}
+	compressed := len(block.Digest) + len(block.MerkleRoot) + len(block.PrevDigest)
+	p.metrics.recordCompressed(compressed)
+	p.lastDigest = block.Digest
+	p.nextBlockIndex++
+	p.pending = nil
+	return nil
+}
+
+// HeadDigest returns the digest of the most recently committed block.
+func (p *Prover) HeadDigest() []byte {
+	return append([]byte(nil), p.lastDigest...)
+}
+
+// Metrics exposes the prover's aggregated performance statistics.
+func (p *Prover) Metrics() Report {
+	return p.metrics.Report()
+}

--- a/alsp/replay.go
+++ b/alsp/replay.go
@@ -1,0 +1,58 @@
+package alsp
+
+import "fmt"
+
+// ReplayEntry bundles one of the supported proof types. Exactly one field must
+// be populated per entry.
+type ReplayEntry struct {
+	RangeProof *RangeProof
+	EventProof *EventProof
+	GapProof   *GapProof
+}
+
+// ReplayOutcome captures the deterministic result of verifying a single entry.
+type ReplayOutcome struct {
+	Entry  ReplayEntry
+	Result VerificationResult
+	Err    error
+}
+
+// Replayer drives a verifier through a series of proofs to make deterministic
+// replays straightforward for auditors.
+type Replayer struct {
+	verifier *Verifier
+}
+
+func NewReplayer(verifier *Verifier) *Replayer {
+	return &Replayer{verifier: verifier}
+}
+
+// Replay processes the supplied entries sequentially. The first error halts the
+// replay and is returned alongside the outcomes collected so far.
+func (r *Replayer) Replay(entries []ReplayEntry) ([]ReplayOutcome, error) {
+	outcomes := make([]ReplayOutcome, 0, len(entries))
+	for _, entry := range entries {
+		outcome := ReplayOutcome{Entry: entry}
+		switch {
+		case entry.RangeProof != nil:
+			res, err := r.verifier.VerifyRange(*entry.RangeProof)
+			outcome.Result = res
+			outcome.Err = err
+		case entry.EventProof != nil:
+			res, err := r.verifier.VerifyEvent(*entry.EventProof)
+			outcome.Result = res
+			outcome.Err = err
+		case entry.GapProof != nil:
+			res, err := r.verifier.VerifyGap(*entry.GapProof)
+			outcome.Result = res
+			outcome.Err = err
+		default:
+			outcome.Err = fmt.Errorf("%w: empty replay entry", ErrInvalidProof)
+		}
+		outcomes = append(outcomes, outcome)
+		if outcome.Err != nil {
+			return outcomes, outcome.Err
+		}
+	}
+	return outcomes, nil
+}

--- a/alsp/storage.go
+++ b/alsp/storage.go
@@ -1,0 +1,159 @@
+package alsp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Storage abstracts persistence for compressed blocks.
+type Storage interface {
+	SaveBlock(ctx context.Context, block Block) error
+	BlockByIndex(ctx context.Context, index uint64) (Block, error)
+	LatestBlock(ctx context.Context) (Block, error)
+	BlocksInRange(ctx context.Context, start, end uint64) ([]Block, error)
+}
+
+// InMemoryStorage provides a deterministic adapter for tests and
+// demonstrations.
+type InMemoryStorage struct {
+	mu     sync.RWMutex
+	blocks map[uint64]Block
+}
+
+func NewInMemoryStorage() *InMemoryStorage {
+	return &InMemoryStorage{blocks: make(map[uint64]Block)}
+}
+
+func (s *InMemoryStorage) SaveBlock(_ context.Context, block Block) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.blocks[block.Index] = block
+	return nil
+}
+
+func (s *InMemoryStorage) BlockByIndex(_ context.Context, index uint64) (Block, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	block, ok := s.blocks[index]
+	if !ok {
+		return Block{}, ErrBlockNotFound
+	}
+	return block, nil
+}
+
+func (s *InMemoryStorage) LatestBlock(_ context.Context) (Block, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if len(s.blocks) == 0 {
+		return Block{}, ErrBlockNotFound
+	}
+	var max uint64
+	for idx := range s.blocks {
+		if idx > max {
+			max = idx
+		}
+	}
+	return s.blocks[max], nil
+}
+
+func (s *InMemoryStorage) BlocksInRange(_ context.Context, start, end uint64) ([]Block, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var out []Block
+	for i := start; i <= end; i++ {
+		block, ok := s.blocks[i]
+		if ok {
+			out = append(out, block)
+		}
+	}
+	if len(out) == 0 {
+		return nil, ErrBlockNotFound
+	}
+	return out, nil
+}
+
+// FileStorage persists blocks as JSON documents under the provided directory.
+type FileStorage struct {
+	root string
+	mu   sync.Mutex
+}
+
+func NewFileStorage(root string) (*FileStorage, error) {
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		return nil, err
+	}
+	return &FileStorage{root: root}, nil
+}
+
+func (s *FileStorage) SaveBlock(_ context.Context, block Block) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	data, err := json.MarshalIndent(block, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(s.root, formatBlockFilename(block.Index)), data, 0o644)
+}
+
+func (s *FileStorage) BlockByIndex(_ context.Context, index uint64) (Block, error) {
+	data, err := os.ReadFile(filepath.Join(s.root, formatBlockFilename(index)))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Block{}, ErrBlockNotFound
+		}
+		return Block{}, err
+	}
+	var block Block
+	if err := json.Unmarshal(data, &block); err != nil {
+		return Block{}, err
+	}
+	return block, nil
+}
+
+func (s *FileStorage) LatestBlock(ctx context.Context) (Block, error) {
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		return Block{}, err
+	}
+	if len(entries) == 0 {
+		return Block{}, ErrBlockNotFound
+	}
+	var max uint64
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		var idx uint64
+		_, scanErr := fmt.Sscanf(entry.Name(), "block-%d.json", &idx)
+		if scanErr == nil && idx >= max {
+			max = idx
+		}
+	}
+	if max == 0 {
+		return Block{}, ErrBlockNotFound
+	}
+	return s.BlockByIndex(ctx, max)
+}
+
+func (s *FileStorage) BlocksInRange(ctx context.Context, start, end uint64) ([]Block, error) {
+	var out []Block
+	for i := start; i <= end; i++ {
+		block, err := s.BlockByIndex(ctx, i)
+		if err == nil {
+			out = append(out, block)
+		}
+	}
+	if len(out) == 0 {
+		return nil, ErrBlockNotFound
+	}
+	return out, nil
+}
+
+func formatBlockFilename(index uint64) string {
+	return fmt.Sprintf("block-%06d.json", index)
+}

--- a/alsp/types.go
+++ b/alsp/types.go
@@ -1,0 +1,95 @@
+package alsp
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"time"
+)
+
+// Event represents a single audit log entry that will be committed into the
+// compressed ledger. Events are addressed by their monotonically increasing
+// index so proofs can be bound to deterministic positions within the log.
+type Event struct {
+	Index     uint64    `json:"index"`
+	Timestamp time.Time `json:"timestamp"`
+	Payload   []byte    `json:"payload"`
+}
+
+// Digest computes the stable hash for the event. The encoding is deterministic
+// and includes every attribute that contributes to replay consistency.
+func (e Event) Digest() []byte {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, e.Index)
+	ts := e.Timestamp.UTC().UnixNano()
+	tsBuf := make([]byte, 8)
+	binary.BigEndian.PutUint64(tsBuf, uint64(ts))
+
+	h := sha256.New()
+	h.Write(buf)
+	h.Write(tsBuf)
+	h.Write(e.Payload)
+	return h.Sum(nil)
+}
+
+// Block groups a contiguous run of events. Blocks reference the digest of the
+// preceding block, forming a chain that enables succinct consistency proofs.
+type Block struct {
+	Index      uint64    `json:"index"`
+	StartIndex uint64    `json:"startIndex"`
+	EndIndex   uint64    `json:"endIndex"`
+	CreatedAt  time.Time `json:"createdAt"`
+
+	Events []Event `json:"events"`
+
+	MerkleRoot []byte `json:"merkleRoot"`
+	Digest     []byte `json:"digest"`
+	PrevDigest []byte `json:"prevDigest"`
+}
+
+// Header renders the succinct representation of a block that is shared with
+// verifiers.
+func (b Block) Header() BlockHeader {
+	return BlockHeader{
+		Index:      b.Index,
+		StartIndex: b.StartIndex,
+		EndIndex:   b.EndIndex,
+		MerkleRoot: append([]byte(nil), b.MerkleRoot...),
+		Digest:     append([]byte(nil), b.Digest...),
+		PrevDigest: append([]byte(nil), b.PrevDigest...),
+	}
+}
+
+// HexDigest is a helper that turns a digest into a canonical string
+// representation. Proofs and clients rely on the textual form for portability.
+func HexDigest(b []byte) string {
+	return hex.EncodeToString(b)
+}
+
+// BlockHeader represents the information that needs to be persisted or shared
+// with clients so they can independently verify a proof. It intentionally omits
+// the raw events, keeping the compressed representation succinct.
+type BlockHeader struct {
+	Index      uint64 `json:"index"`
+	StartIndex uint64 `json:"startIndex"`
+	EndIndex   uint64 `json:"endIndex"`
+
+	MerkleRoot []byte `json:"merkleRoot"`
+	Digest     []byte `json:"digest"`
+	PrevDigest []byte `json:"prevDigest"`
+}
+
+// Range describes a requested inclusive interval of event indices.
+type Range struct {
+	Start uint64
+	End   uint64
+}
+
+// Validate ensures the range parameters are meaningful. Proof generation uses
+// this guard before attempting any storage lookups.
+func (r Range) Validate() error {
+	if r.End < r.Start {
+		return ErrInvalidRange
+	}
+	return nil
+}

--- a/alsp/verifier.go
+++ b/alsp/verifier.go
@@ -1,0 +1,193 @@
+package alsp
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// VerificationResult summarises a successful proof verification.
+type VerificationResult struct {
+	HeadDigest   []byte
+	CoveredRange Range
+	StartAnchor  []byte
+}
+
+// Verifier checks proofs emitted by the prover against an anchor digest.
+type Verifier struct {
+	anchor []byte
+}
+
+// NewVerifier initialises a verifier with the trusted log head digest. A nil
+// anchor means the verifier will accept any digest and adopt it after the first
+// successful verification.
+func NewVerifier(anchor []byte) *Verifier {
+	return &Verifier{anchor: append([]byte(nil), anchor...)}
+}
+
+// Anchor exposes the current trusted digest.
+func (v *Verifier) Anchor() []byte {
+	return append([]byte(nil), v.anchor...)
+}
+
+// AdvanceAnchor overrides the trusted digest. Callers typically use this after
+// cross-checking a new digest with an external source of truth.
+func (v *Verifier) AdvanceAnchor(digest []byte) {
+	v.anchor = append([]byte(nil), digest...)
+}
+
+// VerifyRange validates a range proof and returns the covered interval on
+// success.
+func (v *Verifier) VerifyRange(proof RangeProof) (VerificationResult, error) {
+	if err := proof.Query.Validate(); err != nil {
+		return VerificationResult{}, err
+	}
+	if len(proof.Blocks) == 0 {
+		return VerificationResult{}, ErrInvalidProof
+	}
+	if err := v.ensureAnchor(proof.HeadDigest); err != nil {
+		return VerificationResult{}, err
+	}
+	if !bytes.Equal(proof.StartAnchor, proof.Blocks[0].Header.PrevDigest) {
+		return VerificationResult{}, ErrInvalidProof
+	}
+
+	var prevHeader *BlockHeader
+	var allIndices []uint64
+	for _, block := range proof.Blocks {
+		if err := validateBlockProof(block, prevHeader); err != nil {
+			return VerificationResult{}, err
+		}
+		if len(block.Events) != len(block.Proofs) {
+			return VerificationResult{}, ErrInvalidProof
+		}
+		for j, event := range block.Events {
+			proofItem := block.Proofs[j]
+			if !bytes.Equal(proofItem.LeafDigest, event.Digest()) {
+				return VerificationResult{}, ErrInvalidProof
+			}
+			if !verifyMerkleProof(block.Header.MerkleRoot, proofItem) {
+				return VerificationResult{}, ErrInvalidProof
+			}
+			allIndices = append(allIndices, event.Index)
+		}
+		prevHeader = &block.Header
+	}
+	if err := ensureCoverage(proof.Query, allIndices); err != nil {
+		return VerificationResult{}, err
+	}
+	v.anchor = append([]byte(nil), proof.HeadDigest...)
+	return VerificationResult{HeadDigest: proof.HeadDigest, CoveredRange: proof.Query, StartAnchor: append([]byte(nil), proof.StartAnchor...)}, nil
+}
+
+// VerifyEvent validates an event proof. The returned range collapses to the
+// event index.
+func (v *Verifier) VerifyEvent(proof EventProof) (VerificationResult, error) {
+	if err := v.ensureAnchor(proof.HeadDigest); err != nil {
+		return VerificationResult{}, err
+	}
+	if len(proof.Block.Events) != 1 || len(proof.Block.Proofs) != 1 {
+		return VerificationResult{}, ErrInvalidProof
+	}
+	if proof.Event.Index != proof.Index {
+		return VerificationResult{}, ErrInvalidProof
+	}
+	if err := validateBlockProof(proof.Block, nil); err != nil {
+		return VerificationResult{}, err
+	}
+	event := proof.Block.Events[0]
+	membership := proof.Block.Proofs[0]
+	if !bytes.Equal(membership.LeafDigest, event.Digest()) {
+		return VerificationResult{}, ErrInvalidProof
+	}
+	if !verifyMerkleProof(proof.Block.Header.MerkleRoot, membership) {
+		return VerificationResult{}, ErrInvalidProof
+	}
+	if event.Index != proof.Index {
+		return VerificationResult{}, ErrInvalidProof
+	}
+	v.anchor = append([]byte(nil), proof.HeadDigest...)
+	return VerificationResult{HeadDigest: proof.HeadDigest, CoveredRange: Range{Start: proof.Index, End: proof.Index}, StartAnchor: append([]byte(nil), proof.Block.Header.PrevDigest...)}, nil
+}
+
+// VerifyGap validates that the provided block headers fence off an empty range.
+func (v *Verifier) VerifyGap(proof GapProof) (VerificationResult, error) {
+	if proof.End < proof.Start {
+		return VerificationResult{}, ErrInvalidRange
+	}
+	if err := v.ensureAnchor(proof.HeadDigest); err != nil {
+		return VerificationResult{}, err
+	}
+	// Ensure digests are self-consistent.
+	if err := validateHeader(proof.Left); err != nil {
+		return VerificationResult{}, err
+	}
+	if err := validateHeader(proof.Right); err != nil {
+		return VerificationResult{}, err
+	}
+	if proof.Right.Index != proof.Left.Index+1 {
+		return VerificationResult{}, ErrInvalidProof
+	}
+	if !bytes.Equal(proof.Right.PrevDigest, proof.Left.Digest) {
+		return VerificationResult{}, ErrInconsistentLog
+	}
+	if proof.Start <= proof.Left.EndIndex {
+		return VerificationResult{}, ErrInvalidProof
+	}
+	if proof.End >= proof.Right.StartIndex {
+		return VerificationResult{}, ErrInvalidProof
+	}
+	v.anchor = append([]byte(nil), proof.HeadDigest...)
+	return VerificationResult{HeadDigest: proof.HeadDigest, CoveredRange: Range{Start: proof.Start, End: proof.End}, StartAnchor: append([]byte(nil), proof.Left.PrevDigest...)}, nil
+}
+
+func (v *Verifier) ensureAnchor(digest []byte) error {
+	if len(v.anchor) == 0 {
+		v.anchor = append([]byte(nil), digest...)
+		return nil
+	}
+	if !bytes.Equal(v.anchor, digest) {
+		return fmt.Errorf("%w: unexpected head digest", ErrInvalidProof)
+	}
+	return nil
+}
+
+func validateBlockProof(block BlockProof, prev *BlockHeader) error {
+	if err := validateHeader(block.Header); err != nil {
+		return err
+	}
+	if prev != nil {
+		if !bytes.Equal(block.Header.PrevDigest, prev.Digest) {
+			return ErrInconsistentLog
+		}
+		if block.Header.StartIndex <= prev.EndIndex {
+			return ErrInconsistentLog
+		}
+	}
+	return nil
+}
+
+func validateHeader(header BlockHeader) error {
+	digest := deriveBlockDigest(header.Index, header.StartIndex, header.EndIndex, header.PrevDigest, header.MerkleRoot)
+	if !bytes.Equal(digest, header.Digest) {
+		return ErrInvalidProof
+	}
+	return nil
+}
+
+func ensureCoverage(r Range, indices []uint64) error {
+	if len(indices) == 0 {
+		return ErrInvalidProof
+	}
+	for i := 1; i < len(indices); i++ {
+		if indices[i] != indices[i-1]+1 {
+			return ErrInvalidProof
+		}
+	}
+	if indices[0] != r.Start {
+		return ErrInvalidProof
+	}
+	if indices[len(indices)-1] != r.End {
+		return ErrInvalidProof
+	}
+	return nil
+}

--- a/sdk/typescript/alsp-client/README.md
+++ b/sdk/typescript/alsp-client/README.md
@@ -1,0 +1,24 @@
+# @summit/alsp-client
+
+TypeScript companion client for the Audit Log Succinctness & Proofs (ALSP) library.
+
+## Features
+
+- Minimal `AlspTransport` abstraction with HTTP and in-memory implementations.
+- `AlspClient` helper that requests proofs and immediately verifies them locally.
+- Deterministic `ReplaySession` to step through stored proofs in order.
+- Merkle verification and digest derivations matching the Go reference implementation.
+
+## Usage
+
+```ts
+import { AlspClient, AlspVerifier, HttpTransport } from "@summit/alsp-client";
+
+const verifier = new AlspVerifier(/* optional trusted head digest */);
+const client = new AlspClient(new HttpTransport("https://alsp.example"), verifier);
+
+const { proof, verification } = await client.proveRange({ start: 100, end: 160 });
+console.log("verified head", verification.headDigest);
+```
+
+All digests are expressed as base64 strings in the JSON wire format, matching the Go encoder output.

--- a/sdk/typescript/alsp-client/package.json
+++ b/sdk/typescript/alsp-client/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@summit/alsp-client",
+  "version": "0.1.0",
+  "description": "TypeScript client and verifier for the ALSP audit log proofs",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  },
+  "private": true,
+  "dependencies": {},
+  "devDependencies": {
+    "typescript": "^5.7.3"
+  }
+}

--- a/sdk/typescript/alsp-client/src/index.ts
+++ b/sdk/typescript/alsp-client/src/index.ts
@@ -1,0 +1,442 @@
+import { createHash } from "crypto";
+
+export interface Range {
+  start: number;
+  end: number;
+}
+
+export interface Event {
+  index: number;
+  timestamp: string;
+  payload: string;
+}
+
+export interface BlockHeader {
+  index: number;
+  startIndex: number;
+  endIndex: number;
+  merkleRoot: string;
+  digest: string;
+  prevDigest: string;
+}
+
+export interface MerkleProof {
+  leafDigest: string;
+  siblingDigests: string[];
+  pathBits: number[];
+}
+
+export interface BlockProof {
+  header: BlockHeader;
+  events: Event[];
+  proofs: MerkleProof[];
+}
+
+export interface RangeProof {
+  query: Range;
+  blocks: BlockProof[];
+  startAnchor: string;
+  headDigest: string;
+}
+
+export interface EventProof {
+  index: number;
+  event: Event;
+  block: BlockProof;
+  headDigest: string;
+}
+
+export interface GapProof {
+  start: number;
+  end: number;
+  left: BlockHeader;
+  right: BlockHeader;
+  headDigest: string;
+}
+
+export interface VerificationResult {
+  headDigest: string;
+  coveredRange: Range;
+  startAnchor: string;
+}
+
+export interface AlspTransport {
+  proveRange(range: Range): Promise<RangeProof>;
+  proveEvent(index: number): Promise<EventProof>;
+  proveGap(start: number, end: number): Promise<GapProof>;
+}
+
+export class HttpTransport implements AlspTransport {
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(private readonly baseUrl: string, fetchImpl?: typeof fetch) {
+    this.fetchImpl = fetchImpl ?? globalThis.fetch;
+    if (!this.fetchImpl) {
+      throw new Error("fetch implementation is required in this environment");
+    }
+  }
+
+  async proveRange(range: Range): Promise<RangeProof> {
+    return this.post<RangeProof>("/proveRange", range);
+  }
+
+  async proveEvent(index: number): Promise<EventProof> {
+    return this.post<EventProof>("/proveEvent", { index });
+  }
+
+  async proveGap(start: number, end: number): Promise<GapProof> {
+    return this.post<GapProof>("/proveGap", { start, end });
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw new Error(`ALSP transport error: ${response.status}`);
+    }
+    return (await response.json()) as T;
+  }
+}
+
+export class MemoryTransport implements AlspTransport {
+  private rangeProofs = new Map<string, RangeProof>();
+  private eventProofs = new Map<number, EventProof>();
+  private gapProofs = new Map<string, GapProof>();
+
+  setRangeProof(range: Range, proof: RangeProof): void {
+    this.rangeProofs.set(rangeKey(range), proof);
+  }
+
+  setEventProof(index: number, proof: EventProof): void {
+    this.eventProofs.set(index, proof);
+  }
+
+  setGapProof(start: number, end: number, proof: GapProof): void {
+    this.gapProofs.set(rangeKey({ start, end }), proof);
+  }
+
+  async proveRange(range: Range): Promise<RangeProof> {
+    const proof = this.rangeProofs.get(rangeKey(range));
+    if (!proof) {
+      throw new Error("no cached range proof available");
+    }
+    return proof;
+  }
+
+  async proveEvent(index: number): Promise<EventProof> {
+    const proof = this.eventProofs.get(index);
+    if (!proof) {
+      throw new Error("no cached event proof available");
+    }
+    return proof;
+  }
+
+  async proveGap(start: number, end: number): Promise<GapProof> {
+    const proof = this.gapProofs.get(rangeKey({ start, end }));
+    if (!proof) {
+      throw new Error("no cached gap proof available");
+    }
+    return proof;
+  }
+}
+
+export class AlspVerifier {
+  private anchor?: string;
+
+  constructor(anchor?: string) {
+    this.anchor = anchor;
+  }
+
+  verifyRange(proof: RangeProof): VerificationResult {
+    validateRange(proof.query);
+    if (!proof.blocks.length) {
+      throw new Error("range proof missing blocks");
+    }
+    this.ensureAnchor(proof.headDigest);
+    if (!equalDigests(proof.startAnchor, proof.blocks[0].header.prevDigest)) {
+      throw new Error("range start anchor mismatch");
+    }
+
+    const covered: number[] = [];
+    let previousHeader: BlockHeader | undefined;
+    for (const block of proof.blocks) {
+      this.validateBlock(block, previousHeader);
+      for (let i = 0; i < block.events.length; i += 1) {
+        const event = block.events[i];
+        const membership = block.proofs[i];
+        const digest = digestEvent(event);
+        if (!equalDigests(encodeDigest(digest), membership.leafDigest)) {
+          throw new Error("event digest mismatch");
+        }
+        if (!verifyMerkleProof(block.header.merkleRoot, membership)) {
+          throw new Error("invalid merkle proof");
+        }
+        covered.push(event.index);
+      }
+      previousHeader = block.header;
+    }
+    ensureCoverage(proof.query, covered);
+    this.anchor = proof.headDigest;
+    return { headDigest: proof.headDigest, coveredRange: proof.query, startAnchor: proof.startAnchor };
+  }
+
+  verifyEvent(proof: EventProof): VerificationResult {
+    this.ensureAnchor(proof.headDigest);
+    if (proof.block.events.length !== 1 || proof.block.proofs.length !== 1) {
+      throw new Error("event proof must contain a single membership witness");
+    }
+    this.validateBlock(proof.block);
+    const event = proof.block.events[0];
+    if (event.index !== proof.index) {
+      throw new Error("event index mismatch");
+    }
+    const digest = digestEvent(event);
+    if (!equalDigests(encodeDigest(digest), proof.block.proofs[0].leafDigest)) {
+      throw new Error("event digest mismatch");
+    }
+    if (!verifyMerkleProof(proof.block.header.merkleRoot, proof.block.proofs[0])) {
+      throw new Error("invalid merkle proof");
+    }
+    this.anchor = proof.headDigest;
+    return {
+      headDigest: proof.headDigest,
+      coveredRange: { start: proof.index, end: proof.index },
+      startAnchor: proof.block.header.prevDigest,
+    };
+  }
+
+  verifyGap(proof: GapProof): VerificationResult {
+    if (proof.end < proof.start) {
+      throw new Error("invalid gap range");
+    }
+    this.ensureAnchor(proof.headDigest);
+    validateHeader(proof.left);
+    validateHeader(proof.right);
+    if (proof.right.index !== proof.left.index + 1) {
+      throw new Error("gap proof requires consecutive blocks");
+    }
+    if (!equalDigests(proof.right.prevDigest, proof.left.digest)) {
+      throw new Error("gap proof digest chain mismatch");
+    }
+    if (proof.start <= proof.left.endIndex) {
+      throw new Error("gap start overlaps left block");
+    }
+    if (proof.end >= proof.right.startIndex) {
+      throw new Error("gap end overlaps right block");
+    }
+    this.anchor = proof.headDigest;
+    return { headDigest: proof.headDigest, coveredRange: { start: proof.start, end: proof.end }, startAnchor: proof.left.prevDigest };
+  }
+
+  private validateBlock(block: BlockProof, previous?: BlockHeader): void {
+    validateHeader(block.header);
+    if (block.events.length !== block.proofs.length) {
+      throw new Error("membership proof count mismatch");
+    }
+    if (previous) {
+      if (!equalDigests(block.header.prevDigest, previous.digest)) {
+        throw new Error("block chain digest mismatch");
+      }
+      if (block.header.startIndex <= previous.endIndex) {
+        throw new Error("block event indices must increase");
+      }
+    }
+  }
+
+  private ensureAnchor(digest: string): void {
+    if (!this.anchor) {
+      this.anchor = digest;
+      return;
+    }
+    if (!equalDigests(this.anchor, digest)) {
+      throw new Error("head digest mismatch");
+    }
+  }
+}
+
+export interface ClientResult<TProof> {
+  proof: TProof;
+  verification: VerificationResult;
+}
+
+export class AlspClient {
+  constructor(private readonly transport: AlspTransport, private readonly verifier: AlspVerifier) {}
+
+  async proveRange(range: Range): Promise<ClientResult<RangeProof>> {
+    const proof = await this.transport.proveRange(range);
+    const verification = this.verifier.verifyRange(proof);
+    return { proof, verification };
+  }
+
+  async proveEvent(index: number): Promise<ClientResult<EventProof>> {
+    const proof = await this.transport.proveEvent(index);
+    const verification = this.verifier.verifyEvent(proof);
+    return { proof, verification };
+  }
+
+  async proveGap(start: number, end: number): Promise<ClientResult<GapProof>> {
+    const proof = await this.transport.proveGap(start, end);
+    const verification = this.verifier.verifyGap(proof);
+    return { proof, verification };
+  }
+}
+
+export type ReplayEntry =
+  | { type: "range"; proof: RangeProof }
+  | { type: "event"; proof: EventProof }
+  | { type: "gap"; proof: GapProof };
+
+export interface ReplayOutcome {
+  entry: ReplayEntry;
+  result?: VerificationResult;
+  error?: Error;
+}
+
+export class ReplaySession {
+  constructor(private readonly verifier: AlspVerifier) {}
+
+  replay(entries: ReplayEntry[]): ReplayOutcome[] {
+    const outcomes: ReplayOutcome[] = [];
+    for (const entry of entries) {
+      try {
+        let result: VerificationResult;
+        if (entry.type === "range") {
+          result = this.verifier.verifyRange(entry.proof);
+        } else if (entry.type === "event") {
+          result = this.verifier.verifyEvent(entry.proof);
+        } else {
+          result = this.verifier.verifyGap(entry.proof);
+        }
+        outcomes.push({ entry, result });
+      } catch (error) {
+        outcomes.push({ entry, error: error as Error });
+        break;
+      }
+    }
+    return outcomes;
+  }
+}
+
+function rangeKey(range: Range): string {
+  return `${range.start}:${range.end}`;
+}
+
+function validateRange(range: Range): void {
+  if (range.end < range.start) {
+    throw new Error("invalid range");
+  }
+}
+
+function ensureCoverage(range: Range, indices: number[]): void {
+  if (!indices.length) {
+    throw new Error("range proof contained no events");
+  }
+  const sorted = [...indices].sort((a, b) => a - b);
+  if (sorted[0] !== range.start) {
+    throw new Error("range proof missing start index");
+  }
+  if (sorted[sorted.length - 1] !== range.end) {
+    throw new Error("range proof missing end index");
+  }
+  for (let i = 1; i < sorted.length; i += 1) {
+    if (sorted[i] !== sorted[i - 1] + 1) {
+      throw new Error("range proof skipped event indices");
+    }
+  }
+}
+
+function validateHeader(header: BlockHeader): void {
+  const expected = deriveBlockDigest(header);
+  if (!equalDigests(expected, header.digest)) {
+    throw new Error("block header digest mismatch");
+  }
+}
+
+function deriveBlockDigest(header: BlockHeader): string {
+  const hash = createHash("sha256");
+  hash.update(Buffer.from("alsp.block"));
+  hash.update(writeUint64(header.index));
+  hash.update(writeUint64(header.startIndex));
+  hash.update(writeUint64(header.endIndex));
+  hash.update(decodeDigest(header.merkleRoot));
+  hash.update(decodeDigest(header.prevDigest));
+  return encodeDigest(hash.digest());
+}
+
+function digestEvent(event: Event): Buffer {
+  const hash = createHash("sha256");
+  hash.update(writeUint64(event.index));
+  hash.update(writeUint64(parseTimestamp(event.timestamp)));
+  hash.update(Buffer.from(event.payload, "base64"));
+  return hash.digest();
+}
+
+function verifyMerkleProof(rootDigest: string, proof: MerkleProof): boolean {
+  let current = leafHash(decodeDigest(proof.leafDigest));
+  for (let i = 0; i < proof.siblingDigests.length; i += 1) {
+    const sibling = decodeDigest(proof.siblingDigests[i]);
+    if (proof.pathBits[i] === 0) {
+      current = nodeHash(current, sibling);
+    } else {
+      current = nodeHash(sibling, current);
+    }
+  }
+  return equalDigests(encodeDigest(current), rootDigest);
+}
+
+function leafHash(leaf: Buffer): Buffer {
+  const hash = createHash("sha256");
+  hash.update(Buffer.from("leaf"));
+  hash.update(leaf);
+  return hash.digest();
+}
+
+function nodeHash(left: Buffer, right: Buffer): Buffer {
+  const hash = createHash("sha256");
+  hash.update(Buffer.from("node"));
+  hash.update(left);
+  hash.update(right);
+  return hash.digest();
+}
+
+function equalDigests(a: string, b: string): boolean {
+  return Buffer.compare(decodeDigest(a), decodeDigest(b)) === 0;
+}
+
+function decodeDigest(value: string): Buffer {
+  if (!value) {
+    return Buffer.alloc(0);
+  }
+  return Buffer.from(value, "base64");
+}
+
+function encodeDigest(value: Buffer): string {
+  return value.toString("base64");
+}
+
+function writeUint64(value: number | bigint): Buffer {
+  let big = BigInt(value);
+  const mod = 1n << 64n;
+  if (big < 0) {
+    big = (big % mod + mod) % mod;
+  }
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64BE(big);
+  return buffer;
+}
+
+function parseTimestamp(timestamp: string): bigint {
+  const match = timestamp.match(/^(.*?)(?:\.(\d+))?Z$/);
+  if (!match) {
+    throw new Error(`invalid timestamp: ${timestamp}`);
+  }
+  const base = Date.parse(`${match[1]}Z`);
+  if (Number.isNaN(base)) {
+    throw new Error(`invalid timestamp: ${timestamp}`);
+  }
+  const fraction = match[2] ? (match[2] + "000000000").slice(0, 9) : "000000000";
+  return BigInt(base) * 1_000_000n + BigInt(fraction);
+}

--- a/sdk/typescript/alsp-client/src/shims-node.d.ts
+++ b/sdk/typescript/alsp-client/src/shims-node.d.ts
@@ -1,0 +1,23 @@
+declare module "crypto" {
+  interface Hash {
+    update(data: string | ArrayBufferView): Hash;
+    digest(): Buffer;
+  }
+  function createHash(algorithm: string): Hash;
+}
+
+declare class Buffer extends Uint8Array {
+  static from(data: string | ArrayBufferView, encoding?: string): Buffer;
+  static alloc(size: number): Buffer;
+  static compare(a: Buffer, b: Buffer): number;
+  writeBigUInt64BE(value: bigint, offset?: number): number;
+  toString(encoding?: string): string;
+}
+
+declare interface ArrayBufferView {
+  readonly buffer: ArrayBuffer;
+  readonly byteOffset: number;
+  readonly byteLength: number;
+}
+
+declare const globalThis: typeof globalThis;

--- a/sdk/typescript/alsp-client/tsconfig.json
+++ b/sdk/typescript/alsp-client/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
## Summary
- build a Go-based ALSP module that compresses audit logs into block digests and produces range, event, and gap proofs with metrics and replay support
- add deterministic tests that validate proof verification, compression ratio targets, and replay determinism
- provide a TypeScript client package with HTTP/memory transports, proof verification, and replay helpers that mirror the Go logic

## Testing
- go test ./... (within alsp)
- npx tsc -p sdk/typescript/alsp-client/tsconfig.json --pretty false

------
https://chatgpt.com/codex/tasks/task_e_68d79044bbac8333bf10269e74e1150d