### PR TITLE
feat: add policy-constrained backfill orchestrator

### DIFF
--- a/pcbo/README.md
+++ b/pcbo/README.md
@@ -1,0 +1,95 @@
+# Policy-Constrained Backfill Orchestrator (PCBO)
+
+PCBO coordinates historical data backfills under strict consent, jurisdiction, and retention controls. It
+combines a Go orchestration service with a TypeScript command-line interface to plan, dry-run, and execute
+retroactive loads while emitting deterministic evidence.
+
+## Components
+
+- **Go orchestrator** (`cmd/pcbo-orchestrator`): exposes HTTP endpoints for planning, policy-gated dry runs, and
+  live execution. Execution outputs include reconciliation reports, rollback manifests, and Merkle-based proofs.
+- **TypeScript CLI** (`cli`): connects to the orchestrator and surfaces plan/dry-run/execute workflows directly
+  from the terminal.
+
+## Endpoints
+
+| Endpoint        | Purpose                                                             |
+| --------------- | ------------------------------------------------------------------- |
+| `POST /v1/plan` | Returns the deterministic partition plan for a request.             |
+| `POST /v1/dry-run` | Produces the add/omit diff per partition with policy explainability. |
+| `POST /v1/execute` | Runs the backfill, blocks on policy breaches, and returns proofs.   |
+
+Payloads include the historical records to ingest, existing target identifiers, and the policy configuration.
+All timestamps are ISO-8601 strings.
+
+## CLI Usage
+
+```bash
+# Install dependencies and build the CLI
+yarn --cwd pcbo/cli install
+
+# Dry-run a request located at request.json
+node pcbo/cli/dist/index.js dry-run --input request.json --host localhost --port 8080
+
+# Execute and write the response to disk
+node pcbo/cli/dist/index.js execute --input request.json --output run-output.json
+```
+
+You can also invoke the packaged binary after building:
+
+```bash
+npm --prefix pcbo/cli install
+npm --prefix pcbo/cli run build
+pcbo/cli/dist/index.js plan --input request.json
+```
+
+### Request Skeleton
+
+```json
+{
+  "runId": "retro-run-001",
+  "dataset": "events",
+  "start": "2024-01-01T00:00:00Z",
+  "end": "2024-01-02T00:00:00Z",
+  "chunkSeconds": 3600,
+  "policies": {
+    "requireConsent": true,
+    "allowedJurisdictions": ["US", "CA"],
+    "retentionCutoff": "2023-12-01T00:00:00Z"
+  },
+  "sourceRecords": [
+    {
+      "id": "rec-1",
+      "occurredAt": "2024-01-01T00:15:00Z",
+      "jurisdiction": "US",
+      "consentGranted": true,
+      "retentionExpiresAt": "2025-01-01T00:00:00Z"
+    }
+  ],
+  "existingTargetIds": ["rec-legacy-1"],
+  "metadata": {
+    "initiator": "ops-team"
+  }
+}
+```
+
+## Proof Verification
+
+Each executed partition emits a record count and Merkle root calculated over sorted identifiers. Offline
+verification can recompute the root using the included `VerifyMerkleRoot` helper from the Go package or an
+external tool that mirrors the hashing strategy.
+
+## Testing
+
+Run Go unit tests:
+
+```bash
+(cd pcbo && go test ./...)
+```
+
+The CLI can be type-checked and tested with:
+
+```bash
+npm --prefix pcbo/cli run build
+npm --prefix pcbo/cli test
+```

