### PR TITLE
feat: add QSET quorum-based tool secret escrow service

### DIFF
--- a/sdk/python/maestro_sdk/__init__.py
+++ b/sdk/python/maestro_sdk/__init__.py
@@ -1,0 +1,8 @@
+from .client import MaestroClient
+from .qset import CreateRequestPayload, QsetClient
+
+__all__ = [
+    'MaestroClient',
+    'QsetClient',
+    'CreateRequestPayload',
+]

--- a/sdk/python/maestro_sdk/qset.py
+++ b/sdk/python/maestro_sdk/qset.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+import httpx
+
+
+@dataclass
+class CreateRequestPayload:
+    requester: str
+    tool: str
+    purpose: str
+    scopes: Optional[list[str]] = None
+    expires_at: Optional[str] = None
+
+    def to_json(self) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "requester": self.requester,
+            "tool": self.tool,
+            "purpose": self.purpose,
+        }
+        if self.scopes is not None:
+            payload["scopes"] = self.scopes
+        if self.expires_at is not None:
+            payload["expiresAt"] = self.expires_at
+        return payload
+
+
+class QsetClient:
+    """Minimal client for the QSET service."""
+
+    def __init__(self, base_url: str, approver_key: Optional[str] = None, *, client: Optional[httpx.Client] = None) -> None:
+        self._base_url = base_url.rstrip('/')
+        self._approver_key = approver_key
+        self._client = client or httpx.Client(base_url=self._base_url)
+
+    def close(self) -> None:
+        self._client.close()
+
+    def create_request(self, payload: CreateRequestPayload | Dict[str, Any]) -> Dict[str, Any]:
+        body = payload.to_json() if isinstance(payload, CreateRequestPayload) else payload
+        return self._post('/requests', json=body)
+
+    def get_request(self, request_id: str) -> Dict[str, Any]:
+        return self._get(f'/requests/{request_id}')
+
+    def approve_request(self, request_id: str, approver_key: Optional[str] = None) -> Dict[str, Any]:
+        return self._post(f'/requests/{request_id}/approve', approver_key=approver_key)
+
+    def deny_request(self, request_id: str, approver_key: Optional[str] = None) -> Dict[str, Any]:
+        return self._post(f'/requests/{request_id}/deny', approver_key=approver_key)
+
+    def mint_token(self, request_id: str, approver_key: Optional[str] = None) -> Dict[str, Any]:
+        return self._post(f'/requests/{request_id}/mint', approver_key=approver_key)
+
+    def attenuate_token(self, token_id: str, payload: Dict[str, Any], approver_key: Optional[str] = None) -> Dict[str, Any]:
+        return self._post(f'/tokens/{token_id}/attenuate', json=payload, approver_key=approver_key)
+
+    def get_ledger_public_key(self) -> str:
+        response = self._get('/ledger/public-key')
+        return response['publicKey']
+
+    def _headers(self, approver_key: Optional[str] = None) -> Dict[str, str]:
+        headers = {'Content-Type': 'application/json'}
+        key = approver_key or self._approver_key
+        if key:
+            headers['X-Approver-Key'] = key
+        return headers
+
+    def _get(self, path: str) -> Dict[str, Any]:
+        response = self._client.get(path, headers=self._headers())
+        response.raise_for_status()
+        return response.json()
+
+    def _post(
+        self,
+        path: str,
+        *,
+        json: Optional[Dict[str, Any]] = None,
+        approver_key: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        response = self._client.post(path, json=json, headers=self._headers(approver_key))
+        response.raise_for_status()
+        return response.json()
+
+    def __enter__(self) -> "QsetClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,2 +1,3 @@
 export * from './client';
 export * from '../sdk/ts/src/generated';
+export * from './qset';

--- a/sdk/typescript/src/qset.ts
+++ b/sdk/typescript/src/qset.ts
@@ -1,0 +1,107 @@
+export interface CreateRequestPayload {
+  requester: string;
+  tool: string;
+  purpose: string;
+  scopes?: string[];
+  expiresAt?: string;
+}
+
+export interface RequestRecord {
+  id: string;
+  requester: string;
+  tool: string;
+  purpose: string;
+  scopes: string[];
+  expiresAt: string;
+  createdAt: string;
+  status: 'pending' | 'approved' | 'denied';
+  approvals: Record<string, string>;
+  denials: Record<string, string>;
+  tokenId?: string;
+}
+
+export interface TokenRecord {
+  id: string;
+  requestId: string;
+  parentId?: string;
+  scopes: string[];
+  expiresAt: string;
+  issuedAt: string;
+  secret: string;
+}
+
+export interface AttenuatePayload {
+  scopes?: string[];
+  expiresAt?: string;
+}
+
+export class QsetClient {
+  constructor(private readonly baseUrl: string, private readonly approverKey?: string) {}
+
+  async createRequest(payload: CreateRequestPayload): Promise<RequestRecord> {
+    return this.post<RequestRecord>('/requests', payload);
+  }
+
+  async getRequest(id: string): Promise<RequestRecord> {
+    return this.get<RequestRecord>(`/requests/${id}`);
+  }
+
+  async approveRequest(id: string, approverKey?: string): Promise<RequestRecord> {
+    return this.post<RequestRecord>(`/requests/${id}/approve`, undefined, approverKey);
+  }
+
+  async denyRequest(id: string, approverKey?: string): Promise<RequestRecord> {
+    return this.post<RequestRecord>(`/requests/${id}/deny`, undefined, approverKey);
+  }
+
+  async mintToken(id: string, approverKey?: string): Promise<TokenRecord> {
+    return this.post<TokenRecord>(`/requests/${id}/mint`, undefined, approverKey);
+  }
+
+  async attenuateToken(id: string, payload: AttenuatePayload, approverKey?: string): Promise<TokenRecord> {
+    return this.post<TokenRecord>(`/tokens/${id}/attenuate`, payload, approverKey);
+  }
+
+  async getLedgerPublicKey(): Promise<string> {
+    const response = await this.get<{ publicKey: string }>('/ledger/public-key');
+    return response.publicKey;
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    const response = await fetch(this.baseUrl + path, {
+      headers: this.headers(),
+    });
+    if (!response.ok) {
+      throw this.error(response);
+    }
+    return (await response.json()) as T;
+  }
+
+  private async post<T>(path: string, body?: unknown, approverKey?: string): Promise<T> {
+    const headers = this.headers(approverKey);
+    const response = await fetch(this.baseUrl + path, {
+      method: 'POST',
+      headers,
+      body: body === undefined ? undefined : JSON.stringify(body),
+    });
+    if (!response.ok) {
+      throw this.error(response);
+    }
+    return (await response.json()) as T;
+  }
+
+  private headers(approverKey?: string): HeadersInit {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    const key = approverKey ?? this.approverKey;
+    if (key) {
+      headers['X-Approver-Key'] = key;
+    }
+    return headers;
+  }
+
+  private error(response: Response): Error {
+    return new Error(`QSET request failed: ${response.status}`);
+  }
+}

--- a/services/qset/chaos_test.go
+++ b/services/qset/chaos_test.go
@@ -1,0 +1,189 @@
+package qset_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/summit/qset/internal/core"
+	"github.com/summit/qset/internal/testutil"
+)
+
+type chaosRequest struct {
+	core.Request
+}
+
+type chaosToken struct {
+	core.Token
+}
+
+func TestChaosInvariants(t *testing.T) {
+	harness := testutil.NewHarness(t)
+	handler := harness.Server.Handler()
+	rng := rand.New(rand.NewSource(1234))
+
+	approvers := []string{"alice-key", "bob-key", "carol-key"}
+	scopes := []string{"repo", "workflow", "org"}
+	var requestIDs []string
+	tokens := map[string]chaosToken{}
+
+	for i := 0; i < 250; i++ {
+		op := rng.Intn(5)
+		switch op {
+		case 0: // create
+			body := map[string]any{
+				"requester": randomRequester(rng),
+				"tool":      "github",
+				"purpose":   randomPurpose(rng),
+				"scopes":    subset(rng, scopes),
+			}
+			payload, _ := json.Marshal(body)
+			req := httptest.NewRequest(http.MethodPost, "/requests", bytes.NewReader(payload))
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			if rec.Code == http.StatusCreated || rec.Code == http.StatusOK {
+				var resp chaosRequest
+				_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+				if !contains(requestIDs, resp.ID) {
+					requestIDs = append(requestIDs, resp.ID)
+				}
+			}
+		case 1: // approve
+			if len(requestIDs) == 0 {
+				continue
+			}
+			id := requestIDs[rng.Intn(len(requestIDs))]
+			key := approvers[rng.Intn(len(approvers))]
+			req := httptest.NewRequest(http.MethodPost, "/requests/"+id+"/approve", nil)
+			req.Header.Set("X-Approver-Key", key)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		case 2: // deny
+			if len(requestIDs) == 0 {
+				continue
+			}
+			id := requestIDs[rng.Intn(len(requestIDs))]
+			key := approvers[rng.Intn(len(approvers))]
+			req := httptest.NewRequest(http.MethodPost, "/requests/"+id+"/deny", nil)
+			req.Header.Set("X-Approver-Key", key)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+		case 3: // mint
+			if len(requestIDs) == 0 {
+				continue
+			}
+			id := requestIDs[rng.Intn(len(requestIDs))]
+			key := approvers[rng.Intn(len(approvers))]
+			req := httptest.NewRequest(http.MethodPost, "/requests/"+id+"/mint", nil)
+			req.Header.Set("X-Approver-Key", key)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			if rec.Code == http.StatusCreated || rec.Code == http.StatusOK {
+				var tok chaosToken
+				_ = json.Unmarshal(rec.Body.Bytes(), &tok)
+				tokens[tok.ID] = tok
+			}
+		case 4: // attenuate
+			if len(tokens) == 0 {
+				continue
+			}
+			// Pick random token
+			var parent chaosToken
+			for _, tok := range tokens {
+				parent = tok
+				break
+			}
+			subsetScopes := subset(rng, parent.Scopes)
+			if len(subsetScopes) == 0 {
+				subsetScopes = []string{parent.Scopes[0]}
+			}
+			expires := parent.ExpiresAt.Add(time.Duration(-rng.Intn(3600)) * time.Second)
+			body := map[string]any{
+				"scopes":    subsetScopes,
+				"expiresAt": expires.Format(time.RFC3339),
+			}
+			payload, _ := json.Marshal(body)
+			req := httptest.NewRequest(http.MethodPost, "/tokens/"+parent.ID+"/attenuate", bytes.NewReader(payload))
+			req.Header.Set("X-Approver-Key", approvers[rng.Intn(len(approvers))])
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			if rec.Code == http.StatusCreated {
+				var child chaosToken
+				_ = json.Unmarshal(rec.Body.Bytes(), &child)
+				tokens[child.ID] = child
+			}
+		}
+	}
+
+	// Invariant checks
+	for _, id := range requestIDs {
+		req := httptest.NewRequest(http.MethodGet, "/requests/"+id, nil)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("failed to fetch request %s", id)
+		}
+		var resp chaosRequest
+		_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+		if resp.TokenID != "" && resp.Status != core.StatusApproved {
+			t.Fatalf("token minted without approval for %s", id)
+		}
+		if resp.Status == core.StatusApproved && len(resp.Approvals) < harness.Cfg.Quorum {
+			t.Fatalf("approval count below quorum for %s", id)
+		}
+	}
+
+	for _, tok := range tokens {
+		if tok.ParentID != "" {
+			parent := tokens[tok.ParentID]
+			if !core.IsSubset(parent.Scopes, tok.Scopes) {
+				t.Fatalf("attenuation escalated scopes: %v -> %v", parent.Scopes, tok.Scopes)
+			}
+			if tok.ExpiresAt.After(parent.ExpiresAt) {
+				t.Fatalf("attenuation extended expiry")
+			}
+		} else {
+			toolScopes, _ := harness.Server.ToolScopes("github")
+			if !core.IsSubset(toolScopes, tok.Scopes) {
+				t.Fatalf("mint produced wider scopes than tool policy")
+			}
+		}
+	}
+}
+
+func randomRequester(r *rand.Rand) string {
+	return []string{"dev", "qa", "ops"}[r.Intn(3)]
+}
+
+func randomPurpose(r *rand.Rand) string {
+	return []string{"deploy", "ci", "incident"}[r.Intn(3)]
+}
+
+func subset(r *rand.Rand, scopes []string) []string {
+	if len(scopes) == 0 {
+		return nil
+	}
+	var out []string
+	for _, scope := range scopes {
+		if r.Intn(2) == 1 {
+			out = append(out, scope)
+		}
+	}
+	if len(out) == 0 {
+		out = append(out, scopes[r.Intn(len(scopes))])
+	}
+	return out
+}
+
+func contains(list []string, id string) bool {
+	for _, v := range list {
+		if v == id {
+			return true
+		}
+	}
+	return false
+}

