### PR TITLE
feat: add coec cross-org experiment coordination

### DIFF
--- a/sdk/typescript/jest.config.cjs
+++ b/sdk/typescript/jest.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    '^.+\.ts$': ['ts-jest', { tsconfig: './tsconfig.json' }],
+  },
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  roots: ['<rootDir>/test'],
+};

--- a/sdk/typescript/src/coec/client.ts
+++ b/sdk/typescript/src/coec/client.ts
@@ -1,0 +1,197 @@
+export interface CohortConfig {
+  name: string;
+  fraction: number;
+}
+
+export interface MetricDefinition {
+  name: string;
+  aggregation: 'sum' | 'mean';
+  sensitivity: number;
+  description?: string;
+  lowerIsBetter?: boolean;
+}
+
+export interface EligibilityRule {
+  attribute: string;
+  operator: 'eq' | 'ne' | 'gt' | 'gte' | 'lt' | 'lte' | 'in' | 'nin';
+  value: unknown;
+}
+
+export interface EligibilityFilter {
+  all?: EligibilityRule[];
+  any?: EligibilityRule[];
+}
+
+export interface OrgRegistration {
+  orgId: string;
+}
+
+export interface DPConfig {
+  epsilon: number;
+  delta: number;
+  sensitivity: number;
+}
+
+export interface ExperimentConfig {
+  id?: string;
+  description?: string;
+  vrfKey?: string;
+  cohorts: CohortConfig[];
+  eligibilityFilter?: EligibilityFilter;
+  metrics: MetricDefinition[];
+  dpConfig?: DPConfig;
+  organisations: OrgRegistration[];
+}
+
+export interface ExperimentRegistrationResponse {
+  experiment: ExperimentConfig;
+  vrfKey: string;
+  publicKeys: Record<string, string>;
+}
+
+export interface AssignmentResponse {
+  cohort: string;
+  vrf: { value: string; proof: string };
+}
+
+export interface PreregistrationPayload {
+  orgId: string;
+  payload: Record<string, unknown>;
+}
+
+export interface SamplingCertificateRequest {
+  orgId: string;
+  cohort: string;
+  sampleSize: number;
+  seed: string;
+}
+
+export interface MetricSubmission {
+  orgId: string;
+  cohort: string;
+  mask: number;
+  count: number;
+  metrics: Record<string, number>;
+}
+
+export interface MetricResult {
+  value: number;
+  noiseApplied: boolean;
+  stdError: number;
+  aggregation: string;
+}
+
+export interface CohortResult {
+  metrics: Record<string, MetricResult>;
+  count: number;
+}
+
+export interface OrgResult {
+  orgId: string;
+  cohorts: Record<string, CohortResult>;
+  dpConfig?: DPConfig;
+}
+
+export interface SamplingCertificate extends SamplingCertificateRequest {
+  experimentId: string;
+  digest: string;
+  issuedAt: string;
+}
+
+export interface ResultBrief {
+  experimentId: string;
+  orgId: string;
+  results: OrgResult;
+  certificates: SamplingCertificate[];
+  preregistrations: PreregistrationPayload[];
+  signedAt: string;
+  signature: string;
+  publicKey: string;
+}
+
+type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export class CoecClient {
+  private readonly fetcher: Fetcher;
+
+  constructor(private readonly baseUrl: string, fetcher?: Fetcher) {
+    this.fetcher = fetcher ?? (globalThis.fetch as Fetcher);
+    if (!this.fetcher) {
+      throw new Error('Fetch implementation is required for CoecClient');
+    }
+  }
+
+  async registerExperiment(config: ExperimentConfig): Promise<ExperimentRegistrationResponse> {
+    return this.post<ExperimentRegistrationResponse>('/experiments', config);
+  }
+
+  async assignCohort(id: string, subjectId: string, attributes: Record<string, unknown> = {}): Promise<AssignmentResponse> {
+    const payload = { subjectId, attributes };
+    return this.post<AssignmentResponse>(`/experiments/${id}/assign`, payload);
+  }
+
+  async recordPreregistration(id: string, prereg: PreregistrationPayload): Promise<PreregistrationPayload & { createdAt: string }> {
+    return this.post(`/experiments/${id}/preregister`, prereg);
+  }
+
+  async issueSamplingCertificate(id: string, request: SamplingCertificateRequest): Promise<SamplingCertificate> {
+    return this.post(`/experiments/${id}/samples`, request);
+  }
+
+  async submitMetrics(id: string, submission: MetricSubmission): Promise<void> {
+    await this.post<void>(`/experiments/${id}/metrics`, submission, true);
+  }
+
+  async finalise(id: string): Promise<ResultBrief[]> {
+    return this.post<ResultBrief[]>(`/experiments/${id}/finalise`, {});
+  }
+
+  async getBrief(id: string, orgId: string): Promise<ResultBrief> {
+    return this.get<ResultBrief>(`/experiments/${id}/briefs/${orgId}`);
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    const response = await this.fetcher(this.resolve(path));
+    return this.parse<T>(response);
+  }
+
+  private async post<T>(path: string, body: unknown, expectEmpty = false): Promise<T> {
+    const response = await this.fetcher(this.resolve(path), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (expectEmpty) {
+      if (!response.ok) {
+        await this.raise(response);
+      }
+      return undefined as T;
+    }
+    return this.parse<T>(response);
+  }
+
+  private resolve(path: string): string {
+    return new URL(path, this.baseUrl).toString();
+  }
+
+  private async parse<T>(response: Response): Promise<T> {
+    if (!response.ok) {
+      await this.raise(response);
+    }
+    const text = await response.text();
+    return text ? (JSON.parse(text) as T) : (undefined as T);
+  }
+
+  private async raise(response: Response): Promise<never> {
+    let message = response.statusText || 'Request failed';
+    try {
+      const body = await response.json();
+      if (body?.error) {
+        message = body.error;
+      }
+    } catch {
+      // ignore
+    }
+    throw new Error(`COEC request failed (${response.status}): ${message}`);
+  }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,2 +1,4 @@
 export * from './client';
 export * from '../sdk/ts/src/generated';
+
+export * from './coec/client';

--- a/sdk/typescript/test/coec-client.test.ts
+++ b/sdk/typescript/test/coec-client.test.ts
@@ -1,0 +1,67 @@
+import { CoecClient, ExperimentConfig, MetricSubmission } from '../src/coec/client';
+
+describe('CoecClient', () => {
+  const baseUrl = 'https://coec.test';
+
+  const makeFetch = () => jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => new Response(null));
+
+  it('registers an experiment and returns key material', async () => {
+    const fetchMock = makeFetch();
+    const responsePayload = {
+      experiment: { id: 'exp-1', cohorts: [], metrics: [], organisations: [] } as ExperimentConfig,
+      vrfKey: 'secret',
+      publicKeys: { orgA: 'pub' },
+    };
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify(responsePayload), {
+        status: 201,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const client = new CoecClient(baseUrl, fetchMock);
+    const experimentConfig: ExperimentConfig = {
+      id: 'exp-1',
+      cohorts: [{ name: 'control', fraction: 0.5 }],
+      metrics: [],
+      organisations: [{ orgId: 'orgA' }],
+    };
+
+    const result = await client.registerExperiment(experimentConfig);
+    expect(result).toEqual(responsePayload);
+    expect(fetchMock).toHaveBeenCalledWith('https://coec.test/experiments', expect.objectContaining({ method: 'POST' }));
+  });
+
+  it('submits metrics without expecting a response body', async () => {
+    const fetchMock = makeFetch();
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 202 }));
+
+    const client = new CoecClient(baseUrl, fetchMock);
+    const submission: MetricSubmission = {
+      orgId: 'orgA',
+      cohort: 'control',
+      mask: 0,
+      count: 100,
+      metrics: { ctr: 0.5 },
+    };
+
+    await expect(client.submitMetrics('exp-1', submission)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://coec.test/experiments/exp-1/metrics',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('raises descriptive errors when the service responds with failure', async () => {
+    const fetchMock = makeFetch();
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'invalid' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const client = new CoecClient(baseUrl, fetchMock);
+    await expect(client.getBrief('exp-1', 'orgA')).rejects.toThrow('invalid');
+  });
+});