--- a/pcbo/cli/package.json
+++ b/pcbo/cli/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@summit/pcbo-cli",
+  "version": "0.1.0",
+  "description": "CLI for interacting with the policy-constrained backfill orchestrator",
+  "type": "module",
+  "bin": {
+    "pcbo": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint src --ext .ts",
+    "test": "node --test dist",
+    "prepare": "npm run build"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.16.11",
+    "eslint": "^9.15.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/pcbo/cli/src/index.ts
+++ b/pcbo/cli/src/index.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+interface CliOptions {
+  command: 'plan' | 'dry-run' | 'execute';
+  host: string;
+  port: number;
+  input: string;
+  output?: string;
+}
+
+const HELP_TEXT = `pcbo <command> [options]\n\nCommands:\n  plan       Generate the deterministic partition plan\n  dry-run    Evaluate the dry-run diff with policy gates\n  execute    Run the backfill and emit proofs/reports\n\nOptions:\n  --host <host>     Orchestrator host (default: localhost)\n  --port <port>     Orchestrator port (default: 8080)\n  --input <file>    Path to JSON request payload (required)\n  --output <file>   Optional file to write the response\n  --help            Show this help message\n`;
+
+function parseArgs(argv: string[]): CliOptions | null {
+  if (argv.length === 0) {
+    return null;
+  }
+  const [command, ...rest] = argv;
+  if (!['plan', 'dry-run', 'execute'].includes(command)) {
+    return null;
+  }
+  const options: Record<string, string> = {};
+  for (let i = 0; i < rest.length; i += 1) {
+    const key = rest[i];
+    if (!key.startsWith('--')) {
+      throw new Error(`unexpected argument: ${key}`);
+    }
+    const value = rest[i + 1];
+    if (value === undefined || value.startsWith('--')) {
+      throw new Error(`missing value for ${key}`);
+    }
+    options[key.slice(2)] = value;
+    i += 1;
+  }
+  if (!options.input) {
+    throw new Error('missing required option --input');
+  }
+  const host = options.host ?? 'localhost';
+  const port = options.port ? Number.parseInt(options.port, 10) : 8080;
+  if (Number.isNaN(port)) {
+    throw new Error('port must be a number');
+  }
+  return {
+    command: command as CliOptions['command'],
+    host,
+    port,
+    input: resolve(options.input),
+    output: options.output ? resolve(options.output) : undefined,
+  };
+}
+
+async function main(): Promise<void> {
+  try {
+    const parsed = parseArgs(process.argv.slice(2));
+    if (!parsed) {
+      process.stdout.write(HELP_TEXT);
+      process.exit(0);
+      return;
+    }
+    const payload = JSON.parse(readFileSync(parsed.input, 'utf8'));
+    const endpoint = parsed.command === 'dry-run' ? 'dry-run' : parsed.command;
+    const url = new URL(`/v1/${endpoint}`, `http://${parsed.host}:${parsed.port}`);
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const text = await response.text();
+    let parsedBody: unknown;
+    try {
+      parsedBody = text.length ? JSON.parse(text) : {};
+    } catch (error) {
+      throw new Error(`failed to parse orchestrator response: ${(error as Error).message}`);
+    }
+
+    const serialized = JSON.stringify(parsedBody, null, 2);
+    if (parsed.output) {
+      writeFileSync(parsed.output, `${serialized}\n`);
+    } else {
+      process.stdout.write(`${serialized}\n`);
+    }
+
+    if (!response.ok) {
+      const violations = (parsedBody as { report?: { policyViolations?: unknown } }).report?.policyViolations;
+      if (Array.isArray(violations) && violations.length > 0) {
+        process.stderr.write('policy violations detected:\n');
+        process.stderr.write(`${JSON.stringify(violations, null, 2)}\n`);
+      }
+      process.exit(2);
+    }
+  } catch (error) {
+    process.stderr.write(`${(error as Error).message}\n`);
+    process.stderr.write(HELP_TEXT);
+    process.exit(1);
+  }
+}
+
+void main();

--- a/pcbo/cli/tsconfig.json
+++ b/pcbo/cli/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/pcbo/cmd/pcbo-orchestrator/main.go
+++ b/pcbo/cmd/pcbo-orchestrator/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+
+	"pcbo/internal/api"
+)
+
+func main() {
+	port := flag.Int("port", 8080, "port to listen on")
+	flag.Parse()
+
+	server := api.NewServer()
+	addr := fmt.Sprintf(":%d", *port)
+	log.Printf("pcbo orchestrator listening on %s", addr)
+	if err := http.ListenAndServe(addr, server.Handler()); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/pcbo/doc.go
+++ b/pcbo/doc.go
@@ -1,0 +1,2 @@
+// Package pcbo provides the top-level module marker for the orchestrator.
+package pcbo

--- a/pcbo/go.mod
+++ b/pcbo/go.mod
@@ -1,0 +1,4 @@
+module pcbo
+
+go 1.21
+

--- a/pcbo/internal/api/server.go
+++ b/pcbo/internal/api/server.go
@@ -1,0 +1,100 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"pcbo/internal/orchestrator"
+)
+
+// Server implements the HTTP interface for the orchestrator engine.
+type Server struct {
+	engine orchestrator.Engine
+}
+
+// NewServer instantiates a Server with default engine.
+func NewServer() *Server {
+	return &Server{engine: orchestrator.NewEngine()}
+}
+
+// Handler returns the HTTP handler configured with routing.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/plan", s.plan)
+	mux.HandleFunc("/v1/dry-run", s.dryRun)
+	mux.HandleFunc("/v1/execute", s.execute)
+	return mux
+}
+
+func (s *Server) plan(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	req, normalized, err := s.parseRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	plan := s.engine.Plan(normalized)
+	response := map[string]any{
+		"runId":    req.RunID,
+		"dataset":  req.Dataset,
+		"plan":     plan,
+		"metadata": req.Metadata,
+	}
+	s.writeJSON(w, http.StatusOK, response)
+}
+
+func (s *Server) dryRun(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	_, normalized, err := s.parseRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	result := s.engine.DryRun(normalized)
+	s.writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) execute(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	_, normalized, err := s.parseRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	result := s.engine.Execute(normalized)
+	status := http.StatusOK
+	if len(result.Report.PolicyViolations) > 0 {
+		status = http.StatusConflict
+	}
+	s.writeJSON(w, status, result)
+}
+
+func (s *Server) parseRequest(r *http.Request) (orchestrator.BackfillRequest, orchestrator.NormalizedRequest, error) {
+	decoder := json.NewDecoder(r.Body)
+	var req orchestrator.BackfillRequest
+	if err := decoder.Decode(&req); err != nil {
+		return orchestrator.BackfillRequest{}, orchestrator.NormalizedRequest{}, err
+	}
+	normalized, err := req.Normalize()
+	if err != nil {
+		return orchestrator.BackfillRequest{}, orchestrator.NormalizedRequest{}, err
+	}
+	return req, normalized, nil
+}
+
+func (s *Server) writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	_ = encoder.Encode(payload)
+}

