### PR TITLE
feat: add provenance-preserving etl generator

### DIFF
--- a/tools/ppeg/README.md
+++ b/tools/ppeg/README.md
@@ -1,0 +1,24 @@
+# PPEG
+
+The Provenance-Preserving ETL Generator (PPEG) turns declarative YAML specs into
+fully-instrumented ETL pipelines. Generated pipelines:
+
+- produce byte-identical outputs for the provided fixtures;
+- track per-step hashes, dataset fingerprints, and policy version stamps; and
+- emit attestation events that can be forwarded to AGQL.
+
+## Usage
+
+```bash
+ppeg generate path/to/spec.yaml --out-dir build/pipeline
+python build/pipeline/pipeline.py
+```
+
+Compare provenance logs between runs with:
+
+```bash
+ppeg diff outputs/prev/provenance.json outputs/new/provenance.json
+```
+
+See `tests/` for golden fixtures and integration tests demonstrating the
+provenance trail reconstruction guarantees.

--- a/tools/ppeg/ppeg/__init__.py
+++ b/tools/ppeg/ppeg/__init__.py
@@ -1,0 +1,15 @@
+"""Provenance-Preserving ETL Generator (PPEG).
+
+This package exposes the public API for the ppeg code generation tool.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:  # pragma: no cover - best effort metadata discovery
+    __version__ = version("ppeg")
+except PackageNotFoundError:  # pragma: no cover - used in repo tests
+    __version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/tools/ppeg/ppeg/cli.py
+++ b/tools/ppeg/ppeg/cli.py
@@ -1,0 +1,58 @@
+"""Command line interface for the PPEG tool."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Callable, Iterable
+
+from .codegen import PipelineGenerator
+from .diff_inspector import diff_provenance, render_diff_report
+from .spec import SpecLoader
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="ppeg", description="Provenance-preserving ETL generator")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    generate_parser = subparsers.add_parser("generate", help="Generate a pipeline from a YAML spec")
+    generate_parser.add_argument("spec", type=Path, help="Path to the YAML specification")
+    generate_parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("generated"),
+        help="Directory to place generated artifacts",
+    )
+    generate_parser.set_defaults(func=_cmd_generate)
+
+    diff_parser = subparsers.add_parser("diff", help="Compare provenance logs from two runs")
+    diff_parser.add_argument("before", type=Path, help="Path to the baseline provenance JSON")
+    diff_parser.add_argument("after", type=Path, help="Path to the new provenance JSON")
+    diff_parser.set_defaults(func=_cmd_diff)
+
+    return parser
+
+
+def _cmd_generate(args: argparse.Namespace) -> int:
+    loader = SpecLoader()
+    spec = loader.load(args.spec)
+    generator = PipelineGenerator(spec)
+    generator.generate(args.out_dir)
+    return 0
+
+
+def _cmd_diff(args: argparse.Namespace) -> int:
+    diffs = diff_provenance(args.before, args.after)
+    print(render_diff_report(diffs))
+    return 0
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    func: Callable[[argparse.Namespace], int] = getattr(args, "func")
+    return func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tools/ppeg/ppeg/codegen.py
+++ b/tools/ppeg/ppeg/codegen.py
@@ -1,0 +1,363 @@
+"""Code generation utilities for PPEG."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+from string import Template
+from textwrap import indent
+from typing import Dict, List
+
+from .spec import LoadedSpec, PipelineSpec, SinkSpec, SourceSpec, StepSpec
+
+
+PIPELINE_TEMPLATE = Template('''"""Auto-generated pipeline with provenance instrumentation."""
+
+from __future__ import annotations
+
+import csv
+import json
+import hashlib
+import os
+import sqlite3
+from contextlib import closing
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+PIPELINE_NAME = ${pipeline_name}
+POLICY_VERSION = ${policy_version}
+SPEC_ROOT = (Path(__file__).parent / ${spec_root}).resolve()
+PIPELINE_ROOT = Path(__file__).parent
+OUTPUT_ROOT = PIPELINE_ROOT / "outputs"
+PROVENANCE_PATH = OUTPUT_ROOT / "provenance.json"
+ATTESTATION_PATH = OUTPUT_ROOT / "attestations.json"
+AGQL_ENDPOINT = os.getenv("PPEG_AGQL_ENDPOINT")
+
+OUTPUT_ROOT.mkdir(parents=True, exist_ok=True)
+
+SOURCE_REGISTRY: Dict[str, Dict[str, Any]] = json.loads(${source_registry})
+SINK_REGISTRY: Dict[str, Dict[str, Any]] = json.loads(${sink_registry})
+STEP_REGISTRY: Dict[str, Dict[str, Any]] = json.loads(${step_registry})
+STEP_ORDER: List[str] = json.loads(${step_order})
+
+_PROVENANCE: List[Dict[str, Any]] = []
+_ATTESTATIONS: List[Dict[str, Any]] = []
+
+def _hash_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+def _fingerprint_rows(rows: Iterable[Dict[str, Any]]) -> str:
+    materialised = list(rows)
+    canonical = json.dumps(materialised, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    return _hash_bytes(canonical.encode("utf-8"))
+
+def _read_csv(path: Path) -> List[Dict[str, Any]]:
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        reader = csv.DictReader(fh)
+        return [dict(row) for row in reader]
+
+def _write_csv(path: Path, rows: Iterable[Dict[str, Any]]) -> None:
+    data = list(rows)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not data:
+        path.write_text("", encoding="utf-8")
+        return
+    fieldnames = sorted(data[0].keys())
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in data:
+            writer.writerow(row)
+
+def _rows_from_sql(query: str, rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    if not rows:
+        return []
+    columns = sorted(rows[0].keys())
+    with closing(sqlite3.connect(":memory:")) as conn:
+        conn.row_factory = sqlite3.Row
+        create_stmt = "CREATE TABLE input (" + ", ".join(f'"{col}" TEXT' for col in columns) + ")"
+        conn.execute(create_stmt)
+        insert_stmt = "INSERT INTO input VALUES (" + ", ".join(["?"] * len(columns)) + ")"
+        data = [[row.get(col) for col in columns] for row in rows]
+        conn.executemany(insert_stmt, data)
+        conn.commit()
+        cursor = conn.execute(query)
+        return [dict(record) for record in cursor.fetchall()]
+
+def emit_attestation(event: Dict[str, Any]) -> None:
+    payload = {
+        "pipeline": PIPELINE_NAME,
+        "policy_version": POLICY_VERSION,
+        "step_id": event["step_id"],
+        "step_hash": event["step_hash"],
+        "output_fingerprints": event["outputs"],
+    }
+    _ATTESTATIONS.append(payload)
+    if AGQL_ENDPOINT:
+        try:
+            import json as _json
+            import urllib.request
+
+            request = urllib.request.Request(
+                AGQL_ENDPOINT,
+                data=_json.dumps(payload).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(request, timeout=5):
+                pass
+        except Exception as exc:  # pragma: no cover - network failures logged only
+            failure = dict(payload)
+            failure["delivery_error"] = str(exc)
+            _ATTESTATIONS.append(failure)
+
+def _record(event: Dict[str, Any]) -> None:
+    _PROVENANCE.append(event)
+    emit_attestation(event)
+
+${python_functions}
+
+def run() -> None:
+    runtime_context: Dict[str, Any] = {
+        "pipeline_name": PIPELINE_NAME,
+        "policy_version": POLICY_VERSION,
+        "generated_at": datetime.utcnow().isoformat() + "Z",
+    }
+    datasets: Dict[str, List[Dict[str, Any]]] = {}
+
+    for source_name, info in SOURCE_REGISTRY.items():
+        source_path = (SPEC_ROOT / info["path"]).resolve()
+        rows = _read_csv(source_path) if info["format"] == "csv" else []
+        datasets[source_name] = rows
+        event = {
+            "step_id": f"source:{source_name}",
+            "step_type": "extract",
+            "step_hash": info["step_hash"],
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "policy_version": POLICY_VERSION,
+            "inputs": {},
+            "outputs": {
+                source_name: {
+                    "fingerprint": _fingerprint_rows(rows),
+                    "records": len(rows),
+                    "source_path": str(source_path),
+                }
+            },
+        }
+        _record(event)
+
+    for step_id in STEP_ORDER:
+        info = STEP_REGISTRY[step_id]
+        input_rows = datasets.get(info.get("input"), [])
+        if info["type"] == "sql":
+            sql_path = PIPELINE_ROOT / info["sql_path"]
+            query = sql_path.read_text(encoding="utf-8")
+            output_rows = _rows_from_sql(query, input_rows)
+        elif info["type"] == "python":
+            func = globals()[info["callable"]]
+            output_rows = list(func(input_rows, runtime_context))
+        else:
+            raise ValueError(f"Unsupported step type: {info['type']}")
+
+        datasets[info["output"]] = output_rows
+        inputs = {}
+        if info.get("input"):
+            inputs[info["input"]] = {
+                "fingerprint": _fingerprint_rows(input_rows),
+                "records": len(input_rows),
+            }
+        outputs = {
+            info["output"]: {
+                "fingerprint": _fingerprint_rows(output_rows),
+                "records": len(output_rows),
+            }
+        }
+        event = {
+            "step_id": info["id"],
+            "step_type": info["type"],
+            "step_hash": info["hash"],
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "policy_version": POLICY_VERSION,
+            "inputs": inputs,
+            "outputs": outputs,
+            "parameters": info.get("parameters", {}),
+        }
+        if info.get("sink"):
+            sink_info = SINK_REGISTRY[info["sink"]]
+            sink_path = (PIPELINE_ROOT / sink_info["path"]).resolve()
+            if sink_info["format"] == "csv":
+                _write_csv(sink_path, output_rows)
+            outputs[info["output"]]["materialized_at"] = str(sink_path)
+        _record(event)
+
+    _flush_logs()
+
+def _flush_logs() -> None:
+    PROVENANCE_PATH.write_text(json.dumps(_PROVENANCE, indent=2, sort_keys=True) + "\\n", encoding="utf-8")
+    ATTESTATION_PATH.write_text(json.dumps(_ATTESTATIONS, indent=2, sort_keys=True) + "\\n", encoding="utf-8")
+
+if __name__ == "__main__":
+    run()
+''')
+
+
+class PipelineGenerator:
+    """Generate provenance-instrumented pipelines from YAML specs."""
+
+    def __init__(self, loaded_spec: LoadedSpec):
+        self.loaded_spec = loaded_spec
+        self.pipeline: PipelineSpec = loaded_spec.pipeline
+
+    def generate(self, output_dir: str | Path) -> Path:
+        """Render the pipeline into *output_dir* and return the path."""
+
+        target = Path(output_dir).resolve()
+        target.mkdir(parents=True, exist_ok=True)
+
+        pipeline_path = target / "pipeline.py"
+        pipeline_path.write_text(self._render_pipeline(target), encoding="utf-8")
+
+        sql_dir = target / "sql"
+        sql_dir.mkdir(exist_ok=True)
+        for step in self.pipeline.steps:
+            if step.type == "sql" and step.query:
+                (sql_dir / f"{step.id}.sql").write_text(step.query.strip() + "\n", encoding="utf-8")
+
+        manifest_path = target / "manifest.json"
+        manifest_path.write_text(self._render_manifest(), encoding="utf-8")
+
+        readme_path = target / "README.md"
+        readme_path.write_text(self._render_readme(), encoding="utf-8")
+
+        return pipeline_path
+
+    def _render_manifest(self) -> str:
+        spec = self.pipeline
+        manifest = {
+            "pipeline": {
+                "name": spec.name,
+                "policy_version": spec.policy_version,
+                "description": spec.description,
+                "fingerprint": self._pipeline_fingerprint(),
+            },
+            "sources": {name: _source_manifest(src) for name, src in spec.sources.items()},
+            "sinks": {name: _sink_manifest(sink) for name, sink in spec.sinks.items()},
+            "steps": [self._step_manifest(step) for step in spec.steps],
+        }
+        return json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+
+    def _render_readme(self) -> str:
+        spec = self.pipeline
+        return (
+            f"# {spec.name} pipeline\n\n"
+            f"Policy version: `{spec.policy_version}`\n\n"
+            "Generated by PPEG. Run the pipeline with::\n\n"
+            "    python pipeline.py\n\n"
+            "Artifacts will be written to `outputs/` alongside provenance\n"
+            "(`provenance.json`) and attestation logs (`attestations.json`).\n"
+        )
+
+    def _render_pipeline(self, output_dir: Path) -> str:
+        spec_dir = self.loaded_spec.spec_dir
+        rel_spec_root = os.path.relpath(spec_dir, output_dir)
+
+        source_registry = {
+            name: {
+                "path": str(source.path),
+                "format": source.format,
+                "description": source.description,
+                "step_hash": source.step_hash,
+            }
+            for name, source in self.pipeline.sources.items()
+        }
+        sink_registry = {
+            name: {
+                "path": str(sink.path),
+                "format": sink.format,
+                "description": sink.description,
+            }
+            for name, sink in self.pipeline.sinks.items()
+        }
+        step_registry: Dict[str, Dict[str, object]] = {}
+        step_order: List[str] = []
+        python_functions: List[str] = []
+
+        for step in self.pipeline.steps:
+            step_order.append(step.id)
+            payload: Dict[str, object] = {
+                "id": step.id,
+                "type": step.type,
+                "hash": step.step_hash,
+                "input": step.input,
+                "output": step.output,
+                "description": step.description,
+                "sink": step.sink,
+                "parameters": step.parameters,
+            }
+            if step.type == "sql":
+                payload["sql_path"] = f"sql/{step.id}.sql"
+            if step.type == "python":
+                callable_name = f"_user_step_{step.id}"
+                payload["callable"] = callable_name
+                python_functions.append(self._render_python_step(callable_name, step.code or ""))
+            step_registry[step.id] = payload
+
+        python_block = "\n".join(python_functions) if python_functions else "pass\n"
+
+        rendered = PIPELINE_TEMPLATE.substitute(
+            pipeline_name=json.dumps(self.pipeline.name),
+            policy_version=json.dumps(self.pipeline.policy_version),
+            spec_root=json.dumps(rel_spec_root),
+            source_registry=repr(json.dumps(source_registry, sort_keys=True)),
+            sink_registry=repr(json.dumps(sink_registry, sort_keys=True)),
+            step_registry=repr(json.dumps(step_registry, sort_keys=True)),
+            step_order=repr(json.dumps(step_order)),
+            python_functions=python_block,
+        )
+        return rendered
+
+    def _render_python_step(self, name: str, code: str) -> str:
+        body = code.rstrip() + "\n"
+        return f"def {name}(rows: Iterable[Dict[str, Any]], context: Dict[str, Any]):\n" + indent(body, "    ")
+
+    def _step_manifest(self, step: StepSpec) -> Dict[str, object]:
+        return {
+            "id": step.id,
+            "type": step.type,
+            "hash": step.step_hash,
+            "input": step.input,
+            "output": step.output,
+            "description": step.description,
+            "sink": step.sink,
+            "parameters": step.parameters,
+        }
+
+    def _pipeline_fingerprint(self) -> str:
+        payload = {
+            "policy_version": self.pipeline.policy_version,
+            "steps": [step.step_hash for step in self.pipeline.steps],
+            "sources": {name: src.step_hash for name, src in self.pipeline.sources.items()},
+        }
+        import hashlib
+
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _source_manifest(source: SourceSpec) -> Dict[str, object]:
+    data = asdict(source)
+    data["step_hash"] = source.step_hash
+    data["path"] = str(source.path)
+    return data
+
+
+def _sink_manifest(sink: SinkSpec) -> Dict[str, object]:
+    data = asdict(sink)
+    data["path"] = str(sink.path)
+    return data
+
+
+__all__ = ["PipelineGenerator"]

--- a/tools/ppeg/ppeg/diff_inspector.py
+++ b/tools/ppeg/ppeg/diff_inspector.py
@@ -1,0 +1,99 @@
+"""Diff utilities for provenance-aware pipelines."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class StepDiff:
+    step_id: str
+    change_type: str  # "added", "removed", or "modified"
+    before_fingerprint: Dict[str, str] | None
+    after_fingerprint: Dict[str, str] | None
+
+
+def _load_provenance(path: Path | str) -> List[Mapping[str, object]]:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, list):  # pragma: no cover - defensive guard
+        raise ValueError("Provenance files must contain a list of steps.")
+    return [entry for entry in payload if isinstance(entry, Mapping)]
+
+
+def _fingerprint_map(entry: Mapping[str, object]) -> Dict[str, str]:
+    outputs = entry.get("outputs", {})
+    result: Dict[str, str] = {}
+    if isinstance(outputs, Mapping):
+        for name, payload in outputs.items():
+            if isinstance(payload, Mapping):
+                fingerprint = payload.get("fingerprint")
+                if isinstance(fingerprint, str):
+                    result[str(name)] = fingerprint
+    return result
+
+
+def diff_provenance(before: Path | str, after: Path | str) -> List[StepDiff]:
+    """Compare two provenance files and emit per-step diffs."""
+
+    before_entries = {entry.get("step_id"): entry for entry in _load_provenance(before)}
+    after_entries = {entry.get("step_id"): entry for entry in _load_provenance(after)}
+
+    diffs: List[StepDiff] = []
+    for step_id in sorted(set(before_entries) | set(after_entries)):
+        before_entry = before_entries.get(step_id)
+        after_entry = after_entries.get(step_id)
+        if before_entry and not after_entry:
+            diffs.append(
+                StepDiff(
+                    step_id=str(step_id),
+                    change_type="removed",
+                    before_fingerprint=_fingerprint_map(before_entry),
+                    after_fingerprint=None,
+                )
+            )
+            continue
+        if after_entry and not before_entry:
+            diffs.append(
+                StepDiff(
+                    step_id=str(step_id),
+                    change_type="added",
+                    before_fingerprint=None,
+                    after_fingerprint=_fingerprint_map(after_entry),
+                )
+            )
+            continue
+        assert before_entry and after_entry  # for type checkers
+        before_fp = _fingerprint_map(before_entry)
+        after_fp = _fingerprint_map(after_entry)
+        if before_fp != after_fp:
+            diffs.append(
+                StepDiff(
+                    step_id=str(step_id),
+                    change_type="modified",
+                    before_fingerprint=before_fp,
+                    after_fingerprint=after_fp,
+                )
+            )
+    return diffs
+
+
+def render_diff_report(diffs: Sequence[StepDiff]) -> str:
+    if not diffs:
+        return "No transform changes detected."
+    lines: List[str] = ["Detected transform changes:"]
+    for diff in diffs:
+        if diff.change_type == "modified":
+            lines.append(
+                f"  • {diff.step_id}: fingerprint {diff.before_fingerprint} → {diff.after_fingerprint}"
+            )
+        elif diff.change_type == "added":
+            lines.append(f"  • {diff.step_id}: added with fingerprint {diff.after_fingerprint}")
+        else:
+            lines.append(f"  • {diff.step_id}: removed (previous fingerprint {diff.before_fingerprint})")
+    return "\n".join(lines)
+
+
+__all__ = ["StepDiff", "diff_provenance", "render_diff_report"]

