### PR TITLE
chore: ignore fcs generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,12 @@ conflicts/
 __pycache__/
 *.pyc
 
+# Federated Canary Seeder artifacts
+sdk/fcs-client/package-lock.json
+services/fcs/bin/
+services/fcs/cmd/fcs/fcs
+services/fcs/cmd/fcs/fcs.exe
+
+# Local tooling lock files
+cognitive_insights_engine/poetry.lock
+

--- a/sdk/fcs-client/.gitignore
+++ b/sdk/fcs-client/.gitignore
@@ -1,0 +1,5 @@
+# Ignore local build artifacts and dependency directories
+node_modules/
+dist/
+# npm lock files are managed at the monorepo root; avoid duplicating them here
+package-lock.json

--- a/sdk/fcs-client/README.md
+++ b/sdk/fcs-client/README.md
@@ -1,0 +1,42 @@
+# Federated Canary Seeder TypeScript Client
+
+The `@summit/fcs-client` package provides a small TypeScript wrapper for the Federated Canary Seeder (FCS) service. It helps plant canaries, run detections, fetch attribution reports, and verify signed provenance offline using the service's published public key.
+
+## Installation
+
+```bash
+npm install @summit/fcs-client
+```
+
+## Usage
+
+```ts
+import { FCSClient } from '@summit/fcs-client';
+
+const client = new FCSClient('http://localhost:8080');
+
+const record = await client.seedCanary({
+  scope: 'finance.payables',
+  ttlSeconds: 3600,
+  payload: { invoice: 'CANARY-001' },
+  stores: ['database', 'object'],
+});
+
+const report = await client.getAttributionReport();
+const publicKey = await client.getPublicKey();
+
+const verified = await client.verifyRecord(record, publicKey);
+console.log(`Provenance valid: ${verified}`);
+```
+
+## API
+
+- `seedCanary(spec)` – seed a new canary across the configured stores.
+- `scanDetections()` – run the detector pipeline and obtain individual detections.
+- `getAttributionReport()` – build an attribution report grouped by scope and canary id.
+- `getCanary(id)` – retrieve a specific canary record and provenance bundle.
+- `getPublicKey()` – retrieve the hex encoded Ed25519 public key for offline verification.
+- `verifyProvenance(provenance, publicKeyHex)` – verify a provenance document with a provided public key.
+- `verifyRecord(record, publicKeyHex)` – convenience wrapper around `verifyProvenance`.
+
+The client is fetch-compatible and can operate in browsers or Node.js (18+ where `fetch` is available).

--- a/sdk/fcs-client/package.json
+++ b/sdk/fcs-client/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@summit/fcs-client",
+  "version": "0.1.0",
+  "description": "TypeScript client for the Federated Canary Seeder service",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@noble/ed25519": "^2.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.5.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/sdk/fcs-client/src/index.ts
+++ b/sdk/fcs-client/src/index.ts
@@ -1,0 +1,128 @@
+import { verify } from '@noble/ed25519';
+import type {
+  AttributionReport,
+  CanaryRecord,
+  CanarySpec,
+  Detection,
+  Provenance,
+} from './types.js';
+
+export interface ClientOptions {
+  fetch?: typeof fetch;
+  headers?: HeadersInit;
+}
+
+const textEncoder = new TextEncoder();
+
+function normaliseBaseUrl(baseUrl: string): string {
+  if (!baseUrl.startsWith('http://') && !baseUrl.startsWith('https://')) {
+    throw new Error('baseUrl must include protocol (http or https)');
+  }
+  return baseUrl.replace(/\/$/, '');
+}
+
+function base64UrlToBytes(input: string): Uint8Array {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/');
+  const paddingNeeded = (4 - (normalized.length % 4)) % 4;
+  const padded = normalized + '='.repeat(paddingNeeded);
+  const maybeBuffer = (globalThis as { Buffer?: { from(data: string, encoding: string): Uint8Array | ArrayLike<number> } }).Buffer;
+  if (maybeBuffer) {
+    const bufferResult = maybeBuffer.from(padded, 'base64');
+    return bufferResult instanceof Uint8Array ? bufferResult : new Uint8Array(bufferResult);
+  }
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) {
+    throw new Error('invalid hex string');
+  }
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+function createProvenanceMessage(prov: Provenance): Uint8Array {
+  const seeded = Math.floor(new Date(prov.seededAt).getTime() / 1000);
+  const expires = Math.floor(new Date(prov.expiresAt).getTime() / 1000);
+  const payload = `${prov.canaryId}|${prov.scope}|${prov.ttlSeconds}|${seeded}|${expires}|${prov.retrievalSignature}`;
+  return textEncoder.encode(payload);
+}
+
+export class FCSClient {
+  private readonly baseUrl: string;
+
+  private readonly fetcher: typeof fetch;
+
+  private readonly defaultHeaders: HeadersInit | undefined;
+
+  constructor(baseUrl: string, options: ClientOptions = {}) {
+    this.baseUrl = normaliseBaseUrl(baseUrl);
+    this.fetcher = options.fetch ?? fetch;
+    this.defaultHeaders = options.headers;
+  }
+
+  async seedCanary(spec: CanarySpec): Promise<CanaryRecord> {
+    return this.request<CanaryRecord>('/seed', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(spec),
+    });
+  }
+
+  async scanDetections(): Promise<Detection[]> {
+    return this.request<Detection[]>('/detector/scan', { method: 'GET' });
+  }
+
+  async getAttributionReport(): Promise<AttributionReport> {
+    return this.request<AttributionReport>('/reports/attribution', { method: 'GET' });
+  }
+
+  async getCanary(canaryId: string): Promise<CanaryRecord> {
+    if (!canaryId) {
+      throw new Error('canaryId is required');
+    }
+    return this.request<CanaryRecord>(`/canaries/${encodeURIComponent(canaryId)}`, { method: 'GET' });
+  }
+
+  async getPublicKey(): Promise<string> {
+    const result = await this.request<{ publicKey: string }>('/provenance/public-key', { method: 'GET' });
+    return result.publicKey;
+  }
+
+  async verifyProvenance(prov: Provenance, publicKeyHex: string): Promise<boolean> {
+    const signature = base64UrlToBytes(prov.signature);
+    const publicKey = hexToBytes(publicKeyHex);
+    const message = createProvenanceMessage(prov);
+    return verify(signature, message, publicKey);
+  }
+
+  async verifyRecord(record: CanaryRecord, publicKeyHex: string): Promise<boolean> {
+    return this.verifyProvenance(record.provenance, publicKeyHex);
+  }
+
+  private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: HeadersInit = {
+      ...this.defaultHeaders,
+      ...init.headers,
+    };
+    const response = await this.fetcher(url, { ...init, headers });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`request failed (${response.status}): ${text}`);
+    }
+    return (await response.json()) as T;
+  }
+}
+
+export type { AttributionReport, CanaryRecord, CanarySpec, Detection, Provenance } from './types.js';