--- a/pcbo/internal/orchestrator/engine.go
+++ b/pcbo/internal/orchestrator/engine.go
@@ -1,0 +1,181 @@
+package orchestrator
+
+import (
+	"sort"
+	"time"
+)
+
+// Engine executes deterministic planning, dry-run, and execution flows.
+type Engine struct{}
+
+// NewEngine constructs a stateless Engine.
+func NewEngine() Engine {
+	return Engine{}
+}
+
+// Plan returns the partitioning for the supplied request.
+func (Engine) Plan(req NormalizedRequest) []Partition {
+	return BuildPartitions(req.Start, req.End, req.ChunkSize)
+}
+
+// DryRun produces the diff between source records and current target state.
+func (e Engine) DryRun(req NormalizedRequest) DryRunResult {
+	plan := e.Plan(req)
+	chunks := make([]DryRunChunk, 0, len(plan))
+	summary := DryRunSummary{}
+
+	for _, partition := range plan {
+		records := filterRecords(req, partition)
+		violations := evaluatePolicies(req, records)
+		chunk := DryRunChunk{
+			Partition:        partition,
+			Adds:             []string{},
+			Duplicates:       []string{},
+			PolicyViolations: violations,
+		}
+		if len(violations) > 0 {
+			chunk.Status = "blocked"
+			summary.TotalBlocked++
+		} else {
+			adds, duplicates := splitAdds(records, req.ExistingTargetIDs)
+			chunk.Status = statusFromAdds(adds, duplicates)
+			chunk.Adds = adds
+			chunk.Duplicates = duplicates
+			summary.TotalAdds += len(adds)
+			summary.TotalDuplicates += len(duplicates)
+		}
+		chunks = append(chunks, chunk)
+	}
+
+	return DryRunResult{
+		RunID:    req.RunID,
+		Dataset:  req.Dataset,
+		Plan:     plan,
+		Chunks:   chunks,
+		Summary:  summary,
+		Metadata: req.Metadata,
+	}
+}
+
+// Execute performs the backfill if no policy violations occur.
+func (e Engine) Execute(req NormalizedRequest) ExecutionResult {
+	plan := e.Plan(req)
+	existing := copySet(req.ExistingTargetIDs)
+	report := ReconciliationReport{
+		RunID:            req.RunID,
+		Dataset:          req.Dataset,
+		GeneratedAt:      time.Now().UTC(),
+		Summary:          ReportSummary{},
+		Partitions:       make([]PartitionReport, 0, len(plan)),
+		PolicyViolations: []PolicyViolation{},
+		Metadata:         req.Metadata,
+	}
+	manifest := RollbackManifest{
+		RunID:       req.RunID,
+		GeneratedAt: report.GeneratedAt,
+		Entries:     make([]RollbackEntry, 0, len(plan)),
+		Metadata:    req.Metadata,
+	}
+
+	for _, partition := range plan {
+		records := filterRecords(req, partition)
+		violations := evaluatePolicies(req, records)
+		adds, duplicates := splitAdds(records, existing)
+		partitionReport := PartitionReport{
+			Partition:        partition,
+			Duplicates:       duplicates,
+			PolicyViolations: violations,
+			Proof: PartitionProof{
+				Partition: partition,
+				Count:     0,
+				Merkle:    "",
+			},
+		}
+
+		if len(violations) > 0 {
+			partitionReport.Status = "blocked"
+			report.Summary.BlockedPartitions++
+			report.PolicyViolations = append(report.PolicyViolations, violations...)
+			manifest.Entries = append(manifest.Entries, RollbackEntry{Partition: partition, RecordIDs: []string{}})
+			report.Partitions = append(report.Partitions, partitionReport)
+			continue
+		}
+
+		if len(adds) == 0 {
+			partitionReport.Status = "noop"
+		} else {
+			partitionReport.Status = "applied"
+			partitionReport.AppliedRecords = len(adds)
+			report.Summary.AppliedRecords += len(adds)
+			manifest.Entries = append(manifest.Entries, RollbackEntry{Partition: partition, RecordIDs: adds})
+			for _, id := range adds {
+				existing[id] = struct{}{}
+			}
+			partitionReport.Proof = PartitionProof{
+				Partition: partition,
+				Count:     len(adds),
+				Merkle:    ComputeMerkleRoot(adds),
+			}
+		}
+
+		if len(duplicates) > 0 {
+			report.Summary.DuplicateRecords += len(duplicates)
+		}
+
+		partitionReport.Duplicates = duplicates
+		report.Partitions = append(report.Partitions, partitionReport)
+	}
+
+	if len(manifest.Entries) == 0 {
+		manifest.Entries = []RollbackEntry{}
+	}
+
+	return ExecutionResult{
+		Plan:     plan,
+		Report:   report,
+		Rollback: manifest,
+	}
+}
+
+func filterRecords(req NormalizedRequest, partition Partition) []Record {
+	records := make([]Record, 0)
+	for _, record := range req.SourceRecords {
+		if (record.OccurredAt.Equal(partition.RangeFrom) || record.OccurredAt.After(partition.RangeFrom)) && record.OccurredAt.Before(partition.RangeTo) {
+			records = append(records, record)
+		}
+	}
+	return records
+}
+
+func splitAdds(records []Record, existing map[string]struct{}) ([]string, []string) {
+	adds := make([]string, 0)
+	duplicates := make([]string, 0)
+	for _, record := range records {
+		if _, found := existing[record.ID]; found {
+			duplicates = append(duplicates, record.ID)
+		} else {
+			adds = append(adds, record.ID)
+		}
+	}
+	sort.Strings(adds)
+	sort.Strings(duplicates)
+	return adds, duplicates
+}
+
+func statusFromAdds(adds, duplicates []string) string {
+	if len(adds) == 0 {
+		if len(duplicates) == 0 {
+			return "noop"
+		}
+		return "deduplicated"
+	}
+	return "applied"
+}
+
+func copySet(in map[string]struct{}) map[string]struct{} {
+	out := make(map[string]struct{}, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}

--- a/pcbo/internal/orchestrator/engine_test.go
+++ b/pcbo/internal/orchestrator/engine_test.go
@@ -1,0 +1,97 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+)
+
+func sampleRequest() NormalizedRequest {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	records := []Record{
+		{ID: "a", OccurredAt: base.Add(10 * time.Minute), Jurisdiction: "US", ConsentGranted: true, RetentionExpiresAt: base.Add(240 * time.Hour)},
+		{ID: "b", OccurredAt: base.Add(70 * time.Minute), Jurisdiction: "US", ConsentGranted: true, RetentionExpiresAt: base.Add(240 * time.Hour)},
+		{ID: "c", OccurredAt: base.Add(130 * time.Minute), Jurisdiction: "CA", ConsentGranted: false, RetentionExpiresAt: base.Add(240 * time.Hour)},
+		{ID: "d", OccurredAt: base.Add(190 * time.Minute), Jurisdiction: "US", ConsentGranted: true, RetentionExpiresAt: base.Add(-1 * time.Hour)},
+	}
+	return NormalizedRequest{
+		RunID:     "run-123",
+		Dataset:   "events",
+		Start:     base,
+		End:       base.Add(4 * time.Hour),
+		ChunkSize: time.Hour,
+		Policies: NormalizedPolicy{
+			RequireConsent: true,
+			AllowedJurisdictions: map[string]struct{}{
+				"US": {},
+			},
+			RetentionCutoff: base,
+		},
+		SourceRecords: records,
+		ExistingTargetIDs: map[string]struct{}{
+			"b": {},
+		},
+		Metadata: map[string]any{"initiator": "test"},
+	}
+}
+
+func TestPlanDeterministic(t *testing.T) {
+	engine := NewEngine()
+	req := sampleRequest()
+	plan := engine.Plan(req)
+	plan2 := engine.Plan(req)
+	if len(plan) != len(plan2) {
+		t.Fatalf("plan lengths mismatch: %d vs %d", len(plan), len(plan2))
+	}
+	for i := range plan {
+		if plan[i] != plan2[i] {
+			t.Fatalf("plan entries differ at %d: %+v vs %+v", i, plan[i], plan2[i])
+		}
+	}
+}
+
+func TestDryRunMatchesExecuteAdds(t *testing.T) {
+	engine := NewEngine()
+	req := sampleRequest()
+	dryRun := engine.DryRun(req)
+	exec := engine.Execute(req)
+	for i, chunk := range dryRun.Chunks {
+		if chunk.Partition != exec.Plan[i] {
+			t.Fatalf("plan mismatch: %+v vs %+v", chunk.Partition, exec.Plan[i])
+		}
+		if len(chunk.Adds) != exec.Report.Partitions[i].AppliedRecords {
+			t.Fatalf("chunk %d adds mismatch: %d vs %d", i, len(chunk.Adds), exec.Report.Partitions[i].AppliedRecords)
+		}
+	}
+}
+
+func TestPolicyViolationsBlockExecution(t *testing.T) {
+	engine := NewEngine()
+	req := sampleRequest()
+	result := engine.Execute(req)
+	blocked := 0
+	for _, p := range result.Report.Partitions {
+		if p.Status == "blocked" {
+			blocked++
+			if len(p.PolicyViolations) == 0 {
+				t.Fatalf("blocked partition missing policy violations")
+			}
+		}
+	}
+	if blocked == 0 {
+		t.Fatalf("expected at least one blocked partition")
+	}
+	if len(result.Report.PolicyViolations) == 0 {
+		t.Fatalf("expected report level policy violations")
+	}
+}
+
+func TestMerkleProofRoundTrip(t *testing.T) {
+	ids := []string{"z", "a", "m"}
+	root := ComputeMerkleRoot(ids)
+	if root == "" {
+		t.Fatalf("expected non-empty root")
+	}
+	if !VerifyMerkleRoot(ids, root) {
+		t.Fatalf("verification failed")
+	}
+}

