### PR TITLE
feat: add consent drift forecaster

### DIFF
--- a/cdf/__init__.py
+++ b/cdf/__init__.py
@@ -1,0 +1,455 @@
+"""Consent Drift Forecaster (CDF).
+
+Provides a lightweight state-space forecaster with changepoint controls for
+consent-rate trajectories. The module operates on basic Python data
+structures so it can run in constrained environments while still emitting
+forecasts, simulations, and a signed planning brief.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from itertools import groupby
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+import hashlib
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class Scenario:
+  """Configuration for a mitigation scenario."""
+
+  name: str
+  sampling_factor: float = 1.0
+  minimal_view_penalty: float = 0.0
+  cadence_modifier: float = 1.0
+  variability: float = 0.0
+
+
+@dataclass(frozen=True)
+class CDFConfig:
+  """Hyper-parameters for the consent drift forecaster."""
+
+  changepoint_threshold: float = 0.035
+  max_changepoints: int = 4
+  changepoint_scale: float = 2.5
+  process_noise_level: float = 0.0004
+  measurement_noise_level: float = 0.0009
+  coverage_baseline: float = 0.85
+  dp_budget_per_million: float = 1.3
+  kpi_weights: Dict[str, float] = field(
+      default_factory=lambda: {"coverage": 0.6, "dp": 0.3, "minimal_view": 0.1}
+  )
+  signature_salt: str = "cdf-v1"
+  seed: int = 1234
+
+
+@dataclass(frozen=True)
+class PlanningBrief:
+  """Structured planning brief emitted by the forecaster."""
+
+  text: str
+  signature: str
+
+
+@dataclass(frozen=True)
+class ConsentRecord:
+  date: datetime
+  cohort: str
+  region: str
+  consent_rate: float
+  population: float
+
+
+class ConsentDriftForecaster:
+  """State-space forecaster with changepoint aware uncertainty control."""
+
+  def __init__(
+      self,
+      config: Optional[CDFConfig] = None,
+      scenarios: Optional[Sequence[Scenario]] = None,
+  ) -> None:
+    self.config = config or CDFConfig()
+    self.scenarios: Tuple[Scenario, ...] = tuple(
+        scenarios
+        if scenarios is not None
+        else (
+            Scenario("base"),
+            Scenario("sampling", sampling_factor=0.92),
+            Scenario("minimal-view", minimal_view_penalty=0.05),
+            Scenario("cadence", cadence_modifier=1.15),
+        )
+    )
+    self._fitted: Dict[Tuple[str, str], Dict[str, Any]] = {}
+    self._history: List[ConsentRecord] = []
+
+  # ---------------------------------------------------------------------------
+  # Public API
+  # ---------------------------------------------------------------------------
+  def fit(self, records: Iterable[Any]) -> None:
+    """Fit state-space models for each cohort/region combination."""
+    normalized = self._normalize_records(records)
+    if not normalized:
+      raise ValueError("No consent records supplied to fit().")
+
+    normalized.sort(key=lambda rec: (rec.cohort, rec.region, rec.date))
+    self._history = list(normalized)
+    self._fitted.clear()
+
+    for (cohort, region), group_iter in groupby(normalized, key=lambda rec: (rec.cohort, rec.region)):
+      group = list(group_iter)
+      series = np.array([rec.consent_rate for rec in group], dtype=float)
+      changepoints = self._detect_changepoints(series)
+      states, Q, R = self._fit_series(series, changepoints)
+      offset = self._infer_offset([rec.date for rec in group])
+      self._fitted[(cohort, region)] = {
+          "states": states,
+          "changepoints": changepoints,
+          "Q": Q,
+          "R": R,
+          "last_state": states[-1][0],
+          "last_cov": states[-1][1],
+          "dates": [rec.date for rec in group],
+          "offset": offset,
+          "population": float(group[-1].population),
+      }
+
+  def forecast(self, horizon: int, seed: Optional[int] = None) -> List[Dict[str, Any]]:
+    if not self._fitted:
+      raise RuntimeError("Forecaster must be fitted before forecasting.")
+    if horizon <= 0:
+      raise ValueError("Forecast horizon must be positive.")
+
+    rows: List[Dict[str, Any]] = []
+    rng = np.random.default_rng(seed if seed is not None else self.config.seed)
+    for (cohort, region), meta in self._fitted.items():
+      state_mean = meta["last_state"].copy()
+      state_cov = meta["last_cov"].copy()
+      offset: timedelta = meta["offset"]
+      last_date: datetime = meta["dates"][-1]
+      Q = meta["Q"]
+      R = meta["R"]
+
+      for step in range(1, horizon + 1):
+        state_mean, state_cov, obs_mean, obs_std = self._forecast_step(
+            state_mean, state_cov, Q, R
+        )
+        future_date = self._advance_date(last_date, offset, step)
+        interval_scale = 1.96
+        rows.append(
+            {
+                "cohort": cohort,
+                "region": region,
+                "date": future_date,
+                "forecast": float(obs_mean),
+                "lower": float(max(0.0, obs_mean - interval_scale * obs_std)),
+                "upper": float(min(1.0, obs_mean + interval_scale * obs_std)),
+                "simulation_draw": float(rng.uniform()),
+            }
+        )
+
+    rows.sort(key=lambda row: (row["cohort"], row["region"], row["date"]))
+    return rows
+
+  def backtest(
+      self, records: Optional[Iterable[Any]] = None, horizon: int = 2
+  ) -> Dict[str, Any]:
+    if records is None:
+      if not self._history:
+        raise RuntimeError("No training history available for backtest().")
+      history = list(self._history)
+    else:
+      history = self._normalize_records(records)
+    history.sort(key=lambda rec: (rec.cohort, rec.region, rec.date))
+
+    mape_by_group: Dict[Tuple[str, str], float] = {}
+    aggregate_errors: List[float] = []
+
+    for (cohort, region), group_iter in groupby(history, key=lambda rec: (rec.cohort, rec.region)):
+      group = list(group_iter)
+      if len(group) <= horizon:
+        continue
+      train = group[:-horizon]
+      test = group[-horizon:]
+      series_train = np.array([rec.consent_rate for rec in train], dtype=float)
+      series_test = np.array([rec.consent_rate for rec in test], dtype=float)
+      changepoints = self._detect_changepoints(series_train)
+      states, Q, R = self._fit_series(series_train, changepoints)
+      last_state = states[-1][0]
+      last_cov = states[-1][1]
+      forecasts = self._forecast_path(last_state, last_cov, Q, R, horizon)
+      preds = np.array(forecasts["mean"])
+      epsilon = np.clip(np.abs(series_test), 1e-3, None)
+      mape = float(np.mean(np.abs(series_test - preds) / epsilon))
+      mape_by_group[(cohort, region)] = mape
+      aggregate_errors.append(mape)
+
+    global_mape = float(np.mean(aggregate_errors)) if aggregate_errors else float("nan")
+    return {"global_mape": global_mape, "mape_by_group": mape_by_group}
+
+  def simulate_impacts(
+      self,
+      forecast_rows: Iterable[Mapping[str, Any]],
+      seed: Optional[int] = None,
+  ) -> List[Dict[str, Any]]:
+    if not self._fitted:
+      raise RuntimeError("Forecaster must be fitted before simulation.")
+
+    forecast_list = [dict(row) for row in forecast_rows]
+    forecast_list.sort(key=lambda row: (row["cohort"], row["region"], row["date"]))
+    grouped: Dict[Tuple[str, str], List[Dict[str, Any]]] = {}
+    for row in forecast_list:
+      key = (row["cohort"], row["region"])
+      grouped.setdefault(key, []).append(row)
+
+    rng = np.random.default_rng(seed if seed is not None else self.config.seed)
+    rows: List[Dict[str, Any]] = []
+
+    for scenario in self.scenarios:
+      for (cohort, region), group in grouped.items():
+        population = float(self._fitted[(cohort, region)]["population"])
+        for row in group:
+          rate = float(np.clip(row["forecast"], 0.0, 1.0))
+          jitter = rng.normal(0.0, scenario.variability) if scenario.variability else 0.0
+          adjusted_rate = float(np.clip(rate + jitter, 0.0, 1.0))
+          consenting_users = population * adjusted_rate
+          expected_coverage = (
+              self.config.coverage_baseline
+              * scenario.sampling_factor
+              * adjusted_rate
+          )
+          dp_budget = (
+              self.config.dp_budget_per_million
+              * (consenting_users / 1_000_000.0)
+              * scenario.cadence_modifier
+          )
+          kpi = (
+              self.config.kpi_weights.get("coverage", 0.0) * expected_coverage
+              - self.config.kpi_weights.get("dp", 0.0) * dp_budget
+              - self.config.kpi_weights.get("minimal_view", 0.0)
+              * scenario.minimal_view_penalty
+          )
+          rows.append(
+              {
+                  "scenario": scenario.name,
+                  "date": row["date"],
+                  "cohort": cohort,
+                  "region": region,
+                  "expected_coverage": expected_coverage,
+                  "dp_budget_millions": dp_budget,
+                  "kpi_score": kpi,
+              }
+          )
+
+    rows.sort(key=lambda row: (row["scenario"], row["cohort"], row["region"], row["date"]))
+    return rows
+
+  def generate_planning_brief(
+      self,
+      forecast_rows: Iterable[Mapping[str, Any]],
+      impacts_rows: Iterable[Mapping[str, Any]],
+      seed: Optional[int] = None,
+  ) -> PlanningBrief:
+    forecast_list = [dict(row) for row in forecast_rows]
+    impacts_list = [dict(row) for row in impacts_rows]
+    if not forecast_list or not impacts_list:
+      raise ValueError("Forecast and impact data are required for planning brief generation.")
+
+    forecast_list.sort(key=lambda row: row["date"])
+    start = forecast_list[0]["date"].date()
+    end = forecast_list[-1]["date"].date()
+
+    summary_lines: List[str] = [
+        "Consent Drift Forecaster Planning Brief",
+        f"Forecast horizon covers {start.isoformat()} to {end.isoformat()}.",
+    ]
+
+    scenario_summary: Dict[str, Dict[str, float]] = {}
+    for row in impacts_list:
+      stats = scenario_summary.setdefault(
+          row["scenario"], {"coverage": [], "dp": [], "kpi": []}
+      )
+      stats["coverage"].append(row["expected_coverage"])
+      stats["dp"].append(row["dp_budget_millions"])
+      stats["kpi"].append(row["kpi_score"])
+
+    for scenario, stats in sorted(scenario_summary.items()):
+      coverage = float(np.mean(stats["coverage"]))
+      dp_budget = float(np.mean(stats["dp"]))
+      kpi = float(np.mean(stats["kpi"]))
+      summary_lines.append(
+          f"- {scenario.title()}: coverage {coverage:.2%}, DP budget ${dp_budget:.3f}M, KPI {kpi:.3f}."
+      )
+
+    base_impacts = [row for row in impacts_list if row["scenario"] == "base"]
+    if base_impacts:
+      base_impacts.sort(key=lambda row: row["expected_coverage"])
+      summary_lines.append("Risk outlook:")
+      for row in base_impacts[:2]:
+        summary_lines.append(
+            f"  • {row['cohort']}/{row['region']} coverage dips to {row['expected_coverage']:.2%}."
+        )
+    else:
+      summary_lines.append("Risk outlook: no base scenario impacts available.")
+
+    summary_lines.append("Mitigation levers stress-tested: sampling, minimal-view, cadence.")
+    rng = np.random.default_rng(seed if seed is not None else self.config.seed)
+    note_options = (
+        "Recommend pre-emptive sampling guardrails.",
+        "Minimal-view fallback remains optional at this horizon.",
+        "Cadence adjustment reserves capacity for DP budget shocks.",
+    )
+    summary_lines.append(f"Analyst note: {rng.choice(note_options)}")
+
+    digest_input = self.config.signature_salt + "|" + "|".join(summary_lines)
+    signature = hashlib.sha256(digest_input.encode("utf-8")).hexdigest()
+    return PlanningBrief("\n".join(summary_lines), signature)
+
+  # ---------------------------------------------------------------------------
+  # Internal helpers
+  # ---------------------------------------------------------------------------
+  def _normalize_records(self, records: Iterable[Any]) -> List[ConsentRecord]:
+    normalized: List[ConsentRecord] = []
+    for record in records:
+      if isinstance(record, ConsentRecord):
+        normalized.append(record)
+        continue
+      if isinstance(record, Mapping):
+        normalized.append(
+            ConsentRecord(
+                date=self._coerce_datetime(record.get("date")),
+                cohort=str(record.get("cohort")),
+                region=str(record.get("region")),
+                consent_rate=float(record.get("consent_rate")),
+                population=float(record.get("population")),
+            )
+        )
+        continue
+      raise TypeError("Records must be mappings or ConsentRecord instances.")
+    return normalized
+
+  def _coerce_datetime(self, value: Any) -> datetime:
+    if isinstance(value, datetime):
+      return value
+    if isinstance(value, str):
+      return datetime.fromisoformat(value)
+    if hasattr(value, "item"):
+      extracted = value.item()
+      if isinstance(extracted, datetime):
+        return extracted
+      if isinstance(extracted, str):
+        return datetime.fromisoformat(extracted)
+    raise TypeError(f"Unsupported date value: {value!r}")
+
+  def _detect_changepoints(self, series: np.ndarray) -> Tuple[int, ...]:
+    if series.size < 3:
+      return tuple()
+    diffs = np.diff(series)
+    threshold = self.config.changepoint_threshold
+    candidate_idx = np.where(np.abs(diffs) >= threshold)[0] + 1
+    if candidate_idx.size == 0:
+      return tuple()
+    magnitudes = np.abs(diffs[candidate_idx - 1])
+    order = np.argsort(magnitudes)[::-1]
+    limited = candidate_idx[order][: self.config.max_changepoints]
+    return tuple(int(idx) for idx in np.sort(limited))
+
+  def _fit_series(
+      self, series: np.ndarray, changepoints: Tuple[int, ...]
+  ) -> Tuple[List[Tuple[np.ndarray, np.ndarray]], np.ndarray, float]:
+    level_var = max(
+        self.config.process_noise_level,
+        float(np.var(np.diff(series)) * 0.25) if series.size > 1 else self.config.process_noise_level,
+    )
+    trend_var = level_var / 3.0
+    meas_var = max(
+        self.config.measurement_noise_level,
+        float(np.var(series) * 0.05),
+    )
+    Q = np.array([[level_var, 0.0], [0.0, trend_var]])
+    R = meas_var + 1e-6
+    states = self._run_filter(series, changepoints, Q, R)
+    return states, Q, R
+
+  def _run_filter(
+      self,
+      series: np.ndarray,
+      changepoints: Tuple[int, ...],
+      Q: np.ndarray,
+      R: float,
+  ) -> List[Tuple[np.ndarray, np.ndarray]]:
+    F = np.array([[1.0, 1.0], [0.0, 1.0]])
+    H = np.array([1.0, 0.0])
+    state_mean = np.array([series[0], 0.0])
+    state_cov = np.eye(2) * 0.05
+    stored: List[Tuple[np.ndarray, np.ndarray]] = []
+
+    for idx, value in enumerate(series):
+      if idx > 0:
+        state_mean = F @ state_mean
+        state_cov = F @ state_cov @ F.T + Q
+      if idx in changepoints:
+        state_cov += np.eye(2) * self.config.changepoint_scale
+      innovation = value - H @ state_mean
+      S = float(H @ state_cov @ H.T + R)
+      K = (state_cov @ H) / S
+      state_mean = state_mean + K * innovation
+      state_cov = (np.eye(2) - np.outer(K, H)) @ state_cov
+      stored.append((state_mean.copy(), state_cov.copy()))
+    return stored
+
+  def _forecast_step(
+      self,
+      state_mean: np.ndarray,
+      state_cov: np.ndarray,
+      Q: np.ndarray,
+      R: float,
+  ) -> Tuple[np.ndarray, np.ndarray, float, float]:
+    F = np.array([[1.0, 1.0], [0.0, 1.0]])
+    H = np.array([1.0, 0.0])
+    state_mean = F @ state_mean
+    state_cov = F @ state_cov @ F.T + Q
+    obs_mean = float(H @ state_mean)
+    obs_var = float(H @ state_cov @ H.T + R)
+    obs_std = float(np.sqrt(max(obs_var, 1e-9)))
+    return state_mean, state_cov, obs_mean, obs_std
+
+  def _forecast_path(
+      self,
+      state_mean: np.ndarray,
+      state_cov: np.ndarray,
+      Q: np.ndarray,
+      R: float,
+      horizon: int,
+  ) -> Dict[str, List[float]]:
+    means: List[float] = []
+    lowers: List[float] = []
+    uppers: List[float] = []
+    for _ in range(horizon):
+      state_mean, state_cov, obs_mean, obs_std = self._forecast_step(state_mean, state_cov, Q, R)
+      means.append(obs_mean)
+      lowers.append(max(0.0, obs_mean - 1.96 * obs_std))
+      uppers.append(min(1.0, obs_mean + 1.96 * obs_std))
+    return {"mean": means, "lower": lowers, "upper": uppers}
+
+  def _infer_offset(self, dates: List[datetime]) -> timedelta:
+    if len(dates) >= 2:
+      diffs = [dates[idx] - dates[idx - 1] for idx in range(1, len(dates))]
+      total = sum(diffs, timedelta())
+      average = total / len(diffs)
+      if average.total_seconds() > 0:
+        return average
+    return timedelta(days=30)
+
+  def _advance_date(self, reference: datetime, offset: timedelta, step: int) -> datetime:
+    return reference + offset * step
+
+
+__all__ = [
+    "CDFConfig",
+    "ConsentDriftForecaster",
+    "PlanningBrief",
+    "Scenario",
+    "ConsentRecord",
+]

--- a/tests/cdf/golden_impacts.json
+++ b/tests/cdf/golden_impacts.json
@@ -1,0 +1,434 @@
+[
+  {
+    "scenario": "base",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.597159,
+    "dp_budget_millions": 1.095963,
+    "kpi_score": 0.029507
+  },
+  {
+    "scenario": "base",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.59932,
+    "dp_budget_millions": 1.099929,
+    "kpi_score": 0.029613
+  },
+  {
+    "scenario": "base",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.601481,
+    "dp_budget_millions": 1.103895,
+    "kpi_score": 0.02972
+  },
+  {
+    "scenario": "base",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.704343,
+    "dp_budget_millions": 1.292677,
+    "kpi_score": 0.034803
+  },
+  {
+    "scenario": "base",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.709136,
+    "dp_budget_millions": 1.301473,
+    "kpi_score": 0.03504
+  },
+  {
+    "scenario": "base",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.713928,
+    "dp_budget_millions": 1.310268,
+    "kpi_score": 0.035276
+  },
+  {
+    "scenario": "base",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.699938,
+    "dp_budget_millions": 1.016968,
+    "kpi_score": 0.114872
+  },
+  {
+    "scenario": "base",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.702875,
+    "dp_budget_millions": 1.021235,
+    "kpi_score": 0.115354
+  },
+  {
+    "scenario": "base",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.705811,
+    "dp_budget_millions": 1.025503,
+    "kpi_score": 0.115836
+  },
+  {
+    "scenario": "base",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.660423,
+    "dp_budget_millions": 0.959556,
+    "kpi_score": 0.108387
+  },
+  {
+    "scenario": "base",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.661462,
+    "dp_budget_millions": 0.961065,
+    "kpi_score": 0.108558
+  },
+  {
+    "scenario": "base",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.662501,
+    "dp_budget_millions": 0.962574,
+    "kpi_score": 0.108728
+  },
+  {
+    "scenario": "cadence",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.597159,
+    "dp_budget_millions": 1.260357,
+    "kpi_score": -0.019812
+  },
+  {
+    "scenario": "cadence",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.59932,
+    "dp_budget_millions": 1.264918,
+    "kpi_score": -0.019883
+  },
+  {
+    "scenario": "cadence",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.601481,
+    "dp_budget_millions": 1.26948,
+    "kpi_score": -0.019955
+  },
+  {
+    "scenario": "cadence",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.704343,
+    "dp_budget_millions": 1.486579,
+    "kpi_score": -0.023368
+  },
+  {
+    "scenario": "cadence",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.709136,
+    "dp_budget_millions": 1.496694,
+    "kpi_score": -0.023527
+  },
+  {
+    "scenario": "cadence",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.713928,
+    "dp_budget_millions": 1.506808,
+    "kpi_score": -0.023686
+  },
+  {
+    "scenario": "cadence",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.699938,
+    "dp_budget_millions": 1.169513,
+    "kpi_score": 0.069109
+  },
+  {
+    "scenario": "cadence",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.702875,
+    "dp_budget_millions": 1.174421,
+    "kpi_score": 0.069399
+  },
+  {
+    "scenario": "cadence",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.705811,
+    "dp_budget_millions": 1.179328,
+    "kpi_score": 0.069689
+  },
+  {
+    "scenario": "cadence",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.660423,
+    "dp_budget_millions": 1.10349,
+    "kpi_score": 0.065207
+  },
+  {
+    "scenario": "cadence",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.661462,
+    "dp_budget_millions": 1.105225,
+    "kpi_score": 0.06531
+  },
+  {
+    "scenario": "cadence",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.662501,
+    "dp_budget_millions": 1.106961,
+    "kpi_score": 0.065412
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.597159,
+    "dp_budget_millions": 1.095963,
+    "kpi_score": 0.024507
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.59932,
+    "dp_budget_millions": 1.099929,
+    "kpi_score": 0.024613
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.601481,
+    "dp_budget_millions": 1.103895,
+    "kpi_score": 0.02472
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.704343,
+    "dp_budget_millions": 1.292677,
+    "kpi_score": 0.029803
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.709136,
+    "dp_budget_millions": 1.301473,
+    "kpi_score": 0.03004
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.713928,
+    "dp_budget_millions": 1.310268,
+    "kpi_score": 0.030276
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.699938,
+    "dp_budget_millions": 1.016968,
+    "kpi_score": 0.109872
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.702875,
+    "dp_budget_millions": 1.021235,
+    "kpi_score": 0.110354
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.705811,
+    "dp_budget_millions": 1.025503,
+    "kpi_score": 0.110836
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.660423,
+    "dp_budget_millions": 0.959556,
+    "kpi_score": 0.103387
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.661462,
+    "dp_budget_millions": 0.961065,
+    "kpi_score": 0.103558
+  },
+  {
+    "scenario": "minimal-view",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.662501,
+    "dp_budget_millions": 0.962574,
+    "kpi_score": 0.103728
+  },
+  {
+    "scenario": "sampling",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.549386,
+    "dp_budget_millions": 1.095963,
+    "kpi_score": 0.000843
+  },
+  {
+    "scenario": "sampling",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.551375,
+    "dp_budget_millions": 1.099929,
+    "kpi_score": 0.000846
+  },
+  {
+    "scenario": "sampling",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "alpha",
+    "region": "EU",
+    "expected_coverage": 0.553363,
+    "dp_budget_millions": 1.103895,
+    "kpi_score": 0.000849
+  },
+  {
+    "scenario": "sampling",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.647996,
+    "dp_budget_millions": 1.292677,
+    "kpi_score": 0.000994
+  },
+  {
+    "scenario": "sampling",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.652405,
+    "dp_budget_millions": 1.301473,
+    "kpi_score": 0.001001
+  },
+  {
+    "scenario": "sampling",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "alpha",
+    "region": "NA",
+    "expected_coverage": 0.656814,
+    "dp_budget_millions": 1.310268,
+    "kpi_score": 0.001008
+  },
+  {
+    "scenario": "sampling",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.643943,
+    "dp_budget_millions": 1.016968,
+    "kpi_score": 0.081275
+  },
+  {
+    "scenario": "sampling",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.646645,
+    "dp_budget_millions": 1.021235,
+    "kpi_score": 0.081616
+  },
+  {
+    "scenario": "sampling",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "beta",
+    "region": "EU",
+    "expected_coverage": 0.649347,
+    "dp_budget_millions": 1.025503,
+    "kpi_score": 0.081957
+  },
+  {
+    "scenario": "sampling",
+    "date": "2024-12-31T10:54:32.727273",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.607589,
+    "dp_budget_millions": 0.959556,
+    "kpi_score": 0.076687
+  },
+  {
+    "scenario": "sampling",
+    "date": "2025-01-30T21:49:05.454546",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.608545,
+    "dp_budget_millions": 0.961065,
+    "kpi_score": 0.076807
+  },
+  {
+    "scenario": "sampling",
+    "date": "2025-03-02T08:43:38.181819",
+    "cohort": "beta",
+    "region": "NA",
+    "expected_coverage": 0.609501,
+    "dp_budget_millions": 0.962574,
+    "kpi_score": 0.076928
+  }
+]

--- a/tests/cdf/test_forecaster.py
+++ b/tests/cdf/test_forecaster.py
@@ -1,0 +1,138 @@
+import json
+from datetime import datetime
+from pathlib import Path
+import sys
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+  sys.path.insert(0, str(ROOT))
+
+from cdf import CDFConfig, ConsentDriftForecaster
+
+
+FIXTURE_PATH = Path(__file__).with_name("golden_impacts.json")
+
+
+def build_fixture_records():
+  dates = [datetime(2024, month, 1) for month in range(1, 13)]
+  cohorts = ["alpha", "beta"]
+  regions = ["NA", "EU"]
+  populations = {"alpha": 1_200_000, "beta": 950_000}
+
+  noise_map = {
+      ("alpha", "NA"): np.linspace(-0.004, 0.003, len(dates)),
+      ("alpha", "EU"): np.linspace(0.002, -0.003, len(dates)),
+      ("beta", "NA"): np.linspace(0.001, -0.002, len(dates)),
+      ("beta", "EU"): np.linspace(-0.003, 0.002, len(dates)),
+  }
+
+  records = []
+  for cohort in cohorts:
+    for region in regions:
+      base = 0.72 if cohort == "alpha" else 0.75
+      trend = 0.005 if region == "NA" else 0.003
+      for idx, date in enumerate(dates):
+        value = base + trend * idx + noise_map[(cohort, region)][idx]
+        if cohort == "alpha" and region == "NA" and idx >= 6:
+          value += 0.045
+        if cohort == "alpha" and region == "EU" and idx >= 7:
+          value -= 0.05
+        if cohort == "beta" and region == "NA" and idx >= 8:
+          value -= 0.025
+        if cohort == "beta" and region == "EU" and idx >= 5:
+          value += 0.035
+        records.append(
+            {
+                "date": date.isoformat(),
+                "cohort": cohort,
+                "region": region,
+                "consent_rate": float(np.clip(value, 0.4, 0.95)),
+                "population": populations[cohort],
+            }
+        )
+  records.sort(key=lambda item: (item["cohort"], item["region"], item["date"]))
+  return records
+
+
+def _round_records(records):
+  rounded = []
+  for item in records:
+    rounded.append(
+        {
+            **item,
+            "date": item["date"].isoformat() if isinstance(item["date"], datetime) else item["date"],
+            "expected_coverage": round(item.get("expected_coverage", 0.0), 6)
+            if "expected_coverage" in item
+            else item.get("expected_coverage"),
+            "dp_budget_millions": round(item.get("dp_budget_millions", 0.0), 6)
+            if "dp_budget_millions" in item
+            else item.get("dp_budget_millions"),
+            "kpi_score": round(item.get("kpi_score", 0.0), 6)
+            if "kpi_score" in item
+            else item.get("kpi_score"),
+            "forecast": round(item.get("forecast", 0.0), 6)
+            if "forecast" in item
+            else item.get("forecast"),
+            "lower": round(item.get("lower", 0.0), 6)
+            if "lower" in item
+            else item.get("lower"),
+            "upper": round(item.get("upper", 0.0), 6)
+            if "upper" in item
+            else item.get("upper"),
+        }
+    )
+  return rounded
+
+
+def test_backtest_hits_mape_target():
+  records = build_fixture_records()
+  forecaster = ConsentDriftForecaster(CDFConfig(seed=2025))
+  forecaster.fit(records)
+  scores = forecaster.backtest(horizon=2)
+  assert scores["global_mape"] < 0.06
+  assert all(value < 0.075 for value in scores["mape_by_group"].values())
+
+
+def test_simulated_impacts_match_golden_snapshot():
+  records = build_fixture_records()
+  forecaster = ConsentDriftForecaster(CDFConfig(seed=2025))
+  forecaster.fit(records)
+  forecast = forecaster.forecast(horizon=3, seed=2025)
+  impacts = forecaster.simulate_impacts(forecast, seed=2025)
+
+  with FIXTURE_PATH.open() as fh:
+    expected = json.load(fh)
+
+  actual = [
+      {
+          **row,
+          "date": row["date"].isoformat(),
+          "expected_coverage": round(row["expected_coverage"], 6),
+          "dp_budget_millions": round(row["dp_budget_millions"], 6),
+          "kpi_score": round(row["kpi_score"], 6),
+      }
+      for row in impacts
+  ]
+
+  assert actual == expected
+
+
+def test_seed_control_keeps_paths_identical():
+  records = build_fixture_records()
+  forecaster = ConsentDriftForecaster(CDFConfig(seed=303))
+  forecaster.fit(records)
+
+  forecast_a = forecaster.forecast(horizon=4, seed=303)
+  impacts_a = forecaster.simulate_impacts(forecast_a, seed=303)
+  brief_a = forecaster.generate_planning_brief(forecast_a, impacts_a, seed=303)
+
+  forecast_b = forecaster.forecast(horizon=4, seed=303)
+  impacts_b = forecaster.simulate_impacts(forecast_b, seed=303)
+  brief_b = forecaster.generate_planning_brief(forecast_b, impacts_b, seed=303)
+
+  assert _round_records(forecast_a) == _round_records(forecast_b)
+  assert _round_records(impacts_a) == _round_records(impacts_b)
+  assert brief_a.text == brief_b.text
+  assert brief_a.signature == brief_b.signature


### PR DESCRIPTION
## Summary
- add a consent drift forecaster module that performs state-space inference with changepoint handling
- provide deterministic impact simulation outputs and signed planning briefs for sampling, minimal-view, and cadence scenarios
- add focused pytest coverage with golden snapshot verification and seed-stability checks

## Testing
- pytest --override-ini addopts="" tests/cdf/test_forecaster.py

------
https://chatgpt.com/codex/tasks/task_e_68d78f05d3408333a688b49b901c2f7a