### PR TITLE
feat: enrich IntelCraft graph ingestion toolkit

### DIFF
--- a/intelgraph/README.md
+++ b/intelgraph/README.md
@@ -8,11 +8,13 @@ A next-generation intelligence analysis platform that synthesizes and surpasses 
 ## 🚀 Quick Start
 
 ### Prerequisites
+
 - Node.js 18+
 - Docker & Docker Compose
 - Git
 
 ### Setup Instructions
+
 ```bash
 # 1. Navigate to the directory
 cd intelgraph-platform
@@ -40,19 +42,22 @@ npm run docker:dev
 This package addresses ALL issues identified in the repository state assessment:
 
 ### Security Issues Resolved
+
 - ✅ Removes .env files from git history
-- ✅ Removes .DS_Store files from git history  
+- ✅ Removes .DS_Store files from git history
 - ✅ Removes zip files from repository
 - ✅ Creates comprehensive .gitignore
 - ✅ Implements proper secrets management
 
 ### File System Issues Resolved
+
 - ✅ Normalizes file naming (removes "(3).js" patterns)
 - ✅ Organizes project structure properly
 - ✅ Removes spaces from file names
 - ✅ Implements consistent naming conventions
 
 ### Development Issues Resolved
+
 - ✅ Sets up proper Git hooks
 - ✅ Implements CI/CD pipeline
 - ✅ Creates Docker development environment
@@ -62,6 +67,7 @@ This package addresses ALL issues identified in the repository state assessment:
 ## 🏗️ MVP-0 Features Implemented
 
 ### Core Platform Features
+
 - ✅ **Authentication**: JWT with refresh tokens, RBAC
 - ✅ **GraphQL API**: Complete CRUD operations for all entities
 - ✅ **Graph Database**: Neo4j with proper constraints and indexes
@@ -70,15 +76,56 @@ This package addresses ALL issues identified in the repository state assessment:
 - ✅ **Investigation Management**: Complete workflow support
 
 ### Technical Implementation
+
 - ✅ **Backend**: Node.js, Express, Apollo GraphQL
 - ✅ **Frontend**: React 18, Redux Toolkit, Material-UI
 - ✅ **Databases**: Neo4j (graph), PostgreSQL (metadata), Redis (cache)
 - ✅ **Infrastructure**: Docker, Kubernetes, Helm, Terraform
 - ✅ **Monitoring**: Prometheus, Grafana, ELK Stack
+- ✅ **IntelCraft Integration**: Native ingestion of IntelCraft tradecraft elements into the core graph analytics engine
+
+### IntelCraft Tradecraft Graph API
+
+```python
+from intelgraph import (
+    Graph,
+    integrate_intelcraft_elements,
+    normalize_intelcraft_elements,
+)
+
+graph = Graph()
+
+payload = [
+    {
+        "element_id": "actor:alpha",
+        "name": "Alpha Actor",
+        "category": "actor",
+        "metadata": {"aliases": ["Alpha"]},
+        "relationships": [
+            {
+                "target_id": "campaign:gamma",
+                "relation_type": "leads",
+                "weight": 0.75,
+            }
+        ],
+    },
+    {
+        "element_id": "campaign:gamma",
+        "name": "Gamma Campaign",
+        "category": "campaign",
+    },
+]
+
+elements = normalize_intelcraft_elements(payload)
+integrate_intelcraft_elements(graph, elements)
+```
+
+The helper automatically deep-merges attributes for existing nodes and relationships, ensuring repeated ingestions enrich—rather than overwrite—tradecraft context.
 
 ## 🛠️ Development Workflow
 
 ### Daily Development
+
 ```bash
 # Start development
 npm run docker:dev
@@ -94,6 +141,7 @@ npm run build
 ```
 
 ### Feature Development
+
 ```bash
 # Create feature branch
 git checkout -b feature/new-feature
@@ -112,12 +160,14 @@ git push origin feature/new-feature
 ## 📊 Architecture
 
 ### Technology Stack
+
 - **Frontend**: React 18, Redux Toolkit, Material-UI, Cytoscape.js
 - **Backend**: Node.js, Express, Apollo GraphQL, Socket.io
 - **Databases**: Neo4j (graph), PostgreSQL (metadata), Redis (cache)
 - **Infrastructure**: Docker, Kubernetes, Helm, Terraform
 
 ### System Components
