### PR TITLE
feat: add iftc static analyzer

### DIFF
--- a/ga-graphai/packages/iftc/AGENTS.md
+++ b/ga-graphai/packages/iftc/AGENTS.md
@@ -1,0 +1,3 @@
+- Static analyzer implementation lives here.
+- Use 2 spaces for TypeScript and keep files formatted with Prettier defaults.
+- Provide unit tests under `tests/` and run `npm test` after changes.

--- a/ga-graphai/packages/iftc/package.json
+++ b/ga-graphai/packages/iftc/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "iftc",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "types": "./src/index.ts",
+  "bin": {
+    "iftc": "./dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "ts-node": "^10.9.2",
+    "tslib": "^2.6.2",
+    "typescript": "^5.4.5",
+    "vitest": "^1.5.0"
+  }
+}

--- a/ga-graphai/packages/iftc/src/analyzer.ts
+++ b/ga-graphai/packages/iftc/src/analyzer.ts
@@ -1,0 +1,220 @@
+import {
+  AnalysisResult,
+  AnnotatedFile,
+  FlowDiagnostic,
+  FlowEdge,
+  Label,
+  SecurityLevel,
+  Transform,
+} from './types';
+
+const SECURITY_RANK: Record<SecurityLevel, number> = {
+  low: 0,
+  medium: 1,
+  high: 2,
+};
+
+function formatPurposes(label: Label | undefined): string {
+  if (!label) {
+    return 'purposes: ∅';
+  }
+  if (label.purposes.size === 0) {
+    return 'purposes: ∅';
+  }
+  return `purposes: ${Array.from(label.purposes).sort().join(', ')}`;
+}
+
+function formatTrace(source: Label | undefined, target: Label | undefined, flow: FlowEdge): string[] {
+  const segments: string[] = [];
+  const srcDescription = source
+    ? `${source.id} [${source.security}] ${formatPurposes(source)} @ ${source.filePath}:${source.line}`
+    : `${flow.source} [unlabeled] @ ${flow.filePath}:${flow.line}`;
+  segments.push(srcDescription);
+  const tgtDescription = target
+    ? `${target.id} [${target.security}] ${formatPurposes(target)} @ ${target.filePath}:${target.line}`
+    : `${flow.target} [unlabeled] @ ${flow.filePath}:${flow.line}`;
+  segments.push(tgtDescription);
+  return segments;
+}
+
+function buildSuggestionForMissingLabel(node: 'source' | 'target', flow: FlowEdge): string {
+  const element = node === 'source' ? flow.source : flow.target;
+  return `Declare a label for \`${element}\` using @label before referencing it in flows.`;
+}
+
+function buildSuggestionForSecurity(flow: FlowEdge, transform?: Transform): string {
+  if (!flow.transform) {
+    return 'Annotate the flow with an approved transform using `@flow A -> B via transform-id`.';
+  }
+  if (!transform) {
+    return `Register the transform \`${flow.transform}\` with \`@transform ${flow.transform} kind=transform\`.`;
+  }
+  return 'Ensure the transform documented with @transform enforces the required downgrade policy.';
+}
+
+function buildSuggestionForPurpose(flow: FlowEdge, transform?: Transform): string {
+  if (!flow.transform) {
+    return 'Route the downgrade through a declared redactor via `@flow A -> B via redactor-id`.';
+  }
+  if (!transform) {
+    return `Register \`${flow.transform}\` as a redactor using \`@redactor ${flow.transform}\`.`;
+  }
+  if (transform.kind !== 'redactor') {
+    return `Mark \`${transform.name}\` as kind=redactor to permit purpose reduction.`;
+  }
+  return 'Verify the redactor removes purpose-restricted fields before the downgrade.';
+}
+
+export function analyzeAnnotatedFiles(files: AnnotatedFile[]): AnalysisResult {
+  const labels = new Map<string, Label>();
+  const transforms = new Map<string, Transform>();
+  const flows: FlowEdge[] = [];
+  const errors: FlowDiagnostic[] = [];
+
+  for (const file of files) {
+    for (const label of file.labels) {
+      labels.set(label.id, label);
+    }
+    for (const transform of file.transforms) {
+      transforms.set(transform.name, transform);
+    }
+    flows.push(...file.flows);
+  }
+
+  const sortedFlows = [...flows].sort((a, b) => {
+    if (a.filePath === b.filePath) {
+      return a.line - b.line;
+    }
+    return a.filePath.localeCompare(b.filePath);
+  });
+
+  for (const flow of sortedFlows) {
+    const source = labels.get(flow.source);
+    const target = labels.get(flow.target);
+    if (!source) {
+      errors.push({
+        type: 'missing-label',
+        message: `Flow references source \`${flow.source}\` which is not labeled.`,
+        trace: formatTrace(undefined, target, flow),
+        suggestion: buildSuggestionForMissingLabel('source', flow),
+        filePath: flow.filePath,
+        line: flow.line,
+      });
+      continue;
+    }
+    if (!target) {
+      errors.push({
+        type: 'missing-label',
+        message: `Flow references target \`${flow.target}\` which is not labeled.`,
+        trace: formatTrace(source, undefined, flow),
+        suggestion: buildSuggestionForMissingLabel('target', flow),
+        filePath: flow.filePath,
+        line: flow.line,
+      });
+      continue;
+    }
+
+    const transform = flow.transform ? transforms.get(flow.transform) : undefined;
+    const sourceRank = SECURITY_RANK[source.security];
+    const targetRank = SECURITY_RANK[target.security];
+
+    if (sourceRank > targetRank) {
+      if (!flow.transform) {
+        errors.push({
+          type: 'security-violation',
+          message: `High to low security flow \`${source.id} -> ${target.id}\` lacks an approved transform.`,
+          trace: formatTrace(source, target, flow),
+          suggestion: buildSuggestionForSecurity(flow, transform),
+          filePath: flow.filePath,
+          line: flow.line,
+        });
+        continue;
+      }
+      if (flow.transform && !transform) {
+        errors.push({
+          type: 'security-violation',
+          message: `Transform \`${flow.transform}\` is not registered for flow \`${source.id} -> ${target.id}\`.`,
+          trace: formatTrace(source, target, flow),
+          suggestion: buildSuggestionForSecurity(flow, transform),
+          filePath: flow.filePath,
+          line: flow.line,
+        });
+        continue;
+      }
+    }
+
+    const targetPurposes = target.purposes;
+    const sourcePurposes = source.purposes;
+
+    const missingPurposes = Array.from(targetPurposes).filter((purpose) => !sourcePurposes.has(purpose));
+    if (missingPurposes.length > 0) {
+      errors.push({
+        type: 'purpose-violation',
+        message: `Flow introduces unauthorized purposes (${missingPurposes.join(', ')}) for \`${target.id}\`.`,
+        trace: formatTrace(source, target, flow),
+        suggestion: `Extend the source consent to include ${missingPurposes.join(', ')} or block the flow.`,
+        filePath: flow.filePath,
+        line: flow.line,
+      });
+      continue;
+    }
+
+    const isDowngrade =
+      targetPurposes.size > 0 &&
+      targetPurposes.size < sourcePurposes.size &&
+      Array.from(targetPurposes).every((purpose) => sourcePurposes.has(purpose));
+
+    if (isDowngrade) {
+      if (!flow.transform) {
+        errors.push({
+          type: 'purpose-violation',
+          message: `Purpose downgrade on \`${source.id} -> ${target.id}\` must pass through a redactor.`,
+          trace: formatTrace(source, target, flow),
+          suggestion: buildSuggestionForPurpose(flow),
+          filePath: flow.filePath,
+          line: flow.line,
+        });
+        continue;
+      }
+      if (!transform) {
+        errors.push({
+          type: 'purpose-violation',
+          message: `Purpose downgrade references \`${flow.transform}\` but it is not registered as a redactor.`,
+          trace: formatTrace(source, target, flow),
+          suggestion: buildSuggestionForPurpose(flow, transform),
+          filePath: flow.filePath,
+          line: flow.line,
+        });
+        continue;
+      }
+      if (transform.kind !== 'redactor') {
+        errors.push({
+          type: 'purpose-violation',
+          message: `Purpose downgrade requires \`${transform.name}\` to be marked kind=redactor.`,
+          trace: formatTrace(source, target, flow),
+          suggestion: buildSuggestionForPurpose(flow, transform),
+          filePath: flow.filePath,
+          line: flow.line,
+        });
+        continue;
+      }
+    }
+  }
+
+  errors.sort((a, b) => {
+    if (a.filePath === b.filePath) {
+      if (a.line === b.line) {
+        return a.message.localeCompare(b.message);
+      }
+      return a.line - b.line;
+    }
+    return a.filePath.localeCompare(b.filePath);
+  });
+
+  return {
+    labels,
+    flows: sortedFlows,
+    transforms,
+    errors,
+  };
+}