--- a/sdk/fcs-client/src/types.ts
+++ b/sdk/fcs-client/src/types.ts
@@ -1,0 +1,49 @@
+export type StoreKind = 'database' | 'object' | 'search' | 'vector';
+
+export interface CanarySpec {
+  scope: string;
+  ttlSeconds: number;
+  payload: Record<string, unknown>;
+  stores: StoreKind[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface Provenance {
+  canaryId: string;
+  scope: string;
+  ttlSeconds: number;
+  seededAt: string;
+  expiresAt: string;
+  retrievalSignature: string;
+  signature: string;
+}
+
+export interface CanaryRecord {
+  id: string;
+  spec: CanarySpec;
+  seededAt: string;
+  expiresAt: string;
+  provenance: Provenance;
+}
+
+export interface Detection {
+  canaryId: string;
+  scope: string;
+  store: StoreKind;
+  observed: string;
+  confidence: number;
+  provenance: Provenance;
+}
+
+export interface AttributionFinding {
+  canaryId: string;
+  scope: string;
+  stores: StoreKind[];
+  confidence: number;
+  provenance: Provenance;
+}
+
+export interface AttributionReport {
+  generatedAt: string;
+  findings: AttributionFinding[];
+}

--- a/sdk/fcs-client/tsconfig.json
+++ b/sdk/fcs-client/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "Node",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM"]
+  },
+  "include": ["src/**/*"]
+}

--- a/services/fcs/.gitignore
+++ b/services/fcs/.gitignore
@@ -1,0 +1,6 @@
+# Ignore Go build artifacts
+bin/
+*.test
+*.out
+cmd/fcs/fcs
+cmd/fcs/fcs.exe

--- a/services/fcs/cmd/fcs/main.go
+++ b/services/fcs/cmd/fcs/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"flag"
+	"log"
+
+	"example.com/summit/fcs/internal/httpserver"
+	"example.com/summit/fcs/internal/model"
+	"example.com/summit/fcs/internal/provenance"
+	"example.com/summit/fcs/internal/service"
+	"example.com/summit/fcs/internal/store"
+)
+
+func main() {
+	addr := flag.String("addr", ":8080", "address for the FCS HTTP server")
+	flag.Parse()
+
+	provManager, err := provenance.NewRandomManager()
+	if err != nil {
+		log.Fatalf("failed to initialise provenance manager: %v", err)
+	}
+
+	stores := map[model.StoreKind]store.Store{
+		model.StoreDatabase: store.NewMemoryStore(model.StoreDatabase),
+		model.StoreObject:   store.NewMemoryStore(model.StoreObject),
+		model.StoreSearch:   store.NewMemoryStore(model.StoreSearch),
+		model.StoreVector:   store.NewMemoryStore(model.StoreVector),
+	}
+
+	pipeline, err := service.NewPipeline(stores, provManager)
+	if err != nil {
+		log.Fatalf("failed to initialise pipeline: %v", err)
+	}
+
+	server := httpserver.NewServer(pipeline)
+
+	log.Printf("FCS server starting on %s", *addr)
+	if err := server.ListenAndServe(*addr); err != nil {
+		log.Printf("server stopped: %v", err)
+	}
+}

--- a/services/fcs/go.mod
+++ b/services/fcs/go.mod
@@ -1,0 +1,5 @@
+module example.com/summit/fcs
+
+go 1.22
+
+require github.com/google/uuid v1.6.0