--- a/services/qset/cmd/qset-verify/main.go
+++ b/services/qset/cmd/qset-verify/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/summit/qset/internal/ledger"
+)
+
+func main() {
+	var logPath string
+	var publicKey string
+	flag.StringVar(&logPath, "log", "qset.log", "Path to ledger log file")
+	flag.StringVar(&publicKey, "public-key", "", "Base64 encoded ledger public key")
+	flag.Parse()
+
+	if publicKey == "" {
+		log.Fatal("public key required")
+	}
+	key, err := ledger.DecodePublicKey(publicKey)
+	if err != nil {
+		log.Fatalf("invalid public key: %v", err)
+	}
+	if err := ledger.VerifyFile(logPath, key); err != nil {
+		log.Fatalf("ledger verification failed: %v", err)
+	}
+	fmt.Println("ledger verified")
+}

--- a/services/qset/cmd/qset/main.go
+++ b/services/qset/cmd/qset/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/summit/qset/internal/config"
+	"github.com/summit/qset/internal/ledger"
+	"github.com/summit/qset/internal/server"
+	"github.com/summit/qset/internal/storage"
+)
+
+func main() {
+	var configPath string
+	var addr string
+	flag.StringVar(&configPath, "config", "config.yaml", "Path to QSET YAML config")
+	flag.StringVar(&addr, "addr", ":8080", "HTTP listen address")
+	flag.Parse()
+
+	cfgBytes, err := ioutil.ReadFile(configPath)
+	if err != nil {
+		log.Fatalf("failed to read config: %v", err)
+	}
+
+	cfg, err := config.Parse(cfgBytes)
+	if err != nil {
+		log.Fatalf("failed to parse config: %v", err)
+	}
+
+	seed, err := ledger.DecodePrivateSeed(cfg.Ledger.SecretKey)
+	if err != nil {
+		log.Fatalf("invalid ledger secret key: %v", err)
+	}
+
+	led, err := ledger.New(cfg.Ledger.Path, seed)
+	if err != nil {
+		log.Fatalf("failed to bootstrap ledger: %v", err)
+	}
+
+	store := storage.NewMemory()
+	srv := server.New(cfg, store, led)
+
+	log.Printf("QSET listening on %s (ledger public key: %s)", addr, led.PublicKey())
+	if err := http.ListenAndServe(addr, srv.Handler()); err != nil {
+		log.Fatalf("server error: %v", err)
+	}
+}