--- a/ga-graphai/packages/iftc/src/cli.ts
+++ b/ga-graphai/packages/iftc/src/cli.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { analyzeAnnotatedFiles, parseAnnotatedFile } from './index.js';
+
+function printUsage(): void {
+  console.log('Usage: iftc <file> [file ...]');
+  console.log('Each file must contain @label, @flow, @transform directives in comments.');
+}
+
+function renderDiagnostic(index: number, total: number, message: string): string {
+  return `\n[${index + 1}/${total}] ${message}`;
+}
+
+function renderTrace(trace: string[]): string {
+  return trace.map((step) => `  ↳ ${step}`).join('\n');
+}
+
+async function main(): Promise<void> {
+  const inputs = process.argv.slice(2);
+  if (inputs.length === 0) {
+    printUsage();
+    process.exitCode = 1;
+    return;
+  }
+
+  const files = inputs.map((input) => {
+    const filePath = path.resolve(process.cwd(), input);
+    const content = fs.readFileSync(filePath, 'utf8');
+    return parseAnnotatedFile(filePath, content);
+  });
+
+  const result = analyzeAnnotatedFiles(files);
+  if (result.errors.length === 0) {
+    console.log(`✓ iftc passed (${result.flows.length} flows checked)`);
+    return;
+  }
+
+  console.error(`✗ iftc blocked ${result.errors.length} unsafe flow(s)`);
+  result.errors.forEach((error, index) => {
+    console.error(renderDiagnostic(index, result.errors.length, error.message));
+    console.error(renderTrace(error.trace));
+    console.error(`  suggestion: ${error.suggestion}`);
+  });
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  console.error('iftc failed with an unexpected error:', error);
+  process.exit(1);
+});

