### PR TITLE
feat(ci): enforce supply chain security gates

### DIFF
--- a/.github/workflows/evidence-bundle-release.yml
+++ b/.github/workflows/evidence-bundle-release.yml
@@ -22,391 +22,396 @@ jobs:
     permissions:
       contents: write
       packages: read
-      id-token: write  # For cosign signing
-      attestations: write  # For SLSA provenance
+      id-token: write # For cosign signing
+      attestations: write # For SLSA provenance
     outputs:
       evidence-hash: ${{ steps.bundle.outputs.evidence-hash }}
       bundle-path: ${{ steps.bundle.outputs.bundle-path }}
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0  # Full history for provenance
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history for provenance
 
-    - name: Set up environment variables
-      id: vars
-      run: |
-        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-          RELEASE_TAG="${{ github.event.inputs.release_tag }}"
-        else
-          RELEASE_TAG="${{ github.ref_name }}"
-        fi
-
-        echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
-        echo "BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
-        echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
-        echo "GIT_SHORT_COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
-        echo "release-tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
-
-    - name: Install dependencies
-      run: |
-        # Install cosign for signature verification
-        curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64"
-        sudo mv cosign-linux-amd64 /usr/local/bin/cosign
-        sudo chmod +x /usr/local/bin/cosign
-
-        # Install syft for SBOM generation
-        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
-
-        # Install grype for vulnerability scanning
-        curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
-
-    - name: Log in to Container Registry
-      uses: docker/login-action@v3
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Create evidence bundle directory structure
-      run: |
-        mkdir -p evidence-bundle-${RELEASE_TAG}/
-        mkdir -p evidence-bundle-${RELEASE_TAG}/{sbom,security,signing,performance,policies,runbooks,charts}
-        mkdir -p evidence-bundle-${RELEASE_TAG}/reports/{slo,chaos,load-test}
-
-        echo "📁 Evidence bundle directory structure created"
-
-    - name: Generate and verify Helm chart
-      run: |
-        # Package Helm chart
-        helm package charts/intelgraph-maestro -d evidence-bundle-${RELEASE_TAG}/charts/
-
-        # Generate checksum
-        cd evidence-bundle-${RELEASE_TAG}/charts/
-        CHART_FILE=$(ls *.tgz)
-        sha256sum ${CHART_FILE} > ${CHART_FILE}.sha256
-
-        echo "✅ Helm chart packaged and checksummed"
-
-    - name: Generate SBOMs for all container images
-      run: |
-        IMAGES=(
-          "${IMAGE_PREFIX}/api:${RELEASE_TAG}"
-          "${IMAGE_PREFIX}/client:${RELEASE_TAG}"
-          "${IMAGE_PREFIX}/gateway:${RELEASE_TAG}"
-        )
-
-        for image in "${IMAGES[@]}"; do
-          component=$(echo $image | cut -d'/' -f3 | cut -d':' -f1)
-          echo "🔍 Generating SBOM for ${component}..."
-
-          # Generate SPDX SBOM
-          syft ${image} -o spdx-json=evidence-bundle-${RELEASE_TAG}/sbom/${component}-spdx.json
-
-          # Generate vulnerability report
-          grype ${image} -o json > evidence-bundle-${RELEASE_TAG}/security/${component}-trivy-report.json || true
-
-          echo "✅ SBOM and vulnerability scan completed for ${component}"
-        done
-
-    - name: Verify container image signatures
-      run: |
-        IMAGES=(
-          "${IMAGE_PREFIX}/api:${RELEASE_TAG}"
-          "${IMAGE_PREFIX}/client:${RELEASE_TAG}"
-          "${IMAGE_PREFIX}/gateway:${RELEASE_TAG}"
-        )
-
-        for image in "${IMAGES[@]}"; do
-          component=$(echo $image | cut -d'/' -f3 | cut -d':' -f1)
-          echo "🔐 Verifying signature for ${component}..."
-
-          # Verify with cosign (may fail if not signed yet)
-          cosign verify ${image} \
-            --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
-            --certificate-identity-regexp="^https://github.com/intelgraph/" \
-            > evidence-bundle-${RELEASE_TAG}/signing/${component}-cosign-verify.log 2>&1 || \
-            echo "⚠️ Signature verification failed for ${image} (may not be signed yet)"
-
-          # Get Rekor UUID if available
-          cosign verify ${image} --output=json 2>/dev/null | \
-            jq -r '.[0].optional.Bundle.Payload.logID // "not-found"' \
-            > evidence-bundle-${RELEASE_TAG}/signing/${component}-rekor-uuid.txt || \
-            echo "not-found" > evidence-bundle-${RELEASE_TAG}/signing/${component}-rekor-uuid.txt
-        done
-
-    - name: Package OPA policies
-      run: |
-        echo "📋 Packaging OPA policy bundle..."
-
-        # Create policy bundle
-        cd policies/opa
-        tar -czf ../../evidence-bundle-${RELEASE_TAG}/policies/opa-bundle.tar.gz .
-        cd ../../
-
-        # Generate checksum
-        sha256sum evidence-bundle-${RELEASE_TAG}/policies/opa-bundle.tar.gz > \
-          evidence-bundle-${RELEASE_TAG}/policies/opa-bundle.tar.gz.sha256
-
-        echo "✅ OPA policy bundle created and checksummed"
-
-    - name: Generate GraphQL schema artifacts
-      run: |
-        echo "🔍 Collecting GraphQL schema and persisted operations..."
-
-        # Copy GraphQL schema
-        mkdir -p evidence-bundle-${RELEASE_TAG}/graphql
-        find . -name "*.graphql" -o -name "schema.gql" | head -1 | \
-          xargs -I {} cp {} evidence-bundle-${RELEASE_TAG}/graphql/schema.graphql 2>/dev/null || \
-          echo "query { __schema { types { name } } }" > evidence-bundle-${RELEASE_TAG}/graphql/schema.graphql
-
-        # Generate persisted operations if script exists
-        if [ -f "client/scripts/generate-persisted-operations.js" ]; then
-          cd client && node scripts/generate-persisted-operations.js
-          cp persisted-operations.json ../evidence-bundle-${RELEASE_TAG}/graphql/
-          cd ..
-        else
-          echo '{"operations": {}}' > evidence-bundle-${RELEASE_TAG}/graphql/persisted-operations.json
-        fi
-
-        # Generate checksums
-        cd evidence-bundle-${RELEASE_TAG}/graphql
-        sha256sum *.json *.graphql > checksums.sha256
-        cd ../../
-
-        echo "✅ GraphQL artifacts collected"
-
-    - name: Collect database migrations
-      run: |
-        echo "🗄️ Collecting database migration files..."
-
-        mkdir -p evidence-bundle-${RELEASE_TAG}/db/migrations
-
-        # Copy PostgreSQL migrations if they exist
-        if [ -d "db/migrations" ]; then
-          cp -r db/migrations/* evidence-bundle-${RELEASE_TAG}/db/migrations/
-        fi
-
-        # Copy Neo4j migrations if they exist
-        if [ -d "graph/migrations" ]; then
-          mkdir -p evidence-bundle-${RELEASE_TAG}/graph/migrations
-          cp -r graph/migrations/* evidence-bundle-${RELEASE_TAG}/graph/migrations/
-        fi
-
-        echo "✅ Database migrations collected"
-
-    - name: Collect runbooks and documentation
-      run: |
-        echo "📚 Collecting runbooks and operational documentation..."
-
-        # Copy runbooks if they exist
-        if [ -d "runbooks" ]; then
-          cp -r runbooks/* evidence-bundle-${RELEASE_TAG}/runbooks/
-        fi
-
-        # Copy key documentation files
-        docs_files=(
-          "GO_LIVE_CUTOVER.md"
-          "GO_LIVE_APPROVAL.md"
-          "ALERT_POLICIES.yaml"
-          "EVIDENCE_BUNDLE.manifest.json"
-        )
-
-        for doc in "${docs_files[@]}"; do
-          if [ -f "$doc" ]; then
-            cp "$doc" evidence-bundle-${RELEASE_TAG}/
+      - name: Set up environment variables
+        id: vars
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            RELEASE_TAG="${{ github.event.inputs.release_tag }}"
+          else
+            RELEASE_TAG="${{ github.ref_name }}"
           fi
-        done
 
-        echo "✅ Documentation collected"
+          echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
+          echo "BUILD_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
+          echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "GIT_SHORT_COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-    - name: Generate performance test reports
-      run: |
-        echo "📊 Generating mock performance test reports..."
+          echo "release-tag=${RELEASE_TAG}" >> $GITHUB_OUTPUT
 
-        # Create mock k6 performance report
-        cat > evidence-bundle-${RELEASE_TAG}/reports/k6-baseline-test.json << 'EOF'
-        {
-          "metrics": {
-            "http_req_duration": {"avg": 245.5, "p95": 320.0, "p99": 456.2},
-            "http_req_failed": {"rate": 0.008},
-            "http_reqs": {"count": 12450, "rate": 207.5},
-            "vus": {"value": 100}
-          },
-          "test_timestamp": "2025-09-21T16:30:00Z",
-          "test_duration": "10m",
-          "slo_compliance": true
-        }
-        EOF
+      - name: Install dependencies
+        run: |
+          # Install cosign for signature verification
+          curl -O -L "https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64"
+          sudo mv cosign-linux-amd64 /usr/local/bin/cosign
+          sudo chmod +x /usr/local/bin/cosign
 
-        # Create mock SLO compliance report
-        cat > evidence-bundle-${RELEASE_TAG}/reports/slo-compliance-report.json << 'EOF'
-        {
-          "measurement_window": "24h",
-          "slos": {
-            "api_availability": {"target": 99.9, "actual": 99.97, "status": "met"},
-            "api_p95_latency_ms": {"target": 350, "actual": 285, "status": "met"},
-            "graph_query_p95_ms": {"target": 1200, "actual": 890, "status": "met"},
-            "error_rate_percent": {"target": 0.1, "actual": 0.008, "status": "met"}
-          },
-          "generated_at": "2025-09-21T16:30:00Z"
-        }
-        EOF
+          # Install syft for SBOM generation
+          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 
-        echo "✅ Performance reports generated"
+          # Install grype for vulnerability scanning
+          curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin
 
-    - name: Populate evidence bundle manifest
-      id: manifest
-      run: |
-        echo "📋 Populating evidence bundle manifest..."
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-        # Calculate dynamic values
-        API_DIGEST=$(docker inspect ${IMAGE_PREFIX}/api:${RELEASE_TAG} --format='{{index .RepoDigests 0}}' 2>/dev/null | cut -d@ -f2 || echo "sha256:not-available")
-        CLIENT_DIGEST=$(docker inspect ${IMAGE_PREFIX}/client:${RELEASE_TAG} --format='{{index .RepoDigests 0}}' 2>/dev/null | cut -d@ -f2 || echo "sha256:not-available")
-        GATEWAY_DIGEST=$(docker inspect ${IMAGE_PREFIX}/gateway:${RELEASE_TAG} --format='{{index .RepoDigests 0}}' 2>/dev/null | cut -d@ -f2 || echo "sha256:not-available")
+      - name: Create evidence bundle directory structure
+        run: |
+          mkdir -p evidence-bundle-${RELEASE_TAG}/
+          mkdir -p evidence-bundle-${RELEASE_TAG}/{sbom,security,signing,performance,policies,runbooks,charts}
+          mkdir -p evidence-bundle-${RELEASE_TAG}/reports/{slo,chaos,load-test}
 
-        OPA_BUNDLE_HASH=$(sha256sum evidence-bundle-${RELEASE_TAG}/policies/opa-bundle.tar.gz | cut -d' ' -f1)
-        SCHEMA_HASH=$(sha256sum evidence-bundle-${RELEASE_TAG}/graphql/schema.graphql | cut -d' ' -f1)
-        PERSISTED_OPS_HASH=$(sha256sum evidence-bundle-${RELEASE_TAG}/graphql/persisted-operations.json | cut -d' ' -f1)
+          echo "📁 Evidence bundle directory structure created"
 
-        # Create populated manifest
-        sed -e "s/{{ .Release.GitCommit }}/${GIT_COMMIT}/g" \
-            -e "s/{{ .Release.BuildTime }}/${BUILD_TIMESTAMP}/g" \
-            -e "s/{{ .Release.Pipeline }}/${GITHUB_RUN_ID}/g" \
-            -e "s/{{ .Release.Approver }}/${GITHUB_ACTOR}/g" \
-            -e "s/{{ .Images.API.Digest }}/${API_DIGEST}/g" \
-            -e "s/{{ .Images.Client.Digest }}/${CLIENT_DIGEST}/g" \
-            -e "s/{{ .Images.Gateway.Digest }}/${GATEWAY_DIGEST}/g" \
-            -e "s/{{ sha256sum policies\/opa\/bundle.tar.gz }}/${OPA_BUNDLE_HASH}/g" \
-            -e "s/{{ sha256sum graphql\/schema.graphql }}/${SCHEMA_HASH}/g" \
-            -e "s/{{ sha256sum graphql\/persisted-operations.json }}/${PERSISTED_OPS_HASH}/g" \
-            EVIDENCE_BUNDLE.manifest.json > evidence-bundle-${RELEASE_TAG}/EVIDENCE_BUNDLE.manifest.json
+      - name: Generate and verify Helm chart
+        run: |
+          # Package Helm chart
+          helm package charts/intelgraph-maestro -d evidence-bundle-${RELEASE_TAG}/charts/
 
-        echo "✅ Evidence bundle manifest populated"
+          # Generate checksum
+          cd evidence-bundle-${RELEASE_TAG}/charts/
+          CHART_FILE=$(ls *.tgz)
+          sha256sum ${CHART_FILE} > ${CHART_FILE}.sha256
 
-    - name: Create and sign evidence bundle
-      id: bundle
-      run: |
-        echo "📦 Creating evidence bundle archive..."
+          echo "✅ Helm chart packaged and checksummed"
 
-        # Create compressed archive
-        tar -czf evidence-bundle-${RELEASE_TAG}.tar.gz evidence-bundle-${RELEASE_TAG}/
+      - name: Generate SBOMs and vulnerability reports
+        run: |
+          set -euo pipefail
 
-        # Generate final checksum
-        BUNDLE_HASH=$(sha256sum evidence-bundle-${RELEASE_TAG}.tar.gz | cut -d' ' -f1)
-        echo "${BUNDLE_HASH}  evidence-bundle-${RELEASE_TAG}.tar.gz" > evidence-bundle-${RELEASE_TAG}.tar.gz.sha256
+          IMAGES=(
+            "${IMAGE_PREFIX}/api:${RELEASE_TAG}"
+            "${IMAGE_PREFIX}/client:${RELEASE_TAG}"
+            "${IMAGE_PREFIX}/gateway:${RELEASE_TAG}"
+          )
 
-        # Sign the bundle with cosign (keyless signing)
-        cosign sign-blob evidence-bundle-${RELEASE_TAG}.tar.gz \
-          --output-signature evidence-bundle-${RELEASE_TAG}.tar.gz.sig \
-          --output-certificate evidence-bundle-${RELEASE_TAG}.tar.gz.crt
+          for image in "${IMAGES[@]}"; do
+            component=$(echo "$image" | cut -d'/' -f3 | cut -d':' -f1)
+            echo "🔍 Generating SBOM and license manifest for ${component}..."
 
-        echo "📦 Evidence bundle size: $(du -h evidence-bundle-${RELEASE_TAG}.tar.gz | cut -f1)"
-        echo "🔐 Evidence bundle SHA256: ${BUNDLE_HASH}"
+            syft "$image" -o json > "evidence-bundle-${RELEASE_TAG}/sbom/${component}-sbom.json"
+            syft convert "evidence-bundle-${RELEASE_TAG}/sbom/${component}-sbom.json" -o spdx-json > "evidence-bundle-${RELEASE_TAG}/sbom/${component}-sbom.spdx.json"
 
-        # Set outputs
-        echo "evidence-hash=${BUNDLE_HASH}" >> $GITHUB_OUTPUT
-        echo "bundle-path=evidence-bundle-${RELEASE_TAG}.tar.gz" >> $GITHUB_OUTPUT
+            jq --arg component "$component" --arg image "$image" --arg generated "${BUILD_TIMESTAMP}" 'def allowed: ["MIT","MIT-0","MIT-OK","Apache-2.0","BSD-2-Clause","BSD-3-Clause","ISC","Open-Data-OK"]; def restricted: ["Restricted-TOS"]; def isin($list; $value): ($list | index($value)) != null; def license_policy($licenses): if any($licenses[]; isin(restricted; .)) then "restricted" elif ($licenses | length > 0 and all($licenses[]; isin(allowed; .))) then "allowed" else "review" end; {component: $component, image: $image, generated: $generated, packages: [((.artifacts // [])[] | ([(.licenses // [])[] | .value] | unique) as $licenses | {name, version, licenses: $licenses, policy: license_policy($licenses)})]}' "evidence-bundle-${RELEASE_TAG}/sbom/${component}-sbom.json" > "evidence-bundle-${RELEASE_TAG}/sbom/${component}-license-manifest.json"
 
-        echo "✅ Evidence bundle created and signed"
+            echo "🛡️ Running Grype scan for ${component} (fail on high)..."
+            grype "$image" --fail-on high -o json | tee "evidence-bundle-${RELEASE_TAG}/security/${component}-grype-report.json" >/dev/null
 
-    - name: Generate SLSA provenance
-      uses: actions/attest-build-provenance@v1
-      with:
-        subject-path: evidence-bundle-${{ env.RELEASE_TAG }}.tar.gz
+            echo "✅ SBOM, license manifest, and vulnerability scan completed for ${component}"
+          done
 
-    - name: Upload evidence bundle to release
-      if: startsWith(github.ref, 'refs/tags/')
-      run: |
-        echo "📤 Uploading evidence bundle to GitHub release..."
+      - name: Verify container image signatures
+        run: |
+          IMAGES=(
+            "${IMAGE_PREFIX}/api:${RELEASE_TAG}"
+            "${IMAGE_PREFIX}/client:${RELEASE_TAG}"
+            "${IMAGE_PREFIX}/gateway:${RELEASE_TAG}"
+          )
 
-        # Check if release exists, create if not
-        if ! gh release view ${RELEASE_TAG} >/dev/null 2>&1; then
-          echo "Creating release ${RELEASE_TAG}..."
-          gh release create ${RELEASE_TAG} \
-            --title "IntelGraph Maestro ${RELEASE_TAG}" \
-            --notes "Enterprise-grade production release with complete compliance evidence bundle." \
-            --verify-tag
-        fi
+          for image in "${IMAGES[@]}"; do
+            component=$(echo $image | cut -d'/' -f3 | cut -d':' -f1)
+            echo "🔐 Verifying signature for ${component}..."
 
-        # Upload evidence bundle and related files
-        gh release upload ${RELEASE_TAG} \
-          evidence-bundle-${RELEASE_TAG}.tar.gz \
-          evidence-bundle-${RELEASE_TAG}.tar.gz.sha256 \
-          evidence-bundle-${RELEASE_TAG}.tar.gz.sig \
-          evidence-bundle-${RELEASE_TAG}.tar.gz.crt \
-          --clobber
+            # Verify with cosign (may fail if not signed yet)
+            cosign verify ${image} \
+              --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+              --certificate-identity-regexp="^https://github.com/intelgraph/" \
+              > evidence-bundle-${RELEASE_TAG}/signing/${component}-cosign-verify.log 2>&1 || \
+              echo "⚠️ Signature verification failed for ${image} (may not be signed yet)"
 
-        echo "✅ Evidence bundle uploaded to release"
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            # Get Rekor UUID if available
+            cosign verify ${image} --output=json 2>/dev/null | \
+              jq -r '.[0].optional.Bundle.Payload.logID // "not-found"' \
+              > evidence-bundle-${RELEASE_TAG}/signing/${component}-rekor-uuid.txt || \
+              echo "not-found" > evidence-bundle-${RELEASE_TAG}/signing/${component}-rekor-uuid.txt
+          done
 
-    - name: Post evidence bundle summary
-      run: |
-        echo "## 📦 Evidence Bundle Generated Successfully" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Release:** \`${RELEASE_TAG}\`" >> $GITHUB_STEP_SUMMARY
-        echo "**Bundle Hash:** \`${{ steps.bundle.outputs.evidence-hash }}\`" >> $GITHUB_STEP_SUMMARY
-        echo "**Bundle Size:** \`$(du -h ${{ steps.bundle.outputs.bundle-path }} | cut -f1)\`" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### 📋 Included Artifacts" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ Helm charts with production values" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ Container image SBOMs (SPDX format)" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ Vulnerability scan reports" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ Cosign signature verification" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ OPA policy bundle with checksums" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ GraphQL schema + persisted operations" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ Database migration scripts" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ Performance and SLO reports" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ Operational runbooks" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ Compliance documentation" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### 🔐 Security Attestations" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ SLSA Level 3 build provenance" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ Cosign keyless signing" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ Rekor transparency log" >> $GITHUB_STEP_SUMMARY
-        echo "- ✅ Container image signatures verified" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**🎉 Evidence bundle ready for production deployment and compliance audit!**"
+      - name: Package OPA policies
+        run: |
+          echo "📋 Packaging OPA policy bundle..."
+
+          # Create policy bundle
+          cd policies/opa
+          tar -czf ../../evidence-bundle-${RELEASE_TAG}/policies/opa-bundle.tar.gz .
+          cd ../../
+
+          # Generate checksum
+          sha256sum evidence-bundle-${RELEASE_TAG}/policies/opa-bundle.tar.gz > \
+            evidence-bundle-${RELEASE_TAG}/policies/opa-bundle.tar.gz.sha256
+
+          echo "✅ OPA policy bundle created and checksummed"
+
+      - name: Generate GraphQL schema artifacts
+        run: |
+          echo "🔍 Collecting GraphQL schema and persisted operations..."
+
+          # Copy GraphQL schema
+          mkdir -p evidence-bundle-${RELEASE_TAG}/graphql
+          find . -name "*.graphql" -o -name "schema.gql" | head -1 | \
+            xargs -I {} cp {} evidence-bundle-${RELEASE_TAG}/graphql/schema.graphql 2>/dev/null || \
+            echo "query { __schema { types { name } } }" > evidence-bundle-${RELEASE_TAG}/graphql/schema.graphql
+
+          # Generate persisted operations if script exists
+          if [ -f "client/scripts/generate-persisted-operations.js" ]; then
+            cd client && node scripts/generate-persisted-operations.js
+            cp persisted-operations.json ../evidence-bundle-${RELEASE_TAG}/graphql/
+            cd ..
+          else
+            echo '{"operations": {}}' > evidence-bundle-${RELEASE_TAG}/graphql/persisted-operations.json
+          fi
+
+          # Generate checksums
+          cd evidence-bundle-${RELEASE_TAG}/graphql
+          sha256sum *.json *.graphql > checksums.sha256
+          cd ../../
+
+          echo "✅ GraphQL artifacts collected"
+
+      - name: Collect database migrations
+        run: |
+          echo "🗄️ Collecting database migration files..."
+
+          mkdir -p evidence-bundle-${RELEASE_TAG}/db/migrations
+
+          # Copy PostgreSQL migrations if they exist
+          if [ -d "db/migrations" ]; then
+            cp -r db/migrations/* evidence-bundle-${RELEASE_TAG}/db/migrations/
+          fi
+
+          # Copy Neo4j migrations if they exist
+          if [ -d "graph/migrations" ]; then
+            mkdir -p evidence-bundle-${RELEASE_TAG}/graph/migrations
+            cp -r graph/migrations/* evidence-bundle-${RELEASE_TAG}/graph/migrations/
+          fi
+
+          echo "✅ Database migrations collected"
+
+      - name: Collect runbooks and documentation
+        run: |
+          echo "📚 Collecting runbooks and operational documentation..."
+
+          # Copy runbooks if they exist
+          if [ -d "runbooks" ]; then
+            cp -r runbooks/* evidence-bundle-${RELEASE_TAG}/runbooks/
+          fi
+
+          # Copy key documentation files
+          docs_files=(
+            "GO_LIVE_CUTOVER.md"
+            "GO_LIVE_APPROVAL.md"
+            "ALERT_POLICIES.yaml"
+            "EVIDENCE_BUNDLE.manifest.json"
+          )
+
+          for doc in "${docs_files[@]}"; do
+            if [ -f "$doc" ]; then
+              cp "$doc" evidence-bundle-${RELEASE_TAG}/
+            fi
+          done
+
+          echo "✅ Documentation collected"
+
+      - name: Generate performance test reports
+        run: |
+          echo "📊 Generating mock performance test reports..."
+
+          # Create mock k6 performance report
+          cat > evidence-bundle-${RELEASE_TAG}/reports/k6-baseline-test.json << 'EOF'
+          {
+            "metrics": {
+              "http_req_duration": {"avg": 245.5, "p95": 320.0, "p99": 456.2},
+              "http_req_failed": {"rate": 0.008},
+              "http_reqs": {"count": 12450, "rate": 207.5},
+              "vus": {"value": 100}
+            },
+            "test_timestamp": "2025-09-21T16:30:00Z",
+            "test_duration": "10m",
+            "slo_compliance": true
+          }
+          EOF
+
+          # Create mock SLO compliance report
+          cat > evidence-bundle-${RELEASE_TAG}/reports/slo-compliance-report.json << 'EOF'
+          {
+            "measurement_window": "24h",
+            "slos": {
+              "api_availability": {"target": 99.9, "actual": 99.97, "status": "met"},
+              "api_p95_latency_ms": {"target": 350, "actual": 285, "status": "met"},
+              "graph_query_p95_ms": {"target": 1200, "actual": 890, "status": "met"},
+              "error_rate_percent": {"target": 0.1, "actual": 0.008, "status": "met"}
+            },
+            "generated_at": "2025-09-21T16:30:00Z"
+          }
+          EOF
+
+          echo "✅ Performance reports generated"
+
+      - name: Populate evidence bundle manifest
+        id: manifest
+        run: |
+          echo "📋 Populating evidence bundle manifest..."
+
+          # Calculate dynamic values
+          API_DIGEST=$(docker inspect ${IMAGE_PREFIX}/api:${RELEASE_TAG} --format='{{index .RepoDigests 0}}' 2>/dev/null | cut -d@ -f2 || echo "sha256:not-available")
+          CLIENT_DIGEST=$(docker inspect ${IMAGE_PREFIX}/client:${RELEASE_TAG} --format='{{index .RepoDigests 0}}' 2>/dev/null | cut -d@ -f2 || echo "sha256:not-available")
+          GATEWAY_DIGEST=$(docker inspect ${IMAGE_PREFIX}/gateway:${RELEASE_TAG} --format='{{index .RepoDigests 0}}' 2>/dev/null | cut -d@ -f2 || echo "sha256:not-available")
+
+          OPA_BUNDLE_HASH=$(sha256sum evidence-bundle-${RELEASE_TAG}/policies/opa-bundle.tar.gz | cut -d' ' -f1)
+          SCHEMA_HASH=$(sha256sum evidence-bundle-${RELEASE_TAG}/graphql/schema.graphql | cut -d' ' -f1)
+          PERSISTED_OPS_HASH=$(sha256sum evidence-bundle-${RELEASE_TAG}/graphql/persisted-operations.json | cut -d' ' -f1)
+
+          # Create populated manifest
+          sed -e "s/{{ .Release.GitCommit }}/${GIT_COMMIT}/g" \
+              -e "s/{{ .Release.BuildTime }}/${BUILD_TIMESTAMP}/g" \
+              -e "s/{{ .Release.Pipeline }}/${GITHUB_RUN_ID}/g" \
+              -e "s/{{ .Release.Approver }}/${GITHUB_ACTOR}/g" \
+              -e "s/{{ .Images.API.Digest }}/${API_DIGEST}/g" \
+              -e "s/{{ .Images.Client.Digest }}/${CLIENT_DIGEST}/g" \
+              -e "s/{{ .Images.Gateway.Digest }}/${GATEWAY_DIGEST}/g" \
+              -e "s/{{ sha256sum policies\/opa\/bundle.tar.gz }}/${OPA_BUNDLE_HASH}/g" \
+              -e "s/{{ sha256sum graphql\/schema.graphql }}/${SCHEMA_HASH}/g" \
+              -e "s/{{ sha256sum graphql\/persisted-operations.json }}/${PERSISTED_OPS_HASH}/g" \
+              EVIDENCE_BUNDLE.manifest.json > evidence-bundle-${RELEASE_TAG}/EVIDENCE_BUNDLE.manifest.json
+
+          echo "✅ Evidence bundle manifest populated"
+
+      - name: Create and sign evidence bundle
+        id: bundle
+        run: |
+          echo "📦 Creating evidence bundle archive..."
+
+          # Create compressed archive
+          tar -czf evidence-bundle-${RELEASE_TAG}.tar.gz evidence-bundle-${RELEASE_TAG}/
+
+          # Generate final checksum
+          BUNDLE_HASH=$(sha256sum evidence-bundle-${RELEASE_TAG}.tar.gz | cut -d' ' -f1)
+          echo "${BUNDLE_HASH}  evidence-bundle-${RELEASE_TAG}.tar.gz" > evidence-bundle-${RELEASE_TAG}.tar.gz.sha256
+
+          # Sign the bundle with cosign (keyless signing)
+          cosign sign-blob evidence-bundle-${RELEASE_TAG}.tar.gz \
+            --output-signature evidence-bundle-${RELEASE_TAG}.tar.gz.sig \
+            --output-certificate evidence-bundle-${RELEASE_TAG}.tar.gz.crt
+
+          echo "📦 Evidence bundle size: $(du -h evidence-bundle-${RELEASE_TAG}.tar.gz | cut -f1)"
+          echo "🔐 Evidence bundle SHA256: ${BUNDLE_HASH}"
+
+          # Set outputs
+          echo "evidence-hash=${BUNDLE_HASH}" >> $GITHUB_OUTPUT
+          echo "bundle-path=evidence-bundle-${RELEASE_TAG}.tar.gz" >> $GITHUB_OUTPUT
+
+          echo "✅ Evidence bundle created and signed"
+
+      - name: Generate SLSA provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: evidence-bundle-${{ env.RELEASE_TAG }}.tar.gz
+
+      - name: Upload evidence bundle to release
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          echo "📤 Uploading evidence bundle to GitHub release..."
+
+          # Check if release exists, create if not
+          if ! gh release view ${RELEASE_TAG} >/dev/null 2>&1; then
+            echo "Creating release ${RELEASE_TAG}..."
+            gh release create ${RELEASE_TAG} \
+              --title "IntelGraph Maestro ${RELEASE_TAG}" \
+              --notes "Enterprise-grade production release with complete compliance evidence bundle." \
+              --verify-tag
+          fi
+
+          # Upload evidence bundle and related files
+          gh release upload ${RELEASE_TAG} \
+            evidence-bundle-${RELEASE_TAG}.tar.gz \
+            evidence-bundle-${RELEASE_TAG}.tar.gz.sha256 \
+            evidence-bundle-${RELEASE_TAG}.tar.gz.sig \
+            evidence-bundle-${RELEASE_TAG}.tar.gz.crt \
+            --clobber
+
+          echo "✅ Evidence bundle uploaded to release"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Post evidence bundle summary
+        run: |
+          echo "## 📦 Evidence Bundle Generated Successfully" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Release:** \`${RELEASE_TAG}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Bundle Hash:** \`${{ steps.bundle.outputs.evidence-hash }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Bundle Size:** \`$(du -h ${{ steps.bundle.outputs.bundle-path }} | cut -f1)\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 📋 Included Artifacts" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Helm charts with production values" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Container image SBOMs (SPDX format)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ License manifests with policy tags" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Vulnerability scan reports (Grype fail-on-high)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Cosign signature verification" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ OPA policy bundle with checksums" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ GraphQL schema + persisted operations" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Database migration scripts" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Performance and SLO reports" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Operational runbooks" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Compliance documentation" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### 🔐 Security Attestations" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ SLSA Level 3 build provenance" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Cosign keyless signing" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Rekor transparency log" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Container image signatures verified" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**🎉 Evidence bundle ready for production deployment and compliance audit!**"
 
   validate-evidence-bundle:
     name: Validate Evidence Bundle
     runs-on: ubuntu-latest
     needs: generate-evidence-bundle
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Download evidence bundle
-      run: |
-        # This would download from the release in a real scenario
-        echo "📥 Evidence bundle validation would happen here"
-        echo "Bundle hash: ${{ needs.generate-evidence-bundle.outputs.evidence-hash }}"
+      - name: Download evidence bundle
+        run: |
+          # This would download from the release in a real scenario
+          echo "📥 Evidence bundle validation would happen here"
+          echo "Bundle hash: ${{ needs.generate-evidence-bundle.outputs.evidence-hash }}"
 
-        # Validate bundle structure
-        echo "✅ Bundle structure validation passed"
+          # Validate bundle structure
+          echo "✅ Bundle structure validation passed"
 
-        # Validate checksums
-        echo "✅ Checksum validation passed"
+          # Validate checksums
+          echo "✅ Checksum validation passed"
 
-        # Validate signatures
-        echo "✅ Signature validation passed"
+          # Validate signatures
+          echo "✅ Signature validation passed"
 
-    - name: Compliance check summary
-      run: |
-        echo "## 🛡️ Evidence Bundle Compliance Validation" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "| Check | Status | Details |" >> $GITHUB_STEP_SUMMARY
-        echo "|-------|--------|---------|" >> $GITHUB_STEP_SUMMARY
-        echo "| Bundle Structure | ✅ PASS | All required directories present |" >> $GITHUB_STEP_SUMMARY
-        echo "| Artifact Checksums | ✅ PASS | SHA256 hashes verified |" >> $GITHUB_STEP_SUMMARY
-        echo "| Digital Signatures | ✅ PASS | Cosign signatures valid |" >> $GITHUB_STEP_SUMMARY
-        echo "| SBOM Completeness | ✅ PASS | All container SBOMs included |" >> $GITHUB_STEP_SUMMARY
-        echo "| Security Scans | ✅ PASS | Vulnerability reports included |" >> $GITHUB_STEP_SUMMARY
-        echo "| Policy Bundle | ✅ PASS | OPA policies verified |" >> $GITHUB_STEP_SUMMARY
-        echo "| Performance Data | ✅ PASS | SLO compliance reports included |" >> $GITHUB_STEP_SUMMARY
-        echo "| Documentation | ✅ PASS | Runbooks and procedures complete |" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**🎯 Evidence bundle meets all enterprise compliance requirements!**"
+      - name: Compliance check summary
+        run: |
+          echo "## 🛡️ Evidence Bundle Compliance Validation" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Check | Status | Details |" >> $GITHUB_STEP_SUMMARY
+          echo "|-------|--------|---------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Bundle Structure | ✅ PASS | All required directories present |" >> $GITHUB_STEP_SUMMARY
+          echo "| Artifact Checksums | ✅ PASS | SHA256 hashes verified |" >> $GITHUB_STEP_SUMMARY
+          echo "| Digital Signatures | ✅ PASS | Cosign signatures valid |" >> $GITHUB_STEP_SUMMARY
+          echo "| SBOM Completeness | ✅ PASS | All container SBOMs included |" >> $GITHUB_STEP_SUMMARY
+          echo "| Security Scans | ✅ PASS | Vulnerability reports included |" >> $GITHUB_STEP_SUMMARY
+          echo "| Policy Bundle | ✅ PASS | OPA policies verified |" >> $GITHUB_STEP_SUMMARY
+          echo "| Performance Data | ✅ PASS | SLO compliance reports included |" >> $GITHUB_STEP_SUMMARY
+          echo "| Documentation | ✅ PASS | Runbooks and procedures complete |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**🎯 Evidence bundle meets all enterprise compliance requirements!**"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,13 +1,33 @@
 name: gitleaks
+
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
+    branches: [main]
+
 jobs:
   scan:
+    name: Secret scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: gitleaks
-        uses: zricethezav/gitleaks-action@v2
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          config-path: .gitleaks.toml
+          args: detect --no-banner --redact --report-format json --report-path gitleaks-report.json
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: gitleaks-report.json
+          if-no-files-found: error

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/labeler@v5
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
 
   dependency-review:
     runs-on: ubuntu-latest
@@ -24,14 +24,14 @@ jobs:
       - uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: high
-          allow-licenses: "MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC"
-          deny-licenses: "GPL-2.0,GPL-3.0"
+          allow-licenses: 'MIT,MIT-0,MIT-OK,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,Open-Data-OK'
+          deny-licenses: 'GPL-2.0,GPL-3.0,Restricted-TOS'
 
   quick-checks:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -40,24 +40,24 @@ jobs:
           cache-dependency-path: |
             client/package-lock.json
             server/package-lock.json
-      
+
       - name: Install dependencies
         run: |
           cd client && npm ci
           cd ../server && npm ci
-      
+
       - name: Lint client
         run: cd client && npm run lint --if-present
         continue-on-error: true
-      
-      - name: Lint server  
+
+      - name: Lint server
         run: cd server && npm run lint --if-present
         continue-on-error: true
-      
+
       - name: Test client
         run: cd client && npm run test --if-present -- --watchAll=false
         continue-on-error: true
-      
+
       - name: Test server
         run: cd server && npm run test --if-present -- --ci
         continue-on-error: true

--- a/.github/workflows/supply-chain-security.yml
+++ b/.github/workflows/supply-chain-security.yml
@@ -1,0 +1,44 @@
+name: Supply Chain Security
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+jobs:
+  sbom-and-scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate SBOM (Syft)
+        id: syft
+        uses: anchore/sbom-action@v0.17.6
+        with:
+          path: .
+          format: spdx-json
+          output-file: intelgraph-repo.spdx.json
+          upload-artifact: true
+          artifact-name: repo-sbom
+
+      - name: Vulnerability scan (Grype)
+        uses: anchore/scan-action@v3
+        with:
+          path: .
+          fail-build: true
+          severity-cutoff: high
+          output-format: sarif
+          output-file: grype-results.sarif
+
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: grype-results.sarif

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ node_modules
 **/*.snap
 **/generated/**
 **/.graphqlrc*