--- a/services/coec/cmd/coec/main.go
+++ b/services/coec/cmd/coec/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/summit-hq/coec/internal/server"
+	"github.com/summit-hq/coec/internal/service"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	manager := service.NewManager()
+	httpServer := server.New(manager)
+	addr := ":" + port
+
+	log.Printf("COEC service listening on %s", addr)
+	if err := http.ListenAndServe(addr, httpServer.Routes()); err != nil {
+		log.Fatalf("server failed: %v", err)
+	}
+}

--- a/services/coec/go.mod
+++ b/services/coec/go.mod
@@ -1,0 +1,8 @@
+module github.com/summit-hq/coec
+
+go 1.21
+
+require (
+	github.com/go-chi/chi/v5 v5.0.10
+	github.com/google/uuid v1.6.0
+)

--- a/services/coec/go.sum
+++ b/services/coec/go.sum
@@ -1,0 +1,4 @@
+github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=
+github.com/go-chi/chi/v5 v5.0.10/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITLSKoi8=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/services/coec/internal/aggregation/aggregator.go
+++ b/services/coec/internal/aggregation/aggregator.go
@@ -1,0 +1,232 @@
+package aggregation
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"strings"
+)
+
+// MetricDefinition describes how a KPI should be aggregated.
+type MetricDefinition struct {
+	Name          string  `json:"name"`
+	Aggregation   string  `json:"aggregation"`
+	Sensitivity   float64 `json:"sensitivity"`
+	Description   string  `json:"description,omitempty"`
+	LowerIsBetter bool    `json:"lowerIsBetter,omitempty"`
+}
+
+// DPConfig configures optional Laplace noise for secure aggregation.
+type DPConfig struct {
+	Epsilon     float64 `json:"epsilon"`
+	Delta       float64 `json:"delta"`
+	Sensitivity float64 `json:"sensitivity"`
+}
+
+// ContributionShare is compatible with FTMA-style masked value reporting.
+type ContributionShare struct {
+	Mask    float64            `json:"mask"`
+	Metrics map[string]float64 `json:"metrics"`
+	Count   int                `json:"count"`
+}
+
+// Contribution represents a single org's aggregated submission for a cohort.
+type Contribution struct {
+	OrgID  string            `json:"orgId"`
+	Cohort string            `json:"cohort"`
+	Share  ContributionShare `json:"share"`
+}
+
+type metricAggregate struct {
+	sum   float64
+	sumsq float64
+	count int
+}
+
+// State maintains aggregated statistics without retaining partner level details.
+type State struct {
+	metrics    map[string]map[string]map[string]*metricAggregate // org -> cohort -> metric -> aggregate
+	registered map[string]MetricDefinition
+	dpConfig   *DPConfig
+	randomSalt []byte
+}
+
+// NewState constructs a State configured for the provided metrics.
+func NewState(defs []MetricDefinition, dp *DPConfig, randomSalt []byte) *State {
+	reg := make(map[string]MetricDefinition)
+	for _, def := range defs {
+		reg[def.Name] = def
+	}
+	return &State{
+		metrics:    make(map[string]map[string]map[string]*metricAggregate),
+		registered: reg,
+		dpConfig:   dp,
+		randomSalt: append([]byte(nil), randomSalt...),
+	}
+}
+
+// ApplyContribution ingests a masked contribution share and updates aggregated statistics.
+func (s *State) ApplyContribution(c Contribution) error {
+	if c.Share.Count <= 0 {
+		return errors.New("count must be positive")
+	}
+	if _, ok := s.metrics[c.OrgID]; !ok {
+		s.metrics[c.OrgID] = make(map[string]map[string]*metricAggregate)
+	}
+	if _, ok := s.metrics[c.OrgID][c.Cohort]; !ok {
+		s.metrics[c.OrgID][c.Cohort] = make(map[string]*metricAggregate)
+	}
+	for name, value := range c.Share.Metrics {
+		def, ok := s.registered[name]
+		if !ok {
+			return fmt.Errorf("metric %s is not registered", name)
+		}
+		agg, ok := s.metrics[c.OrgID][c.Cohort][name]
+		if !ok {
+			agg = &metricAggregate{}
+			s.metrics[c.OrgID][c.Cohort][name] = agg
+		}
+		actual := value - c.Share.Mask
+		if stringsEqualFold(def.Aggregation, "mean") {
+			weighted := actual * float64(c.Share.Count)
+			agg.sum += weighted
+			agg.sumsq += actual * actual * float64(c.Share.Count)
+		} else {
+			agg.sum += actual
+			agg.sumsq += actual * actual
+		}
+		agg.count += c.Share.Count
+	}
+	return nil
+}
+
+// CohortResult summarises aggregated metrics for a single cohort.
+type CohortResult struct {
+	Metrics map[string]MetricResult `json:"metrics"`
+	Count   int                     `json:"count"`
+}
+
+// MetricResult contains summary stats and privacy annotations.
+type MetricResult struct {
+	Value        float64 `json:"value"`
+	NoiseApplied bool    `json:"noiseApplied"`
+	StdError     float64 `json:"stdError"`
+	Aggregation  string  `json:"aggregation"`
+}
+
+// OrgResult is the complete aggregated view for an organisation.
+type OrgResult struct {
+	OrgID    string                  `json:"orgId"`
+	Cohorts  map[string]CohortResult `json:"cohorts"`
+	DPConfig *DPConfig               `json:"dpConfig,omitempty"`
+}
+
+// ResultsCollection is a sorted slice of org results for deterministic serialisation.
+type ResultsCollection []OrgResult
+
+func (r ResultsCollection) Len() int           { return len(r) }
+func (r ResultsCollection) Less(i, j int) bool { return r[i].OrgID < r[j].OrgID }
+func (r ResultsCollection) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
+
+// Snapshot finalises the aggregated statistics and emits deterministic results per org/cohort/metric.
+func (s *State) Snapshot(experimentID string) (ResultsCollection, error) {
+	results := make([]OrgResult, 0, len(s.metrics))
+	for orgID, cohorts := range s.metrics {
+		cohortRes := make(map[string]CohortResult)
+		for cohortName, metrics := range cohorts {
+			metricResults := make(map[string]MetricResult)
+			var totalCount int
+			for metricName, agg := range metrics {
+				def := s.registered[metricName]
+				value := agg.sum
+				if stringsEqualFold(def.Aggregation, "mean") && agg.count > 0 {
+					value = agg.sum / float64(agg.count)
+				}
+				noiseApplied := false
+				stdErr := computeStdError(def.Aggregation, agg)
+				if s.dpConfig != nil && s.dpConfig.Epsilon > 0 {
+					noise := s.laplaceNoise(experimentID, orgID, cohortName, metricName)
+					value += noise
+					noiseApplied = true
+				}
+				metricResults[metricName] = MetricResult{
+					Value:        value,
+					NoiseApplied: noiseApplied,
+					StdError:     stdErr,
+					Aggregation:  def.Aggregation,
+				}
+				totalCount = agg.count
+			}
+			cohortRes[cohortName] = CohortResult{Metrics: metricResults, Count: totalCount}
+		}
+		results = append(results, OrgResult{OrgID: orgID, Cohorts: cohortRes, DPConfig: s.dpConfig})
+	}
+	sort.Sort(ResultsCollection(results))
+	return results, nil
+}
+
+func (s *State) laplaceNoise(experimentID, orgID, cohort, metric string) float64 {
+	if s.dpConfig == nil || s.dpConfig.Epsilon == 0 {
+		return 0
+	}
+	scale := s.dpConfig.Sensitivity / math.Max(s.dpConfig.Epsilon, 1e-9)
+	seedMaterial := struct {
+		Experiment string `json:"experiment"`
+		Org        string `json:"org"`
+		Cohort     string `json:"cohort"`
+		Metric     string `json:"metric"`
+		Salt       []byte `json:"salt"`
+	}{
+		Experiment: experimentID,
+		Org:        orgID,
+		Cohort:     cohort,
+		Metric:     metric,
+		Salt:       s.randomSalt,
+	}
+	bytes, _ := json.Marshal(seedMaterial)
+	hash := sha512.Sum512(bytes)
+	seed := int64(binary.BigEndian.Uint64(hash[:8]))
+	r := rand.New(rand.NewSource(seed))
+	u := r.Float64() - 0.5
+	if u == 0 {
+		u = 1e-9
+	}
+	return scale * math.Copysign(1, u) * math.Log(1-2*math.Abs(u))
+}
+
+func computeStdError(kind string, agg *metricAggregate) float64 {
+	if agg.count == 0 {
+		return 0
+	}
+	if stringsEqualFold(kind, "mean") {
+		mean := agg.sum / float64(agg.count)
+		variance := agg.sumsq/float64(agg.count) - mean*mean
+		if variance < 0 {
+			variance = 0
+		}
+		return math.Sqrt(variance) / math.Sqrt(float64(agg.count))
+	}
+	return math.Sqrt(agg.sumsq) / float64(agg.count)
+}
+
+func stringsEqualFold(a, b string) bool {
+	return strings.EqualFold(strings.TrimSpace(a), strings.TrimSpace(b))
+}
+
+// SerializeResults produces a canonical JSON representation for signing.
+func SerializeResults(results ResultsCollection) (string, error) {
+	clone := make([]OrgResult, len(results))
+	copy(clone, results)
+	sort.Sort(ResultsCollection(clone))
+	data, err := json.Marshal(clone)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(data), nil
+}