--- a/services/fcs/go.sum
+++ b/services/fcs/go.sum
@@ -1,0 +1,2 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/services/fcs/internal/httpserver/server.go
+++ b/services/fcs/internal/httpserver/server.go
@@ -1,0 +1,126 @@
+package httpserver
+
+import (
+	"encoding/json"
+	"fmt"
+	stdhttp "net/http"
+	"strings"
+	"time"
+
+	"example.com/summit/fcs/internal/model"
+	"example.com/summit/fcs/internal/service"
+)
+
+// Server exposes the FCS service over HTTP.
+type Server struct {
+	pipeline *service.Pipeline
+}
+
+// NewServer builds a server with the required dependencies.
+func NewServer(pipeline *service.Pipeline) *Server {
+	return &Server{pipeline: pipeline}
+}
+
+// Routes exposes the HTTP handler for integration into custom servers.
+func (s *Server) Routes() stdhttp.Handler {
+	mux := stdhttp.NewServeMux()
+	mux.HandleFunc("/seed", s.handleSeed)
+	mux.HandleFunc("/detector/scan", s.handleScan)
+	mux.HandleFunc("/reports/attribution", s.handleAttribution)
+	mux.HandleFunc("/provenance/public-key", s.handlePublicKey)
+	mux.HandleFunc("/canaries/", s.handleCanary)
+	return mux
+}
+
+func (s *Server) handleSeed(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if r.Method != stdhttp.MethodPost {
+		w.WriteHeader(stdhttp.StatusMethodNotAllowed)
+		return
+	}
+	defer r.Body.Close()
+	var spec model.CanarySpec
+	if err := json.NewDecoder(r.Body).Decode(&spec); err != nil {
+		httpError(w, stdhttp.StatusBadRequest, "invalid payload: %v", err)
+		return
+	}
+	record, err := s.pipeline.Seed(r.Context(), spec)
+	if err != nil {
+		httpError(w, stdhttp.StatusBadRequest, err.Error())
+		return
+	}
+	respondJSON(w, stdhttp.StatusCreated, record)
+}
+
+func (s *Server) handleScan(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if r.Method != stdhttp.MethodGet {
+		w.WriteHeader(stdhttp.StatusMethodNotAllowed)
+		return
+	}
+	detections, err := s.pipeline.Scan(r.Context())
+	if err != nil {
+		httpError(w, stdhttp.StatusInternalServerError, "detector scan failed: %v", err)
+		return
+	}
+	respondJSON(w, stdhttp.StatusOK, detections)
+}
+
+func (s *Server) handleAttribution(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if r.Method != stdhttp.MethodGet {
+		w.WriteHeader(stdhttp.StatusMethodNotAllowed)
+		return
+	}
+	report, err := s.pipeline.BuildAttributionReport(r.Context())
+	if err != nil {
+		httpError(w, stdhttp.StatusInternalServerError, "build report failed: %v", err)
+		return
+	}
+	respondJSON(w, stdhttp.StatusOK, report)
+}
+
+func (s *Server) handlePublicKey(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if r.Method != stdhttp.MethodGet {
+		w.WriteHeader(stdhttp.StatusMethodNotAllowed)
+		return
+	}
+	respondJSON(w, stdhttp.StatusOK, map[string]string{"publicKey": s.pipeline.PublicKeyHex()})
+}
+
+func (s *Server) handleCanary(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+	if r.Method != stdhttp.MethodGet {
+		w.WriteHeader(stdhttp.StatusMethodNotAllowed)
+		return
+	}
+	id := strings.TrimPrefix(r.URL.Path, "/canaries/")
+	if id == "" || strings.Contains(id, "/") {
+		httpError(w, stdhttp.StatusBadRequest, "missing canary id")
+		return
+	}
+	record, ok := s.pipeline.Get(r.Context(), id)
+	if !ok {
+		w.WriteHeader(stdhttp.StatusNotFound)
+		return
+	}
+	respondJSON(w, stdhttp.StatusOK, record)
+}
+
+func httpError(w stdhttp.ResponseWriter, status int, format string, args ...any) {
+	respondJSON(w, status, map[string]string{"error": fmt.Sprintf(format, args...)})
+}
+
+func respondJSON(w stdhttp.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(payload)
+}
+
+// ListenAndServe starts the HTTP server on the provided address.
+func (s *Server) ListenAndServe(addr string) error {
+	server := &stdhttp.Server{
+		Addr:              addr,
+		Handler:           s.Routes(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return server.ListenAndServe()
+}

--- a/services/fcs/internal/model/types.go
+++ b/services/fcs/internal/model/types.go
@@ -1,0 +1,94 @@
+package model
+
+import (
+	"maps"
+	"slices"
+	"time"
+)
+
+// StoreKind represents the supported storage backends for canary placement.
+type StoreKind string
+
+const (
+	StoreDatabase StoreKind = "database"
+	StoreObject   StoreKind = "object"
+	StoreSearch   StoreKind = "search"
+	StoreVector   StoreKind = "vector"
+)
+
+// CanarySpec describes the canary to be planted across federated stores.
+type CanarySpec struct {
+	Scope      string         `json:"scope"`
+	TTLSeconds int64          `json:"ttlSeconds"`
+	Payload    map[string]any `json:"payload"`
+	Stores     []StoreKind    `json:"stores"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+}
+
+// CanaryRecord is the canonical representation of a canary with provenance.
+type CanaryRecord struct {
+	ID         string     `json:"id"`
+	Spec       CanarySpec `json:"spec"`
+	SeededAt   time.Time  `json:"seededAt"`
+	ExpiresAt  time.Time  `json:"expiresAt"`
+	Provenance Provenance `json:"provenance"`
+}
+
+// StoredCanary represents an instance of a canary in a specific store.
+type StoredCanary struct {
+	Store  StoreKind    `json:"store"`
+	Record CanaryRecord `json:"record"`
+}
+
+// Provenance captures the signed metadata for a canary seed event.
+type Provenance struct {
+	CanaryID           string    `json:"canaryId"`
+	Scope              string    `json:"scope"`
+	TTLSeconds         int64     `json:"ttlSeconds"`
+	SeededAt           time.Time `json:"seededAt"`
+	ExpiresAt          time.Time `json:"expiresAt"`
+	RetrievalSignature string    `json:"retrievalSignature"`
+	Signature          string    `json:"signature"`
+}
+
+// Detection represents a verified observation of a canary in a store.
+type Detection struct {
+	CanaryID   string     `json:"canaryId"`
+	Scope      string     `json:"scope"`
+	Store      StoreKind  `json:"store"`
+	Observed   time.Time  `json:"observed"`
+	Confidence float64    `json:"confidence"`
+	Provenance Provenance `json:"provenance"`
+}
+
+// AttributionFinding groups detections that belong to the same canary.
+type AttributionFinding struct {
+	CanaryID   string      `json:"canaryId"`
+	Scope      string      `json:"scope"`
+	Stores     []StoreKind `json:"stores"`
+	Confidence float64     `json:"confidence"`
+	Provenance Provenance  `json:"provenance"`
+}
+
+// AttributionReport summarises all findings for investigator review.
+type AttributionReport struct {
+	GeneratedAt time.Time            `json:"generatedAt"`
+	Findings    []AttributionFinding `json:"findings"`
+}
+
+// CloneCanarySpec returns a defensive copy of the provided canary spec so that
+// subsequent mutations by callers do not alter stored provenance records.
+func CloneCanarySpec(spec CanarySpec) CanarySpec {
+	clone := CanarySpec{
+		Scope:      spec.Scope,
+		TTLSeconds: spec.TTLSeconds,
+		Stores:     slices.Clone(spec.Stores),
+	}
+	if spec.Payload != nil {
+		clone.Payload = maps.Clone(spec.Payload)
+	}
+	if spec.Metadata != nil {
+		clone.Metadata = maps.Clone(spec.Metadata)
+	}
+	return clone
+}

--- a/services/fcs/internal/model/types_test.go
+++ b/services/fcs/internal/model/types_test.go
@@ -1,0 +1,40 @@
+package model
+
+import "testing"
+
+func TestCloneCanarySpec(t *testing.T) {
+	spec := CanarySpec{
+		Scope:      "scope.alpha",
+		TTLSeconds: 120,
+		Payload: map[string]any{
+			"account": "A-1",
+		},
+		Metadata: map[string]any{
+			"owner": "blue-team",
+		},
+		Stores: []StoreKind{StoreObject, StoreDatabase},
+	}
+
+	clone := CloneCanarySpec(spec)
+
+	if &clone == &spec {
+		t.Fatalf("expected clone to be a new struct")
+	}
+	if len(clone.Stores) != len(spec.Stores) {
+		t.Fatalf("expected stores length %d, got %d", len(spec.Stores), len(clone.Stores))
+	}
+
+	spec.Payload["account"] = "tampered"
+	spec.Metadata["owner"] = "red-team"
+	spec.Stores[0] = StoreVector
+
+	if clone.Payload["account"] != "A-1" {
+		t.Fatalf("expected payload to remain unchanged, got %v", clone.Payload["account"])
+	}
+	if clone.Metadata["owner"] != "blue-team" {
+		t.Fatalf("expected metadata to remain unchanged, got %v", clone.Metadata["owner"])
+	}
+	if clone.Stores[0] != StoreObject {
+		t.Fatalf("expected clone stores to remain independent")
+	}
+}

--- a/services/fcs/internal/provenance/manager.go
+++ b/services/fcs/internal/provenance/manager.go
@@ -1,0 +1,105 @@
+package provenance
+
+import (
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"example.com/summit/fcs/internal/model"
+)
+
+// Manager issues provenance proofs for planted canaries and verifies them offline.
+type Manager struct {
+	privKey       ed25519.PrivateKey
+	pubKey        ed25519.PublicKey
+	retrievalSeed []byte
+}
+
+// NewManager builds a manager from an existing ed25519 key pair and retrieval seed.
+func NewManager(privateKey ed25519.PrivateKey, retrievalSeed []byte) (*Manager, error) {
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return nil, errors.New("invalid private key length")
+	}
+	pub := privateKey.Public().(ed25519.PublicKey)
+	if len(retrievalSeed) == 0 {
+		retrievalSeed = make([]byte, 32)
+		if _, err := rand.Read(retrievalSeed); err != nil {
+			return nil, fmt.Errorf("generate retrieval seed: %w", err)
+		}
+	}
+	seed := make([]byte, len(retrievalSeed))
+	copy(seed, retrievalSeed)
+	return &Manager{privKey: privateKey, pubKey: pub, retrievalSeed: seed}, nil
+}
+
+// NewRandomManager generates fresh keys for runtime usage.
+func NewRandomManager() (*Manager, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate ed25519 key: %w", err)
+	}
+	retrievalSeed := make([]byte, 32)
+	if _, err := rand.Read(retrievalSeed); err != nil {
+		return nil, fmt.Errorf("generate retrieval seed: %w", err)
+	}
+	return &Manager{privKey: priv, pubKey: pub, retrievalSeed: retrievalSeed}, nil
+}
+
+// BuildProvenance constructs and signs provenance for a canary placement.
+func (m *Manager) BuildProvenance(canaryID, scope string, ttlSeconds int64, seededAt, expiresAt time.Time) (model.Provenance, error) {
+	retrievalSignature := m.computeRetrievalSignature(canaryID, scope, seededAt, expiresAt)
+	prov := model.Provenance{
+		CanaryID:           canaryID,
+		Scope:              scope,
+		TTLSeconds:         ttlSeconds,
+		SeededAt:           seededAt.UTC(),
+		ExpiresAt:          expiresAt.UTC(),
+		RetrievalSignature: retrievalSignature,
+	}
+	msg := messageForProvenance(prov)
+	sig := ed25519.Sign(m.privKey, msg)
+	prov.Signature = base64.RawStdEncoding.EncodeToString(sig)
+	return prov, nil
+}
+
+// VerifyProvenance validates the ed25519 signature for offline validation.
+func (m *Manager) VerifyProvenance(prov model.Provenance) bool {
+	msg := messageForProvenance(prov)
+	sig, err := base64.RawStdEncoding.DecodeString(prov.Signature)
+	if err != nil {
+		return false
+	}
+	return ed25519.Verify(m.pubKey, msg, sig)
+}
+
+// PublicKeyHex returns the hex encoded ed25519 public key for offline verification.
+func (m *Manager) PublicKeyHex() string {
+	return hex.EncodeToString(m.pubKey)
+}
+
+// computeRetrievalSignature derives a deterministic retrieval signature token.
+func (m *Manager) computeRetrievalSignature(canaryID, scope string, seededAt, expiresAt time.Time) string {
+	mac := hmac.New(sha256.New, m.retrievalSeed)
+	// Retrieval signature binds the identity, scope, and critical timestamps.
+	fmt.Fprintf(mac, "%s|%s|%d|%d", canaryID, scope, seededAt.Unix(), expiresAt.Unix())
+	return base64.RawStdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func messageForProvenance(prov model.Provenance) []byte {
+	// Canonical message ordering to guarantee offline verification parity.
+	payload := fmt.Sprintf("%s|%s|%d|%d|%d|%s",
+		prov.CanaryID,
+		prov.Scope,
+		prov.TTLSeconds,
+		prov.SeededAt.Unix(),
+		prov.ExpiresAt.Unix(),
+		prov.RetrievalSignature,
+	)
+	return []byte(payload)
+}

--- a/services/fcs/internal/service/pipeline.go
+++ b/services/fcs/internal/service/pipeline.go
@@ -1,0 +1,265 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"example.com/summit/fcs/internal/model"
+	"example.com/summit/fcs/internal/provenance"
+	"example.com/summit/fcs/internal/store"
+)
+
+// Pipeline encapsulates the end-to-end canary lifecycle: seeding, detection,
+// and attribution reporting. Collapsing the responsibilities into a single
+// coordination struct keeps the business rules in one place and avoids the
+// need for callers to wire three separate services together.
+type Pipeline struct {
+	stores   map[model.StoreKind]store.Store
+	prov     *provenance.Manager
+	mu       sync.RWMutex
+	registry map[string]model.CanaryRecord
+}
+
+// NewPipeline constructs a Pipeline ensuring the provided stores are uniquely
+// keyed by their StoreKind. The resulting Pipeline is safe for concurrent use.
+func NewPipeline(stores map[model.StoreKind]store.Store, prov *provenance.Manager) (*Pipeline, error) {
+	if prov == nil {
+		return nil, errors.New("provenance manager is required")
+	}
+	if len(stores) == 0 {
+		return nil, errors.New("at least one store must be configured")
+	}
+
+	normalised := make(map[model.StoreKind]store.Store, len(stores))
+	for kind, st := range stores {
+		if st == nil {
+			return nil, fmt.Errorf("store %s is nil", kind)
+		}
+		if _, exists := normalised[kind]; exists {
+			return nil, fmt.Errorf("duplicate store configured for %s", kind)
+		}
+		normalised[kind] = st
+	}
+
+	return &Pipeline{
+		stores:   normalised,
+		prov:     prov,
+		registry: make(map[string]model.CanaryRecord),
+	}, nil
+}
+
+// Seed plants a canary across the requested federated stores and returns the
+// resulting record containing signed provenance.
+func (p *Pipeline) Seed(ctx context.Context, spec model.CanarySpec) (model.CanaryRecord, error) {
+	if spec.Scope == "" {
+		return model.CanaryRecord{}, errors.New("scope is required")
+	}
+	if spec.TTLSeconds <= 0 {
+		return model.CanaryRecord{}, errors.New("ttlSeconds must be greater than zero")
+	}
+	if len(spec.Stores) == 0 {
+		return model.CanaryRecord{}, errors.New("at least one store must be specified")
+	}
+
+	seenStores := make(map[model.StoreKind]struct{}, len(spec.Stores))
+	for _, kind := range spec.Stores {
+		if _, ok := p.stores[kind]; !ok {
+			return model.CanaryRecord{}, fmt.Errorf("store %s not configured", kind)
+		}
+		if _, duplicate := seenStores[kind]; duplicate {
+			return model.CanaryRecord{}, fmt.Errorf("store %s specified multiple times", kind)
+		}
+		seenStores[kind] = struct{}{}
+	}
+
+	seededAt := time.Now().UTC()
+	expiresAt := seededAt.Add(time.Duration(spec.TTLSeconds) * time.Second)
+	canaryID := uuid.NewString()
+
+	prov, err := p.prov.BuildProvenance(canaryID, spec.Scope, spec.TTLSeconds, seededAt, expiresAt)
+	if err != nil {
+		return model.CanaryRecord{}, fmt.Errorf("build provenance: %w", err)
+	}
+
+	normalisedSpec := model.CloneCanarySpec(spec)
+	sort.Slice(normalisedSpec.Stores, func(i, j int) bool {
+		return normalisedSpec.Stores[i] < normalisedSpec.Stores[j]
+	})
+
+	record := model.CanaryRecord{
+		ID:         canaryID,
+		Spec:       normalisedSpec,
+		SeededAt:   seededAt,
+		ExpiresAt:  expiresAt,
+		Provenance: prov,
+	}
+
+	for _, kind := range spec.Stores {
+		st := p.stores[kind]
+		if err := st.Put(ctx, model.StoredCanary{Store: kind, Record: record}); err != nil {
+			return model.CanaryRecord{}, fmt.Errorf("store %s put failed: %w", kind, err)
+		}
+	}
+
+	p.mu.Lock()
+	p.registry[canaryID] = record
+	p.mu.Unlock()
+
+	return record, nil
+}
+
+// Get returns the seeded canary by id when tracked locally.
+func (p *Pipeline) Get(_ context.Context, canaryID string) (model.CanaryRecord, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	record, ok := p.registry[canaryID]
+	return record, ok
+}
+
+// List exposes all canaries tracked by the pipeline.
+func (p *Pipeline) List(_ context.Context) []model.CanaryRecord {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	out := make([]model.CanaryRecord, 0, len(p.registry))
+	for _, record := range p.registry {
+		out = append(out, record)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// Scan enumerates every configured store, returning detections with validated
+// provenance for canaries that have not yet expired.
+func (p *Pipeline) Scan(ctx context.Context) ([]model.Detection, error) {
+	now := time.Now().UTC()
+	detections := make([]model.Detection, 0)
+
+	for _, st := range p.stores {
+		results, err := st.List(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, stored := range results {
+			if stored.Record.ExpiresAt.Before(now) {
+				continue
+			}
+			if !p.prov.VerifyProvenance(stored.Record.Provenance) {
+				continue
+			}
+			observed := now
+			confidence := detectionConfidence(stored.Record, observed)
+			detections = append(detections, model.Detection{
+				CanaryID:   stored.Record.ID,
+				Scope:      stored.Record.Spec.Scope,
+				Store:      stored.Store,
+				Observed:   observed,
+				Confidence: confidence,
+				Provenance: stored.Record.Provenance,
+			})
+		}
+	}
+
+	sort.Slice(detections, func(i, j int) bool {
+		if detections[i].Scope == detections[j].Scope {
+			return detections[i].CanaryID < detections[j].CanaryID
+		}
+		return detections[i].Scope < detections[j].Scope
+	})
+
+	return detections, nil
+}
+
+// BuildAttributionReport groups detections by canary and scope to produce a
+// structured attribution report. The function is deterministic to make tests
+// and API clients simpler.
+func (p *Pipeline) BuildAttributionReport(ctx context.Context) (model.AttributionReport, error) {
+	detections, err := p.Scan(ctx)
+	if err != nil {
+		return model.AttributionReport{}, err
+	}
+
+	grouped := make(map[string]model.AttributionFinding)
+	for _, detection := range detections {
+		finding, ok := grouped[detection.CanaryID]
+		if !ok {
+			finding = model.AttributionFinding{
+				CanaryID:   detection.CanaryID,
+				Scope:      detection.Scope,
+				Stores:     []model.StoreKind{detection.Store},
+				Confidence: detection.Confidence,
+				Provenance: detection.Provenance,
+			}
+		} else {
+			finding.Stores = append(finding.Stores, detection.Store)
+			if detection.Confidence < finding.Confidence {
+				finding.Confidence = detection.Confidence
+			}
+		}
+		grouped[detection.CanaryID] = finding
+	}
+
+	findings := make([]model.AttributionFinding, 0, len(grouped))
+	for _, finding := range grouped {
+		sort.Slice(finding.Stores, func(i, j int) bool { return finding.Stores[i] < finding.Stores[j] })
+		findings = append(findings, finding)
+	}
+
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].Scope == findings[j].Scope {
+			return findings[i].CanaryID < findings[j].CanaryID
+		}
+		return findings[i].Scope < findings[j].Scope
+	})
+
+	return model.AttributionReport{
+		GeneratedAt: time.Now().UTC(),
+		Findings:    findings,
+	}, nil
+}
+
+// PublicKeyHex returns the provenance manager's public key for clients that
+// need to perform offline verification.
+func (p *Pipeline) PublicKeyHex() string {
+	return p.prov.PublicKeyHex()
+}
+
+// VerifyProvenance proxies verification to the provenance manager. This keeps
+// validation logic colocated with the pipeline while still allowing tests or
+// alternate front-ends to re-use the logic.
+func (p *Pipeline) VerifyProvenance(prov model.Provenance) bool {
+	return p.prov.VerifyProvenance(prov)
+}
+
+func detectionConfidence(record model.CanaryRecord, observed time.Time) float64 {
+	lifetime := record.ExpiresAt.Sub(record.SeededAt)
+	if lifetime <= 0 {
+		return 0.5
+	}
+	remaining := record.ExpiresAt.Sub(observed)
+	if remaining <= 0 {
+		return 0.5
+	}
+	ratio := remaining.Seconds() / lifetime.Seconds()
+	if ratio < 0 {
+		ratio = 0
+	}
+	if ratio > 1 {
+		ratio = 1
+	}
+	confidence := 0.5 + 0.5*ratio
+	if confidence > 0.99 {
+		confidence = 0.99
+	}
+	if confidence < 0.5 {
+		confidence = 0.5
+	}
+	return confidence
+}

--- a/services/fcs/internal/service/service_test.go
+++ b/services/fcs/internal/service/service_test.go
@@ -1,0 +1,176 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"example.com/summit/fcs/internal/model"
+	"example.com/summit/fcs/internal/provenance"
+	"example.com/summit/fcs/internal/store"
+)
+
+func newPipeline(t *testing.T) *Pipeline {
+	t.Helper()
+	provManager, err := provenance.NewRandomManager()
+	if err != nil {
+		t.Fatalf("failed to create provenance manager: %v", err)
+	}
+	stores := map[model.StoreKind]store.Store{
+		model.StoreDatabase: store.NewMemoryStore(model.StoreDatabase),
+		model.StoreObject:   store.NewMemoryStore(model.StoreObject),
+		model.StoreSearch:   store.NewMemoryStore(model.StoreSearch),
+		model.StoreVector:   store.NewMemoryStore(model.StoreVector),
+	}
+	pipeline, err := NewPipeline(stores, provManager)
+	if err != nil {
+		t.Fatalf("failed to create pipeline: %v", err)
+	}
+	return pipeline
+}
+
+func TestSeedAndScan(t *testing.T) {
+	pipeline := newPipeline(t)
+
+	spec := model.CanarySpec{
+		Scope:      "finance.payables",
+		TTLSeconds: 3600,
+		Payload: map[string]any{
+			"account": "CANARY-123",
+			"value":   42,
+		},
+		Stores: []model.StoreKind{model.StoreDatabase, model.StoreObject},
+	}
+
+	record, err := pipeline.Seed(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("seed failed: %v", err)
+	}
+
+	if record.ID == "" {
+		t.Fatalf("expected record ID to be generated")
+	}
+
+	if !pipeline.VerifyProvenance(record.Provenance) {
+		t.Fatalf("provenance signature failed verification")
+	}
+
+	detections, err := pipeline.Scan(context.Background())
+	if err != nil {
+		t.Fatalf("pipeline scan failed: %v", err)
+	}
+	if len(detections) != 2 {
+		t.Fatalf("expected 2 detections, got %d", len(detections))
+	}
+	for _, detection := range detections {
+		if detection.CanaryID != record.ID {
+			t.Fatalf("unexpected canary id %s", detection.CanaryID)
+		}
+		if detection.Confidence < 0.5 || detection.Confidence > 0.99 {
+			t.Fatalf("confidence outside expected range: %f", detection.Confidence)
+		}
+	}
+}
+
+func TestBuildAttributionReport(t *testing.T) {
+	pipeline := newPipeline(t)
+
+	spec := model.CanarySpec{
+		Scope:      "research.biotech",
+		TTLSeconds: 120,
+		Payload: map[string]any{
+			"docId": "HX-99",
+		},
+		Stores: []model.StoreKind{model.StoreSearch, model.StoreVector, model.StoreObject},
+	}
+
+	record, err := pipeline.Seed(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("seed failed: %v", err)
+	}
+
+	report, err := pipeline.BuildAttributionReport(context.Background())
+	if err != nil {
+		t.Fatalf("report generation failed: %v", err)
+	}
+
+	if len(report.Findings) != 1 {
+		t.Fatalf("expected one finding, got %d", len(report.Findings))
+	}
+
+	finding := report.Findings[0]
+	if finding.CanaryID != record.ID {
+		t.Fatalf("unexpected canary id %s", finding.CanaryID)
+	}
+	if len(finding.Stores) != 3 {
+		t.Fatalf("expected three stores, got %d", len(finding.Stores))
+	}
+	if finding.Scope != spec.Scope {
+		t.Fatalf("expected scope %s got %s", spec.Scope, finding.Scope)
+	}
+	if finding.Confidence < 0.9 {
+		t.Fatalf("expected high confidence, got %f", finding.Confidence)
+	}
+	if finding.Provenance.CanaryID != record.ID {
+		t.Fatalf("finding provenance mismatch")
+	}
+	if finding.Provenance.ExpiresAt.Before(time.Now().UTC()) {
+		t.Fatalf("provenance indicates expired canary unexpectedly")
+	}
+}
+
+func TestSeedNormalisesSpec(t *testing.T) {
+	pipeline := newPipeline(t)
+
+	spec := model.CanarySpec{
+		Scope:      "ops.data-loss",
+		TTLSeconds: 1800,
+		Payload: map[string]any{
+			"account": "A-100",
+		},
+		Metadata: map[string]any{
+			"owner": "purple-team",
+		},
+		Stores: []model.StoreKind{model.StoreObject, model.StoreDatabase},
+	}
+
+	record, err := pipeline.Seed(context.Background(), spec)
+	if err != nil {
+		t.Fatalf("seed failed: %v", err)
+	}
+
+	// Mutate original spec after seeding; stored record should remain stable.
+	spec.Payload["account"] = "tampered"
+	spec.Metadata["owner"] = "red-team"
+	spec.Stores[0] = model.StoreVector
+
+	if record.Spec.Payload["account"] != "A-100" {
+		t.Fatalf("expected payload to be copied, got %v", record.Spec.Payload["account"])
+	}
+	if record.Spec.Metadata["owner"] != "purple-team" {
+		t.Fatalf("expected metadata to be copied, got %v", record.Spec.Metadata["owner"])
+	}
+	if len(record.Spec.Stores) != 2 {
+		t.Fatalf("expected two stores, got %d", len(record.Spec.Stores))
+	}
+	if record.Spec.Stores[0] != model.StoreDatabase || record.Spec.Stores[1] != model.StoreObject {
+		t.Fatalf("expected stores to be sorted and copied, got %v", record.Spec.Stores)
+	}
+}
+
+func TestSeedRejectsDuplicateStores(t *testing.T) {
+	pipeline := newPipeline(t)
+
+	spec := model.CanarySpec{
+		Scope:      "ops.duplicate",
+		TTLSeconds: 600,
+		Stores: []model.StoreKind{
+			model.StoreDatabase,
+			model.StoreDatabase,
+		},
+	}
+
+	if _, err := pipeline.Seed(context.Background(), spec); err == nil {
+		t.Fatalf("expected error for duplicate stores")
+	}
+}

--- a/services/fcs/internal/store/memory.go
+++ b/services/fcs/internal/store/memory.go
@@ -1,0 +1,51 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"example.com/summit/fcs/internal/model"
+)
+
+// MemoryStore is an in-memory implementation of Store used for testing and default deployments.
+type MemoryStore struct {
+	kind    model.StoreKind
+	mu      sync.RWMutex
+	records map[string]model.StoredCanary
+}
+
+// NewMemoryStore creates a memory backed store for the provided kind.
+func NewMemoryStore(kind model.StoreKind) *MemoryStore {
+	return &MemoryStore{
+		kind:    kind,
+		records: make(map[string]model.StoredCanary),
+	}
+}
+
+// Type returns the store kind supported by this memory store.
+func (m *MemoryStore) Type() model.StoreKind {
+	return m.kind
+}
+
+// Put stores the provided canary, ensuring the store kind matches expectations.
+func (m *MemoryStore) Put(_ context.Context, canary model.StoredCanary) error {
+	if canary.Store != m.kind {
+		return errors.New("store kind mismatch for canary placement")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.records[canary.Record.ID] = canary
+	return nil
+}
+
+// List returns all canaries held by the store.
+func (m *MemoryStore) List(context.Context) ([]model.StoredCanary, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	out := make([]model.StoredCanary, 0, len(m.records))
+	for _, c := range m.records {
+		out = append(out, c)
+	}
+	return out, nil
+}

--- a/services/fcs/internal/store/store.go
+++ b/services/fcs/internal/store/store.go
@@ -1,0 +1,14 @@
+package store
+
+import (
+	"context"
+
+	"example.com/summit/fcs/internal/model"
+)
+
+// Store abstracts a federated data store capable of holding canary records.
+type Store interface {
+	Type() model.StoreKind
+	Put(ctx context.Context, canary model.StoredCanary) error
+	List(ctx context.Context) ([]model.StoredCanary, error)
+}


### PR DESCRIPTION
## Summary
- drop the FCS client package lock and add scoped ignores so only source files are tracked
- extend the repo gitignore to block FCS build outputs and stray poetry locks that could be flagged as binaries

## Testing
- go test ./... (from services/fcs)
- npm run build (from sdk/fcs-client)


------
https://chatgpt.com/codex/tasks/task_e_68d78d28e4f483338deab8b33f61088b