--- a/services/qset/config.example.yaml
+++ b/services/qset/config.example.yaml
@@ -1,0 +1,19 @@
+approvers:
+  - name: alice
+    key: alice-key
+  - name: bob
+    key: bob-key
+  - name: carol
+    key: carol-key
+quorum: 2
+tools:
+  - id: github
+    description: GitHub automation token
+    scopes:
+      - repo
+      - workflow
+      - org
+    maxDuration: 24h
+ledger:
+  path: qset.log
+  secretKey: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=

--- a/services/qset/go.mod
+++ b/services/qset/go.mod
@@ -1,0 +1,5 @@
+module github.com/summit/qset
+
+go 1.21
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/services/qset/go.sum
+++ b/services/qset/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/services/qset/internal/config/config.go
+++ b/services/qset/internal/config/config.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config represents the runtime configuration for the QSET service.
+type Config struct {
+	Approvers []ApproverConfig `yaml:"approvers"`
+	Quorum    int              `yaml:"quorum"`
+	Tools     []ToolConfig     `yaml:"tools"`
+	Ledger    LedgerConfig     `yaml:"ledger"`
+}
+
+// ApproverConfig defines an individual approver and their API key.
+type ApproverConfig struct {
+	Name string `yaml:"name"`
+	Key  string `yaml:"key"`
+}
+
+// ToolConfig captures the policy metadata for an issuable tool.
+type ToolConfig struct {
+	ID          string   `yaml:"id"`
+	Description string   `yaml:"description"`
+	Scopes      []string `yaml:"scopes"`
+	MaxDuration Duration `yaml:"maxDuration"`
+}
+
+// LedgerConfig configures append-only ledger behavior.
+type LedgerConfig struct {
+	Path      string `yaml:"path"`
+	SecretKey string `yaml:"secretKey"`
+}
+
+// Duration wraps time.Duration for YAML parsing.
+type Duration struct {
+	time.Duration
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (d *Duration) UnmarshalYAML(value *yaml.Node) error {
+	if value.Tag == "!!null" {
+		*d = Duration{}
+		return nil
+	}
+	var raw string
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	dur, err := time.ParseDuration(raw)
+	if err != nil {
+		return err
+	}
+	d.Duration = dur
+	return nil
+}
+
+// MarshalYAML implements yaml.Marshaler.
+func (d Duration) MarshalYAML() (interface{}, error) {
+	if d.Duration == 0 {
+		return nil, nil
+	}
+	return d.String(), nil
+}
+
+// Validate performs structural validation over the configuration.
+func (c Config) Validate() error {
+	if len(c.Approvers) == 0 {
+		return errors.New("at least one approver must be configured")
+	}
+	if c.Quorum <= 0 {
+		return errors.New("quorum must be positive")
+	}
+	if c.Quorum > len(c.Approvers) {
+		return fmt.Errorf("quorum %d exceeds number of approvers %d", c.Quorum, len(c.Approvers))
+	}
+	if len(c.Tools) == 0 {
+		return errors.New("at least one tool must be configured")
+	}
+	toolIDs := map[string]struct{}{}
+	for _, tool := range c.Tools {
+		if tool.ID == "" {
+			return errors.New("tool id cannot be empty")
+		}
+		if _, exists := toolIDs[tool.ID]; exists {
+			return fmt.Errorf("duplicate tool id %s", tool.ID)
+		}
+		toolIDs[tool.ID] = struct{}{}
+		if len(tool.Scopes) == 0 {
+			return fmt.Errorf("tool %s must define at least one scope", tool.ID)
+		}
+		if tool.MaxDuration.Duration <= 0 {
+			return fmt.Errorf("tool %s must define a positive maxDuration", tool.ID)
+		}
+	}
+	if c.Ledger.Path == "" {
+		return errors.New("ledger.path is required")
+	}
+	if c.Ledger.SecretKey == "" {
+		return errors.New("ledger.secretKey is required")
+	}
+	return nil
+}
+
+// Parse consumes a YAML payload and returns the parsed Config.
+func Parse(data []byte) (Config, error) {
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return Config{}, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}

--- a/services/qset/internal/core/types.go
+++ b/services/qset/internal/core/types.go
@@ -1,0 +1,84 @@
+package core
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sort"
+	"strings"
+	"time"
+)
+
+// RequestStatus enumerates the lifecycle states for a request.
+type RequestStatus string
+
+const (
+	StatusPending  RequestStatus = "pending"
+	StatusApproved RequestStatus = "approved"
+	StatusDenied   RequestStatus = "denied"
+)
+
+// Request captures the approval state for a tool issuance request.
+type Request struct {
+	ID        string               `json:"id"`
+	Requester string               `json:"requester"`
+	Tool      string               `json:"tool"`
+	Purpose   string               `json:"purpose"`
+	Scopes    []string             `json:"scopes"`
+	ExpiresAt time.Time            `json:"expiresAt"`
+	CreatedAt time.Time            `json:"createdAt"`
+	Status    RequestStatus        `json:"status"`
+	Approvals map[string]time.Time `json:"approvals"`
+	Denials   map[string]time.Time `json:"denials"`
+	TokenID   string               `json:"tokenId"`
+}
+
+// Token represents an issued secret with attenuation metadata.
+type Token struct {
+	ID        string    `json:"id"`
+	RequestID string    `json:"requestId"`
+	ParentID  string    `json:"parentId,omitempty"`
+	Scopes    []string  `json:"scopes"`
+	ExpiresAt time.Time `json:"expiresAt"`
+	IssuedAt  time.Time `json:"issuedAt"`
+	Secret    string    `json:"secret"`
+}
+
+// DeterministicRequestID returns a stable identifier for an issuance request.
+func DeterministicRequestID(requester, tool, purpose string, scopes []string, expiresAt time.Time) (string, error) {
+	normalized := append([]string{}, scopes...)
+	sort.Strings(normalized)
+	payload := map[string]any{
+		"requester": requester,
+		"tool":      tool,
+		"purpose":   purpose,
+		"scopes":    normalized,
+		"expiresAt": expiresAt.UTC().Format(time.RFC3339Nano),
+	}
+	bytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(bytes)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+// CloneScopes returns a copy of scopes.
+func CloneScopes(in []string) []string {
+	cp := append([]string{}, in...)
+	return cp
+}
+
+// IsSubset returns true when child is a subset of parent.
+func IsSubset(parent, child []string) bool {
+	parentSet := map[string]struct{}{}
+	for _, s := range parent {
+		parentSet[strings.ToLower(s)] = struct{}{}
+	}
+	for _, s := range child {
+		if _, ok := parentSet[strings.ToLower(s)]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/services/qset/internal/ledger/ledger.go
+++ b/services/qset/internal/ledger/ledger.go
@@ -1,0 +1,239 @@
+package ledger
+
+import (
+	"bufio"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Attribute is a key/value pair embedded in ledger entries.
+type Attribute struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// EntryPayload represents the canonical material that is hashed and signed.
+type EntryPayload struct {
+	Index      int         `json:"index"`
+	Timestamp  time.Time   `json:"timestamp"`
+	Event      string      `json:"event"`
+	RequestID  string      `json:"requestId,omitempty"`
+	TokenID    string      `json:"tokenId,omitempty"`
+	Attributes []Attribute `json:"attributes,omitempty"`
+	PrevHash   string      `json:"prevHash,omitempty"`
+}
+
+// Entry is the persisted ledger record.
+type Entry struct {
+	EntryPayload
+	Hash      string `json:"hash"`
+	Signature string `json:"signature"`
+}
+
+// Ledger implements an append-only, signed log of service events.
+type Ledger struct {
+	mu       sync.Mutex
+	path     string
+	private  ed25519.PrivateKey
+	public   ed25519.PublicKey
+	lastHash string
+	index    int
+}
+
+// New constructs or resumes a ledger from disk.
+func New(path string, secretKey []byte) (*Ledger, error) {
+	if len(secretKey) != ed25519.SeedSize {
+		return nil, fmt.Errorf("ledger secret key must be %d bytes", ed25519.SeedSize)
+	}
+	priv := ed25519.NewKeyFromSeed(secretKey)
+	ledger := &Ledger{
+		path:    path,
+		private: priv,
+		public:  priv.Public().(ed25519.PublicKey),
+	}
+	if err := ledger.bootstrap(); err != nil {
+		return nil, err
+	}
+	return ledger, nil
+}
+
+func (l *Ledger) bootstrap() error {
+	file, err := os.Open(l.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		var entry Entry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			return fmt.Errorf("failed to parse ledger entry: %w", err)
+		}
+		if err := l.verifyEntry(entry); err != nil {
+			return fmt.Errorf("ledger integrity violation: %w", err)
+		}
+		l.index = entry.Index
+		l.lastHash = entry.Hash
+	}
+	return scanner.Err()
+}
+
+// Append adds an event to the ledger.
+func (l *Ledger) Append(event, requestID, tokenID string, attrs []Attribute) (Entry, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	payload := EntryPayload{
+		Index:      l.index + 1,
+		Timestamp:  time.Now().UTC(),
+		Event:      event,
+		RequestID:  requestID,
+		TokenID:    tokenID,
+		Attributes: sortAttributes(attrs),
+		PrevHash:   l.lastHash,
+	}
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return Entry{}, err
+	}
+	sum := sha256.Sum256(payloadBytes)
+	hash := base64.StdEncoding.EncodeToString(sum[:])
+	sig := ed25519.Sign(l.private, sum[:])
+
+	entry := Entry{EntryPayload: payload, Hash: hash, Signature: base64.StdEncoding.EncodeToString(sig)}
+
+	if err := l.appendToDisk(entry); err != nil {
+		return Entry{}, err
+	}
+	l.index = payload.Index
+	l.lastHash = hash
+	return entry, nil
+}
+
+func (l *Ledger) appendToDisk(entry Entry) error {
+	file, err := os.OpenFile(l.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	enc := json.NewEncoder(file)
+	if err := enc.Encode(entry); err != nil {
+		return err
+	}
+	return nil
+}
+
+func sortAttributes(attrs []Attribute) []Attribute {
+	cp := append([]Attribute{}, attrs...)
+	sort.Slice(cp, func(i, j int) bool { return cp[i].Key < cp[j].Key })
+	return cp
+}
+
+func (l *Ledger) verifyEntry(entry Entry) error {
+	payloadBytes, err := json.Marshal(entry.EntryPayload)
+	if err != nil {
+		return err
+	}
+	sum := sha256.Sum256(payloadBytes)
+	decodedSig, err := base64.StdEncoding.DecodeString(entry.Signature)
+	if err != nil {
+		return err
+	}
+	if !ed25519.Verify(l.public, sum[:], decodedSig) {
+		return errors.New("invalid ledger signature")
+	}
+	if entry.Hash != base64.StdEncoding.EncodeToString(sum[:]) {
+		return errors.New("hash mismatch")
+	}
+	if entry.EntryPayload.Index != 1 && entry.EntryPayload.PrevHash == "" {
+		return errors.New("missing prev hash")
+	}
+	if l.lastHash != "" && entry.EntryPayload.PrevHash != l.lastHash {
+		return fmt.Errorf("broken chain: expected %s got %s", l.lastHash, entry.EntryPayload.PrevHash)
+	}
+	return nil
+}
+
+// PublicKey returns the ledger public key as base64.
+func (l *Ledger) PublicKey() string {
+	return base64.StdEncoding.EncodeToString(l.public)
+}
+
+// VerifyFile performs offline verification for a ledger file.
+func VerifyFile(path string, publicKey ed25519.PublicKey) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	var prevHash string
+	var index int
+	for scanner.Scan() {
+		var entry Entry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			return err
+		}
+		payloadBytes, err := json.Marshal(entry.EntryPayload)
+		if err != nil {
+			return err
+		}
+		sum := sha256.Sum256(payloadBytes)
+		decodedSig, err := base64.StdEncoding.DecodeString(entry.Signature)
+		if err != nil {
+			return err
+		}
+		if !ed25519.Verify(publicKey, sum[:], decodedSig) {
+			return fmt.Errorf("invalid signature at index %d", entry.Index)
+		}
+		if entry.Hash != base64.StdEncoding.EncodeToString(sum[:]) {
+			return fmt.Errorf("hash mismatch at index %d", entry.Index)
+		}
+		if entry.Index != index+1 {
+			return fmt.Errorf("unexpected index %d", entry.Index)
+		}
+		if index > 0 && entry.PrevHash != prevHash {
+			return fmt.Errorf("chain mismatch at index %d", entry.Index)
+		}
+		prevHash = entry.Hash
+		index = entry.Index
+	}
+	return scanner.Err()
+}
+
+// DecodePublicKey converts a base64 string into a public key instance.
+func DecodePublicKey(b64 string) (ed25519.PublicKey, error) {
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("expected %d bytes public key", ed25519.PublicKeySize)
+	}
+	return ed25519.PublicKey(raw), nil
+}
+
+// DecodePrivateSeed decodes a base64-encoded ed25519 seed.
+func DecodePrivateSeed(b64 string) ([]byte, error) {
+	raw, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, err
+	}
+	if len(raw) != ed25519.SeedSize {
+		return nil, fmt.Errorf("expected %d byte seed", ed25519.SeedSize)
+	}
+	return raw, nil
+}