+
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
 │   React Client  │◄──►│  GraphQL API    │◄──►│    Neo4j DB     │
@@ -139,7 +189,9 @@ git push origin feature/new-feature
 ## 🔧 Configuration
 
 ### Environment Variables
+
 Copy `.env.example` to `.env` and configure:
+
 - Database credentials
 - JWT secrets
 - Feature flags
@@ -148,6 +200,7 @@ Copy `.env.example` to `.env` and configure:
 ## 🧪 Testing
 
 ### Test Suites
+
 - **Unit Tests**: Jest for components and services
 - **Integration Tests**: Supertest for API testing
 - **E2E Tests**: Playwright for user workflows
@@ -156,16 +209,19 @@ Copy `.env.example` to `.env` and configure:
 ## 🚀 Deployment
 
 ### Development
+
 ```bash
 npm run docker:dev
 ```
 
 ### Staging
+
 ```bash
 npm run deploy:staging
 ```
 
 ### Production
+
 ```bash
 npm run deploy:prod
 ```
@@ -173,6 +229,7 @@ npm run deploy:prod
 ## 🛡️ Security
 
 ### Implemented Security
+
 - JWT authentication with refresh tokens
 - Role-based access control (RBAC)
 - Input validation and sanitization

--- a/intelgraph/__init__.py
+++ b/intelgraph/__init__.py
@@ -1,1 +1,36 @@
 
+"""IntelGraph Python utilities exposed for external use."""
+
+from .graph_analytics.core_analytics import (
+    Graph,
+    calculate_betweenness_centrality,
+    calculate_eigenvector_centrality,
+    detect_communities_leiden,
+    detect_communities_louvain,
+    detect_roles_and_brokers,
+    find_k_shortest_paths,
+    find_shortest_path,
+)
+from .intelcraft import (
+    IntelCraftElement,
+    IntelCraftRelationship,
+    build_intelcraft_graph,
+    integrate_intelcraft_elements,
+    normalize_intelcraft_elements,
+)
+
+__all__ = [
+    "Graph",
+    "calculate_betweenness_centrality",
+    "calculate_eigenvector_centrality",
+    "detect_communities_leiden",
+    "detect_communities_louvain",
+    "detect_roles_and_brokers",
+    "find_k_shortest_paths",
+    "find_shortest_path",
+    "IntelCraftElement",
+    "IntelCraftRelationship",
+    "build_intelcraft_graph",
+    "integrate_intelcraft_elements",
+    "normalize_intelcraft_elements",
+]

--- a/intelgraph/graph_analytics/core_analytics.py
+++ b/intelgraph/graph_analytics/core_analytics.py
@@ -1,31 +1,140 @@
+"""Lightweight graph analytics utilities used across IntelGraph."""
 
-# intelgraph/graph_analytics/core_analytics.py
+from __future__ import annotations
 
 from collections import deque
+from typing import Any, Dict, List, MutableMapping, Optional, Set
+
 
 class Graph:
-    """
-    A simple in-memory graph representation using adjacency lists.
-    For demonstration purposes.
-    """
-    def __init__(self):
-        self.adj = {}
+    """A simple in-memory undirected graph with attribute support."""
 
-    def add_node(self, node):
+    def __init__(self) -> None:
+        self.adj: Dict[Any, List[Any]] = {}
+        self.node_attrs: Dict[Any, Dict[str, Any]] = {}
+        self.edge_attrs: Dict[tuple[Any, Any], Dict[str, Any]] = {}
+
+    def add_node(self, node: Any, attributes: Optional[Dict[str, Any]] = None) -> None:
         if node not in self.adj:
             self.adj[node] = []
+        if node not in self.node_attrs:
+            self.node_attrs[node] = {}
+        if attributes:
+            self.node_attrs[node].update(attributes)
 
-    def add_edge(self, u, v):
+    def update_node_attributes(self, node: Any, attributes: Dict[str, Any]) -> None:
+        self.add_node(node)
+        self.node_attrs[node].update(attributes)
+
+    def merge_node_attributes(self, node: Any, attributes: Dict[str, Any]) -> None:
+        """Merge ``attributes`` into ``node`` using a deep merge strategy."""
+
+        self.add_node(node)
+        self.node_attrs[node] = _merge_attribute_dicts(self.node_attrs[node], attributes)
+
+    def get_node_attributes(self, node: Any) -> Dict[str, Any]:
+        return dict(self.node_attrs.get(node, {}))
+
+    def add_edge(self, u: Any, v: Any, attributes: Optional[Dict[str, Any]] = None) -> None:
         self.add_node(u)
         self.add_node(v)