--- a/ga-graphai/packages/iftc/src/index.ts
+++ b/ga-graphai/packages/iftc/src/index.ts
@@ -1,0 +1,12 @@
+export { parseAnnotatedFile } from './parser.js';
+export { analyzeAnnotatedFiles } from './analyzer.js';
+export type {
+  AnalysisResult,
+  AnnotatedFile,
+  FlowDiagnostic,
+  FlowEdge,
+  Label,
+  SecurityLevel,
+  Transform,
+  TransformKind,
+} from './types.js';

--- a/ga-graphai/packages/iftc/src/parser.ts
+++ b/ga-graphai/packages/iftc/src/parser.ts
@@ -1,0 +1,151 @@
+import { AnnotatedFile, FlowEdge, Label, Transform, TransformKind } from './types';
+
+const COMMENT_PREFIXES = ['//', '#', '--'];
+
+interface ParseContext {
+  labels: Label[];
+  flows: FlowEdge[];
+  transforms: Transform[];
+}
+
+const SECURITY_LEVELS = new Set(['low', 'medium', 'high']);
+
+function parseOptions(raw: string): Record<string, string> {
+  const options: Record<string, string> = {};
+  const regex = /(\w+)=((?:"[^"]+"?)|(?:'[^']+'?)|[^\s]+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(raw)) !== null) {
+    const [, key, value] = match;
+    const cleaned = value.replace(/^['"]|['"]$/g, '');
+    options[key] = cleaned;
+  }
+  return options;
+}
+
+function toPurposes(raw: string | undefined): Set<string> {
+  if (!raw) {
+    return new Set();
+  }
+  return new Set(
+    raw
+      .split(',')
+      .map((token) => token.trim())
+      .filter((token) => token.length > 0)
+  );
+}
+
+function toTransformKind(value: string | undefined): TransformKind {
+  if (value === 'redactor') {
+    return 'redactor';
+  }
+  return 'transform';
+}
+
+export function parseAnnotatedFile(filePath: string, content: string): AnnotatedFile {
+  const ctx: ParseContext = { labels: [], flows: [], transforms: [] };
+  const lines = content.split(/\r?\n/);
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+    const prefix = COMMENT_PREFIXES.find((candidate) => trimmed.startsWith(candidate));
+    if (!prefix) {
+      return;
+    }
+    const directive = trimmed.slice(prefix.length).trim();
+    if (!directive.startsWith('@')) {
+      return;
+    }
+
+    const [head, ...restParts] = directive.slice(1).split(/\s+/);
+    const rest = restParts.join(' ');
+    switch (head) {
+      case 'label': {
+        const labelMatch = /(\S+)/.exec(rest);
+        if (!labelMatch) {
+          return;
+        }
+        const id = labelMatch[1];
+        const options = parseOptions(rest.slice(id.length).trim());
+        const security = options.security;
+        if (!security || !SECURITY_LEVELS.has(security)) {
+          throw new Error(
+            `Invalid or missing security level for label ${id} in ${filePath}:${index + 1}`
+          );
+        }
+        const label: Label = {
+          id,
+          security: security as Label['security'],
+          purposes: toPurposes(options.purposes),
+          filePath,
+          line: index + 1,
+        };
+        ctx.labels.push(label);
+        return;
+      }
+      case 'flow': {
+        const flowMatch = /(\S+)\s*->\s*(\S+)(.*)/.exec(rest);
+        if (!flowMatch) {
+          return;
+        }
+        const [, source, target, tail] = flowMatch;
+        const options = parseOptions(tail);
+        let transform = options.via;
+        if (!transform) {
+          const viaMatch = /via\s+([^\s]+)/.exec(tail);
+          if (viaMatch) {
+            transform = viaMatch[1];
+          }
+        }
+        const flow: FlowEdge = {
+          source,
+          target,
+          transform,
+          filePath,
+          line: index + 1,
+        };
+        ctx.flows.push(flow);
+        return;
+      }
+      case 'transform': {
+        const nameMatch = /(\S+)/.exec(rest);
+        if (!nameMatch) {
+          return;
+        }
+        const name = nameMatch[1];
+        const options = parseOptions(rest.slice(name.length).trim());
+        const kind = toTransformKind(options.kind);
+        const transform: Transform = {
+          name,
+          kind,
+          filePath,
+          line: index + 1,
+        };
+        ctx.transforms.push(transform);
+        return;
+      }
+      case 'redactor': {
+        const nameMatch = /(\S+)/.exec(rest);
+        if (!nameMatch) {
+          return;
+        }
+        const transform: Transform = {
+          name: nameMatch[1],
+          kind: 'redactor',
+          filePath,
+          line: index + 1,
+        };
+        ctx.transforms.push(transform);
+        return;
+      }
+      default:
+        return;
+    }
+  });
+
+  return {
+    filePath,
+    labels: ctx.labels,
+    flows: ctx.flows,
+    transforms: ctx.transforms,
+  };
+}