--- a/services/qset/internal/server/server.go
+++ b/services/qset/internal/server/server.go
@@ -1,0 +1,414 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/summit/qset/internal/config"
+	"github.com/summit/qset/internal/core"
+	"github.com/summit/qset/internal/ledger"
+	"github.com/summit/qset/internal/storage"
+)
+
+// Server is the HTTP front-end for the QSET service.
+type Server struct {
+	cfg          config.Config
+	store        *storage.Memory
+	ledger       *ledger.Ledger
+	approverKeys map[string]string
+	tools        map[string]config.ToolConfig
+}
+
+// New constructs a new Server instance.
+func New(cfg config.Config, store *storage.Memory, ledger *ledger.Ledger) *Server {
+	keys := make(map[string]string, len(cfg.Approvers))
+	for _, appr := range cfg.Approvers {
+		keys[strings.TrimSpace(appr.Key)] = appr.Name
+	}
+	tools := make(map[string]config.ToolConfig, len(cfg.Tools))
+	for _, tool := range cfg.Tools {
+		tools[tool.ID] = tool
+	}
+	return &Server{
+		cfg:          cfg,
+		store:        store,
+		ledger:       ledger,
+		approverKeys: keys,
+		tools:        tools,
+	}
+}
+
+// Handler wires the server into an http.Handler.
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/requests", s.handleRequests)
+	mux.HandleFunc("/requests/", s.handleRequestByID)
+	mux.HandleFunc("/tokens/", s.handleTokenByID)
+	mux.HandleFunc("/ledger/public-key", s.handlePublicKey)
+	return mux
+}
+
+func (s *Server) handleRequests(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		s.handleCreateRequest(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleRequestByID(w http.ResponseWriter, r *http.Request) {
+	segments := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(segments) < 2 {
+		http.NotFound(w, r)
+		return
+	}
+	id := segments[1]
+	if len(segments) == 2 && r.Method == http.MethodGet {
+		s.handleGetRequest(w, r, id)
+		return
+	}
+	if len(segments) == 3 {
+		switch segments[2] {
+		case "approve":
+			if r.Method == http.MethodPost {
+				s.handleApprove(w, r, id)
+				return
+			}
+		case "deny":
+			if r.Method == http.MethodPost {
+				s.handleDeny(w, r, id)
+				return
+			}
+		case "mint":
+			if r.Method == http.MethodPost {
+				s.handleMint(w, r, id)
+				return
+			}
+		}
+	}
+	http.Error(w, "not found", http.StatusNotFound)
+}
+
+func (s *Server) handleTokenByID(w http.ResponseWriter, r *http.Request) {
+	segments := strings.Split(strings.Trim(r.URL.Path, "/"), "/")
+	if len(segments) < 2 {
+		http.NotFound(w, r)
+		return
+	}
+	id := segments[1]
+	if len(segments) == 3 && segments[2] == "attenuate" && r.Method == http.MethodPost {
+		s.handleAttenuate(w, r, id)
+		return
+	}
+	http.Error(w, "not found", http.StatusNotFound)
+}
+
+func (s *Server) handlePublicKey(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	respond(w, http.StatusOK, map[string]string{"publicKey": s.ledger.PublicKey()})
+}
+
+type createRequestInput struct {
+	Requester string   `json:"requester"`
+	Tool      string   `json:"tool"`
+	Purpose   string   `json:"purpose"`
+	Scopes    []string `json:"scopes"`
+	ExpiresAt string   `json:"expiresAt"`
+}
+
+func (s *Server) handleCreateRequest(w http.ResponseWriter, r *http.Request) {
+	var input createRequestInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	tool, ok := s.tools[input.Tool]
+	if !ok {
+		http.Error(w, "unknown tool", http.StatusBadRequest)
+		return
+	}
+	if input.Requester == "" || input.Purpose == "" {
+		http.Error(w, "requester and purpose required", http.StatusBadRequest)
+		return
+	}
+	if len(input.Scopes) == 0 {
+		input.Scopes = core.CloneScopes(tool.Scopes)
+	}
+	if !core.IsSubset(tool.Scopes, input.Scopes) {
+		http.Error(w, "requested scopes exceed tool policy", http.StatusBadRequest)
+		return
+	}
+	var (
+		expires         time.Time
+		canonicalExpiry time.Time
+	)
+	if input.ExpiresAt == "" {
+		expires = time.Now().Add(tool.MaxDuration.Duration)
+		canonicalExpiry = time.Unix(0, 0).Add(tool.MaxDuration.Duration)
+	} else {
+		parsed, err := time.Parse(time.RFC3339, input.ExpiresAt)
+		if err != nil {
+			http.Error(w, "invalid expiresAt", http.StatusBadRequest)
+			return
+		}
+		expires = parsed
+		canonicalExpiry = expires
+	}
+	if expires.After(time.Now().Add(tool.MaxDuration.Duration)) {
+		http.Error(w, "expiry exceeds tool policy", http.StatusBadRequest)
+		return
+	}
+	expires = expires.UTC()
+	id, err := core.DeterministicRequestID(input.Requester, input.Tool, input.Purpose, input.Scopes, canonicalExpiry.UTC())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if existing, ok := s.store.GetRequest(id); ok {
+		respond(w, http.StatusOK, existing)
+		return
+	}
+	req := &core.Request{
+		ID:        id,
+		Requester: input.Requester,
+		Tool:      input.Tool,
+		Purpose:   input.Purpose,
+		Scopes:    core.CloneScopes(input.Scopes),
+		ExpiresAt: expires,
+		CreatedAt: time.Now().UTC(),
+		Status:    core.StatusPending,
+		Approvals: map[string]time.Time{},
+		Denials:   map[string]time.Time{},
+	}
+	stored := s.store.UpsertRequest(req)
+	_, _ = s.ledger.Append("request.created", stored.ID, "", []ledger.Attribute{
+		{Key: "requester", Value: stored.Requester},
+		{Key: "tool", Value: stored.Tool},
+	})
+	respond(w, http.StatusCreated, stored)
+}
+
+func (s *Server) handleGetRequest(w http.ResponseWriter, r *http.Request, id string) {
+	req, ok := s.store.GetRequest(id)
+	if !ok {
+		http.Error(w, "request not found", http.StatusNotFound)
+		return
+	}
+	respond(w, http.StatusOK, req)
+}
+
+func (s *Server) handleApprove(w http.ResponseWriter, r *http.Request, id string) {
+	approver, err := s.authorizeApprover(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	req, ok := s.store.GetRequest(id)
+	if !ok {
+		http.Error(w, "request not found", http.StatusNotFound)
+		return
+	}
+	if req.Status == core.StatusDenied {
+		http.Error(w, "request denied", http.StatusConflict)
+		return
+	}
+	if req.Status == core.StatusApproved && req.Approvals[approver] != (time.Time{}) {
+		respond(w, http.StatusOK, req)
+		return
+	}
+	req.Approvals[approver] = time.Now().UTC()
+	delete(req.Denials, approver)
+	req.Status = s.resolveStatus(req)
+	if err := s.store.UpdateRequest(req); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = s.ledger.Append("request.approved", req.ID, "", []ledger.Attribute{{Key: "approver", Value: approver}})
+	respond(w, http.StatusOK, req)
+}
+
+func (s *Server) handleDeny(w http.ResponseWriter, r *http.Request, id string) {
+	approver, err := s.authorizeApprover(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	req, ok := s.store.GetRequest(id)
+	if !ok {
+		http.Error(w, "request not found", http.StatusNotFound)
+		return
+	}
+	if req.TokenID != "" {
+		http.Error(w, "token already minted", http.StatusConflict)
+		return
+	}
+	req.Denials[approver] = time.Now().UTC()
+	delete(req.Approvals, approver)
+	req.Status = core.StatusDenied
+	if err := s.store.UpdateRequest(req); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = s.ledger.Append("request.denied", req.ID, "", []ledger.Attribute{{Key: "approver", Value: approver}})
+	respond(w, http.StatusOK, req)
+}
+
+func (s *Server) handleMint(w http.ResponseWriter, r *http.Request, id string) {
+	approver, err := s.authorizeApprover(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	_ = approver // minting requires authenticated operator but we don't record
+	req, ok := s.store.GetRequest(id)
+	if !ok {
+		http.Error(w, "request not found", http.StatusNotFound)
+		return
+	}
+	if req.Status != core.StatusApproved {
+		http.Error(w, "quorum not satisfied", http.StatusForbidden)
+		return
+	}
+	if req.TokenID != "" {
+		token, ok := s.store.GetToken(req.TokenID)
+		if !ok {
+			http.Error(w, "token missing", http.StatusInternalServerError)
+			return
+		}
+		respond(w, http.StatusOK, token)
+		return
+	}
+	secret := storage.GenerateSecret()
+	token := &core.Token{
+		RequestID: req.ID,
+		Scopes:    core.CloneScopes(req.Scopes),
+		ExpiresAt: req.ExpiresAt,
+		IssuedAt:  time.Now().UTC(),
+		Secret:    secret,
+	}
+	minted, err := s.store.MintToken(token)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	req.TokenID = minted.ID
+	if err := s.store.UpdateRequest(req); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = s.ledger.Append("token.minted", req.ID, minted.ID, []ledger.Attribute{{Key: "scopes", Value: strings.Join(minted.Scopes, ",")}})
+	respond(w, http.StatusCreated, minted)
+}
+
+type attenuateInput struct {
+	Scopes    []string `json:"scopes"`
+	ExpiresAt string   `json:"expiresAt"`
+}
+
+func (s *Server) handleAttenuate(w http.ResponseWriter, r *http.Request, id string) {
+	approver, err := s.authorizeApprover(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	_ = approver
+	parent, ok := s.store.GetToken(id)
+	if !ok {
+		http.Error(w, "token not found", http.StatusNotFound)
+		return
+	}
+	var input attenuateInput
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(input.Scopes) == 0 {
+		input.Scopes = core.CloneScopes(parent.Scopes)
+	}
+	if !core.IsSubset(parent.Scopes, input.Scopes) {
+		http.Error(w, "attenuation must reduce scopes", http.StatusBadRequest)
+		return
+	}
+	expires := parent.ExpiresAt
+	if input.ExpiresAt != "" {
+		parsed, err := time.Parse(time.RFC3339, input.ExpiresAt)
+		if err != nil {
+			http.Error(w, "invalid expiresAt", http.StatusBadRequest)
+			return
+		}
+		expires = parsed
+	}
+	if expires.After(parent.ExpiresAt) {
+		http.Error(w, "attenuation cannot extend expiry", http.StatusBadRequest)
+		return
+	}
+	secret := storage.GenerateSecret()
+	token := &core.Token{
+		RequestID: parent.RequestID,
+		ParentID:  parent.ID,
+		Scopes:    core.CloneScopes(input.Scopes),
+		ExpiresAt: expires,
+		IssuedAt:  time.Now().UTC(),
+		Secret:    secret,
+	}
+	minted, err := s.store.MintToken(token)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = s.ledger.Append("token.attenuated", parent.RequestID, minted.ID, []ledger.Attribute{{Key: "parent", Value: parent.ID}})
+	respond(w, http.StatusCreated, minted)
+}
+
+func (s *Server) authorizeApprover(r *http.Request) (string, error) {
+	key := strings.TrimSpace(r.Header.Get("X-Approver-Key"))
+	if key == "" {
+		return "", errors.New("approver key required")
+	}
+	name, ok := s.approverKeys[key]
+	if !ok {
+		return "", errors.New("invalid approver key")
+	}
+	return name, nil
+}
+
+func (s *Server) resolveStatus(req *core.Request) core.RequestStatus {
+	if len(req.Denials) > 0 {
+		return core.StatusDenied
+	}
+	unique := make(map[string]struct{})
+	for k := range req.Approvals {
+		unique[k] = struct{}{}
+	}
+	if len(unique) >= s.cfg.Quorum {
+		return core.StatusApproved
+	}
+	return core.StatusPending
+}
+
+func respond(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(v)
+}
+
+// ToolScopes exposes tool scopes for clients (useful in tests).
+func (s *Server) ToolScopes(tool string) ([]string, bool) {
+	cfg, ok := s.tools[tool]
+	if !ok {
+		return nil, false
+	}
+	scopes := append([]string{}, cfg.Scopes...)
+	sort.Strings(scopes)
+	return scopes, true
+}

--- a/services/qset/internal/server/server_test.go
+++ b/services/qset/internal/server/server_test.go
@@ -1,0 +1,253 @@
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/summit/qset/internal/core"
+	"github.com/summit/qset/internal/ledger"
+	"github.com/summit/qset/internal/testutil"
+)
+
+type responseRequest struct {
+	core.Request
+}
+
+type responseToken struct {
+	core.Token
+}
+
+func TestQuorumRequiredForMint(t *testing.T) {
+	harness := testutil.NewHarness(t)
+	handler := harness.Server.Handler()
+
+	reqBody := map[string]any{
+		"requester": "dev1",
+		"tool":      "github",
+		"purpose":   "release",
+		"scopes":    []string{"repo", "workflow"},
+	}
+	reqJSON, _ := json.Marshal(reqBody)
+	rec := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/requests", bytes.NewReader(reqJSON))
+	handler.ServeHTTP(rec, request)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 got %d: %s", rec.Code, rec.Body.String())
+	}
+	var created responseRequest
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Attempt mint without quorum.
+	mintReq := httptest.NewRequest(http.MethodPost, "/requests/"+created.ID+"/mint", nil)
+	mintReq.Header.Set("X-Approver-Key", "alice-key")
+	mintRec := httptest.NewRecorder()
+	handler.ServeHTTP(mintRec, mintReq)
+	if mintRec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 got %d", mintRec.Code)
+	}
+
+	approve := func(key string) {
+		req := httptest.NewRequest(http.MethodPost, "/requests/"+created.ID+"/approve", nil)
+		req.Header.Set("X-Approver-Key", key)
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("approve (%s) => %d: %s", key, rec.Code, rec.Body.String())
+		}
+	}
+
+	approve("alice-key")
+	approve("bob-key")
+
+	mintReq2 := httptest.NewRequest(http.MethodPost, "/requests/"+created.ID+"/mint", nil)
+	mintReq2.Header.Set("X-Approver-Key", "alice-key")
+	mintRec2 := httptest.NewRecorder()
+	handler.ServeHTTP(mintRec2, mintReq2)
+	if mintRec2.Code != http.StatusCreated {
+		t.Fatalf("expected 201 got %d: %s", mintRec2.Code, mintRec2.Body.String())
+	}
+	var token responseToken
+	if err := json.Unmarshal(mintRec2.Body.Bytes(), &token); err != nil {
+		t.Fatalf("token decode: %v", err)
+	}
+	if token.Secret == "" {
+		t.Fatal("expected secret")
+	}
+}
+
+func TestAttenuationConstraints(t *testing.T) {
+	harness := testutil.NewHarness(t)
+	handler := harness.Server.Handler()
+
+	body := map[string]any{
+		"requester": "dev2",
+		"tool":      "github",
+		"purpose":   "ci",
+	}
+	payload, _ := json.Marshal(body)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/requests", bytes.NewReader(payload))
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create => %d", rec.Code)
+	}
+	var created responseRequest
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+
+	// Approve twice.
+	for _, key := range []string{"alice-key", "bob-key"} {
+		r := httptest.NewRequest(http.MethodPost, "/requests/"+created.ID+"/approve", nil)
+		r.Header.Set("X-Approver-Key", key)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, r)
+		if rr.Code != http.StatusOK {
+			t.Fatalf("approve => %d", rr.Code)
+		}
+	}
+
+	mint := httptest.NewRequest(http.MethodPost, "/requests/"+created.ID+"/mint", nil)
+	mint.Header.Set("X-Approver-Key", "alice-key")
+	mintRec := httptest.NewRecorder()
+	handler.ServeHTTP(mintRec, mint)
+	if mintRec.Code != http.StatusCreated {
+		t.Fatalf("mint => %d: %s", mintRec.Code, mintRec.Body.String())
+	}
+	var token responseToken
+	_ = json.Unmarshal(mintRec.Body.Bytes(), &token)
+
+	// Try to extend scopes (should fail).
+	badPayload := map[string]any{"scopes": []string{"repo", "workflow", "admin"}}
+	badJSON, _ := json.Marshal(badPayload)
+	badReq := httptest.NewRequest(http.MethodPost, "/tokens/"+token.ID+"/attenuate", bytes.NewReader(badJSON))
+	badReq.Header.Set("X-Approver-Key", "alice-key")
+	badRec := httptest.NewRecorder()
+	handler.ServeHTTP(badRec, badReq)
+	if badRec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 got %d", badRec.Code)
+	}
+
+	// Try to extend expiry (should fail).
+	extendPayload := map[string]any{"expiresAt": token.ExpiresAt.Add(1 * time.Hour).Format(time.RFC3339)}
+	extendJSON, _ := json.Marshal(extendPayload)
+	extendReq := httptest.NewRequest(http.MethodPost, "/tokens/"+token.ID+"/attenuate", bytes.NewReader(extendJSON))
+	extendReq.Header.Set("X-Approver-Key", "alice-key")
+	extendRec := httptest.NewRecorder()
+	handler.ServeHTTP(extendRec, extendReq)
+	if extendRec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 got %d", extendRec.Code)
+	}
+
+	// Valid attenuation reduces scopes and expiry.
+	okPayload := map[string]any{
+		"scopes":    []string{"repo"},
+		"expiresAt": token.ExpiresAt.Add(-1 * time.Hour).Format(time.RFC3339),
+	}
+	okJSON, _ := json.Marshal(okPayload)
+	okReq := httptest.NewRequest(http.MethodPost, "/tokens/"+token.ID+"/attenuate", bytes.NewReader(okJSON))
+	okReq.Header.Set("X-Approver-Key", "alice-key")
+	okRec := httptest.NewRecorder()
+	handler.ServeHTTP(okRec, okReq)
+	if okRec.Code != http.StatusCreated {
+		t.Fatalf("expected 201 got %d: %s", okRec.Code, okRec.Body.String())
+	}
+}
+
+func TestDeterministicRequests(t *testing.T) {
+	harness := testutil.NewHarness(t)
+	handler := harness.Server.Handler()
+
+	payload := map[string]any{
+		"requester": "dev3",
+		"tool":      "github",
+		"purpose":   "release",
+		"scopes":    []string{"repo"},
+	}
+	jsonBody, _ := json.Marshal(payload)
+
+	rec1 := httptest.NewRecorder()
+	handler.ServeHTTP(rec1, httptest.NewRequest(http.MethodPost, "/requests", bytes.NewReader(jsonBody)))
+	if rec1.Code != http.StatusCreated {
+		t.Fatalf("create1 => %d", rec1.Code)
+	}
+	var first responseRequest
+	_ = json.Unmarshal(rec1.Body.Bytes(), &first)
+
+	// Approve once.
+	apprReq := httptest.NewRequest(http.MethodPost, "/requests/"+first.ID+"/approve", nil)
+	apprReq.Header.Set("X-Approver-Key", "alice-key")
+	apprRec := httptest.NewRecorder()
+	handler.ServeHTTP(apprRec, apprReq)
+	if apprRec.Code != http.StatusOK {
+		t.Fatalf("approve => %d", apprRec.Code)
+	}
+
+	// Duplicate request returns same ID and carries prior approval state.
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, httptest.NewRequest(http.MethodPost, "/requests", bytes.NewReader(jsonBody)))
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("create2 => %d", rec2.Code)
+	}
+	var second responseRequest
+	_ = json.Unmarshal(rec2.Body.Bytes(), &second)
+	if second.ID != first.ID {
+		t.Fatalf("expected same id got %s vs %s", second.ID, first.ID)
+	}
+	if len(second.Approvals) != 1 {
+		t.Fatalf("expected one approval got %d", len(second.Approvals))
+	}
+	if second.Status != core.StatusPending {
+		t.Fatalf("expected pending got %s", second.Status)
+	}
+}
+
+func TestLedgerVerification(t *testing.T) {
+	harness := testutil.NewHarness(t)
+	handler := harness.Server.Handler()
+
+	body := map[string]any{
+		"requester": "ops",
+		"tool":      "github",
+		"purpose":   "release",
+	}
+	req := httptest.NewRequest(http.MethodPost, "/requests", bytes.NewReader(mustJSON(body)))
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create => %d", rec.Code)
+	}
+	var created responseRequest
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Force some ledger activity.
+	for _, key := range []string{"alice-key", "bob-key"} {
+		approve := httptest.NewRequest(http.MethodPost, "/requests/"+created.ID+"/approve", nil)
+		approve.Header.Set("X-Approver-Key", key)
+		recorder := httptest.NewRecorder()
+		handler.ServeHTTP(recorder, approve)
+		if recorder.Code != http.StatusOK {
+			t.Fatalf("approve => %d", recorder.Code)
+		}
+	}
+
+	// Verify ledger.
+	pubKey, err := ledger.DecodePublicKey(harness.PublicKey())
+	if err != nil {
+		t.Fatalf("decode public key: %v", err)
+	}
+	if err := ledger.VerifyFile(harness.Cfg.Ledger.Path, pubKey); err != nil {
+		t.Fatalf("verification failed: %v", err)
+	}
+}
+
+func mustJSON(v any) []byte {
+	data, _ := json.Marshal(v)
+	return data
+}

