### PR TITLE
feat: add unified slo observability instrumentation

### DIFF
--- a/ALERT_POLICIES.yaml
+++ b/ALERT_POLICIES.yaml
@@ -148,6 +148,102 @@ spec:
           This may indicate a credential attack or OIDC configuration issue.
         runbook_url: "https://runbooks.intelgraph.ai/auth-failures"
 
+  - name: intelgraph.unified.slo
+    interval: 30s
+    rules:
+      - record: gateway:slo_error_ratio_5m
+        expr: sum(rate(error_rate{service="gateway"}[5m])) / sum(rate(batch_throughput{service="gateway"}[5m]))
+
+      - record: gateway:slo_error_ratio_1h
+        expr: sum(rate(error_rate{service="gateway"}[1h])) / sum(rate(batch_throughput{service="gateway"}[1h]))
+
+      - record: connectors:slo_error_ratio_5m
+        expr: sum(rate(error_rate{service="connectors"}[5m])) / sum(rate(batch_throughput{service="connectors"}[5m]))
+
+      - record: connectors:slo_error_ratio_1h
+        expr: sum(rate(error_rate{service="connectors"}[1h])) / sum(rate(batch_throughput{service="connectors"}[1h]))
+
+      - record: gateway:unit_cost_per_million
+        expr: sum(rate(cost_per_call_sum{service="gateway"}[15m])) / sum(rate(cost_per_call_count{service="gateway"}[15m])) * 1000000
+
+      - record: connectors:unit_cost_per_thousand
+        expr: sum(rate(cost_per_call_sum{service="connectors"}[15m])) / sum(rate(cost_per_call_count{service="connectors"}[15m])) * 1000
+
+      - alert: GatewayFastBurnRate
+        expr: gateway:slo_error_ratio_5m / 0.001 > 2
+        for: 5m
+        labels:
+          severity: critical
+          service: gateway
+          slo: availability
+          alert_destination: pagerduty
+        annotations:
+          summary: "Gateway SLO fast burn rate >2x budget"
+          description: |-
+            Gateway error ratio is {{ $value | printf "%.3f" }} which exceeds 2x the 0.1% error budget.
+            Immediate investigation required to protect the SLO.
+          runbook_url: "https://runbooks.intelgraph.ai/gateway-slo"
+
+      - alert: GatewaySlowBurnRate
+        expr: gateway:slo_error_ratio_1h / 0.001 > 14
+        for: 15m
+        labels:
+          severity: warning
+          service: gateway
+          slo: availability
+          alert_destination: webhook
+        annotations:
+          summary: "Gateway SLO slow burn >14x budget"
+          description: "Gateway error ratio is persistently above threshold across one hour."
+
+      - alert: ConnectorsFastBurnRate
+        expr: connectors:slo_error_ratio_5m / 0.005 > 2
+        for: 10m
+        labels:
+          severity: critical
+          service: connectors
+          slo: reliability
+          alert_destination: pagerduty
+        annotations:
+          summary: "Connectors fast burn exceeds target"
+          description: "Connectors pipeline is consuming >2x the allowed error budget."
+
+      - alert: ConnectorsSlowBurnRate
+        expr: connectors:slo_error_ratio_1h / 0.005 > 9
+        for: 30m
+        labels:
+          severity: warning
+          service: connectors
+          slo: reliability
+          alert_destination: webhook
+        annotations:
+          summary: "Connectors slow burn indicates chronic failures"
+          description: "Error budget usage sustained above threshold for an hour."
+
+      - alert: GatewayCostBudgetEighty
+        expr: gateway:unit_cost_per_million > 80
+        for: 15m
+        labels:
+          severity: warning
+          service: gateway
+          category: cost
+          alert_destination: pagerduty
+        annotations:
+          summary: "Gateway unit cost exceeded 80% budget"
+          description: "Unit cost per 1M GraphQL calls is {{ $value | printf \"$%.2f\" }} which is above the 80% guardrail."
+
+      - alert: ConnectorsCostBudgetEighty
+        expr: connectors:unit_cost_per_thousand > 0.8
+        for: 15m
+        labels:
+          severity: warning
+          service: connectors
+          category: cost
+          alert_destination: webhook
+        annotations:
+          summary: "Connectors unit cost exceeded 80% budget"
+          description: "Unit cost per 1K events is {{ $value | printf \"$%.4f\" }} which is above the 80% guardrail."
+
     # OIDC JWKS rotation failure
     - alert: IntelGraphJWKSRotationFailed
       expr: |