--- a/ga-graphai/packages/iftc/src/types.ts
+++ b/ga-graphai/packages/iftc/src/types.ts
@@ -1,0 +1,54 @@
+export type SecurityLevel = 'low' | 'medium' | 'high';
+
+export interface Label {
+  id: string;
+  security: SecurityLevel;
+  purposes: Set<string>;
+  filePath: string;
+  line: number;
+}
+
+export type TransformKind = 'transform' | 'redactor';
+
+export interface Transform {
+  name: string;
+  kind: TransformKind;
+  filePath: string;
+  line: number;
+}
+
+export interface FlowEdge {
+  source: string;
+  target: string;
+  transform?: string;
+  filePath: string;
+  line: number;
+}
+
+export interface AnnotatedFile {
+  filePath: string;
+  labels: Label[];
+  flows: FlowEdge[];
+  transforms: Transform[];
+}
+
+export type DiagnosticType =
+  | 'missing-label'
+  | 'security-violation'
+  | 'purpose-violation';
+
+export interface FlowDiagnostic {
+  type: DiagnosticType;
+  message: string;
+  trace: string[];
+  suggestion: string;
+  filePath: string;
+  line: number;
+}
+
+export interface AnalysisResult {
+  labels: Map<string, Label>;
+  flows: FlowEdge[];
+  transforms: Map<string, Transform>;
+  errors: FlowDiagnostic[];
+}