-        self.adj[u].append(v)
-        # For undirected graph, add the reverse edge as well
-        self.adj[v].append(u)
+        if v not in self.adj[u]:
+            self.adj[u].append(v)
+        if u not in self.adj[v]:
+            self.adj[v].append(u)
+        if attributes:
+            key = self._edge_key(u, v)
+            data = self.edge_attrs.setdefault(key, {})
+            data.update(attributes)
 
-def find_shortest_path(graph: Graph, start_node, end_node) -> list:
-    """
-    Finds the shortest path between two nodes in an unweighted graph using BFS.
-    """
+    def update_edge_attributes(self, u: Any, v: Any, attributes: Dict[str, Any]) -> None:
+        self.add_edge(u, v)
+        key = self._edge_key(u, v)
+        data = self.edge_attrs.setdefault(key, {})
+        data.update(attributes)
+
+    def merge_edge_attributes(self, u: Any, v: Any, attributes: Dict[str, Any]) -> None:
+        """Merge ``attributes`` into the edge ``(u, v)``."""
+
+        self.add_edge(u, v)
+        key = self._edge_key(u, v)
+        current = self.edge_attrs.setdefault(key, {})
+        self.edge_attrs[key] = _merge_attribute_dicts(current, attributes)
+
+    def get_edge_attributes(self, u: Any, v: Any) -> Dict[str, Any]:
+        return dict(self.edge_attrs.get(self._edge_key(u, v), {}))
+
+    def neighbors(self, node: Any) -> List[Any]:
+        return list(self.adj.get(node, []))
+
+    def has_node(self, node: Any) -> bool:
+        return node in self.adj
+
+    def has_edge(self, u: Any, v: Any) -> bool:
+        key = self._edge_key(u, v)
+        return key in self.edge_attrs or (u in self.adj and v in self.adj[u])
+
+    def _edge_key(self, u: Any, v: Any) -> tuple[Any, Any]:
+        return tuple(sorted((u, v), key=repr))
+
+
+def _merge_attribute_dicts(
+    original: MutableMapping[str, Any],
+    incoming: MutableMapping[str, Any],
+) -> Dict[str, Any]:
+    """Merge ``incoming`` into ``original`` preserving nested structures."""
+
+    result: Dict[str, Any] = dict(original)
+    for key, value in incoming.items():
+        if key not in result:
+            result[key] = value
+            continue
+
+        existing = result[key]
+        result[key] = _merge_attribute_values(existing, value)
+    return result
+
+
+def _merge_attribute_values(existing: Any, incoming: Any) -> Any:
+    if isinstance(existing, MutableMapping) and isinstance(incoming, MutableMapping):
+        return _merge_attribute_dicts(existing, incoming)
+
+    if isinstance(existing, list) and isinstance(incoming, list):
+        seen: Set[Any] = set()
+        merged: List[Any] = []
+        for item in existing + incoming:
+            marker = _hashable_marker(item)
+            if marker in seen:
+                continue
+            seen.add(marker)
+            merged.append(item)
+        return merged
+
+    if isinstance(existing, set) and isinstance(incoming, set):
+        return existing | incoming
+
+    if isinstance(existing, tuple) and isinstance(incoming, tuple):
+        merged_list = _merge_attribute_values(list(existing), list(incoming))
+        return tuple(merged_list) if isinstance(merged_list, list) else merged_list
+
+    return incoming
+
+
+def _hashable_marker(value: Any) -> Any:
+    if isinstance(value, MutableMapping):
+        return tuple(sorted((k, _hashable_marker(v)) for k, v in value.items()))
+    if isinstance(value, list):
+        return tuple(_hashable_marker(item) for item in value)
+    if isinstance(value, set):
+        return tuple(sorted(_hashable_marker(item) for item in value))
+    if isinstance(value, tuple):
+        return tuple(_hashable_marker(item) for item in value)
+    return value
+
+
+def find_shortest_path(graph: Graph, start_node: Any, end_node: Any) -> List[Any]:
+    """Find the shortest path between ``start_node`` and ``end_node``."""
+
     if start_node not in graph.adj or end_node not in graph.adj:
         return []
 
