### PR TITLE
docs: outline canary reliability mvp plan

### DIFF
--- a/docs/release/canary_manager_synthetic_probes_auto_rollback.md
+++ b/docs/release/canary_manager_synthetic_probes_auto_rollback.md
@@ -1,0 +1,96 @@
+# Reliability & Release Initiative — Canary Manager, Synthetic Probes, Auto-Rollback
+
+## Mission & Outcomes
+
+- **Objective:** Reduce change-failure rate through coordinated canary orchestration, synthetic verification, and automated rollback governed by policy.
+- **Key Results:**
+  - Median rollback execution < 5 minutes.
+  - False abort rate < 2% per quarter.
+  - Synthetic probe service availability ≥ 99.9%.
+
+## Scope (MVP, 6 Weeks)
+
+1. **Canary Controller**
+   - Deploy Argo Rollouts (or Flagger) with standardized rollout templates (`rollouts.yaml`).
+   - Integrate metrics-based promotions using multiple indicators (latency, error rate, saturation, synthetic probe scores).
+   - Emit promote/abort webhooks to downstream automations.
+2. **Synthetic Probe Service**
+   - Implement HTTP flow definitions in YAML, mapped to SLO objectives.
+   - Support environment-specific targets (staging, pre-prod, prod) with shared libraries for auth/session setup.
+   - Stream probe results to observability platform and error-budget calculators.
+3. **Rollback Engine**
+   - Automate rollback through CI/CD integration with policy evaluation (error budget, change windows).
+   - Enforce signed manifest validation and admission policy checks before promotion.
+
+## Definition of Ready
+
+- Documented promotion criteria and guardrail thresholds for each environment.
+- Published error budget policies (limits, burn-rate formulas, freeze conditions).
+- Enumerated target environments with required blast-radius limits and dependencies.
+
+## Definition of Done
+
+- Canary promotions require both synthetic probe passes and real-user metric health.
+- Automatic rollback triggers on SLO burn or policy violations, completing within the target <5m median.
+- Promotion, probe, and rollback events logged with signed evidence artifacts.
+
+## Deliverables
+
+- Versioned `rollouts.yaml` templates and controller configuration packs.
+- Synthetic probe definitions (YAML) plus shared libraries for auth, fixtures, and observability wiring.
+- Rollout playbooks covering promotion, pause, abort, and rollback drills.
+- Dashboards: SLO burn, canary cohort comparison, synthetic probe reliability, and rollback latency.
+- Incident runbook for rollback execution and verification.
+- Promotion and rollback logs archived for compliance evidence.
+
+## Interfaces
+
+- **Rollout manifests:** `rollouts.yaml` (per service); annotation schema documented.
+- **Synthetic probes:** YAML flows referencing shared configs; schedule + SLO binding metadata.
+- **Automation webhooks:** Promote/abort endpoints for notifying CI/CD, ChatOps, and incident tooling.
+
+## Security Gates
+
+- All deployment manifests must be signed (cosign/Sigstore) prior to admission.
+- Admission controllers reject unsigned container images.
+- Policy checks enforce provenance and environment-specific allowlists before promotion.
+
+## Observability & Evidence
+
+- Live dashboards demonstrating healthy canary promotion.
+- Recorded rollback simulation/game-day showcasing automated recovery.
+- Promotion logs capturing decision criteria, metrics snapshots, and signatures.
+
+## Risk Mitigation
+
+- **Metric flakiness:** Use composite health scoring across primary metrics, synthetic probes, and event logs; include manual override protocol.
+- **Hidden dependencies:** Synthetic end-to-end probes mimic real user journeys to surface upstream/downstream coupling issues.
+- **Probe drift:** Periodic replay validation and schema linting to maintain probe fidelity.
+
+## Track B (Post-MVP Explorations)
+
+- Adaptive canaries that adjust traffic weights and feature flags based on live metric confidence.
+- Chaos-lite fault injections during canary stages to validate rollback responsiveness.
+
+## Execution Plan
+
+| Week | Focus                           | Key Activities                                                                                                                 | Outputs                                                              |
+| ---- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| 1    | Program kickoff & design        | Confirm DoR artifacts, finalize controller choice, define rollout templates, outline probe architecture.                       | Architecture diagram, rollout template draft, probe schema draft.    |
+| 2    | Controller & policy scaffolding | Deploy canary controller to staging, wire baseline metrics, author promotion/abort policies, integrate signed-manifest checks. | Staging controller live, policy docs, signed manifest pipeline step. |
+| 3    | Synthetic probe MVP             | Build probe runner, author critical HTTP flows, connect to observability, set SLO targets per environment.                     | Probe repo, CI job, dashboards seeded.                               |
+| 4    | Rollback automation             | Implement CI/CD hooks for rollback, add webhook listeners, simulate failure scenarios, document runbooks.                      | Rollback engine scripts, runbook v1, webhook audit trail.            |
+| 5    | Integrated canary rehearsals    | Execute end-to-end canary with synthetic + real metrics, iterate thresholds, capture evidence artifacts.                       | Canary demo recording, promotion logs, tuned thresholds.             |
+| 6    | Hardening & handoff             | Conduct rollback game day, finalize dashboards, polish documentation, review security/admission policies.                      | Final dashboards, incident runbook, acceptance sign-off package.     |
+
+## Governance & Reporting
+
+- Weekly readiness review covering SLO adherence, probe uptime, and outstanding risks.
+- Change advisory board notified via promote/abort webhook events.
+- Evidence bundle aggregated into release readiness checklist.
+
+## Success Metrics
+
+- Median rollback duration measured during drills and live incidents.
+- False abort rate tracked via incident reviews and controller logs.
+- Probe service uptime validated by health checks and SLO monitors.


### PR DESCRIPTION
## Summary
- add a reliability and release initiative plan covering canary orchestration, synthetic probes, and automated rollback
- document scope, ready/done definitions, deliverables, interfaces, and security/observability controls
- provide execution timeline, governance checkpoints, and success metrics for the six-week MVP

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d8e5817d8c8333bf880d5bcab41db5