--- a/ga-graphai/packages/iftc/tests/analyzer.test.ts
+++ b/ga-graphai/packages/iftc/tests/analyzer.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { analyzeAnnotatedFiles, parseAnnotatedFile } from '../src/index.js';
+
+function parseFixture(filePath: string, content: string) {
+  return parseAnnotatedFile(filePath, content);
+}
+
+describe('iftc analyzer', () => {
+  it('passes safe flows that respect transforms and redactors', () => {
+    const tsFixture = `
+// @label raw_profile security=high purposes=analytics,marketing
+// @label sanitized_profile security=low purposes=analytics,marketing
+// @label analytics_feed security=low purposes=analytics
+// @transform scrubber kind=transform
+// @redactor consent_trim
+// @flow raw_profile -> sanitized_profile via scrubber
+// @flow sanitized_profile -> analytics_feed via consent_trim
+`;
+
+    const result = analyzeAnnotatedFiles([
+      parseFixture('etl/pipeline.ts', tsFixture),
+    ]);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.flows).toHaveLength(2);
+  });
+
+  it('blocks high to low flows without a transform', () => {
+    const pyFixture = `
+# @label pii_event_stream security=high purposes=analytics
+# @label public_dashboard security=low purposes=analytics
+# @flow pii_event_stream -> public_dashboard
+`;
+
+    const result = analyzeAnnotatedFiles([
+      parseFixture('etl/loader.py', pyFixture),
+    ]);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].type).toBe('security-violation');
+    expect(result.errors[0].message).toContain('High to low security flow');
+    expect(result.errors[0].suggestion).toContain('approved transform');
+  });
+
+  it('requires redactors for purpose downgrades', () => {
+    const sqlFixture = `
+-- @label marketing_pool security=medium purposes=analytics,marketing
+-- @label analytics_pool security=medium purposes=analytics
+-- @transform normalize_fields kind=transform
+-- @flow marketing_pool -> analytics_pool via normalize_fields
+`;
+
+    const result = analyzeAnnotatedFiles([
+      parseFixture('warehouse/view.sql', sqlFixture),
+    ]);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].type).toBe('purpose-violation');
+    expect(result.errors[0].message).toContain('Purpose downgrade');
+    expect(result.errors[0].suggestion).toContain('redactor');
+  });
+
+  it('produces deterministic diagnostics for repeated runs', () => {
+    const gqlFixture = `
+# @label consented_profile security=high purposes=personalization,analytics
+# @label personalization_payload security=medium purposes=personalization
+# @flow consented_profile -> personalization_payload
+`;
+
+    const parsed = parseFixture('api/profile.resolver.ts', gqlFixture);
+    const runOne = analyzeAnnotatedFiles([parsed]);
+    const runTwo = analyzeAnnotatedFiles([parsed]);
+
+    expect(runOne.errors).toEqual(runTwo.errors);
+  });
+});

--- a/ga-graphai/packages/iftc/tsconfig.build.json
+++ b/ga-graphai/packages/iftc/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "allowImportingTsExtensions": false
+  },
+  "exclude": ["tests"]
+}

--- a/ga-graphai/packages/iftc/tsconfig.json
+++ b/ga-graphai/packages/iftc/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src", "tests"]
+}


### PR DESCRIPTION
## Summary
- add a new ga-graphai iftc package that parses @label/@flow annotations across TS, Python, SQL, and GraphQL sources
- enforce security-level downgrades and purpose changes with deterministic diagnostics and actionable suggestions
- wire up a CLI entry point and unit tests covering safe flows, violations, and repeatability

## Testing
- cd ga-graphai/packages/iftc && npm test


------
https://chatgpt.com/codex/tasks/task_e_68d795caddb883339a2da23f8b343149