--- a/ga-graphai/packages/gateway/package.json
+++ b/ga-graphai/packages/gateway/package.json
@@ -10,6 +10,7 @@
     "test": "vitest run && node --test tests"
   },
   "dependencies": {
+    "@opentelemetry/api": "^1.8.0",
     "body-parser": "^1.20.2",
     "common-types": "file:../common-types",
     "express": "^4.19.2",

--- a/ga-graphai/packages/gateway/src/metrics.js
+++ b/ga-graphai/packages/gateway/src/metrics.js
@@ -1,4 +1,194 @@
+import { Counter, Gauge, Histogram, Registry, collectDefaultMetrics } from 'prom-client';
+import { context as otelContext, trace } from '@opentelemetry/api';
 import { percentile } from 'common-types';
+
+const SERVICE_NAME = process.env.OTEL_SERVICE_NAME ?? 'gateway';
+const DEFAULT_TENANT = 'unknown';
+
+export const registry = new Registry();
+collectDefaultMetrics({ register: registry });
+
+const requestLatency = new Histogram({
+  name: 'request_latency',
+  help: 'Latency for incoming requests (seconds).',
+  labelNames: ['tenant', 'service', 'operation'],
+  buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+  registers: [registry]
+});
+
+const errorRate = new Counter({
+  name: 'error_rate',
+  help: 'Total errors observed by operation.',
+  labelNames: ['tenant', 'service', 'operation'],
+  registers: [registry]
+});
+
+const queueDepth = new Gauge({
+  name: 'queue_depth',
+  help: 'Number of requests queued or in-flight.',
+  labelNames: ['tenant', 'service'],
+  registers: [registry]
+});
+
+const batchThroughput = new Counter({
+  name: 'batch_throughput',
+  help: 'Count of work items processed.',
+  labelNames: ['tenant', 'service', 'operation'],
+  registers: [registry]
+});
+
+const costPerCall = new Histogram({
+  name: 'cost_per_call',
+  help: 'Distribution of USD cost per invocation.',
+  labelNames: ['tenant', 'service', 'operation'],
+  buckets: [0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1],
+  registers: [registry]
+});
+
+function buildLabels(overrides = {}) {
+  return {
+    tenant: overrides.tenant ?? DEFAULT_TENANT,
+    service: overrides.service ?? SERVICE_NAME,
+    ...('operation' in overrides ? { operation: overrides.operation } : {})
+  };
+}
+
+function buildOperationLabels(overrides = {}) {
+  return buildLabels({ ...overrides, operation: overrides.operation ?? 'unknown' });
+}
+
+function getExemplarLabels() {
+  const span = trace.getActiveSpan();
+  if (!span) {
+    return undefined;
+  }
+  const spanContext = span.spanContext();
+  if (!spanContext?.traceId) {
+    return undefined;
+  }
+  return { trace_id: spanContext.traceId, span_id: spanContext.spanId };
+}
+
+function observeHistogram(metric, labels, value) {
+  if (!Number.isFinite(value)) {
+    return;
+  }
+  const exemplar = getExemplarLabels();
+  if (exemplar) {
+    metric.observe(labels, value, exemplar);
+  } else {
+    metric.observe(labels, value);
+  }
+}
+
+function incrementCounter(metric, labels, value = 1) {
+  if (!Number.isFinite(value)) {
+    return;
+  }
+  const exemplar = getExemplarLabels();
+  if (exemplar) {
+    metric.inc(labels, value, exemplar);
+  } else {
+    metric.inc(labels, value);
+  }
+}
+
+export function observeQueueDepth(depth, labels = {}) {
+  if (!Number.isFinite(depth)) {
+    return;
+  }
+  queueDepth.set(buildLabels(labels), depth);
+}
+
+export function recordRequestMetric({
+  tenant = DEFAULT_TENANT,
+  operation = 'unknown',
+  latencySeconds,
+  isError = false,
+  costUsd,
+  batchSize = 1,
+  queueSize
+}) {
+  const metricLabels = buildOperationLabels({ tenant, operation });
+  observeHistogram(requestLatency, metricLabels, latencySeconds);
+  if (queueSize !== undefined) {
+    observeQueueDepth(queueSize, { tenant });
+  }
+  incrementCounter(batchThroughput, metricLabels, Math.max(1, batchSize));
+  if (isError) {
+    incrementCounter(errorRate, metricLabels);
+  }
+  if (Number.isFinite(costUsd)) {
+    observeHistogram(costPerCall, metricLabels, costUsd);
+  }
+}
+
+export function observeSuccess(operation, modelId, adapterResult, context = {}) {
+  const latencyMs = adapterResult?.latencyMs ?? adapterResult?.latency ?? adapterResult?.durationMs;
+  const latencySeconds = Number.isFinite(latencyMs) ? latencyMs / 1000 : undefined;
+  const costUsd = adapterResult?.usd ?? adapterResult?.costUsd;
+  recordRequestMetric({
+    tenant: context.tenant ?? DEFAULT_TENANT,
+    operation,
+    latencySeconds,
+    costUsd,
+    batchSize: context.batchSize ?? 1,
+    queueSize: context.queueSize
+  });
+}
+
+export function observePolicyDeny(reason, context = {}) {
+  incrementCounter(
+    errorRate,
+    buildOperationLabels({
+      tenant: context.tenant ?? DEFAULT_TENANT,
+      operation: context.operation ?? 'policy'
+    })
+  );
+}
+
+export function createHttpInstrumentation(options = {}) {
+  const tracer = trace.getTracer(options.tracerName ?? 'gateway-http');
+  return function httpMetricsMiddleware(req, res, next) {
+    const start = process.hrtime.bigint();
+    const span = tracer.startSpan('http.request', {
+      attributes: {
+        'http.method': req.method,
+        'http.route': req.path,
+        'http.target': req.originalUrl ?? req.url,
+        'service.name': SERVICE_NAME
+      }
+    });
+
+    const requestContext = trace.setSpan(otelContext.active(), span);
+    otelContext.with(requestContext, () => next());
+
+    const complete = () => {
+      const end = process.hrtime.bigint();
+      const latencySeconds = Number(end - start) / 1e9;
+      const tenant = req.aiContext?.tenant ?? req.headers['x-tenant'] ?? DEFAULT_TENANT;
+      const operation = options.operationResolver?.(req) ?? req.path ?? 'http';
+      const statusCode = res.statusCode ?? 500;
+      const isError = statusCode >= 400;
+      recordRequestMetric({
+        tenant,
+        operation,
+        latencySeconds,
+        isError
+      });
+      span.setAttribute('http.status_code', statusCode);
+      if (isError) {
+        span.setStatus({ code: 2, message: `HTTP ${statusCode}` });
+      }
+      span.end();
+      res.removeListener('finish', complete);
+      res.removeListener('close', complete);
+    };
+
+    res.on('finish', complete);
+    res.on('close', complete);
+  };
+}
 
 export class MetricsRecorder {
   constructor() {
@@ -9,9 +199,11 @@ export class MetricsRecorder {
     this.total = 0;
   }
 
-  record({ latency, cost, quality, cacheHit }) {
+  record({ latency, cost, quality, cacheHit, tenant = DEFAULT_TENANT, operation = 'orchestrator', queueSize }) {
     if (Number.isFinite(latency)) {
       this.latencies.push(latency);
+      const latencySeconds = latency > 10 ? latency / 1000 : latency;
+      recordRequestMetric({ tenant, operation, latencySeconds, costUsd: cost, batchSize: 1, queueSize });
     }
     if (Number.isFinite(cost)) {
       this.costs.push(cost);

--- a/ga-graphai/packages/graphai/pyproject.toml
+++ b/ga-graphai/packages/graphai/pyproject.toml
@@ -4,4 +4,5 @@ version = "0.1.0"
 dependencies = [
     "fastapi",
     "networkx",
+    "prometheus-client",
 ]

--- a/ga-graphai/packages/graphai/src/observability.py
+++ b/ga-graphai/packages/graphai/src/observability.py
@@ -1,0 +1,110 @@
+"""Observability helpers for the GraphAI routing service."""
+from __future__ import annotations
+
+import time
+from typing import Callable
+
+from fastapi import FastAPI, Request
+from fastapi.responses import PlainTextResponse
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest,
+)
+
+SERVICE_NAME = "graph-ai"
+DEFAULT_TENANT = "unknown"
+
+registry = CollectorRegistry()
+
+request_latency = Histogram(
+    "request_latency",
+    "Latency for GraphAI API calls.",
+    labelnames=["tenant", "service", "operation"],
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1, 2, 5),
+    registry=registry,
+)
+
+error_rate = Counter(
+    "error_rate",
+    "GraphAI error counter.",
+    labelnames=["tenant", "service", "operation"],
+    registry=registry,
+)
+
+queue_depth = Gauge(
+    "queue_depth",
+    "Routing backlog depth.",
+    labelnames=["tenant", "service"],
+    registry=registry,
+)
+
+batch_throughput = Counter(
+    "batch_throughput",
+    "Total requests processed.",
+    labelnames=["tenant", "service", "operation"],
+    registry=registry,
+)
+
+cost_per_call = Histogram(
+    "cost_per_call",
+    "USD cost per routing decision.",
+    labelnames=["tenant", "service", "operation"],
+    buckets=(0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1),
+    registry=registry,
+)
+
+
+def _labels(tenant: str | None, operation: str) -> dict[str, str]:
+    return {
+        "tenant": tenant or DEFAULT_TENANT,
+        "service": SERVICE_NAME,
+        "operation": operation,
+    }
+
+
+def instrument_app(app: FastAPI, *, operation_resolver: Callable[[Request], str] | None = None) -> None:
+    @app.middleware("http")
+    async def _metrics_middleware(request: Request, call_next):
+        start = time.perf_counter()
+        tenant = request.headers.get("x-tenant", DEFAULT_TENANT)
+        operation = operation_resolver(request) if operation_resolver else request.url.path
+        status_code = 200
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        except Exception:
+            status_code = 500
+            error_rate.labels(**_labels(tenant, operation)).inc()
+            raise
+        finally:
+            latency = time.perf_counter() - start
+            request_latency.labels(**_labels(tenant, operation)).observe(latency)
+            batch_throughput.labels(**_labels(tenant, operation)).inc()
+            if status_code >= 400:
+                error_rate.labels(**_labels(tenant, operation)).inc()
+
+    @app.get("/metrics", include_in_schema=False)
+    async def metrics_endpoint() -> PlainTextResponse:
+        payload = generate_latest(registry)
+        return PlainTextResponse(payload.decode("utf-8"), media_type=CONTENT_TYPE_LATEST)
+
+
+def record_decision(
+    *,
+    tenant: str | None,
+    operation: str,
+    latency_ms: float,
+    cost_usd: float,
+) -> None:
+    request_latency.labels(**_labels(tenant, operation)).observe(latency_ms / 1000)
+    batch_throughput.labels(**_labels(tenant, operation)).inc()
+    cost_per_call.labels(**_labels(tenant, operation)).observe(cost_usd)
+
+
+def observe_queue(value: int, *, tenant: str | None = None) -> None:
+    queue_depth.labels(tenant or DEFAULT_TENANT, SERVICE_NAME).set(value)

--- a/infra/grafana/dashboards/api-slo.json
+++ b/infra/grafana/dashboards/api-slo.json
@@ -1,0 +1,146 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.3 },
+              { "color": "red", "value": 0.5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(request_latency_bucket{service=\"gateway\"}[$__rate_interval])) by (le, tenant))",
+          "legendFormat": "{{tenant}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway Request Latency P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.5 },
+              { "color": "red", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "orientation": "vertical",
+        "reduceOptions": { "calcs": ["last"], "fields": "", "values": false },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(error_rate{service=\"gateway\"}[$__rate_interval])) / sum(rate(batch_throughput{service=\"gateway\"}[$__rate_interval])) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway Error Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 0 },
+      "id": 3,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "single" }
+      },
+      "targets": [
+        {
+          "expr": "sum(max_over_time(queue_depth{service=\"gateway\"}[$__interval])) by (tenant)",
+          "legendFormat": "{{tenant}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Depth by Tenant",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "decimals": 2
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "id": 4,
+      "options": {
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "expr": "topk(10, sum(rate(error_rate{service=\"gateway\"}[$__rate_interval])) by (tenant) / sum(rate(batch_throughput{service=\"gateway\"}[$__rate_interval])) )",
+          "format": "table",
+          "refId": "A"
+        }
+      ],
+      "title": "Top Tenants by Error Budget Consumption",
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["slo", "gateway"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "API SLO",
+  "uid": "api-slo",
+  "version": 1
+}

--- a/infra/grafana/dashboards/cost-overview.json
+++ b/infra/grafana/dashboards/cost-overview.json
@@ -1,0 +1,101 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(cost_per_call_sum{service=\"gateway\"}[$__rate_interval])) / sum(rate(cost_per_call_count{service=\"gateway\"}[$__rate_interval])) * 1000000",
+          "refId": "A"
+        }
+      ],
+      "title": "Unit Cost - $ per 1M GraphQL Calls",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 4
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(cost_per_call_sum{service=\"connectors\"}[$__rate_interval])) / sum(rate(cost_per_call_count{service=\"connectors\"}[$__rate_interval])) * 1000",
+          "refId": "A"
+        }
+      ],
+      "title": "Unit Cost - $ per 1K Events",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "currencyUSD",
+          "decimals": 2
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "right" },
+        "tooltip": { "mode": "multi" }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(cost_per_call_sum[$__interval])) by (service)",
+          "legendFormat": "{{service}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Rolling Cost Spend",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["cost", "finance"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Cost Overview",
+  "uid": "cost-overview",
+  "version": 1
+}

--- a/infra/grafana/dashboards/ingest-slo.json
+++ b/infra/grafana/dashboards/ingest-slo.json
@@ -1,0 +1,119 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(request_latency_bucket{service=\"connectors\"}[$__rate_interval])) by (le, tenant))",
+          "legendFormat": "{{tenant}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Connector Run Latency P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "rows"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "displayMode": "list", "placement": "right" }
+      },
+      "targets": [
+        {
+          "expr": "sum(increase(batch_throughput{service=\"connectors\"}[$__interval])) by (tenant)",
+          "legendFormat": "{{tenant}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Rows Processed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percent",
+          "decimals": 2
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "id": 3,
+      "options": {
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["last"], "fields": "", "values": false }
+      },
+      "targets": [
+        {
+          "expr": "sum(rate(error_rate{service=\"connectors\"}[$__rate_interval])) / sum(rate(batch_throughput{service=\"connectors\"}[$__rate_interval])) * 100",
+          "refId": "A"
+        }
+      ],
+      "title": "Connector Error Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": { "unit": "short" }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "id": 4,
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom" }
+      },
+      "targets": [
+        {
+          "expr": "max(queue_depth{service=\"connectors\"})",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Depth",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["slo", "connectors"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Ingest SLO",
+  "uid": "ingest-slo",
+  "version": 1
+}

--- a/infra/helm/intelgraph/templates/otel-config.yaml
+++ b/infra/helm/intelgraph/templates/otel-config.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.otel.enabled }}
+---
+# prettier-ignore-start
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -78,6 +80,13 @@ data:
           service: "{{ include "intelgraph.fullname" . }}"
           environment: "{{ .Values.global.environment }}"
 
+      "prometheus/spanmetrics":
+        endpoint: "0.0.0.0:8890"
+        namespace: intelgraph_spanmetrics
+        enable_open_metrics: true
+        const_labels:
+          environment: "{{ .Values.global.environment }}"
+
       # Logging exporter for debugging
       logging:
         loglevel: {{ .Values.otel.logLevel | default "info" }}
@@ -90,18 +99,49 @@ data:
       zpages:
         endpoint: 0.0.0.0:55679
 
+    connectors:
+      spanmetrics:
+        exemplars:
+          enabled: true
+        dimensions:
+          - name: service.name
+          - name: http.route
+          - name: http.method
+        histogram:
+          explicit:
+            buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5]
+
     service:
       extensions: [health_check, pprof, zpages]
       pipelines:
         traces:
           receivers: [otlp]
           processors: [memory_limiter, resource, probabilistic_sampler, batch]
-          exporters: [jaeger, otlp/traces{{- if .Values.otel.debug }}, logging{{- end }}]
+          exporters:
+            - jaeger
+            - otlp/traces
+            - spanmetrics
+            {{- if .Values.otel.debug }}
+            - logging
+            {{- end }}
 
         metrics:
           receivers: [otlp, prometheus]
           processors: [memory_limiter, resource, batch]
-          exporters: [prometheus{{- if .Values.otel.debug }}, logging{{- end }}]
+          exporters:
+            - prometheus
+            {{- if .Values.otel.debug }}
+            - logging
+            {{- end }}
+
+        "metrics/spanmetrics":
+          receivers: [spanmetrics]
+          processors: [batch]
+          exporters:
+            - "prometheus/spanmetrics"
+            {{- if .Values.otel.debug }}
+            - logging
+            {{- end }}
 
 ---
 apiVersion: apps/v1
@@ -219,3 +259,4 @@ spec:
     {{- include "intelgraph.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: otel-collector
 {{- end }}
+# prettier-ignore-end

--- a/packages/connectors/pyproject.toml
+++ b/packages/connectors/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "pandas",
+    "prometheus-client",
 ]
 
 [project.optional-dependencies]

--- a/packages/connectors/src/main.py
+++ b/packages/connectors/src/main.py
@@ -8,8 +8,10 @@ from datetime import datetime
 
 from . import orchestrator, mapping
 from .models import ConnectorKind, RunStatus, store
+from .observability import instrument_app
 
 app = FastAPI(title="IntelGraph Connectors Demo")
+instrument_app(app)
 
 
 class ConnectorCreate(BaseModel):

--- a/packages/connectors/src/orchestrator.py
+++ b/packages/connectors/src/orchestrator.py
@@ -11,6 +11,7 @@ from typing import Dict, Iterable, Iterator, List, Mapping
 
 from . import dq, mapping
 from .models import Run, RunStatus, store
+from .observability import record_batch
 from .sources.base import BaseSource
 from .sources.file import FileSource
 
@@ -54,4 +55,10 @@ def run_pipeline(run: Run, map_yaml: str | None, dq_field: str | None) -> Run:
 
     run.status = RunStatus.SUCCEEDED
     run.stats = {"rowCount": len(rows)}
+    record_batch(
+        tenant=conn.config.get("tenant"),
+        operation="pipeline",
+        rows=len(rows),
+        cost_usd=conn.config.get("estimatedCostUsd"),
+    )
     return run

--- a/scripts/slo_green_gate.py
+++ b/scripts/slo_green_gate.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Post-deploy validation gate that asserts IntelGraph SLOs are green."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import urllib.parse
+import urllib.request
+import json
+from typing import Tuple
+
+DEFAULT_URL = "http://localhost:9090"
+
+CHECKS: Tuple[Tuple[str, str, float], ...] = (
+    ("Gateway error ratio", "gateway:slo_error_ratio_5m", 0.001),
+    ("Gateway unit cost", "gateway:unit_cost_per_million", 80.0),
+    ("Connectors error ratio", "connectors:slo_error_ratio_5m", 0.005),
+    ("Connectors unit cost", "connectors:unit_cost_per_thousand", 0.8),
+)
+
+
+def _query(prometheus_url: str, query: str) -> float:
+    params = urllib.parse.urlencode({"query": query})
+    url = f"{prometheus_url.rstrip('/')}/api/v1/query?{params}"
+    with urllib.request.urlopen(url, timeout=10) as response:  # noqa: S310 - URL constructed from trusted input
+        payload = json.loads(response.read().decode("utf-8"))
+    if payload.get("status") != "success":  # pragma: no cover - defensive
+        raise RuntimeError(f"Prometheus query failed: {payload}")
+    result = payload.get("data", {}).get("result", [])
+    if not result:
+        return 0.0
+    value = result[0].get("value")
+    if not value or len(value) < 2:
+        return 0.0
+    try:
+        return float(value[1])
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return 0.0
+
+
+def run_checks(prometheus_url: str) -> int:
+    failures: list[str] = []
+    for label, query, threshold in CHECKS:
+        observed = _query(prometheus_url, query)
+        if observed > threshold:
+            failures.append(f"{label} at {observed:.4f} exceeds threshold {threshold}")
+    if failures:
+        for failure in failures:
+            print(f"[FAIL] {failure}")
+        return 1
+    print("All SLO guardrails are green.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate SLOs before promotion")
+    parser.add_argument("--prometheus-url", default=DEFAULT_URL, help="Base URL for Prometheus API")
+    args = parser.parse_args()
+    return run_checks(args.prometheus_url)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- instrument the gateway, connectors, and graph-ai services with standard request/cost metrics and trace exemplars
- extend the OpenTelemetry collector with spanmetrics export, add Grafana SLO/cost dashboards, and configure new burn-rate alerts
- add a post-deploy SLO validation gate script

## Testing
- npm test (fails: ReferenceError PURPOSE_ALLOWLIST is not defined in policy package)
- pytest packages/connectors (fails: ModuleNotFoundError: No module named 'connectors.main')
- pytest ga-graphai/packages/graphai

------
https://chatgpt.com/codex/tasks/task_e_68d80559b5908333ba3d84e67508e18f