--- a/pcbo/internal/orchestrator/planner.go
+++ b/pcbo/internal/orchestrator/planner.go
@@ -1,0 +1,27 @@
+package orchestrator
+
+import "time"
+
+// BuildPartitions creates deterministic contiguous partitions.
+func BuildPartitions(start, end time.Time, chunkSize time.Duration) []Partition {
+	if chunkSize <= 0 {
+		return nil
+	}
+	partitions := []Partition{}
+	index := 0
+	cursor := start
+	for cursor.Before(end) {
+		next := cursor.Add(chunkSize)
+		if next.After(end) {
+			next = end
+		}
+		partitions = append(partitions, Partition{
+			Index:     index,
+			RangeFrom: cursor,
+			RangeTo:   next,
+		})
+		cursor = next
+		index++
+	}
+	return partitions
+}

--- a/pcbo/internal/orchestrator/policy.go
+++ b/pcbo/internal/orchestrator/policy.go
@@ -1,0 +1,34 @@
+package orchestrator
+
+import "fmt"
+
+// evaluatePolicies validates records against configured policies and returns violations.
+func evaluatePolicies(req NormalizedRequest, records []Record) []PolicyViolation {
+	violations := make([]PolicyViolation, 0)
+	for _, record := range records {
+		if req.Policies.RequireConsent && !record.ConsentGranted {
+			violations = append(violations, PolicyViolation{
+				Policy:   "consent",
+				RecordID: record.ID,
+				Reason:   "consent not granted",
+			})
+		}
+		if len(req.Policies.AllowedJurisdictions) > 0 {
+			if _, ok := req.Policies.AllowedJurisdictions[record.Jurisdiction]; !ok {
+				violations = append(violations, PolicyViolation{
+					Policy:   "jurisdiction",
+					RecordID: record.ID,
+					Reason:   fmt.Sprintf("jurisdiction %s not allowed", record.Jurisdiction),
+				})
+			}
+		}
+		if !record.RetentionExpiresAt.After(req.Policies.RetentionCutoff) {
+			violations = append(violations, PolicyViolation{
+				Policy:   "retention",
+				RecordID: record.ID,
+				Reason:   fmt.Sprintf("retention expired at %s", record.RetentionExpiresAt.Format("2006-01-02T15:04:05Z07:00")),
+			})
+		}
+	}
+	return violations
+}

