### PR TITLE
feat: add airgap bundle tooling and region overlays

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,6 @@ node_modules
 **/*.snap
 **/generated/**
 **/.graphqlrc*
+infra/helm/intelgraph/templates/configmap.yaml
+infra/helm/intelgraph/templates/deployment-api-gateway.yaml
+infra/helm/intelgraph/templates/file-drop-pvc.yaml

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,9 @@ migrate-1_0_0:
 cost-report:
 	@bash scripts/ops/cost_report.sh
 
+airgap-bundle:
+	MANIFEST=${MANIFEST:-infra/airgap/bundle.manifest.json} ./infra/airgap/export_bundle.sh
+
 ga:
 	make preflight && npm test && npx @cyclonedx/cyclonedx-npm --output-file sbom.json && ./scripts/release/verify_install.sh
 

--- a/infra/airgap/README.md
+++ b/infra/airgap/README.md
@@ -1,0 +1,51 @@
+# IntelGraph Air-Gap Bundle Toolkit
+
+This toolkit assembles everything required to deploy IntelGraph into disconnected environments. It produces a single archive that contains container images, Helm charts, the bundle manifest, and provenance artifacts. Use the provided export/import helpers so the only allowed egress is a signed bundle file.
+
+## One-command bundle build
+
+```bash
+MANIFEST=infra/airgap/bundle.manifest.json ./infra/airgap/export_bundle.sh
+```
+
+The script calls `build_airgap_bundle.py` which will:
+
+1. Package all charts specified in the manifest (with optional overlay values).
+2. Pull and save the required container images.
+3. Emit a provenance ledger and a resynchronisation manifest.
+4. Create a gzipped archive alongside a `sha256` checksum and optional signature.
+
+Set `SKIP_PULL=true` if images are already available locally. Provide `SIGNING_KEY=/path/to/private.pem` to produce an OpenSSL signature (`.sig`).
+
+## Offline installation
+
+Copy the archive into the air-gapped cluster, then run:
+
+```bash
+./infra/airgap/import_bundle.sh intelgraph-airgap-bundle.tgz
+```
+
+This loads the images, extracts Helm chart packages into `./airgap-charts`, and restores the provenance JSON files into the working directory for later verification.
+
+## Provenance resynchronisation
+
+The bundle includes two ledger files:
+
+- `provenance-ledger.json` – generated digests for charts and images captured at export time.
+- `resync-manifest.json` – compact digest list used when reconnecting to a networked environment.
+
+`resync-manifest.json` is what downstream systems request after connectivity is restored; it can be compared with a freshly generated ledger to validate drift.
+
+## File-drop ingestion
+
+Connector pods already support file-drop ingestion under `CONNECTOR_INGEST_MODE=file-drop`. The air-gapped overlay injects a `PersistentVolumeClaim` named `file-drop` that backs `/var/intelgraph/dropbox`. Operators only need to copy zipped payloads into that directory; the connectors scan for new files every 60 seconds in offline mode. See `infra/runbooks/airgap-bundle.md` for validation steps.
+
+## Provenance verification
+
+Use `infra/airgap/verify_provenance.py` to compare the baseline resync manifest with a newly generated ledger.
+
+```bash
+python3 infra/airgap/verify_provenance.py resync-manifest.json infra/airgap/dist/ledger/resync-manifest.json
+```
+
+A non-zero exit code indicates drift.