--- a/tools/ppeg/ppeg/spec.py
+++ b/tools/ppeg/ppeg/spec.py
@@ -1,0 +1,221 @@
+"""Domain objects for the PPEG YAML specification."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:  # pragma: no cover - optional dependency guard
+    import yaml  # type: ignore
+except Exception as exc:  # pragma: no cover - provides actionable error for users
+    raise RuntimeError(
+        "PyYAML is required to use the PPEG generator. Install it with `pip install pyyaml`."
+    ) from exc
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _hash_payload(payload: Dict[str, object]) -> str:
+    import hashlib
+
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    name: str
+    path: Path
+    format: str = "csv"
+    description: str = ""
+
+    @property
+    def step_hash(self) -> str:
+        return _hash_payload(
+            {
+                "name": self.name,
+                "path": str(self.path),
+                "format": self.format,
+                "description": self.description,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class SinkSpec:
+    name: str
+    path: Path
+    format: str = "csv"
+    description: str = ""
+
+
+@dataclass(frozen=True)
+class StepSpec:
+    id: str
+    type: str
+    input: Optional[str] = None
+    output: Optional[str] = None
+    description: str = ""
+    query: Optional[str] = None
+    code: Optional[str] = None
+    sink: Optional[str] = None
+    parameters: Dict[str, object] = field(default_factory=dict)
+
+    @property
+    def canonical_payload(self) -> Dict[str, object]:
+        payload: Dict[str, object] = {
+            "id": self.id,
+            "type": self.type,
+            "input": self.input,
+            "output": self.output,
+            "description": self.description,
+            "sink": self.sink,
+            "parameters": self.parameters,
+        }
+        if self.query is not None:
+            payload["query"] = self.query
+        if self.code is not None:
+            payload["code"] = self.code
+        return payload
+
+    @property
+    def step_hash(self) -> str:
+        return _hash_payload(self.canonical_payload)
+
+
+@dataclass(frozen=True)
+class PipelineSpec:
+    name: str
+    policy_version: str
+    description: str
+    sources: Dict[str, SourceSpec]
+    sinks: Dict[str, SinkSpec]
+    steps: List[StepSpec]
+
+    def validate(self) -> None:
+        _require(self.steps, "The specification must declare at least one step.")
+        for step in self.steps:
+            if step.type in {"sql", "python"}:
+                _require(step.input is not None, f"Step '{step.id}' requires an input dataset.")
+                _require(step.output is not None, f"Step '{step.id}' requires an output dataset.")
+            if step.type == "sql":
+                _require(step.query is not None, f"SQL step '{step.id}' must define a query.")
+            if step.type == "python":
+                _require(step.code is not None, f"Python step '{step.id}' must include code.")
+            if step.sink is not None:
+                _require(
+                    step.sink in self.sinks,
+                    f"Step '{step.id}' references undefined sink '{step.sink}'.",
+                )
+            if step.input is not None:
+                _require(
+                    step.input in self.sources or any(s.output == step.input for s in self.steps),
+                    f"Step '{step.id}' references unknown input dataset '{step.input}'.",
+                )
+
+
+@dataclass(frozen=True)
+class LoadedSpec:
+    """Wrapper that couples a parsed spec with helpful metadata."""
+
+    pipeline: PipelineSpec
+    spec_path: Path
+
+    @property
+    def spec_dir(self) -> Path:
+        return self.spec_path.parent
+
+
+class SpecLoader:
+    """Utility class for reading and validating YAML specifications."""
+
+    def load(self, path: Path | str) -> LoadedSpec:
+        spec_path = Path(path).resolve()
+        if not spec_path.exists():
+            raise FileNotFoundError(f"Spec file '{spec_path}' was not found.")
+
+        with spec_path.open("r", encoding="utf-8") as fh:
+            raw = yaml.safe_load(fh)
+
+        _require(isinstance(raw, dict), "The spec root must be a mapping.")
+        pipeline_info = raw.get("pipeline") or {}
+        _require(isinstance(pipeline_info, dict), "'pipeline' must be a mapping.")
+        name = pipeline_info.get("name") or "unnamed_pipeline"
+        policy_version = pipeline_info.get("policy_version") or "unknown-policy"
+        description = pipeline_info.get("description") or ""
+
+        sources_raw = raw.get("sources") or {}
+        _require(isinstance(sources_raw, dict), "'sources' must be a mapping.")
+        sources: Dict[str, SourceSpec] = {}
+        for name_key, payload in sources_raw.items():
+            _require(isinstance(payload, dict), f"Source '{name_key}' must be a mapping.")
+            path_value = payload.get("path")
+            _require(path_value, f"Source '{name_key}' must include a path.")
+            src_path = Path(path_value)
+            format_name = payload.get("format") or "csv"
+            sources[name_key] = SourceSpec(
+                name=name_key,
+                path=src_path,
+                format=format_name,
+                description=payload.get("description") or "",
+            )
+
+        sinks_raw = raw.get("sinks") or {}
+        _require(isinstance(sinks_raw, dict), "'sinks' must be a mapping.")
+        sinks: Dict[str, SinkSpec] = {}
+        for name_key, payload in sinks_raw.items():
+            _require(isinstance(payload, dict), f"Sink '{name_key}' must be a mapping.")
+            path_value = payload.get("path")
+            _require(path_value, f"Sink '{name_key}' must include a path.")
+            sink_path = Path(path_value)
+            format_name = payload.get("format") or "csv"
+            sinks[name_key] = SinkSpec(
+                name=name_key,
+                path=sink_path,
+                format=format_name,
+                description=payload.get("description") or "",
+            )
+
+        steps_raw = raw.get("steps") or []
+        _require(isinstance(steps_raw, list), "'steps' must be a list.")
+        steps: List[StepSpec] = []
+        for idx, payload in enumerate(steps_raw):
+            _require(isinstance(payload, dict), f"Step #{idx + 1} must be a mapping.")
+            step = StepSpec(
+                id=payload.get("id") or payload.get("name") or f"step_{idx + 1}",
+                type=payload.get("type") or "python",
+                input=payload.get("input"),
+                output=payload.get("output"),
+                description=payload.get("description") or "",
+                query=payload.get("query"),
+                code=payload.get("code"),
+                sink=payload.get("sink"),
+                parameters=payload.get("parameters") or {},
+            )
+            steps.append(step)
+
+        pipeline = PipelineSpec(
+            name=name,
+            policy_version=policy_version,
+            description=description,
+            sources=sources,
+            sinks=sinks,
+            steps=steps,
+        )
+        pipeline.validate()
+        return LoadedSpec(pipeline=pipeline, spec_path=spec_path)
+
+
+__all__ = [
+    "LoadedSpec",
+    "PipelineSpec",
+    "SinkSpec",
+    "SourceSpec",
+    "SpecLoader",
+    "StepSpec",
+]

--- a/tools/ppeg/pyproject.toml
+++ b/tools/ppeg/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=65", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ppeg"
+version = "0.1.0"
+description = "Provenance-preserving ETL generator"
+readme = "README.md"
+authors = [{name = "Summit"}]
+license = {text = "MIT"}
+requires-python = ">=3.10"
+dependencies = [
+  "PyYAML>=6.0",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.4",
+]
+
+[project.scripts]
+ppeg = "ppeg.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["ppeg*"]

--- a/tools/ppeg/tests/conftest.py
+++ b/tools/ppeg/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for PPEG tests."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+if str(PACKAGE_ROOT) not in sys.path:
+    sys.path.insert(0, str(PACKAGE_ROOT))

--- a/tools/ppeg/tests/data/sales.csv
+++ b/tools/ppeg/tests/data/sales.csv
@@ -1,0 +1,6 @@
+region,amount
+north,100.50
+south,200.00
+north,20.00
+west,80.25
+south,30.75

--- a/tools/ppeg/tests/fixtures/sample_etl.yaml
+++ b/tools/ppeg/tests/fixtures/sample_etl.yaml
@@ -1,0 +1,41 @@
+pipeline:
+  name: sample_sales_pipeline
+  policy_version: policy-v1.0
+  description: Sample sales aggregation pipeline with provenance instrumentation.
+
+sources:
+  sales_ledger:
+    path: ../data/sales.csv
+    format: csv
+    description: Synthetic sales ledger entries.
+
+sinks:
+  regional_totals:
+    path: outputs/regional_totals.csv
+    format: csv
+    description: Aggregated totals per region with policy annotation.
+
+steps:
+  - id: compute_regional_totals
+    type: sql
+    input: sales_ledger
+    output: regional_totals_stage
+    description: Aggregate sales per region using SQL for transparency.
+    query: |
+      SELECT region, SUM(CAST(amount AS REAL)) AS total_amount
+      FROM input
+      GROUP BY region
+      ORDER BY region
+  - id: attach_policy_version
+    type: python
+    input: regional_totals_stage
+    output: regional_totals
+    sink: regional_totals
+    description: Annotate the aggregated totals with the current policy version.
+    code: |
+      for row in rows:
+          yield {
+              "region": row["region"],
+              "total_amount": f"{float(row['total_amount']):.2f}",
+              "policy_version": context["policy_version"],
+          }

--- a/tools/ppeg/tests/golden/regional_totals.csv
+++ b/tools/ppeg/tests/golden/regional_totals.csv
@@ -1,0 +1,4 @@
+policy_version,region,total_amount
+policy-v1.0,north,120.50
+policy-v1.0,south,230.75
+policy-v1.0,west,80.25

--- a/tools/ppeg/tests/test_codegen.py
+++ b/tools/ppeg/tests/test_codegen.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ppeg.codegen import PipelineGenerator
+from ppeg.spec import SpecLoader
+
+
+def test_generate_pipeline(tmp_path: Path) -> None:
+    spec_path = Path(__file__).parent / "fixtures" / "sample_etl.yaml"
+    loader = SpecLoader()
+    loaded = loader.load(spec_path)
+
+    generator = PipelineGenerator(loaded)
+    pipeline_path = generator.generate(tmp_path)
+
+    assert pipeline_path.exists()
+
+    manifest_path = tmp_path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["pipeline"]["name"] == "sample_sales_pipeline"
+    assert manifest["pipeline"]["policy_version"] == "policy-v1.0"
+    assert manifest["pipeline"]["fingerprint"]
+
+    sql_path = tmp_path / "sql" / "compute_regional_totals.sql"
+    assert "GROUP BY region" in sql_path.read_text(encoding="utf-8")
+
+    readme_contents = (tmp_path / "README.md").read_text(encoding="utf-8")
+    assert "python pipeline.py" in readme_contents

--- a/tools/ppeg/tests/test_diff_inspector.py
+++ b/tools/ppeg/tests/test_diff_inspector.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ppeg.diff_inspector import diff_provenance, render_diff_report
+
+
+def test_diff_inspector_highlights_transform_changes(tmp_path: Path) -> None:
+    before = [
+        {
+            "step_id": "source:sales_ledger",
+            "outputs": {"sales_ledger": {"fingerprint": "aaa"}},
+        },
+        {
+            "step_id": "compute_regional_totals",
+            "outputs": {"regional_totals_stage": {"fingerprint": "bbb"}},
+        },
+    ]
+    after = [
+        {
+            "step_id": "source:sales_ledger",
+            "outputs": {"sales_ledger": {"fingerprint": "aaa"}},
+        },
+        {
+            "step_id": "compute_regional_totals",
+            "outputs": {"regional_totals_stage": {"fingerprint": "ccc"}},
+        },
+        {
+            "step_id": "attach_policy_version",
+            "outputs": {"regional_totals": {"fingerprint": "ddd"}},
+        },
+    ]
+
+    before_path = tmp_path / "before.json"
+    after_path = tmp_path / "after.json"
+    before_path.write_text(json.dumps(before), encoding="utf-8")
+    after_path.write_text(json.dumps(after), encoding="utf-8")
+
+    diffs = diff_provenance(before_path, after_path)
+    assert len(diffs) == 2
+    assert {diff.step_id for diff in diffs} == {"compute_regional_totals", "attach_policy_version"}
+
+    report = render_diff_report(diffs)
+    assert "Detected transform changes" in report
+    assert "compute_regional_totals" in report

--- a/tools/ppeg/tests/test_pipeline_execution.py
+++ b/tools/ppeg/tests/test_pipeline_execution.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from ppeg.codegen import PipelineGenerator
+from ppeg.spec import SpecLoader
+
+
+def test_generated_pipeline_runs_with_provenance(tmp_path: Path) -> None:
+    spec_path = Path(__file__).parent / "fixtures" / "sample_etl.yaml"
+    loader = SpecLoader()
+    loaded = loader.load(spec_path)
+
+    generator = PipelineGenerator(loaded)
+    output_dir = tmp_path / "generated"
+    generator.generate(output_dir)
+
+    subprocess.run([sys.executable, "pipeline.py"], cwd=output_dir, check=True)
+
+    produced = output_dir / "outputs" / "regional_totals.csv"
+    expected = Path(__file__).parent / "golden" / "regional_totals.csv"
+    assert produced.read_text(encoding="utf-8") == expected.read_text(encoding="utf-8")
+
+    provenance_path = output_dir / "outputs" / "provenance.json"
+    provenance = json.loads(provenance_path.read_text(encoding="utf-8"))
+    assert len(provenance) == 3  # 1 source + 2 steps
+
+    for entry in provenance:
+        assert entry["policy_version"] == "policy-v1.0"
+        assert entry["outputs"]
+        for dataset_info in entry["outputs"].values():
+            assert dataset_info["fingerprint"]
+
+    attestation_path = output_dir / "outputs" / "attestations.json"
+    attestations = json.loads(attestation_path.read_text(encoding="utf-8"))
+    assert len(attestations) >= len(provenance)
+
+    sink_entry = next(entry for entry in provenance if entry["step_id"] == "attach_policy_version")
+    sink_outputs = sink_entry["outputs"]["regional_totals"]
+    assert sink_outputs["materialized_at"].endswith("outputs/regional_totals.csv")


### PR DESCRIPTION
## Summary
- add the ppeg package for turning YAML ETL specs into provenance-instrumented Python/SQL pipelines
- provide a CLI for codegen and provenance diff inspection alongside AGQL attestation hooks
- ship fixtures plus golden tests that assert reproducible outputs and lineage reconstruction

## Testing
- pytest (tools/ppeg)


------
https://chatgpt.com/codex/tasks/task_e_68d78e123c508333aa93f890171d9fb7