--- a/services/qset/internal/storage/memory.go
+++ b/services/qset/internal/storage/memory.go
@@ -1,0 +1,119 @@
+package storage
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/summit/qset/internal/core"
+)
+
+// Memory is an in-memory implementation of the store backend.
+type Memory struct {
+	mu       sync.Mutex
+	requests map[string]*core.Request
+	tokens   map[string]*core.Token
+}
+
+// NewMemory constructs a Memory store.
+func NewMemory() *Memory {
+	return &Memory{
+		requests: make(map[string]*core.Request),
+		tokens:   make(map[string]*core.Token),
+	}
+}
+
+// UpsertRequest inserts or returns an existing request based on deterministic ID.
+func (m *Memory) UpsertRequest(req *core.Request) *core.Request {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if existing, ok := m.requests[req.ID]; ok {
+		return cloneRequest(existing)
+	}
+	stored := cloneRequest(req)
+	m.requests[req.ID] = stored
+	return cloneRequest(stored)
+}
+
+// GetRequest returns a copy of the stored request.
+func (m *Memory) GetRequest(id string) (*core.Request, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	req, ok := m.requests[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneRequest(req), true
+}
+
+// UpdateRequest mutates an existing request.
+func (m *Memory) UpdateRequest(req *core.Request) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.requests[req.ID]; !ok {
+		return errors.New("request not found")
+	}
+	m.requests[req.ID] = cloneRequest(req)
+	return nil
+}
+
+// MintToken persists a token. Token IDs are generated if empty.
+func (m *Memory) MintToken(tok *core.Token) (*core.Token, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if tok.ID == "" {
+		tok.ID = generateID()
+	}
+	if _, exists := m.tokens[tok.ID]; exists {
+		return nil, fmt.Errorf("token %s already exists", tok.ID)
+	}
+	stored := cloneToken(tok)
+	m.tokens[tok.ID] = stored
+	return cloneToken(stored), nil
+}
+
+// GetToken fetches a token by ID.
+func (m *Memory) GetToken(id string) (*core.Token, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	tok, ok := m.tokens[id]
+	if !ok {
+		return nil, false
+	}
+	return cloneToken(tok), true
+}
+
+func cloneRequest(in *core.Request) *core.Request {
+	cp := *in
+	cp.Scopes = core.CloneScopes(in.Scopes)
+	cp.Approvals = map[string]time.Time{}
+	for k, v := range in.Approvals {
+		cp.Approvals[k] = v
+	}
+	cp.Denials = map[string]time.Time{}
+	for k, v := range in.Denials {
+		cp.Denials[k] = v
+	}
+	return &cp
+}
+
+func cloneToken(in *core.Token) *core.Token {
+	cp := *in
+	cp.Scopes = core.CloneScopes(in.Scopes)
+	return &cp
+}
+
+func GenerateSecret() string {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		panic(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf)
+}
+
+func generateID() string {
+	return GenerateSecret()
+}