+infra/helm/**/templates/*.yaml

--- a/infra/helm/intelgraph/templates/deployment-client.yaml
+++ b/infra/helm/intelgraph/templates/deployment-client.yaml
@@ -53,10 +53,10 @@ spec:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 10
-            periodSeconds: 5
-            timeoutSeconds: 2
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.healthCheck.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthCheck.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.healthCheck.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.healthCheck.readiness.failureThreshold }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources.client | nindent 12 }}

--- a/infra/helm/intelgraph/templates/deployment-server.yaml
+++ b/infra/helm/intelgraph/templates/deployment-server.yaml
@@ -54,10 +54,10 @@ spec:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 3
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.healthCheck.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.healthCheck.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.healthCheck.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.healthCheck.readiness.failureThreshold }}
           {{- end }}
           resources:
             {{- toYaml .Values.resources.server | nindent 12 }}

--- a/infra/helm/intelgraph/templates/pod-security-policy.yaml
+++ b/infra/helm/intelgraph/templates/pod-security-policy.yaml
@@ -109,13 +109,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 subjects:
 - kind: ServiceAccount
-  name: {{ include "intelgraph.serviceAccountName" . }}-api
-  namespace: {{ .Release.Namespace }}
-- kind: ServiceAccount
-  name: {{ include "intelgraph.serviceAccountName" . }}-client
-  namespace: {{ .Release.Namespace }}
-- kind: ServiceAccount
-  name: {{ include "intelgraph.serviceAccountName" . }}-worker
+  name: {{ include "intelgraph.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 
 {{- end }}

--- a/infra/helm/intelgraph/templates/serviceaccount.yaml
+++ b/infra/helm/intelgraph/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "intelgraph.serviceAccountName" . }}
+  labels:
+    {{- include "intelgraph.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/infra/helm/intelgraph/values.yaml
+++ b/infra/helm/intelgraph/values.yaml
@@ -4,29 +4,42 @@ replicaCount: 1
 image:
   server:
     repository: ghcr.io/brianlong/intelgraph/server
-    tag: "dev"
+    tag: 'dev'
     pullPolicy: IfNotPresent
   client:
     repository: ghcr.io/brianlong/intelgraph/client
-    tag: "dev"
+    tag: 'dev'
     pullPolicy: IfNotPresent
 
-nameOverride: ""
-fullnameOverride: ""
+nameOverride: ''
+fullnameOverride: ''
 
 serviceAccount:
   create: true
   annotations: {}
-  name: ""
+  name: ''
 
 podAnnotations: {}
 
 podSecurityContext:
-  fsGroup: 2000
+  runAsNonRoot: true
+  runAsUser: 65532
+  runAsGroup: 65532
+  fsGroup: 65532
+  seccompProfile:
+    type: RuntimeDefault
 
 securityContext:
   runAsNonRoot: true
-  runAsUser: 1000
+  runAsUser: 65532
+  runAsGroup: 65532
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
 
 service:
   type: ClusterIP
@@ -38,7 +51,7 @@ service:
 
 ingress:
   enabled: false
-  className: ""
+  className: ''
   annotations: {}
   hosts:
     - host: chart-example.local
@@ -76,6 +89,7 @@ redis:
 # Global configuration
 global:
   environment: development
+  podSecurityStandards: restricted
   prometheus:
     path: /metrics
   cluster:
@@ -103,7 +117,7 @@ spire:
   agent:
     replicas: 1
   helper:
-    image: "ghcr.io/spiffe/spiffe-helper:0.6.0"
+    image: 'ghcr.io/spiffe/spiffe-helper:0.6.0'
 
 # Services configuration
 services:
@@ -162,7 +176,7 @@ rollout:
 # Monitoring configuration
 monitoring:
   prometheus:
-    server: "prometheus.monitoring.svc.cluster.local:9090"
+    server: 'prometheus.monitoring.svc.cluster.local:9090'
   prometheusRules:
     enabled: false
 
@@ -187,7 +201,7 @@ otel:
 # Preview environment specific settings
 preview:
   enabled: false
-  ttl: "24h"
+  ttl: '24h'
   cleanup: true
 # Zero Trust configuration
 zeroTrust:
@@ -196,10 +210,10 @@ zeroTrust:
 # Audit configuration
 audit:
   wormEnabled: false
-  bucket: "intelgraph-audit-logs"
-  storageSize: "10Gi"
+  bucket: 'intelgraph-audit-logs'
+  storageSize: '10Gi'
   worm:
-    image: "amazon/aws-cli:2.13.32"
+    image: 'amazon/aws-cli:2.13.32'
 
 # mTLS configuration
 mtls:
@@ -207,32 +221,32 @@ mtls:
 
 # AWS configuration
 aws:
-  region: "us-east-1"
+  region: 'us-east-1'
 
 # Security configuration
 security:
   podSecurityPolicy:
-    enabled: false
+    enabled: true
   networkPolicies:
-    enabled: false
+    enabled: true
     defaultDeny:
-      enabled: false
+      enabled: true
 
 # Federal configuration
 federal:
-  classification: "UNCLASSIFIED"
+  classification: 'UNCLASSIFIED'
   airGap:
     enabled: false
   breakGlass:
     emergencyNetworkOverride: false
   fips:
-    enforcementAction: "warn"
+    enforcementAction: 'warn'
   enforcement:
     resourceLimits: false
   limits:
     maxCpu: 2
   hsm:
-    provider: "none"
+    provider: 'none'
   storage:
     fipsCrypto: false
 
@@ -254,10 +268,19 @@ cors:
 
 # Network Policy configuration
 networkPolicy:
-  enabled: false
+  enabled: true
 
 # Health check configuration
 healthCheck:
   enabled: true
   path: /health
   port: 8080
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 3
+  failureThreshold: 3
+  readiness:
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 2
+    failureThreshold: 3

--- a/services/api-gateway/Dockerfile
+++ b/services/api-gateway/Dockerfile
@@ -1,40 +1,40 @@
-FROM node:20-alpine AS base
+# syntax=docker/dockerfile:1.7
+ARG NODE_VERSION=20.14.0
 
-# Install dependencies only when needed
-FROM base AS deps
+FROM node:${NODE_VERSION}-alpine AS deps
 WORKDIR /app
-
-# Copy package files
 COPY package*.json ./
-RUN npm ci --only=production
+RUN npm ci --omit=dev
 
-# Build the application
-FROM base AS builder
+FROM node:${NODE_VERSION}-alpine AS build
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
-
 COPY src ./src
 COPY tsconfig.json ./
 RUN npm run build
 
-# Production image
-FROM base AS runner
-WORKDIR /app
+FROM gcr.io/distroless/nodejs20-debian12:nonroot AS final
+
+LABEL org.opencontainers.image.title="IntelGraph API Gateway"
+LABEL org.opencontainers.image.description="Edge gateway for IntelGraph APIs"
+LABEL org.opencontainers.image.source="https://github.com/BrianCLong/intelgraph"
+LABEL org.opencontainers.image.licenses="MIT"
+
+WORKDIR /home/node/app
 
 ENV NODE_ENV=production
+ENV PORT=4000
 
-# Create non-root user
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 api-gateway
+COPY --from=build --chown=65532:65532 /app/dist ./dist
+COPY --from=deps --chown=65532:65532 /app/node_modules ./node_modules
+COPY --from=deps --chown=65532:65532 /app/package.json ./
 
-# Copy built application
-COPY --from=builder --chown=api-gateway:nodejs /app/dist ./dist
-COPY --from=deps --chown=api-gateway:nodejs /app/node_modules ./node_modules
-COPY --chown=api-gateway:nodejs package.json ./
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD node -e "require('http').get(`http://127.0.0.1:${process.env.PORT||4000}/health`, res => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
 
-USER api-gateway
+USER 65532
 
 EXPOSE 4000
 
-CMD ["node", "dist/index.js"]
+CMD ["dist/index.js"]

--- a/services/client/Dockerfile
+++ b/services/client/Dockerfile
@@ -1,70 +1,44 @@
 # syntax=docker/dockerfile:1.7
 ARG NODE_VERSION=20.14.0
 
-# Dependencies stage
 FROM node:${NODE_VERSION}-alpine AS deps
 RUN corepack enable && apk add --no-cache libc6-compat
 WORKDIR /app
-
-# Copy package management files
 COPY package.json pnpm-lock.yaml ./
 COPY server/package.json ./server/
 COPY client/package.json ./client/
-
-# Install dependencies with cache mount
 RUN --mount=type=cache,target=/root/.local/share/pnpm \
     corepack prepare pnpm@9.0.0 --activate && \
     pnpm install --frozen-lockfile --prefer-offline
 
-# Build stage
 FROM node:${NODE_VERSION}-alpine AS build
 WORKDIR /app
-
-# Copy dependency cache
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/client/node_modules ./client/node_modules
-
-# Copy source code
 COPY . .
-
-# Build client application
 RUN --mount=type=cache,target=/root/.local/share/pnpm \
     cd client && pnpm run build
 
-# Production stage - using nginx for static serving
-FROM nginx:1.25-alpine AS final
+FROM gcr.io/distroless/nodejs20-debian12:nonroot AS final
 
-# Set labels for OCI compliance
 LABEL org.opencontainers.image.title="IntelGraph Client"
-LABEL org.opencontainers.image.description="IntelGraph intelligence analysis platform client"
-LABEL org.opencontainers.image.vendor="IntelGraph"
+LABEL org.opencontainers.image.description="Hardened static client for IntelGraph"
 LABEL org.opencontainers.image.source="https://github.com/BrianCLong/intelgraph"
-LABEL org.opencontainers.image.version="1.0.1"
-LABEL org.opencontainers.image.revision="${VCS_REF:-unknown}"
-LABEL org.opencontainers.image.created="${BUILD_DATE:-unknown}"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Remove default nginx content
-RUN rm -rf /usr/share/nginx/html/*
+WORKDIR /home/node/app
 
-# Copy built application
-COPY --from=build --chown=nginx:nginx /app/client/dist /usr/share/nginx/html
+ENV NODE_ENV=production
+ENV PORT=3000
 
-# Copy nginx configuration
-COPY services/client/nginx.conf /etc/nginx/nginx.conf
+COPY --from=build --chown=65532:65532 /app/client/dist ./dist
+COPY --chown=65532:65532 services/client/server.mjs ./server.mjs
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:80/health || exit 1
+  CMD node -e "require('http').get(`http://127.0.0.1:${process.env.PORT||3000}/health`, res => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
 
-# Run as non-root user
-RUN addgroup -g 101 -S nginx-app && \
-    adduser -S -D -H -u 101 -h /var/cache/nginx -s /sbin/nologin -G nginx-app -g nginx-app nginx-app
+USER 65532
 
-USER nginx-app
+EXPOSE 3000
 
-# Expose port
-EXPOSE 80
-
-# Start nginx
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["server.mjs"]

--- a/services/client/server.mjs
+++ b/services/client/server.mjs
@@ -1,0 +1,104 @@
+import { createReadStream, promises as fsPromises } from 'node:fs';
+import { basename, extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'node:http';
+
+const { access, stat } = fsPromises;
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const distDir = join(__dirname, 'dist');
+const defaultFile = 'index.html';
+const healthPath = '/health';
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2'
+};
+
+const port = Number.parseInt(process.env.PORT ?? '3000', 10);
+
+function resolvePath(urlPath) {
+  const safePath = urlPath.split('?')[0].split('#')[0];
+  const normalized = safePath.startsWith('/') ? safePath.slice(1) : safePath;
+  return join(distDir, normalized || defaultFile);
+}
+
+async function fileExists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function serveFile(filePath, res) {
+  const ext = extname(filePath);
+  const contentType = mimeTypes[ext] ?? 'application/octet-stream';
+  const stats = await stat(filePath);
+
+  res.writeHead(200, {
+    'Content-Type': contentType,
+    'Content-Length': stats.size,
+    'Cache-Control': ext === '.html' ? 'no-cache' : 'public, max-age=86400',
+    'X-Content-Type-Options': 'nosniff',
+    'X-Frame-Options': 'DENY',
+    'X-XSS-Protection': '1; mode=block'
+  });
+
+  createReadStream(filePath).pipe(res);
+}
+
+const server = createServer(async (req, res) => {
+  if (!req.url || req.method !== 'GET') {
+    res.writeHead(405, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Method not allowed' }));
+    return;
+  }
+
+  if (req.url === healthPath) {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'ok', service: basename(distDir) }));
+    return;
+  }
+
+  let candidate = resolvePath(req.url);
+  if (!(await fileExists(candidate))) {
+    candidate = join(distDir, defaultFile);
+  } else {
+    const candidateStats = await stat(candidate);
+    if (candidateStats.isDirectory()) {
+      candidate = join(distDir, defaultFile);
+    }
+  }
+
+  try {
+    await serveFile(candidate, res);
+  } catch (err) {
+    console.error('Failed to serve asset', err);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Internal server error' }));
+  }
+});
+
+server.listen(port, '0.0.0.0', () => {
+  console.log(`client static server listening on ${port}`);
+});
+
+process.on('SIGTERM', () => {
+  server.close(() => process.exit(0));
+});
+
+process.on('SIGINT', () => {
+  server.close(() => process.exit(0));
+});


### PR DESCRIPTION
## Summary
- add supply-chain security workflow with Syft SBOM generation and Grype gating alongside improved gitleaks and dependency-review policies
- harden Helm defaults with pod security/network policies, explicit readiness probes, and a service account template
- move service images to distroless non-root builds and extend the release evidence bundle with license manifests and fail-on-high Grype scans

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d80586570c83338dbbda09fa475171