--- a/pcbo/internal/orchestrator/proofs.go
+++ b/pcbo/internal/orchestrator/proofs.go
@@ -1,0 +1,44 @@
+package orchestrator
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+)
+
+// ComputeMerkleRoot calculates a deterministic Merkle root of record identifiers.
+func ComputeMerkleRoot(ids []string) string {
+	if len(ids) == 0 {
+		return ""
+	}
+	hashed := make([][]byte, len(ids))
+	sorted := append([]string{}, ids...)
+	sort.Strings(sorted)
+	for i, id := range sorted {
+		h := sha256.Sum256([]byte(id))
+		hashed[i] = h[:]
+	}
+
+	for len(hashed) > 1 {
+		nextLevel := make([][]byte, 0, (len(hashed)+1)/2)
+		for i := 0; i < len(hashed); i += 2 {
+			if i+1 >= len(hashed) {
+				combined := append(hashed[i], hashed[i]...)
+				sum := sha256.Sum256(combined)
+				nextLevel = append(nextLevel, sum[:])
+				continue
+			}
+			combined := append(hashed[i], hashed[i+1]...)
+			sum := sha256.Sum256(combined)
+			nextLevel = append(nextLevel, sum[:])
+		}
+		hashed = nextLevel
+	}
+
+	return hex.EncodeToString(hashed[0])
+}
+
+// VerifyMerkleRoot recomputes the root to allow offline validation.
+func VerifyMerkleRoot(ids []string, expected string) bool {
+	return ComputeMerkleRoot(ids) == expected
+}