--- a/services/qset/internal/testutil/testutil.go
+++ b/services/qset/internal/testutil/testutil.go
@@ -1,0 +1,66 @@
+package testutil
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/summit/qset/internal/config"
+	"github.com/summit/qset/internal/ledger"
+	"github.com/summit/qset/internal/server"
+	"github.com/summit/qset/internal/storage"
+)
+
+// Harness bundles together the runtime dependencies for integration tests.
+type Harness struct {
+	pubKey string
+	Cfg    config.Config
+	Store  *storage.Memory
+	Ledger *ledger.Ledger
+	Server *server.Server
+}
+
+// NewHarness constructs a ready-to-use Harness for tests.
+func NewHarness(t *testing.T) *Harness {
+	t.Helper()
+	seed := make([]byte, 32)
+	if _, err := rand.Read(seed); err != nil {
+		t.Fatalf("rand: %v", err)
+	}
+	cfg := config.Config{
+		Approvers: []config.ApproverConfig{
+			{Name: "alice", Key: "alice-key"},
+			{Name: "bob", Key: "bob-key"},
+			{Name: "carol", Key: "carol-key"},
+		},
+		Quorum: 2,
+		Tools: []config.ToolConfig{
+			{
+				ID:          "github",
+				Description: "GitHub API",
+				Scopes:      []string{"repo", "workflow", "org"},
+				MaxDuration: config.Duration{Duration: 24 * time.Hour},
+			},
+		},
+		Ledger: config.LedgerConfig{
+			Path:      t.TempDir() + "/ledger.log",
+			SecretKey: base64.StdEncoding.EncodeToString(seed),
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("config validation: %v", err)
+	}
+	led, err := ledger.New(cfg.Ledger.Path, seed)
+	if err != nil {
+		t.Fatalf("ledger: %v", err)
+	}
+	store := storage.NewMemory()
+	srv := server.New(cfg, store, led)
+	return &Harness{pubKey: led.PublicKey(), Cfg: cfg, Store: store, Ledger: led, Server: srv}
+}
+
+// PublicKey returns the ledger public key used by the harness.
+func (h *Harness) PublicKey() string {
+	return h.pubKey
+}


### PR DESCRIPTION
## Summary
- implement the Go-based QSET service with quorum approvals, attenuation safeguards, deterministic requests, and signed issuance ledger
- add TypeScript and Python SDK clients for interacting with QSET APIs and retrieving ledger public keys
- provide chaos/integration tests and ledger verification tooling to guarantee invariants and offline validation

## Testing
- (cd services/qset && go test ./...)


------
https://chatgpt.com/codex/tasks/task_e_68d78ec61a1c8333a65b1d1e1f3c3b3b