@@ -45,44 +154,64 @@ def find_shortest_path(graph: Graph, start_node, end_node) -> list:
 
     return []
 
-def find_k_shortest_paths(graph, start_node, end_node, k, weight_property=None):
-    """
-    Stub for finding the K shortest paths between two nodes in a graph.
-    """
+
+def find_k_shortest_paths(
+    graph: Graph,
+    start_node: Any,
+    end_node: Any,
+    k: int,
+    weight_property: Optional[str] = None,
+) -> List[List[Any]]:
+    """Stub for finding the ``k`` shortest paths between two nodes."""
+
     print(f"Finding {k} shortest paths from {start_node} to {end_node}")
+    if weight_property:
+        print(f"Ignoring weight property '{weight_property}' in stub implementation")
     return []
 
-def detect_communities_louvain(graph):
-    """
-    Stub for detecting communities using the Louvain method.
-    """
+
+def detect_communities_louvain(graph: Graph) -> Dict[str, Any]:
+    """Stub for detecting communities using the Louvain method."""
+
     print("Detecting communities using Louvain method")
     return {}
 
-def detect_communities_leiden(graph):
-    """
-    Stub for detecting communities using the Leiden method.
-    """
+
+def detect_communities_leiden(graph: Graph) -> Dict[str, Any]:
+    """Stub for detecting communities using the Leiden method."""
+
     print("Detecting communities using Leiden method")
     return {}
 
-def calculate_betweenness_centrality(graph):
-    """
-    Stub for calculating betweenness centrality for nodes in a graph.
-    """
+
+def calculate_betweenness_centrality(graph: Graph) -> Dict[str, Any]:
+    """Stub for calculating betweenness centrality."""
+
     print("Calculating betweenness centrality")
     return {}
 
-def calculate_eigenvector_centrality(graph):
-    """
-    Stub for calculating eigenvector centrality for nodes in a graph.
-    """
+
+def calculate_eigenvector_centrality(graph: Graph) -> Dict[str, Any]:
+    """Stub for calculating eigenvector centrality."""
+
     print("Calculating eigenvector centrality")
     return {}
 
-def detect_roles_and_brokers(graph):
-    """
-    Stub for detecting roles and brokers in a graph.
-    """
+
+def detect_roles_and_brokers(graph: Graph) -> Dict[str, Any]:
+    """Stub for detecting roles and brokers in a graph."""
+
     print("Detecting roles and brokers")
     return {}
+
+
+__all__ = [
+    "Graph",
+    "find_shortest_path",
+    "find_k_shortest_paths",
+    "detect_communities_louvain",
+    "detect_communities_leiden",
+    "calculate_betweenness_centrality",
+    "calculate_eigenvector_centrality",
+    "detect_roles_and_brokers",
+]

--- a/intelgraph/intelcraft/__init__.py
+++ b/intelgraph/intelcraft/__init__.py
@@ -1,0 +1,17 @@
+"""IntelCraft domain objects and integration helpers for IntelGraph."""
+
+from .integration import (
+    IntelCraftElement,
+    IntelCraftRelationship,
+    build_intelcraft_graph,
+    integrate_intelcraft_elements,
+    normalize_intelcraft_elements,
+)
+
+__all__ = [
+    "IntelCraftElement",
+    "IntelCraftRelationship",
+    "build_intelcraft_graph",
+    "integrate_intelcraft_elements",
+    "normalize_intelcraft_elements",
+]