--- a/pcbo/internal/orchestrator/types.go
+++ b/pcbo/internal/orchestrator/types.go
@@ -1,0 +1,263 @@
+package orchestrator
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// BackfillRequest captures the payload submitted by clients before normalization.
+type BackfillRequest struct {
+	RunID             string         `json:"runId"`
+	Dataset           string         `json:"dataset"`
+	Start             string         `json:"start"`
+	End               string         `json:"end"`
+	ChunkSeconds      int            `json:"chunkSeconds"`
+	Policies          PolicyConfig   `json:"policies"`
+	SourceRecords     []RecordInput  `json:"sourceRecords"`
+	ExistingTargetIDs []string       `json:"existingTargetIds"`
+	Metadata          map[string]any `json:"metadata,omitempty"`
+}
+
+// PolicyConfig holds the consent, jurisdiction, and retention constraints.
+type PolicyConfig struct {
+	RequireConsent       bool     `json:"requireConsent"`
+	AllowedJurisdictions []string `json:"allowedJurisdictions"`
+	RetentionCutoff      string   `json:"retentionCutoff"`
+}
+
+// RecordInput models the raw JSON representation of a record to be backfilled.
+type RecordInput struct {
+	ID                 string `json:"id"`
+	OccurredAt         string `json:"occurredAt"`
+	Jurisdiction       string `json:"jurisdiction"`
+	ConsentGranted     bool   `json:"consentGranted"`
+	RetentionExpiresAt string `json:"retentionExpiresAt"`
+}
+
+// NormalizedRequest is a fully parsed representation of a BackfillRequest.
+type NormalizedRequest struct {
+	RunID             string
+	Dataset           string
+	Start             time.Time
+	End               time.Time
+	ChunkSize         time.Duration
+	Policies          NormalizedPolicy
+	SourceRecords     []Record
+	ExistingTargetIDs map[string]struct{}
+	Metadata          map[string]any
+}
+
+// NormalizedPolicy contains typed policy data.
+type NormalizedPolicy struct {
+	RequireConsent       bool
+	AllowedJurisdictions map[string]struct{}
+	RetentionCutoff      time.Time
+}
+
+// Record represents a typed source record.
+type Record struct {
+	ID                 string
+	OccurredAt         time.Time
+	Jurisdiction       string
+	ConsentGranted     bool
+	RetentionExpiresAt time.Time
+}
+
+// Partition denotes a planned chunk of work.
+type Partition struct {
+	Index     int       `json:"index"`
+	RangeFrom time.Time `json:"rangeFrom"`
+	RangeTo   time.Time `json:"rangeTo"`
+}
+
+// PolicyViolation describes a single record failing a policy gate.
+type PolicyViolation struct {
+	Policy   string `json:"policy"`
+	RecordID string `json:"recordId"`
+	Reason   string `json:"reason"`
+}
+
+// DryRunChunk captures the diff for a partition during dry run.
+type DryRunChunk struct {
+	Partition        Partition         `json:"partition"`
+	Status           string            `json:"status"`
+	Adds             []string          `json:"adds"`
+	Duplicates       []string          `json:"duplicates"`
+	PolicyViolations []PolicyViolation `json:"policyViolations"`
+}
+
+// DryRunResult summarises the dry run evaluation.
+type DryRunResult struct {
+	RunID    string         `json:"runId"`
+	Dataset  string         `json:"dataset"`
+	Plan     []Partition    `json:"plan"`
+	Chunks   []DryRunChunk  `json:"chunks"`
+	Summary  DryRunSummary  `json:"summary"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+// DryRunSummary aggregates diff totals.
+type DryRunSummary struct {
+	TotalAdds       int `json:"totalAdds"`
+	TotalDuplicates int `json:"totalDuplicates"`
+	TotalBlocked    int `json:"totalBlocked"`
+}
+
+// PartitionProof captures deterministic evidence for a chunk.
+type PartitionProof struct {
+	Partition Partition `json:"partition"`
+	Count     int       `json:"count"`
+	Merkle    string    `json:"merkle"`
+}
+
+// PartitionReport captures the live execution status for a chunk.
+type PartitionReport struct {
+	Partition        Partition         `json:"partition"`
+	Status           string            `json:"status"`
+	AppliedRecords   int               `json:"appliedRecords"`
+	Duplicates       []string          `json:"duplicates"`
+	PolicyViolations []PolicyViolation `json:"policyViolations"`
+	Proof            PartitionProof    `json:"proof"`
+}
+
+// ReportSummary aggregates live execution outcomes.
+type ReportSummary struct {
+	AppliedRecords    int `json:"appliedRecords"`
+	DuplicateRecords  int `json:"duplicateRecords"`
+	BlockedPartitions int `json:"blockedPartitions"`
+}
+
+// ReconciliationReport describes the run level view returned to callers.
+type ReconciliationReport struct {
+	RunID            string            `json:"runId"`
+	Dataset          string            `json:"dataset"`
+	GeneratedAt      time.Time         `json:"generatedAt"`
+	Summary          ReportSummary     `json:"summary"`
+	Partitions       []PartitionReport `json:"partitions"`
+	PolicyViolations []PolicyViolation `json:"policyViolations"`
+	Metadata         map[string]any    `json:"metadata,omitempty"`
+}
+
+// RollbackEntry documents the records that can be reverted for a chunk.
+type RollbackEntry struct {
+	Partition Partition `json:"partition"`
+	RecordIDs []string  `json:"recordIds"`
+}
+
+// RollbackManifest consolidates rollback entries.
+type RollbackManifest struct {
+	RunID       string          `json:"runId"`
+	GeneratedAt time.Time       `json:"generatedAt"`
+	Entries     []RollbackEntry `json:"entries"`
+	Metadata    map[string]any  `json:"metadata,omitempty"`
+}
+
+// ExecutionResult is returned after a live run.
+type ExecutionResult struct {
+	Plan     []Partition          `json:"plan"`
+	Report   ReconciliationReport `json:"report"`
+	Rollback RollbackManifest     `json:"rollback"`
+}
+
+// Validate ensures the request contains minimum required data.
+func (r BackfillRequest) Validate() error {
+	if r.RunID == "" {
+		return errors.New("runId is required")
+	}
+	if r.Dataset == "" {
+		return errors.New("dataset is required")
+	}
+	if r.Start == "" || r.End == "" {
+		return errors.New("start and end timestamps are required")
+	}
+	if r.ChunkSeconds <= 0 {
+		return errors.New("chunkSeconds must be greater than zero")
+	}
+	if r.Policies.RetentionCutoff == "" {
+		return errors.New("policies.retentionCutoff is required")
+	}
+	return nil
+}
+
+// Normalize converts a BackfillRequest into a NormalizedRequest.
+func (r BackfillRequest) Normalize() (NormalizedRequest, error) {
+	if err := r.Validate(); err != nil {
+		return NormalizedRequest{}, err
+	}
+
+	start, err := time.Parse(time.RFC3339, r.Start)
+	if err != nil {
+		return NormalizedRequest{}, fmt.Errorf("invalid start timestamp: %w", err)
+	}
+	end, err := time.Parse(time.RFC3339, r.End)
+	if err != nil {
+		return NormalizedRequest{}, fmt.Errorf("invalid end timestamp: %w", err)
+	}
+	if !end.After(start) {
+		return NormalizedRequest{}, errors.New("end must be after start")
+	}
+
+	cutoff, err := time.Parse(time.RFC3339, r.Policies.RetentionCutoff)
+	if err != nil {
+		return NormalizedRequest{}, fmt.Errorf("invalid retentionCutoff: %w", err)
+	}
+
+	chunkSize := time.Duration(r.ChunkSeconds) * time.Second
+
+	allowed := make(map[string]struct{}, len(r.Policies.AllowedJurisdictions))
+	for _, j := range r.Policies.AllowedJurisdictions {
+		allowed[j] = struct{}{}
+	}
+
+	normalizedRecords := make([]Record, 0, len(r.SourceRecords))
+	for _, rec := range r.SourceRecords {
+		if rec.ID == "" {
+			return NormalizedRequest{}, errors.New("sourceRecords contain an entry without id")
+		}
+		occurredAt, err := time.Parse(time.RFC3339, rec.OccurredAt)
+		if err != nil {
+			return NormalizedRequest{}, fmt.Errorf("record %s has invalid occurredAt: %w", rec.ID, err)
+		}
+		retentionExpiry, err := time.Parse(time.RFC3339, rec.RetentionExpiresAt)
+		if err != nil {
+			return NormalizedRequest{}, fmt.Errorf("record %s has invalid retentionExpiresAt: %w", rec.ID, err)
+		}
+		normalizedRecords = append(normalizedRecords, Record{
+			ID:                 rec.ID,
+			OccurredAt:         occurredAt,
+			Jurisdiction:       rec.Jurisdiction,
+			ConsentGranted:     rec.ConsentGranted,
+			RetentionExpiresAt: retentionExpiry,
+		})
+	}
+
+	sort.SliceStable(normalizedRecords, func(i, j int) bool {
+		if normalizedRecords[i].OccurredAt.Equal(normalizedRecords[j].OccurredAt) {
+			return normalizedRecords[i].ID < normalizedRecords[j].ID
+		}
+		return normalizedRecords[i].OccurredAt.Before(normalizedRecords[j].OccurredAt)
+	})
+
+	existing := make(map[string]struct{}, len(r.ExistingTargetIDs))
+	for _, id := range r.ExistingTargetIDs {
+		existing[id] = struct{}{}
+	}
+
+	return NormalizedRequest{
+		RunID:     r.RunID,
+		Dataset:   r.Dataset,
+		Start:     start,
+		End:       end,
+		ChunkSize: chunkSize,
+		Policies: NormalizedPolicy{
+			RequireConsent:       r.Policies.RequireConsent,
+			AllowedJurisdictions: allowed,
+			RetentionCutoff:      cutoff,
+		},
+		SourceRecords:     normalizedRecords,
+		ExistingTargetIDs: existing,
+		Metadata:          r.Metadata,
+	}, nil
+}


### PR DESCRIPTION
## Summary
- add a Go-based backfill orchestrator with partition planning, policy evaluation, proofs, and HTTP endpoints
- provide a TypeScript CLI for plan/dry-run/execute interactions with the orchestrator service
- document PCBO usage, payload expectations, and proof verification workflow

## Testing
- go test ./internal/orchestrator -v

------
https://chatgpt.com/codex/tasks/task_e_68d78f2306f88333b96d2116d5988d2e