--- a/infra/airgap/build_airgap_bundle.py
+++ b/infra/airgap/build_airgap_bundle.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Build an offline bundle of container images and Helm charts for air-gapped installs."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+
+def run_command(cmd: List[str], *, cwd: Path | None = None) -> None:
+    """Run a shell command and raise a helpful error on failure."""
+    process = subprocess.run(cmd, cwd=cwd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+    if process.returncode != 0:
+        raise RuntimeError(f"Command {' '.join(cmd)} failed with exit code {process.returncode}\n{process.stdout}")
+    if process.stdout:
+        print(process.stdout)
+
+
+def sha256sum(path: Path) -> str:
+    """Compute the SHA256 digest of a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def ensure_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def package_chart(chart: Dict[str, object], destination: Path) -> Dict[str, object]:
+    chart_path = Path(chart["path"])
+    if not chart_path.exists():
+        raise FileNotFoundError(f"Chart path {chart_path} does not exist")
+
+    values_files: Iterable[str] = chart.get("values", [])  # type: ignore[assignment]
+    values_args: List[str] = []
+    for values_file in values_files:
+        values_args.extend(["--values", values_file])
+
+    # Build dependencies first to ensure packaged chart is self-contained
+    if (chart_path / "Chart.yaml").exists():
+        try:
+            run_command(["helm", "dependency", "build", str(chart_path)])
+        except RuntimeError as exc:
+            raise RuntimeError(f"Failed to build dependencies for {chart['name']}: {exc}") from exc
+
+    ensure_directory(destination)
+    package_args = [
+        "helm",
+        "package",
+        str(chart_path),
+        "--destination",
+        str(destination),
+    ] + values_args
+
+    run_command(package_args)
+
+    # Find the generated tgz file (helm outputs the filename)
+    generated = sorted(destination.glob(f"{chart['name']}-*.tgz"))
+    if not generated:
+        raise RuntimeError(f"Helm did not produce a package for {chart['name']}")
+    latest = max(generated, key=lambda p: p.stat().st_mtime)
+    return {
+        "name": chart["name"],
+        "file": str(latest.relative_to(destination.parent)),
+        "sha256": sha256sum(latest),
+        "size": latest.stat().st_size,
+    }
+
+
+def save_image(image: Dict[str, object], destination: Path, *, skip_pull: bool) -> Dict[str, object]:
+    image_name = image["name"]
+    if not skip_pull:
+        run_command(["docker", "pull", image_name])
+
+    safe_name = image_name.replace("/", "_").replace(":", "-")
+    archive_path = destination / f"{safe_name}.tar"
+    run_command(["docker", "save", "-o", str(archive_path), image_name])
+    return {
+        "name": image_name,
+        "file": str(archive_path.relative_to(destination.parent)),
+        "sha256": sha256sum(archive_path),
+        "size": archive_path.stat().st_size,
+    }
+
+
+def build_bundle(manifest_path: Path, output_dir: Path, *, skip_pull: bool = False) -> Path:
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        manifest = json.load(handle)
+
+    bundle_version = manifest.get("bundleVersion", "0.0.0")
+    output_settings = manifest.get("output", {})
+    archive_name = output_settings.get("archiveName", "airgap-bundle.tgz")
+
+    staging_root = Path(tempfile.mkdtemp(prefix="airgap-bundle-"))
+    charts_dir = staging_root / "charts"
+    images_dir = staging_root / "images"
+    ledger_dir = staging_root / "ledger"
+    manifests_dir = staging_root / "manifests"
+
+    ensure_directory(charts_dir)
+    ensure_directory(images_dir)
+    ensure_directory(ledger_dir)
+    ensure_directory(manifests_dir)
+
+    try:
+        chart_entries: List[Dict[str, object]] = []
+        for chart in manifest.get("charts", []):
+            chart_entries.append(package_chart(chart, charts_dir))
+
+        image_entries: List[Dict[str, object]] = []
+        for image in manifest.get("images", []):
+            image_entries.append(save_image(image, images_dir, skip_pull=skip_pull))
+
+        provenance = {
+            "bundleVersion": bundle_version,
+            "generatedAt": dt.datetime.utcnow().isoformat() + "Z",
+            "charts": chart_entries,
+            "images": image_entries,
+        }
+
+        ledger_path = ledger_dir / Path(manifest.get("provenance", {}).get("ledgerPath", "provenance-ledger.json")).name
+        with ledger_path.open("w", encoding="utf-8") as handle:
+            json.dump(provenance, handle, indent=2)
+            handle.write("\n")
+
+        resync_manifest = {
+            "bundleVersion": bundle_version,
+            "generatedAt": provenance["generatedAt"],
+            "items": chart_entries + image_entries,
+        }
+        resync_path = ledger_dir / Path(manifest.get("provenance", {}).get("resyncManifest", "resync-manifest.json")).name
+        with resync_path.open("w", encoding="utf-8") as handle:
+            json.dump(resync_manifest, handle, indent=2)
+            handle.write("\n")
+
+        manifest_copy = manifests_dir / manifest_path.name
+        shutil.copy2(manifest_path, manifest_copy)
+
+        ensure_directory(output_dir)
+        ledger_output_dir = output_dir / "ledger"
+        ensure_directory(ledger_output_dir)
+        shutil.copy2(ledger_path, ledger_output_dir / ledger_path.name)
+        shutil.copy2(resync_path, ledger_output_dir / resync_path.name)
+
+        archive_path = output_dir / archive_name
+        with tarfile.open(archive_path, "w:gz") as tar:
+            for directory in (charts_dir, images_dir, ledger_dir, manifests_dir):
+                for item in directory.rglob("*"):
+                    tar.add(item, arcname=item.relative_to(staging_root))
+
+        checksum_path = archive_path.with_suffix(archive_path.suffix + ".sha256")
+        with checksum_path.open("w", encoding="utf-8") as handle:
+            handle.write(f"{sha256sum(archive_path)}  {archive_path.name}\n")
+
+        print(f"Bundle written to {archive_path}")
+        print(f"Checksum written to {checksum_path}")
+
+        return archive_path
+    finally:
+        shutil.rmtree(staging_root)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build an IntelGraph air-gap installation bundle")
+    parser.add_argument("--manifest", default="infra/airgap/bundle.manifest.json", type=Path, help="Path to bundle manifest")
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        type=Path,
+        help="Directory to store the resulting archive (defaults to manifest output directory)",
+    )
+    parser.add_argument(
+        "--skip-pull",
+        action="store_true",
+        help="Assume the required container images are already present locally",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    manifest_path: Path = args.manifest
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Manifest {manifest_path} does not exist")
+
+    with manifest_path.open("r", encoding="utf-8") as handle:
+        manifest = json.load(handle)
+
+    default_output_dir = manifest.get("output", {}).get("directory")
+    if args.output_dir:
+        output_dir = args.output_dir
+    elif default_output_dir:
+        output_dir = Path(default_output_dir)
+    else:
+        output_dir = manifest_path.parent / "dist"
+
+    build_bundle(manifest_path, output_dir, skip_pull=args.skip_pull)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/airgap/bundle.manifest.json
+++ b/infra/airgap/bundle.manifest.json
@@ -1,0 +1,35 @@
+{
+  "bundleVersion": "1.0.0",
+  "output": {
+    "archiveName": "intelgraph-airgap-bundle.tgz",
+    "directory": "dist"
+  },
+  "charts": [
+    {
+      "name": "intelgraph",
+      "path": "infra/helm/intelgraph",
+      "values": ["infra/helm/intelgraph/values/airgap.yaml"]
+    },
+    {
+      "name": "gateway",
+      "path": "infra/helm/gateway"
+    },
+    {
+      "name": "postgres",
+      "path": "infra/helm/postgres"
+    },
+    {
+      "name": "redis",
+      "path": "infra/helm/redis"
+    }
+  ],
+  "images": [
+    { "name": "ghcr.io/brianlong/intelgraph/server:dev" },
+    { "name": "ghcr.io/brianlong/intelgraph/client:dev" },
+    { "name": "ghcr.io/brianlong/intelgraph/gateway:dev" }
+  ],
+  "provenance": {
+    "ledgerPath": "ledger/provenance-ledger.json",
+    "resyncManifest": "ledger/resync-manifest.json"
+  }
+}

--- a/infra/airgap/export_bundle.sh
+++ b/infra/airgap/export_bundle.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+MANIFEST=${MANIFEST:-"$SCRIPT_DIR/bundle.manifest.json"}
+export MANIFEST
+OUTPUT_DIR=${OUTPUT_DIR:-"$SCRIPT_DIR/dist"}
+SIGNING_KEY=${SIGNING_KEY:-""}
+SKIP_PULL=${SKIP_PULL:-"false"}
+
+if [[ ! -f "$MANIFEST" ]]; then
+  echo "✖️  bundle manifest not found at $MANIFEST" >&2
+  exit 1
+fi
+
+ARGS=("--manifest" "$MANIFEST" "--output-dir" "$OUTPUT_DIR")
+if [[ "$SKIP_PULL" == "true" ]]; then
+  ARGS+=("--skip-pull")
+fi
+
+python3 "$SCRIPT_DIR/build_airgap_bundle.py" "${ARGS[@]}"
+
+ARCHIVE_NAME=$(python3 - <<'PY'
+import json
+import os
+import sys
+manifest_path = os.environ["MANIFEST"]
+with open(manifest_path, "r", encoding="utf-8") as handle:
+    data = json.load(handle)
+print(data.get("output", {}).get("archiveName", "intelgraph-airgap-bundle.tgz"))
+PY
+)
+BUNDLE_PATH="$OUTPUT_DIR/$ARCHIVE_NAME"
+SHA_PATH="$BUNDLE_PATH.sha256"
+
+if [[ -n "$SIGNING_KEY" ]]; then
+  if [[ ! -f "$SIGNING_KEY" ]]; then
+    echo "✖️  signing key $SIGNING_KEY not found" >&2
+    exit 1
+  fi
+  openssl dgst -sha256 -sign "$SIGNING_KEY" -out "$BUNDLE_PATH.sig" "$BUNDLE_PATH"
+  openssl dgst -sha256 -verify <(openssl pkey -in "$SIGNING_KEY" -pubout) -signature "$BUNDLE_PATH.sig" "$BUNDLE_PATH" >/dev/null
+  echo "🔐 bundle signed -> $BUNDLE_PATH.sig"
+fi
+
+echo "📦 bundle ready: $BUNDLE_PATH"
+echo "🔏 checksum: $SHA_PATH"

--- a/infra/airgap/import_bundle.sh
+++ b/infra/airgap/import_bundle.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <bundle.tgz>" >&2
+  exit 1
+fi
+
+BUNDLE=$1
+shift || true
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+
+tar -xzf "$BUNDLE" -C "$WORKDIR"
+
+if command -v docker >/dev/null; then
+  find "$WORKDIR/images" -name '*.tar' -print0 | while IFS= read -r -d '' image; do
+    echo "📥 loading image $(basename "$image")"
+    docker load -i "$image"
+  done
+fi
+
+if command -v helm >/dev/null; then
+  mkdir -p airgap-charts
+  find "$WORKDIR/charts" -name '*.tgz' -print0 | while IFS= read -r -d '' chart; do
+    cp "$chart" airgap-charts/
+  done
+  echo "✅ Helm charts copied to ./airgap-charts"
+fi
+
+cp "$WORKDIR/ledger"/*.json ./ || true
+cp "$WORKDIR/manifests"/*.json ./ || true
+
+echo "📄 provenance artifacts restored to $(pwd)"

--- a/infra/airgap/verify_provenance.py
+++ b/infra/airgap/verify_provenance.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Compare provenance manifests to confirm digests align."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Iterable, Set
+
+
+def load_manifest(path: Path) -> Dict[str, object]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def extract_digests(manifest: Dict[str, object]) -> Set[str]:
+    items: Iterable[Dict[str, object]]
+    if "items" in manifest:
+        items = manifest["items"]  # type: ignore[assignment]
+    else:
+        charts = manifest.get("charts", [])  # type: ignore[assignment]
+        images = manifest.get("images", [])  # type: ignore[assignment]
+        items = list(charts) + list(images)
+    digests = {entry["sha256"] for entry in items if "sha256" in entry}
+    if not digests:
+        raise ValueError("manifest does not contain any sha256 digests")
+    return digests
+
+
+def compare_manifests(baseline: Path, candidate: Path) -> None:
+    base_digests = extract_digests(load_manifest(baseline))
+    candidate_digests = extract_digests(load_manifest(candidate))
+
+    missing = base_digests - candidate_digests
+    extra = candidate_digests - base_digests
+
+    if missing or extra:
+        if missing:
+            print(f"❌ missing digests: {sorted(missing)}")
+        if extra:
+            print(f"❌ unexpected digests: {sorted(extra)}")
+        raise SystemExit(1)
+
+    print("✅ provenance digests align")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Verify provenance alignment between two manifests")
+    parser.add_argument("baseline", type=Path, help="Path to the baseline manifest (resync-manifest.json)")
+    parser.add_argument("candidate", type=Path, help="Path to the new manifest or ledger")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    compare_manifests(args.baseline, args.candidate)
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/helm/intelgraph/templates/configmap.yaml
+++ b/infra/helm/intelgraph/templates/configmap.yaml
@@ -1,8 +1,48 @@
-# Empty configmap for now. Content to be provided by user if needed.
+# prettier-ignore
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "intelgraph.fullname" . }}-config
   labels:
     {{- include "intelgraph.labels" . | nindent 4 }}
-data: {}
+data:
+  intelgraph-settings.yaml: |
+    apiVersion: v1
+    kind: RuntimeSettings
+    {{- if .Values.regionSharding.enabled }}
+    regionSharding:
+      enabled: true
+      defaultRegion: {{ .Values.regionSharding.defaultRegion | quote }}
+      routingHeader: {{ .Values.regionSharding.routing.header | quote }}
+      fallbackPolicy: {{ .Values.regionSharding.routing.fallbackPolicy | default "nearest" | quote }}
+      regions:
+        {{- range .Values.regionSharding.regions }}
+        - name: {{ .name | quote }}
+          gatewayHost: {{ .gatewayHost | quote }}
+          readReplica:
+            {{- range $k, $v := .readReplica }}
+            {{ $k }}: {{ $v | quote }}
+            {{- end }}
+          {{- with .metrics }}
+          metrics:
+            {{- range $k, $v := . }}
+            {{ $k }}: {{ $v }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      tenants:
+        {{- range $tenant, $config := .Values.regionSharding.tenants }}
+        {{ $tenant }}:
+          region: {{ $config.region | quote }}
+          {{- with $config.fallback }}
+          fallback:
+            {{- range . }}
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+    {{- end }}
+    fileDrop:
+      enabled: {{ .Values.fileDrop.enabled | default false }}
+      path: {{ dig "dropboxPath" .Values.fileDrop | default (dig "bundle" "dropboxPath" (dig "airGap" .Values.federal | default (dict))) | default "/var/intelgraph/dropbox" | quote }}
+      provenancePath: {{ dig "bundle" "ledgerMountPath" (dig "airGap" .Values.federal | default (dict)) | default "/var/intelgraph/provenance" | quote }}

--- a/infra/helm/intelgraph/templates/deployment-api-gateway.yaml
+++ b/infra/helm/intelgraph/templates/deployment-api-gateway.yaml
@@ -1,3 +1,4 @@
+# prettier-ignore
 {{- $service := .Values.services.apiGateway -}}
 {{- if $service.enabled }}
 apiVersion: apps/v1
@@ -43,6 +44,13 @@ spec:
           env:
             {{- include "intelgraph.commonEnv" . | nindent 12 }}
             {{- include "intelgraph.serviceEnv" (dict "service" $service "root" .) | nindent 12 }}
+            {{- if .Values.regionSharding.enabled }}
+            - name: REGION_ROUTING_TABLE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "intelgraph.fullname" . }}-config
+                  key: intelgraph-settings.yaml
+            {{- end }}
           livenessProbe:
             {{- include "intelgraph.livenessProbe" (dict "service" $service "root" .) | nindent 12 }}
           readinessProbe:

--- a/infra/helm/intelgraph/templates/file-drop-pvc.yaml
+++ b/infra/helm/intelgraph/templates/file-drop-pvc.yaml
@@ -1,0 +1,19 @@
+# prettier-ignore
+{{- if and .Values.fileDrop.enabled .Values.fileDrop.pvc }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.fileDrop.pvc.name | default (printf "%s-file-drop" (include "intelgraph.fullname" .)) }}
+  labels:
+    {{- include "intelgraph.labels" . | nindent 4 }}
+    purpose: file-drop
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.fileDrop.pvc.size | default "20Gi" }}
+  {{- with .Values.fileDrop.pvc.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/intelgraph/values.yaml
+++ b/infra/helm/intelgraph/values.yaml
@@ -4,20 +4,20 @@ replicaCount: 1
 image:
   server:
     repository: ghcr.io/brianlong/intelgraph/server
-    tag: "dev"
+    tag: 'dev'
     pullPolicy: IfNotPresent
   client:
     repository: ghcr.io/brianlong/intelgraph/client
-    tag: "dev"
+    tag: 'dev'
     pullPolicy: IfNotPresent
 
-nameOverride: ""
-fullnameOverride: ""
+nameOverride: ''
+fullnameOverride: ''
 
 serviceAccount:
   create: true
   annotations: {}
-  name: ""
+  name: ''
 
 podAnnotations: {}
 
@@ -38,7 +38,7 @@ service:
 
 ingress:
   enabled: false
-  className: ""
+  className: ''
   annotations: {}
   hosts:
     - host: chart-example.local
@@ -103,7 +103,7 @@ spire:
   agent:
     replicas: 1
   helper:
-    image: "ghcr.io/spiffe/spiffe-helper:0.6.0"
+    image: 'ghcr.io/spiffe/spiffe-helper:0.6.0'
 
 # Services configuration
 services:
@@ -162,7 +162,7 @@ rollout:
 # Monitoring configuration
 monitoring:
   prometheus:
-    server: "prometheus.monitoring.svc.cluster.local:9090"
+    server: 'prometheus.monitoring.svc.cluster.local:9090'
   prometheusRules:
     enabled: false
 
@@ -187,7 +187,7 @@ otel:
 # Preview environment specific settings
 preview:
   enabled: false
-  ttl: "24h"
+  ttl: '24h'
   cleanup: true
 # Zero Trust configuration
 zeroTrust:
@@ -196,10 +196,10 @@ zeroTrust:
 # Audit configuration
 audit:
   wormEnabled: false
-  bucket: "intelgraph-audit-logs"
-  storageSize: "10Gi"
+  bucket: 'intelgraph-audit-logs'
+  storageSize: '10Gi'
   worm:
-    image: "amazon/aws-cli:2.13.32"
+    image: 'amazon/aws-cli:2.13.32'
 
 # mTLS configuration
 mtls:
@@ -207,7 +207,7 @@ mtls:
 
 # AWS configuration
 aws:
-  region: "us-east-1"
+  region: 'us-east-1'
 
 # Security configuration
 security:
@@ -220,19 +220,19 @@ security:
 
 # Federal configuration
 federal:
-  classification: "UNCLASSIFIED"
+  classification: 'UNCLASSIFIED'
   airGap:
     enabled: false
   breakGlass:
     emergencyNetworkOverride: false
   fips:
-    enforcementAction: "warn"
+    enforcementAction: 'warn'
   enforcement:
     resourceLimits: false
   limits:
     maxCpu: 2
   hsm:
-    provider: "none"
+    provider: 'none'
   storage:
     fipsCrypto: false
 
@@ -261,3 +261,16 @@ healthCheck:
   enabled: true
   path: /health
   port: 8080
+
+fileDrop:
+  enabled: false
+  pvc: {}
+
+regionSharding:
+  enabled: false
+  defaultRegion: ''
+  routing:
+    header: x-intelgraph-region
+    fallbackPolicy: nearest
+  regions: []
+  tenants: {}

--- a/infra/helm/intelgraph/values/airgap.yaml
+++ b/infra/helm/intelgraph/values/airgap.yaml
@@ -1,0 +1,59 @@
+federal:
+  classification: 'CUI'
+  airGap:
+    enabled: true
+    export:
+      signingRequired: true
+    bundle:
+      ledgerMountPath: /var/intelgraph/provenance
+      dropboxPath: /var/intelgraph/dropbox
+
+services:
+  apiGateway:
+    enabled: true
+    name: intelgraph-gateway
+    replicaCount: 2
+    port: 8080
+  worker:
+    enabled: true
+  analytics:
+    enabled: true
+
+fileDrop:
+  enabled: true
+  dropboxPath: /var/intelgraph/dropbox
+  pvc:
+    name: file-drop
+    storageClassName: airgap-shared
+    size: 50Gi
+
+regionSharding:
+  enabled: true
+  defaultRegion: us-west-2
+  routing:
+    header: x-intelgraph-region
+    fallbackPolicy: nearest
+  regions:
+    - name: us-west-2
+      gatewayHost: gateway.us-west-2.airgap.local
+      readReplica:
+        role: primary
+        endpoint: postgres.primary.svc.cluster.local:5432
+    - name: us-east-1
+      gatewayHost: gateway.us-east-1.airgap.local
+      readReplica:
+        role: read-replica
+        endpoint: postgres.us-east-1.svc.cluster.local:5432
+      metrics:
+        latencyBudgetMs: 120
+    - name: eu-central-1
+      gatewayHost: gateway.eu-central-1.airgap.local
+      readReplica:
+        role: read-replica
+        endpoint: postgres.eu-central-1.svc.cluster.local:5432
+      metrics:
+        latencyBudgetMs: 180
+  tenants:
+    alpha: { region: us-west-2 }
+    bravo: { region: us-east-1, fallback: [us-west-2] }
+    charlie: { region: eu-central-1, fallback: [us-west-2] }

--- a/infra/helm/intelgraph/values/region-sharding.yaml
+++ b/infra/helm/intelgraph/values/region-sharding.yaml
@@ -1,0 +1,28 @@
+regionSharding:
+  enabled: true
+  defaultRegion: us-west-2
+  routing:
+    header: x-intelgraph-region
+    fallbackPolicy: nearest
+  regions:
+    - name: us-west-2
+      gatewayHost: gateway.us-west-2.prod.intelgraph.example
+      readReplica:
+        role: primary
+        endpoint: postgres.primary.us-west-2.rds.amazonaws.com:5432
+    - name: us-east-1
+      gatewayHost: gateway.us-east-1.prod.intelgraph.example
+      readReplica:
+        role: read-replica
+        endpoint: postgres.replica.us-east-1.rds.amazonaws.com:5432
+        promotionWindow: '05:00-05:15'
+    - name: eu-central-1
+      gatewayHost: gateway.eu-central-1.prod.intelgraph.example
+      readReplica:
+        role: read-replica
+        endpoint: postgres.replica.eu-central-1.rds.amazonaws.com:5432
+        promotionWindow: '05:15-05:30'
+  tenants:
+    gov-west: { region: us-west-2 }
+    gov-east: { region: us-east-1, fallback: [us-west-2] }
+    emea: { region: eu-central-1, fallback: [us-west-2] }

--- a/infra/runbooks/airgap-bundle.md
+++ b/infra/runbooks/airgap-bundle.md
@@ -1,0 +1,106 @@
+# Air-Gapped Bundle Build & Offline Validation
+
+This runbook walks through exporting IntelGraph into an air-gapped bundle, importing it into a disconnected `kind` cluster, and validating file-drop ingestion mode without egress.
+
+## 1. Prerequisites
+
+- Docker CLI with the target images cached or accessible via a staging registry.
+- Helm 3.10 or later.
+- `kind` v0.23+ (for offline test cluster).
+- OpenSSL (for bundle signing).
+- Optional: a PEM encoded private key stored at `~/.config/intelgraph/airgap-signing.pem`.
+
+> ℹ️️ The build scripts never contact external endpoints other than the registries required to pull images when `SKIP_PULL=false`. Ensure staging hosts perform these pulls before entering a disconnected enclave.
+
+## 2. Build the bundle
+
+```bash
+# Pull images ahead of time if necessary
+export MANIFEST=infra/airgap/bundle.manifest.json
+./infra/airgap/export_bundle.sh
+```
+
+Artifacts:
+
+- `infra/airgap/dist/intelgraph-airgap-bundle.tgz`
+- `infra/airgap/dist/intelgraph-airgap-bundle.tgz.sha256`
+- Optional signature: `intelgraph-airgap-bundle.tgz.sig`
+- Provenance ledger and resync manifest inside the archive under `ledger/`.
+
+If you must skip network pulls (for example, when building inside a staging enclave) run:
+
+```bash
+SKIP_PULL=true ./infra/airgap/export_bundle.sh
+```
+
+The script assumes images already exist locally (`docker images` verifies this).
+
+## 3. Import into a simulated air-gap
+
+Create a fresh `kind` cluster and copy the bundle into the environment without network access.
+
+```bash
+kind delete cluster --name intelgraph-airgap || true
+kind create cluster --name intelgraph-airgap --config infra/runbooks/kind-airgap-config.yaml
+./infra/airgap/import_bundle.sh infra/airgap/dist/intelgraph-airgap-bundle.tgz
+```
+
+The import script loads Docker images, copies Helm packages into `./airgap-charts`, and places ledger files in the current directory.
+
+## 4. Offline install
+
+```bash
+helm install intelgraph airgap-charts/intelgraph-*.tgz \
+  --namespace intelgraph --create-namespace \
+  --values infra/helm/intelgraph/values/airgap.yaml
+```
+
+Wait for all pods to report `Running`:
+
+```bash
+kubectl get pods -n intelgraph
+```
+
+No egress is configured beyond what Kubernetes requires for DNS within the cluster.
+
+## 5. File-drop ingestion validation
+
+1. Create the file-drop PVC:
+   ```bash
+   kubectl get pvc file-drop -n intelgraph
+   ```
+   The PVC should bind to the offline storage class defined in the overlay.
+2. Copy a connector payload into the shared volume:
+   ```bash
+   kubectl -n intelgraph exec deploy/intelgraph-worker -- mkdir -p /var/intelgraph/dropbox/incoming
+   kubectl cp samples/offline/ingest.zip intelgraph/intelgraph-worker-0:/var/intelgraph/dropbox/incoming/ingest.zip
+   ```
+3. Confirm ingestion without network access by watching the worker logs:
+   ```bash
+   kubectl logs -n intelgraph deploy/intelgraph-worker -f | grep "Processed file-drop payload"
+   ```
+4. Verify the provenance ledger:
+   ```bash
+   sha256sum --check intelgraph-airgap-bundle.tgz.sha256
+   diff <(jq '.items | length' resync-manifest.json) <(jq '.charts | length + .images | length' provenance-ledger.json)
+   ```
+
+## 6. Provenance resynchronisation after reconnect
+
+When connectivity is restored, generate a fresh bundle and compare manifests:
+
+```bash
+./infra/airgap/export_bundle.sh
+python3 - <<'PY'
+import json
+with open('resync-manifest.json') as baseline, open('infra/airgap/dist/ledger/resync-manifest.json') as new:
+    baseline_items = {item['sha256'] for item in json.load(baseline)['items']}
+    new_items = {item['sha256'] for item in json.load(new)['items']}
+    drift = new_items - baseline_items
+    if drift:
+        raise SystemExit(f"Unexpected digests detected: {sorted(drift)}")
+    print('✅ provenance resynchronised')
+PY
+```
+
+Document the run by capturing timestamps for each command and store screenshots of the healthy `kubectl get pods` output in the DR evidence vault.

--- a/infra/runbooks/dr-failover.md
+++ b/infra/runbooks/dr-failover.md
@@ -1,0 +1,49 @@
+# Disaster Recovery Failover Drill
+
+This runbook documents the procedure to fail over IntelGraph to a regional read replica and back out once the primary region is restored. Capture timestamps for each stage and attach screenshots of the Grafana and `kubectl get pods` dashboards to the DR evidence vault.
+
+## Preparation
+
+1. Ensure Terraform state reflects the latest deployment and that `var.read_replica_regions` lists all promoted regions.
+2. Verify the provenance ledger from the most recent air-gap bundle export (`infra/airgap/dist/ledger/provenance-ledger.json`).
+3. Confirm replication status in PostgreSQL:
+   ```bash
+   aws rds describe-db-cluster-endpoints --db-cluster-identifier intelgraph-primary
+   ```
+4. Confirm Redis Global Datastore status:
+   ```bash
+   aws elasticache describe-global-replication-groups --global-replication-group-id intelgraph-cache
+   ```
+
+## Failover execution
+
+| Step | Action                                                                                | Notes                                                                                                                                           |
+| ---- | ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1    | Freeze ingestion by scaling worker deployments to zero in the impacted region.        | `kubectl scale deploy/intelgraph-worker --replicas=0 -n intelgraph`                                                                             |
+| 2    | Promote the target read replica to primary using Terraform.                           | `terraform apply -var-file=dr-failover.tfvars -auto-approve`                                                                                    |
+| 3    | Update Helm release with the new `regionSharding.defaultRegion` and tenant overrides. | `helm upgrade intelgraph airgap-charts/intelgraph-*.tgz -n intelgraph --values values/airgap.yaml --set regionSharding.defaultRegion=us-east-1` |
+| 4    | Validate application health.                                                          | Run smoke tests and `kubectl get pods -n intelgraph`                                                                                            |
+| 5    | Capture Grafana dashboards and `kubectl` output screenshots.                          | Store in DR evidence vault with timestamps.                                                                                                     |
+
+## Backout
+
+1. Rehydrate the original primary region resources with Terraform:
+   ```bash
+   terraform apply -var-file=primary-restore.tfvars -auto-approve
+   ```
+2. Promote the original primary back to write mode using the same procedure as the failover, but pointing to the recovered region.
+3. Re-run Helm upgrade to move tenants back to their original regions using `regionSharding.tenants` overrides.
+4. Resume ingestion by scaling worker deployments back to their steady state.
+5. Verify provenance ledger alignment:
+   ```bash
+   python3 infra/airgap/verify_provenance.py resync-manifest.json infra/airgap/dist/ledger/resync-manifest.json
+   ```
+6. Document the drill outcome with timestamps for failover start, completion, backout start, and completion. Attach screenshots to the DR evidence vault and log the event in `status/DR-activity.log`.
+
+## Evidence checklist
+
+- [ ] Terraform plan and apply outputs stored in runbook evidence folder.
+- [ ] `kubectl get pods -n intelgraph` screenshot before and after failover.
+- [ ] Grafana latency dashboard screenshot for each region.
+- [ ] Signed provenance ledger exported post-drill.
+- [ ] Resync manifest diff report archived.

--- a/infra/runbooks/kind-airgap-config.yaml
+++ b/infra/runbooks/kind-airgap-config.yaml
@@ -1,0 +1,22 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: intelgraph-airgap
+networking:
+  disableDefaultCNI: false
+  kubeProxyMode: iptables
+nodes:
+  - role: control-plane
+    extraPortMappings: []
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        metadata:
+          name: config
+        networking:
+          dnsDomain: intelgraph.local
+  - role: worker
+    labels:
+      intelgraph.io/role: application
+  - role: worker
+    labels:
+      intelgraph.io/role: analytics

--- a/infra/terraform/aws/outputs.tf
+++ b/infra/terraform/aws/outputs.tf
@@ -1,0 +1,9 @@
+output "region_shards" {
+  description = "Computed sharding plan for the primary region and all replicas"
+  value       = local.region_shards
+}
+
+output "tenant_region_assignments" {
+  description = "Map of tenants to their preferred regions and fallback order"
+  value       = local.tenant_region_assignments
+}

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -221,3 +221,25 @@ variable "additional_tags" {
   type        = map(string)
   default     = {}
 }
+# Regional sharding configuration
+variable "read_replica_regions" {
+  description = "List of read replica regions for sharded deployments"
+  type = list(object({
+    name            = string
+    aws_region      = string
+    replica_cluster = string
+    endpoint        = string
+    latency_budget_ms = optional(number)
+  }))
+  default = []
+}
+
+variable "tenant_region_map" {
+  description = "Mapping of tenant identifiers to preferred regions and fallbacks"
+  type = map(object({
+    region           = string
+    fallback         = optional(list(string), [])
+    latency_budget_ms = optional(number)
+  }))
+  default = {}
+}


### PR DESCRIPTION
## Summary
- add an air-gap bundle toolkit with packaging scripts, manifest, and provenance verifier
- provide dedicated Helm values, templates, and runbooks for file-drop ingestion and regional sharding
- surface regional sharding metadata through Terraform outputs and ignore Helm templates from prettier auto-formatting

## Testing
- python3 infra/airgap/verify_provenance.py --help

------
https://chatgpt.com/codex/tasks/task_e_68d80596441c8333972d6dfb9f7b535f