--- a/intelgraph/intelcraft/integration.py
+++ b/intelgraph/intelcraft/integration.py
@@ -1,0 +1,217 @@
+"""IntelCraft tradecraft elements and graph integration helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Union
+
+from ..graph_analytics.core_analytics import Graph
+
+
+@dataclass
+class IntelCraftRelationship:
+    """Relationship between two IntelCraft elements."""
+
+    target_id: str
+    relation_type: str
+    weight: Optional[float] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def as_edge_attributes(self) -> Dict[str, Any]:
+        attributes: Dict[str, Any] = {"relation_type": self.relation_type}
+        if self.weight is not None:
+            attributes["weight"] = self.weight
+        if self.metadata:
+            attributes.update(self.metadata)
+        return attributes
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {
+            "target_id": self.target_id,
+            "relation_type": self.relation_type,
+        }
+        if self.weight is not None:
+            data["weight"] = self.weight
+        if self.metadata:
+            data["metadata"] = dict(self.metadata)
+        return data
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "IntelCraftRelationship":
+        if "target_id" not in payload or "relation_type" not in payload:
+            missing = {key for key in ("target_id", "relation_type") if key not in payload}
+            raise ValueError(f"Relationship payload missing fields: {sorted(missing)}")
+        metadata = payload.get("metadata") or {}
+        if not isinstance(metadata, MutableMapping):
+            raise TypeError("relationship metadata must be a mapping")
+        return cls(
+            target_id=str(payload["target_id"]),
+            relation_type=str(payload["relation_type"]),
+            weight=payload.get("weight"),
+            metadata=dict(metadata),
+        )
+
+
+@dataclass
+class IntelCraftElement:
+    """IntelCraft knowledge element ready for IntelGraph ingestion."""
+
+    element_id: str
+    name: str
+    category: str
+    description: Optional[str] = None
+    confidence: float = 0.5
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    relationships: List[IntelCraftRelationship] = field(default_factory=list)
+
+    def as_node_attributes(self) -> Dict[str, Any]:
+        attributes: Dict[str, Any] = {
+            "name": self.name,
+            "category": self.category,
+            "confidence": self.confidence,
+        }
+        if self.description:
+            attributes["description"] = self.description
+        if self.metadata:
+            attributes.update(self.metadata)
+        return attributes
+
+    def link_to(
+        self,
+        target_id: str,
+        relation_type: str,
+        *,
+        weight: Optional[float] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.relationships.append(
+            IntelCraftRelationship(
+                target_id=target_id,
+                relation_type=relation_type,
+                weight=weight,
+                metadata=metadata or {},
+            )
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "element_id": self.element_id,
+            "name": self.name,
+            "category": self.category,
+            "confidence": self.confidence,
+        }
+        if self.description is not None:
+            data["description"] = self.description
+        if self.metadata:
+            data["metadata"] = dict(self.metadata)
+        if self.relationships:
+            data["relationships"] = [relationship.to_dict() for relationship in self.relationships]
+        return data
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "IntelCraftElement":
+        required = {"element_id", "name", "category"}
+        missing = [key for key in required if key not in payload]
+        if missing:
+            raise ValueError(f"Element payload missing fields: {missing}")
+
+        metadata = payload.get("metadata") or {}
+        if metadata and not isinstance(metadata, MutableMapping):
+            raise TypeError("element metadata must be a mapping")
+
+        raw_relationships = payload.get("relationships")
+        if raw_relationships is None:
+            raw_relationships = []
+        if raw_relationships and not isinstance(raw_relationships, Sequence):
+            raise TypeError("relationships must be provided as a sequence")
+        relationship_payloads: Sequence[Any] = raw_relationships  # type: ignore[assignment]
+        relationships = [
+            relation
+            if isinstance(relation, IntelCraftRelationship)
+            else IntelCraftRelationship.from_dict(relation)
+            for relation in relationship_payloads
+        ]
+
+        return cls(
+            element_id=str(payload["element_id"]),
+            name=str(payload["name"]),
+            category=str(payload["category"]),
+            description=payload.get("description"),
+            confidence=float(payload.get("confidence", 0.5)),
+            metadata=dict(metadata),
+            relationships=list(relationships),
+        )
+
+
+IntelCraftElementInput = Union[IntelCraftElement, Mapping[str, Any]]
+
+
+def integrate_intelcraft_elements(
+    graph: Graph,
+    elements: Iterable[IntelCraftElementInput],
+    *,
+    enrich_targets: bool = True,
+    merge_attributes: bool = True,
+) -> None:
+    """Merge IntelCraft elements into an existing :class:`Graph` instance."""
+
+    normalized_elements = normalize_intelcraft_elements(elements)
+    element_index: Dict[str, IntelCraftElement] = {}
+
+    for element in normalized_elements:
+        if element.element_id in element_index:
+            raise ValueError(f"Duplicate IntelCraft element id: {element.element_id}")
+        element_index[element.element_id] = element
+
+    for element in element_index.values():
+        attrs = element.as_node_attributes()
+        if merge_attributes and graph.has_node(element.element_id):
+            graph.merge_node_attributes(element.element_id, attrs)
+        else:
+            graph.add_node(element.element_id, attributes=attrs)
+
+    for element in element_index.values():
+        for relationship in element.relationships:
+            edge_attributes = relationship.as_edge_attributes()
+            if merge_attributes and graph.has_edge(element.element_id, relationship.target_id):
+                graph.merge_edge_attributes(element.element_id, relationship.target_id, edge_attributes)
+            else:
+                graph.add_edge(element.element_id, relationship.target_id, attributes=edge_attributes)
+            if enrich_targets and relationship.target_id in element_index:
+                linked_from = graph.get_node_attributes(relationship.target_id).get("linked_from", [])
+                new_linked_from = sorted({*linked_from, element.element_id})
+                if merge_attributes:
+                    graph.merge_node_attributes(relationship.target_id, {"linked_from": new_linked_from})
+                else:
+                    graph.update_node_attributes(relationship.target_id, {"linked_from": new_linked_from})
+
+
+def build_intelcraft_graph(elements: Iterable[IntelCraftElementInput]) -> Graph:
+    """Create a new :class:`Graph` populated with IntelCraft elements."""
+
+    graph = Graph()
+    integrate_intelcraft_elements(graph, elements)
+    return graph
+
+
+def normalize_intelcraft_elements(
+    elements: Iterable[IntelCraftElementInput],
+) -> List[IntelCraftElement]:
+    """Return ``IntelCraftElement`` instances for ``elements`` inputs."""
+
+    normalized: List[IntelCraftElement] = []
+    for element in elements:
+        if isinstance(element, IntelCraftElement):
+            normalized.append(element)
+        else:
+            normalized.append(IntelCraftElement.from_dict(element))
+    return normalized
+
+
+__all__ = [
+    "IntelCraftElement",
+    "IntelCraftRelationship",
+    "integrate_intelcraft_elements",
+    "build_intelcraft_graph",
+    "normalize_intelcraft_elements",
+]

--- a/intelgraph/tests/test_intelcraft_integration.py
+++ b/intelgraph/tests/test_intelcraft_integration.py
@@ -1,0 +1,151 @@
+"""Tests for IntelCraft-to-IntelGraph integration helpers."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from intelgraph import (  # noqa: E402  pylint: disable=wrong-import-position
+    Graph,
+    IntelCraftElement,
+    IntelCraftRelationship,
+    build_intelcraft_graph,
+    integrate_intelcraft_elements,
+    normalize_intelcraft_elements,
+)
+
+
+def _create_sample_elements() -> list[IntelCraftElement]:
+    actor = IntelCraftElement(
+        element_id="actor:alpha",
+        name="Alpha Actor",
+        category="actor",
+        description="Threat actor tracked by IntelCraft",
+        confidence=0.9,
+        metadata={"origin": "intelcraft", "sensitivity": "TLP:AMBER"},
+    )
+    campaign = IntelCraftElement(
+        element_id="campaign:gamma",
+        name="Gamma Campaign",
+        category="campaign",
+    )
+    infrastructure = IntelCraftElement(
+        element_id="infra:node-7",
+        name="Node 7",
+        category="infrastructure",
+        metadata={"ip": "203.0.113.7"},
+    )
+
+    actor.link_to("campaign:gamma", "leads")
+    campaign.link_to(
+        "infra:node-7",
+        "utilizes",
+        weight=0.7,
+        metadata={"first_seen": "2024-05-02"},
+    )
+    return [actor, campaign, infrastructure]
+
+
+def test_integrate_intelcraft_elements_populates_graph() -> None:
+    graph = Graph()
+    elements = _create_sample_elements()
+
+    integrate_intelcraft_elements(graph, elements)
+
+    assert set(graph.adj.keys()) == {element.element_id for element in elements}
+    actor_attributes = graph.get_node_attributes("actor:alpha")
+    assert actor_attributes["category"] == "actor"
+    assert actor_attributes["sensitivity"] == "TLP:AMBER"
+
+    edge_attrs = graph.get_edge_attributes("campaign:gamma", "infra:node-7")
+    assert edge_attrs["relation_type"] == "utilizes"
+    assert edge_attrs["weight"] == 0.7
+    assert edge_attrs["first_seen"] == "2024-05-02"
+
+
+def test_build_intelcraft_graph_creates_linked_structure() -> None:
+    elements = _create_sample_elements()
+
+    graph = build_intelcraft_graph(elements)
+
+    assert graph.neighbors("actor:alpha") == ["campaign:gamma"]
+    path = graph.get_node_attributes("campaign:gamma").get("linked_from")
+    assert path == ["actor:alpha"]
+
+
+def test_intelcraft_element_round_trip() -> None:
+    element = IntelCraftElement(
+        element_id="infra:node-9",
+        name="Node 9",
+        category="infrastructure",
+        confidence=0.7,
+        metadata={"purpose": "command"},
+        relationships=[
+            IntelCraftRelationship(
+                target_id="actor:omega",
+                relation_type="controlled-by",
+                metadata={"since": "2024-03-01"},
+            )
+        ],
+    )
+
+    serialized = element.to_dict()
+    restored = IntelCraftElement.from_dict(serialized)
+
+    assert restored.element_id == element.element_id
+    assert restored.metadata == element.metadata
+    assert restored.relationships[0].metadata == {"since": "2024-03-01"}
+
+
+def test_integrate_merges_existing_node_and_edge_attributes() -> None:
+    graph = Graph()
+    graph.add_node("actor:alpha", attributes={"category": "actor", "aliases": ["A"]})
+    graph.add_edge("actor:alpha", "campaign:gamma", attributes={"relation_type": "leads", "confidence": 0.4})
+
+    integrate_intelcraft_elements(
+        graph,
+        [
+            {
+                "element_id": "actor:alpha",
+                "name": "Alpha Actor",
+                "category": "actor",
+                "metadata": {"aliases": ["Alpha"], "source": "intelcraft"},
+                "relationships": [
+                    {
+                        "target_id": "campaign:gamma",
+                        "relation_type": "leads",
+                        "weight": 0.8,
+                    }
+                ],
+            },
+            {
+                "element_id": "campaign:gamma",
+                "name": "Gamma Campaign",
+                "category": "campaign",
+            },
+        ],
+    )
+
+    attributes = graph.get_node_attributes("actor:alpha")
+    assert attributes["aliases"] == ["A", "Alpha"]
+    assert attributes["source"] == "intelcraft"
+
+    edge_attrs = graph.get_edge_attributes("actor:alpha", "campaign:gamma")
+    assert edge_attrs["weight"] == 0.8
+    assert edge_attrs["confidence"] == 0.4
+
+
+def test_normalize_intelcraft_elements_accepts_dicts() -> None:
+    normalized = normalize_intelcraft_elements(
+        [
+            {
+                "element_id": "actor:alpha",
+                "name": "Alpha Actor",
+                "category": "actor",
+            }
+        ]
+    )
+
+    assert normalized[0].element_id == "actor:alpha"