--- a/services/coec/internal/eligibility/filters.go
+++ b/services/coec/internal/eligibility/filters.go
@@ -1,0 +1,175 @@
+package eligibility
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Rule defines a simple eligibility predicate evaluated against participant attributes.
+type Rule struct {
+	Attribute string      `json:"attribute"`
+	Operator  string      `json:"operator"`
+	Value     interface{} `json:"value"`
+}
+
+// Filter groups rules using AND/OR semantics.
+type Filter struct {
+	All []Rule `json:"all,omitempty"`
+	Any []Rule `json:"any,omitempty"`
+}
+
+// Evaluate determines if the provided attributes satisfy the filter.
+func (f Filter) Evaluate(attrs map[string]interface{}) bool {
+	if len(f.All) == 0 && len(f.Any) == 0 {
+		return true
+	}
+	if len(f.All) > 0 {
+		for _, rule := range f.All {
+			if !rule.evaluate(attrs) {
+				return false
+			}
+		}
+	}
+	if len(f.Any) > 0 {
+		for _, rule := range f.Any {
+			if rule.evaluate(attrs) {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
+
+func (r Rule) evaluate(attrs map[string]interface{}) bool {
+	value, ok := attrs[r.Attribute]
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(r.Operator) {
+	case "eq":
+		return compareEquality(value, r.Value)
+	case "ne":
+		return !compareEquality(value, r.Value)
+	case "gt":
+		return compareOrder(value, r.Value) > 0
+	case "gte":
+		return compareOrder(value, r.Value) >= 0
+	case "lt":
+		return compareOrder(value, r.Value) < 0
+	case "lte":
+		return compareOrder(value, r.Value) <= 0
+	case "in":
+		return contains(r.Value, value)
+	case "nin":
+		return !contains(r.Value, value)
+	default:
+		return false
+	}
+}
+
+func compareEquality(left, right interface{}) bool {
+	switch l := left.(type) {
+	case string:
+		if r, ok := right.(string); ok {
+			return l == r
+		}
+	case float64:
+		switch r := right.(type) {
+		case float64:
+			return l == r
+		case int:
+			return l == float64(r)
+		}
+	case int:
+		switch r := right.(type) {
+		case float64:
+			return float64(l) == r
+		case int:
+			return l == r
+		}
+	case bool:
+		if r, ok := right.(bool); ok {
+			return l == r
+		}
+	}
+	return false
+}
+
+func compareOrder(left, right interface{}) int {
+	lf, lok := toFloat(left)
+	rf, rok := toFloat(right)
+	if !lok || !rok {
+		return 0
+	}
+	if lf < rf {
+		return -1
+	}
+	if lf > rf {
+		return 1
+	}
+	return 0
+}
+
+func contains(haystack interface{}, needle interface{}) bool {
+	switch v := haystack.(type) {
+	case []interface{}:
+		for _, item := range v {
+			if compareEquality(item, needle) {
+				return true
+			}
+		}
+	case []string:
+		if s, ok := needle.(string); ok {
+			for _, item := range v {
+				if item == s {
+					return true
+				}
+			}
+		}
+	case []float64:
+		if f, ok := toFloat(needle); ok {
+			for _, item := range v {
+				if item == f {
+					return true
+				}
+			}
+		}
+	case []int:
+		if f, ok := toFloat(needle); ok {
+			for _, item := range v {
+				if float64(item) == f {
+					return true
+				}
+			}
+		}
+	case map[string]interface{}:
+		if s, ok := needle.(string); ok {
+			_, ok := v[s]
+			return ok
+		}
+	case string:
+		if s, ok := needle.(string); ok {
+			return strings.Contains(v, s)
+		}
+	}
+	return false
+}
+
+func toFloat(value interface{}) (float64, bool) {
+	switch v := value.(type) {
+	case int:
+		return float64(v), true
+	case float64:
+		return v, true
+	case float32:
+		return float64(v), true
+	case string:
+		var f float64
+		_, err := fmt.Sscanf(v, "%f", &f)
+		if err == nil {
+			return f, true
+		}
+	}
+	return 0, false
+}

--- a/services/coec/internal/models/models.go
+++ b/services/coec/internal/models/models.go
@@ -1,0 +1,77 @@
+package models
+
+import (
+	"crypto/ed25519"
+	"time"
+
+	"github.com/summit-hq/coec/internal/aggregation"
+	"github.com/summit-hq/coec/internal/eligibility"
+)
+
+// Cohort defines a traffic split for a given experiment arm.
+type Cohort struct {
+	Name     string  `json:"name"`
+	Fraction float64 `json:"fraction"`
+}
+
+// OrgRegistration describes an organisation participating in the experiment.
+type OrgRegistration struct {
+	OrgID string `json:"orgId"`
+}
+
+// ExperimentConfig contains the data required to bootstrap an experiment.
+type ExperimentConfig struct {
+	ID                string                         `json:"id"`
+	Description       string                         `json:"description"`
+	VRFKey            string                         `json:"vrfKey,omitempty"`
+	Cohorts           []Cohort                       `json:"cohorts"`
+	EligibilityFilter eligibility.Filter             `json:"eligibilityFilter"`
+	Metrics           []aggregation.MetricDefinition `json:"metrics"`
+	DPConfig          *aggregation.DPConfig          `json:"dpConfig,omitempty"`
+	Organisations     []OrgRegistration              `json:"organisations"`
+}
+
+// PreregistrationHook captures the preregistration payload from an organisation.
+type PreregistrationHook struct {
+	OrgID     string                 `json:"orgId"`
+	Payload   map[string]interface{} `json:"payload"`
+	CreatedAt time.Time              `json:"createdAt"`
+}
+
+// SamplingCertificate records cohort sampling attestation information.
+type SamplingCertificate struct {
+	ExperimentID string    `json:"experimentId"`
+	OrgID        string    `json:"orgId"`
+	Cohort       string    `json:"cohort"`
+	SampleSize   int       `json:"sampleSize"`
+	Seed         string    `json:"seed"`
+	Digest       string    `json:"digest"`
+	IssuedAt     time.Time `json:"issuedAt"`
+}
+
+// ResultBrief summarises experiment outcomes for a single organisation.
+type ResultBrief struct {
+	ExperimentID string                `json:"experimentId"`
+	OrgID        string                `json:"orgId"`
+	Results      aggregation.OrgResult `json:"results"`
+	Certificates []SamplingCertificate `json:"certificates"`
+	Prereg       []PreregistrationHook `json:"preregistrations"`
+	SignedAt     time.Time             `json:"signedAt"`
+	Signature    string                `json:"signature"`
+	PublicKey    ed25519.PublicKey     `json:"publicKey"`
+}
+
+// ExperimentState is the in-memory representation managed by the service.
+type ExperimentState struct {
+	Config        ExperimentConfig
+	VRFSecret     []byte
+	Seed          []byte
+	CreatedAt     time.Time
+	Aggregator    *aggregation.State
+	OrgPrivateKey map[string]ed25519.PrivateKey
+	OrgPublicKey  map[string]ed25519.PublicKey
+	Prereg        []PreregistrationHook
+	Certificates  []SamplingCertificate
+	Briefs        map[string]ResultBrief
+	Completed     bool
+}

--- a/services/coec/internal/server/http.go
+++ b/services/coec/internal/server/http.go
@@ -1,0 +1,188 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+
+	"github.com/summit-hq/coec/internal/aggregation"
+	"github.com/summit-hq/coec/internal/models"
+	"github.com/summit-hq/coec/internal/service"
+)
+
+// HTTPServer exposes the COEC manager via JSON HTTP APIs.
+type HTTPServer struct {
+	manager *service.Manager
+}
+
+// New constructs an HTTP server wrapper for the manager.
+func New(manager *service.Manager) *HTTPServer {
+	return &HTTPServer{manager: manager}
+}
+
+// Routes configures the router with all endpoints.
+func (s *HTTPServer) Routes() http.Handler {
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	r.Post("/experiments", s.createExperiment)
+	r.Post("/experiments/{id}/assign", s.assignCohort)
+	r.Post("/experiments/{id}/preregister", s.preregister)
+	r.Post("/experiments/{id}/samples", s.issueSample)
+	r.Post("/experiments/{id}/metrics", s.submitMetrics)
+	r.Post("/experiments/{id}/finalise", s.finalise)
+	r.Get("/experiments/{id}/briefs/{orgId}", s.getBrief)
+
+	return r
+}
+
+func (s *HTTPServer) createExperiment(w http.ResponseWriter, r *http.Request) {
+	var cfg models.ExperimentConfig
+	if err := json.NewDecoder(r.Body).Decode(&cfg); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	exp, vrfKey, publicKeys, err := s.manager.CreateExperiment(cfg)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	response := map[string]interface{}{
+		"experiment": exp,
+		"vrfKey":     vrfKey,
+		"publicKeys": publicKeys,
+	}
+	writeJSON(w, http.StatusCreated, response)
+}
+
+func (s *HTTPServer) assignCohort(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var payload struct {
+		SubjectID  string                 `json:"subjectId"`
+		Attributes map[string]interface{} `json:"attributes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if payload.SubjectID == "" {
+		writeError(w, http.StatusBadRequest, errMissing("subjectId"))
+		return
+	}
+	assignment, err := s.manager.AssignCohort(id, payload.SubjectID, payload.Attributes)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, assignment)
+}
+
+func (s *HTTPServer) preregister(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var payload models.PreregistrationHook
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if payload.OrgID == "" {
+		writeError(w, http.StatusBadRequest, errMissing("orgId"))
+		return
+	}
+	hook, err := s.manager.RecordPreregistration(id, payload)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, hook)
+}
+
+func (s *HTTPServer) issueSample(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var payload models.SamplingCertificate
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if payload.OrgID == "" || payload.Cohort == "" {
+		writeError(w, http.StatusBadRequest, errMissing("orgId/cohort"))
+		return
+	}
+	cert, err := s.manager.IssueSamplingCertificate(id, payload)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusCreated, cert)
+}
+
+func (s *HTTPServer) submitMetrics(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	var payload struct {
+		OrgID   string             `json:"orgId"`
+		Cohort  string             `json:"cohort"`
+		Mask    float64            `json:"mask"`
+		Count   int                `json:"count"`
+		Metrics map[string]float64 `json:"metrics"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	if payload.OrgID == "" || payload.Cohort == "" {
+		writeError(w, http.StatusBadRequest, errMissing("orgId/cohort"))
+		return
+	}
+	contribution := aggregation.Contribution{
+		OrgID:  payload.OrgID,
+		Cohort: payload.Cohort,
+		Share: aggregation.ContributionShare{
+			Mask:    payload.Mask,
+			Metrics: payload.Metrics,
+			Count:   payload.Count,
+		},
+	}
+	if err := s.manager.SubmitContribution(id, contribution); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (s *HTTPServer) finalise(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	briefs, err := s.manager.FinaliseExperiment(id)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, briefs)
+}
+
+func (s *HTTPServer) getBrief(w http.ResponseWriter, r *http.Request) {
+	id := chi.URLParam(r, "id")
+	orgID := chi.URLParam(r, "orgId")
+	brief, err := s.manager.GetBrief(id, orgID)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, brief)
+}
+
+func writeJSON(w http.ResponseWriter, status int, payload interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+func writeError(w http.ResponseWriter, status int, err error) {
+	writeJSON(w, status, map[string]string{"error": err.Error()})
+}
+
+func errMissing(field string) error {
+	return fmt.Errorf("missing field %s", field)
+}

--- a/services/coec/internal/service/service.go
+++ b/services/coec/internal/service/service.go
@@ -1,0 +1,298 @@
+package service
+
+import (
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/summit-hq/coec/internal/aggregation"
+	"github.com/summit-hq/coec/internal/models"
+	"github.com/summit-hq/coec/internal/vrf"
+)
+
+// Manager orchestrates experiment coordination lifecycles.
+type Manager struct {
+	mu          sync.RWMutex
+	experiments map[string]*models.ExperimentState
+}
+
+// NewManager constructs a manager with in-memory storage.
+func NewManager() *Manager {
+	return &Manager{experiments: make(map[string]*models.ExperimentState)}
+}
+
+// CreateExperiment registers a new experiment and prepares the secure aggregation state.
+func (m *Manager) CreateExperiment(cfg models.ExperimentConfig) (models.ExperimentConfig, string, map[string]string, error) {
+	if len(cfg.Cohorts) == 0 {
+		return models.ExperimentConfig{}, "", nil, errors.New("at least one cohort required")
+	}
+	var total float64
+	for _, cohort := range cfg.Cohorts {
+		if cohort.Fraction <= 0 {
+			return models.ExperimentConfig{}, "", nil, fmt.Errorf("cohort %s has invalid fraction", cohort.Name)
+		}
+		total += cohort.Fraction
+	}
+	if total > 1.0001 {
+		return models.ExperimentConfig{}, "", nil, errors.New("cohort fractions must sum to <= 1")
+	}
+	secret, err := decodeOrGenerateSecret(cfg.VRFKey)
+	if err != nil {
+		return models.ExperimentConfig{}, "", nil, err
+	}
+	if cfg.ID == "" {
+		cfg.ID = uuid.NewString()
+	}
+	cfg.VRFKey = ""
+	seed := sha512.Sum512(secret)
+	aggState := aggregation.NewState(cfg.Metrics, cfg.DPConfig, seed[:])
+	orgPriv := make(map[string]ed25519.PrivateKey)
+	orgPub := make(map[string]ed25519.PublicKey)
+	for _, org := range cfg.Organisations {
+		pub, priv := deriveOrgKey(secret, org.OrgID)
+		orgPriv[org.OrgID] = priv
+		orgPub[org.OrgID] = pub
+	}
+	state := &models.ExperimentState{
+		Config:        cfg,
+		VRFSecret:     secret,
+		Seed:          seed[:],
+		CreatedAt:     time.Now().UTC(),
+		Aggregator:    aggState,
+		OrgPrivateKey: orgPriv,
+		OrgPublicKey:  orgPub,
+		Prereg:        []models.PreregistrationHook{},
+		Certificates:  []models.SamplingCertificate{},
+		Briefs:        make(map[string]models.ResultBrief),
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, exists := m.experiments[cfg.ID]; exists {
+		return models.ExperimentConfig{}, "", nil, errors.New("experiment already exists")
+	}
+	m.experiments[cfg.ID] = state
+	publicKeyMap := make(map[string]string)
+	for orgID, pub := range orgPub {
+		publicKeyMap[orgID] = base64.StdEncoding.EncodeToString(pub)
+	}
+	return cfg, base64.StdEncoding.EncodeToString(secret), publicKeyMap, nil
+}
+
+// AssignmentResponse describes the deterministic cohort assignment for a subject.
+type AssignmentResponse struct {
+	Cohort string     `json:"cohort"`
+	VRF    vrf.Result `json:"vrf"`
+}
+
+// AssignCohort returns the deterministic cohort assignment for a subject if eligible.
+func (m *Manager) AssignCohort(experimentID, subjectID string, attributes map[string]interface{}) (AssignmentResponse, error) {
+	state, err := m.getExperiment(experimentID)
+	if err != nil {
+		return AssignmentResponse{}, err
+	}
+	if !state.Config.EligibilityFilter.Evaluate(attributes) {
+		return AssignmentResponse{}, errors.New("subject not eligible")
+	}
+	eval := vrf.NewEvaluator(state.VRFSecret)
+	result := eval.Evaluate(experimentID + ":" + subjectID)
+	rnd := result.Fraction()
+	var cumulative float64
+	var selected string
+	for _, cohort := range state.Config.Cohorts {
+		cumulative += cohort.Fraction
+		if rnd <= cumulative {
+			selected = cohort.Name
+			break
+		}
+	}
+	if selected == "" {
+		selected = state.Config.Cohorts[len(state.Config.Cohorts)-1].Name
+	}
+	return AssignmentResponse{Cohort: selected, VRF: result}, nil
+}
+
+// RecordPreregistration stores preregistration metadata for compliance.
+func (m *Manager) RecordPreregistration(experimentID string, hook models.PreregistrationHook) (models.PreregistrationHook, error) {
+	state, err := m.getExperiment(experimentID)
+	if err != nil {
+		return models.PreregistrationHook{}, err
+	}
+	hook.CreatedAt = time.Now().UTC()
+	state.Prereg = append(state.Prereg, hook)
+	return hook, nil
+}
+
+// IssueSamplingCertificate generates a CCS sampling certificate for auditability.
+func (m *Manager) IssueSamplingCertificate(experimentID string, cert models.SamplingCertificate) (models.SamplingCertificate, error) {
+	state, err := m.getExperiment(experimentID)
+	if err != nil {
+		return models.SamplingCertificate{}, err
+	}
+	if cert.SampleSize <= 0 {
+		return models.SamplingCertificate{}, errors.New("sample size must be positive")
+	}
+	cert.ExperimentID = experimentID
+	cert.IssuedAt = time.Now().UTC()
+	digest := hmac.New(sha512.New, state.VRFSecret)
+	digest.Write([]byte(experimentID))
+	digest.Write([]byte(cert.OrgID))
+	digest.Write([]byte(cert.Cohort))
+	digest.Write([]byte(strconv.Itoa(cert.SampleSize)))
+	digest.Write([]byte(cert.Seed))
+	cert.Digest = base64.StdEncoding.EncodeToString(digest.Sum(nil))
+	state.Certificates = append(state.Certificates, cert)
+	return cert, nil
+}
+
+// SubmitContribution ingests masked KPI aggregates from an organisation.
+func (m *Manager) SubmitContribution(experimentID string, contribution aggregation.Contribution) error {
+	state, err := m.getExperiment(experimentID)
+	if err != nil {
+		return err
+	}
+	return state.Aggregator.ApplyContribution(contribution)
+}
+
+// FinaliseExperiment snapshots aggregates, signs result briefs, and prevents further mutation.
+func (m *Manager) FinaliseExperiment(experimentID string) ([]models.ResultBrief, error) {
+	state, err := m.getExperiment(experimentID)
+	if err != nil {
+		return nil, err
+	}
+	if state.Completed {
+		briefs := make([]models.ResultBrief, 0, len(state.Briefs))
+		for _, brief := range state.Briefs {
+			briefs = append(briefs, brief)
+		}
+		sort.Slice(briefs, func(i, j int) bool { return briefs[i].OrgID < briefs[j].OrgID })
+		return briefs, nil
+	}
+	results, err := state.Aggregator.Snapshot(experimentID)
+	if err != nil {
+		return nil, err
+	}
+	briefs := make([]models.ResultBrief, 0, len(results))
+	for _, result := range results {
+		payload := struct {
+			ExperimentID string                `json:"experimentId"`
+			Result       aggregation.OrgResult `json:"result"`
+			IssuedAt     time.Time             `json:"issuedAt"`
+		}{
+			ExperimentID: experimentID,
+			Result:       result,
+			IssuedAt:     time.Now().UTC(),
+		}
+		bytes, _ := json.Marshal(payload)
+		priv := state.OrgPrivateKey[result.OrgID]
+		pub := state.OrgPublicKey[result.OrgID]
+		signature := ed25519.Sign(priv, bytes)
+		certs := filterCertificates(state.Certificates, result.OrgID)
+		prereg := filterPrereg(state.Prereg, result.OrgID)
+		brief := models.ResultBrief{
+			ExperimentID: experimentID,
+			OrgID:        result.OrgID,
+			Results:      result,
+			Certificates: certs,
+			Prereg:       prereg,
+			SignedAt:     payload.IssuedAt,
+			Signature:    base64.StdEncoding.EncodeToString(signature),
+			PublicKey:    pub,
+		}
+		state.Briefs[result.OrgID] = brief
+		briefs = append(briefs, brief)
+	}
+	sort.Slice(briefs, func(i, j int) bool { return briefs[i].OrgID < briefs[j].OrgID })
+	state.Completed = true
+	return briefs, nil
+}
+
+// GetBrief returns the signed result brief for a specific organisation.
+func (m *Manager) GetBrief(experimentID, orgID string) (models.ResultBrief, error) {
+	state, err := m.getExperiment(experimentID)
+	if err != nil {
+		return models.ResultBrief{}, err
+	}
+	brief, ok := state.Briefs[orgID]
+	if !ok {
+		return models.ResultBrief{}, errors.New("brief not available; finalise experiment first")
+	}
+	return brief, nil
+}
+
+func (m *Manager) getExperiment(id string) (*models.ExperimentState, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	state, ok := m.experiments[id]
+	if !ok {
+		return nil, errors.New("experiment not found")
+	}
+	return state, nil
+}
+
+func decodeOrGenerateSecret(vrfKey string) ([]byte, error) {
+	if vrfKey != "" {
+		secret, err := base64.StdEncoding.DecodeString(vrfKey)
+		if err != nil {
+			return nil, fmt.Errorf("invalid vrf key: %w", err)
+		}
+		if len(secret) < 32 {
+			return nil, errors.New("vrf key must be at least 32 bytes")
+		}
+		return append([]byte(nil), secret[:32]...), nil
+	}
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		return nil, err
+	}
+	return secret, nil
+}
+
+func deriveOrgKey(secret []byte, orgID string) (ed25519.PublicKey, ed25519.PrivateKey) {
+	h := sha512.New()
+	h.Write(secret)
+	h.Write([]byte(orgID))
+	sum := h.Sum(nil)
+	seed := sum[:32]
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	return pub, priv
+}
+
+func filterCertificates(all []models.SamplingCertificate, orgID string) []models.SamplingCertificate {
+	out := make([]models.SamplingCertificate, 0)
+	for _, cert := range all {
+		if cert.OrgID == orgID {
+			out = append(out, cert)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Cohort == out[j].Cohort {
+			return out[i].IssuedAt.Before(out[j].IssuedAt)
+		}
+		return out[i].Cohort < out[j].Cohort
+	})
+	return out
+}
+
+func filterPrereg(all []models.PreregistrationHook, orgID string) []models.PreregistrationHook {
+	out := make([]models.PreregistrationHook, 0)
+	for _, hook := range all {
+		if hook.OrgID == orgID {
+			out = append(out, hook)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
+	})
+	return out
+}

--- a/services/coec/internal/service/service_test.go
+++ b/services/coec/internal/service/service_test.go
@@ -1,0 +1,181 @@
+package service_test
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/summit-hq/coec/internal/aggregation"
+	"github.com/summit-hq/coec/internal/models"
+	"github.com/summit-hq/coec/internal/service"
+)
+
+func TestDeterministicCohortsAndAggregation(t *testing.T) {
+	manager := service.NewManager()
+	secret := make([]byte, 32)
+	for i := range secret {
+		secret[i] = byte(i + 1)
+	}
+	cfg := models.ExperimentConfig{
+		ID:          "exp-001",
+		Description: "cross-org test",
+		VRFKey:      base64.StdEncoding.EncodeToString(secret),
+		Cohorts: []models.Cohort{
+			{Name: "control", Fraction: 0.5},
+			{Name: "treatment", Fraction: 0.5},
+		},
+		Metrics: []aggregation.MetricDefinition{
+			{Name: "ctr", Aggregation: "mean", Sensitivity: 1.0},
+		},
+		Organisations: []models.OrgRegistration{{OrgID: "orgA"}, {OrgID: "orgB"}},
+	}
+	_, returnedSecret, publicKeys, err := manager.CreateExperiment(cfg)
+	if err != nil {
+		t.Fatalf("create experiment: %v", err)
+	}
+	if returnedSecret != base64.StdEncoding.EncodeToString(secret) {
+		t.Fatalf("unexpected vrf secret: %s", returnedSecret)
+	}
+	if len(publicKeys) != 2 {
+		t.Fatalf("expected 2 public keys, got %d", len(publicKeys))
+	}
+
+	assignment1, err := manager.AssignCohort("exp-001", "subject-007", map[string]interface{}{"country": "us"})
+	if err != nil {
+		t.Fatalf("assign cohort failed: %v", err)
+	}
+	assignment2, err := manager.AssignCohort("exp-001", "subject-007", map[string]interface{}{"country": "us"})
+	if err != nil {
+		t.Fatalf("assign cohort failed: %v", err)
+	}
+	if assignment1.Cohort != assignment2.Cohort {
+		t.Fatalf("cohorts diverged: %s vs %s", assignment1.Cohort, assignment2.Cohort)
+	}
+	if assignment1.VRF.Proof != assignment2.VRF.Proof {
+		t.Fatal("vrf proofs mismatch on replay")
+	}
+
+	baseline := map[string]map[string]float64{
+		"orgA": {"ctr": 0.62},
+		"orgB": {"ctr": 0.55},
+	}
+
+	contributions := []aggregation.Contribution{
+		{
+			OrgID:  "orgA",
+			Cohort: assignment1.Cohort,
+			Share:  aggregation.ContributionShare{Mask: 0, Metrics: map[string]float64{"ctr": 0.62}, Count: 1000},
+		},
+		{
+			OrgID:  "orgB",
+			Cohort: assignment1.Cohort,
+			Share:  aggregation.ContributionShare{Mask: 0, Metrics: map[string]float64{"ctr": 0.55}, Count: 950},
+		},
+	}
+	for _, contrib := range contributions {
+		if err := manager.SubmitContribution("exp-001", contrib); err != nil {
+			t.Fatalf("submit contribution: %v", err)
+		}
+	}
+
+	briefs, err := manager.FinaliseExperiment("exp-001")
+	if err != nil {
+		t.Fatalf("finalise failed: %v", err)
+	}
+	if len(briefs) != 2 {
+		t.Fatalf("expected briefs for 2 orgs, got %d", len(briefs))
+	}
+
+	for _, brief := range briefs {
+		cohort, ok := brief.Results.Cohorts[assignment1.Cohort]
+		if !ok {
+			continue
+		}
+		metric := cohort.Metrics["ctr"]
+		expected := baseline[brief.OrgID]["ctr"]
+		if diff := metric.Value - expected; diff > 1e-9 || diff < -1e-9 {
+			toJSON, _ := json.Marshal(metric)
+			t.Fatalf("metric mismatch for %s: got %s expected %.2f", brief.OrgID, toJSON, expected)
+		}
+
+		payload := struct {
+			ExperimentID string                `json:"experimentId"`
+			Result       aggregation.OrgResult `json:"result"`
+			IssuedAt     time.Time             `json:"issuedAt"`
+		}{
+			ExperimentID: brief.ExperimentID,
+			Result:       brief.Results,
+			IssuedAt:     brief.SignedAt,
+		}
+		bytes, _ := json.Marshal(payload)
+		sig, err := base64.StdEncoding.DecodeString(brief.Signature)
+		if err != nil {
+			t.Fatalf("signature decode failed: %v", err)
+		}
+		if !ed25519.Verify(brief.PublicKey, bytes, sig) {
+			t.Fatalf("signature verification failed for %s", brief.OrgID)
+		}
+	}
+
+	again, err := manager.FinaliseExperiment("exp-001")
+	if err != nil {
+		t.Fatalf("re-finalise failed: %v", err)
+	}
+	if len(again) != len(briefs) {
+		t.Fatalf("expected %d briefs on second finalise, got %d", len(briefs), len(again))
+	}
+	for i := range briefs {
+		if briefs[i].Signature != again[i].Signature {
+			t.Fatalf("non-deterministic signature for %s", briefs[i].OrgID)
+		}
+	}
+}
+
+func TestDifferentialPrivacyDeterminism(t *testing.T) {
+	manager := service.NewManager()
+	secret := make([]byte, 32)
+	for i := range secret {
+		secret[i] = 42
+	}
+	cfg := models.ExperimentConfig{
+		ID:     "exp-dp",
+		VRFKey: base64.StdEncoding.EncodeToString(secret),
+		Cohorts: []models.Cohort{
+			{Name: "cohort", Fraction: 1.0},
+		},
+		Metrics: []aggregation.MetricDefinition{
+			{Name: "lift", Aggregation: "sum", Sensitivity: 1.0},
+		},
+		DPConfig:      &aggregation.DPConfig{Epsilon: 0.5, Delta: 1e-6, Sensitivity: 1.0},
+		Organisations: []models.OrgRegistration{{OrgID: "orgA"}},
+	}
+	if _, _, _, err := manager.CreateExperiment(cfg); err != nil {
+		t.Fatalf("create experiment: %v", err)
+	}
+	contribution := aggregation.Contribution{
+		OrgID:  "orgA",
+		Cohort: "cohort",
+		Share:  aggregation.ContributionShare{Mask: 0.25, Metrics: map[string]float64{"lift": 10.25}, Count: 500},
+	}
+	if err := manager.SubmitContribution("exp-dp", contribution); err != nil {
+		t.Fatalf("submit contribution: %v", err)
+	}
+	first, err := manager.FinaliseExperiment("exp-dp")
+	if err != nil {
+		t.Fatalf("finalise: %v", err)
+	}
+	second, err := manager.FinaliseExperiment("exp-dp")
+	if err != nil {
+		t.Fatalf("re-finalise: %v", err)
+	}
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("expected single brief")
+	}
+	value1 := first[0].Results.Cohorts["cohort"].Metrics["lift"].Value
+	value2 := second[0].Results.Cohorts["cohort"].Metrics["lift"].Value
+	if value1 != value2 {
+		t.Fatalf("dp noise should be deterministic, got %f vs %f", value1, value2)
+	}
+}

--- a/services/coec/internal/vrf/vrf.go
+++ b/services/coec/internal/vrf/vrf.go
@@ -1,0 +1,53 @@
+package vrf
+
+import (
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/binary"
+)
+
+// Evaluator deterministically produces pseudorandom outputs using an HMAC-SHA512 VRF surrogate.
+type Evaluator struct {
+	secret []byte
+}
+
+// NewEvaluator constructs a VRF evaluator with the provided shared secret.
+func NewEvaluator(secret []byte) *Evaluator {
+	secretCopy := make([]byte, len(secret))
+	copy(secretCopy, secret)
+	return &Evaluator{secret: secretCopy}
+}
+
+// Result encapsulates the VRF output and proof material.
+type Result struct {
+	Value []byte
+	Proof string
+}
+
+// Evaluate produces a VRF result for a subject identifier. The output is stable for
+// the same secret+input pair which enables reproducible cohort assignment.
+func (e *Evaluator) Evaluate(input string) Result {
+	mac := hmac.New(sha512.New, e.secret)
+	mac.Write([]byte(input))
+	sum := mac.Sum(nil)
+	proof := base64.StdEncoding.EncodeToString(sum[len(sum)/2:])
+	return Result{Value: sum[:len(sum)/2], Proof: proof}
+}
+
+// Fraction interprets the VRF result as a floating point value in [0, 1).
+func (r Result) Fraction() float64 {
+	if len(r.Value) < 8 {
+		return 0
+	}
+	u := binary.BigEndian.Uint64(r.Value[:8])
+	return float64(u) / float64(^uint64(0))
+}
+
+// Verify re-computes the VRF output to validate the provided proof. Because we are using
+// an HMAC-based construction the proof is just the trailing bytes of the mac output.
+func Verify(secret []byte, input string, proof string) bool {
+	eval := NewEvaluator(secret)
+	result := eval.Evaluate(input)
+	return result.Proof == proof
+}


### PR DESCRIPTION
## Summary
- add the COEC Go service providing VRF cohorting, eligibility evaluation, sampling certificates, DP-ready secure aggregation, and signed briefs
- expose REST endpoints and deterministic tests for cohort replay and differential privacy stability
- deliver a TypeScript SDK client plus Jest configuration to exercise the new APIs

## Testing
- go test ./...
- npm test -- coec-client.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d78deac9c08333b3e0ec9b08a76e1e