--- a/simulated_ingestion/ingestion_pipeline.py
+++ b/simulated_ingestion/ingestion_pipeline.py
@@ -26,7 +26,11 @@ class MockGraphDBClient:
         node_id = node_data.get('properties', {}).get('id') or node_data.get('id')
         if node_id:
             self.nodes.append(node_data)
-            self.graph_representation.add_node(node_id)
+            attributes = {
+                "type": node_data.get('type'),
+                **node_data.get('properties', {}),
+            }
+            self.graph_representation.add_node(node_id, attributes=attributes)
             print(f"Mock DB: Created node {node_data.get('type')}: {node_data.get('properties', {}).get('name')}")
         else:
             print(f"Mock DB: Warning - Node data missing ID: {node_data}")
@@ -37,7 +41,12 @@ class MockGraphDBClient:
         target_id = rel_data.get('target_id')
         if source_id and target_id:
             self.relationships.append(rel_data)
-            self.graph_representation.add_edge(source_id, target_id)
+            edge_attributes = {
+                key: value
+                for key, value in rel_data.items()
+                if key not in {'source_id', 'target_id'}
+            }
+            self.graph_representation.add_edge(source_id, target_id, attributes=edge_attributes)
             print(f"Mock DB: Created relationship {rel_data.get('type')}")
         else:
             print(f"Mock DB: Warning - Relationship data missing source/target ID: {rel_data}")


### PR DESCRIPTION
## Summary
- add deep-merge helpers to the in-memory Graph to preserve existing node and edge context during repeated IntelCraft ingestions
- extend the IntelCraft domain models with serialization/deserialization utilities, dictionary normalization, and merge-aware integration options
- document the updated tradecraft API and cover serialization plus merge semantics with additional integration unit tests

## Testing
- pytest intelgraph/tests/test_intelcraft_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68d8ef4788f4833388f34434c915b744