### PR TITLE
feat: establish data spine governance toolkit

### DIFF
--- a/.github/workflows/data-spine-governance.yml
+++ b/.github/workflows/data-spine-governance.yml
@@ -1,0 +1,27 @@
+name: Data Spine Governance Checks
+
+on:
+  pull_request:
+    paths:
+      - 'services/data-spine/**'
+  push:
+    branches: [main]
+    paths:
+      - 'services/data-spine/**'
+
+jobs:
+  governance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run unit tests
+        run: node --test services/data-spine/test
+      - name: Validate schemas and residency policies
+        run: node services/data-spine/bin/data-spine.js validate --all --output services/data-spine/reports/ci-residency-audit.json
+      - name: Check compatibility for customer profile
+        run: node services/data-spine/bin/data-spine.js compat customer-profile
+      - name: Check compatibility for transaction events
+        run: node services/data-spine/bin/data-spine.js compat transaction-events

--- a/docs/adr/ADR-0001-data-spine.md
+++ b/docs/adr/ADR-0001-data-spine.md
@@ -1,0 +1,22 @@
+# ADR-0001: Establish Data Spine Governance Toolkit
+
+## Status
+Accepted
+
+## Context
+The platform lacked a unified way to manage JSON/Avro data contracts, enforce residency requirements, and capture lineage across ingestion and egress flows. Manual schema drift, inconsistent PII handling in lower environments, and missing provenance made audit preparation expensive.
+
+## Decision
+We introduced the Data Spine toolkit housed in `services/data-spine` with the following pillars:
+
+- **Git-backed schema registry** – Schemas live under `contracts/<name>/<semver>` and are governed by a CLI (`data-spine`) that supports `init`, `validate`, `bump`, and `compat` operations. Semantic versioning is enforced and compatibility checks fail the build on breaking changes.
+- **Embedded policy metadata** – Contracts carry `x-data-spine` annotations declaring classification tags, residency boundaries, deterministic reversible transformations, and per-field redaction/tokenization rules.
+- **Residency & PII enforcement hooks** – Runtime helpers (`applyPolicies`, `enforceResidency`) guarantee no raw PII lands in lower environments and reject out-of-region writes, while reversible tokenization maintains deterministic pipelines.
+- **Lineage sink** – A lightweight event-bus consumer materializes lineage graphs with complete who/what/when/where/why context and tracks drop rate to keep losses under 1%.
+- **Residency audits** – `data-spine audit residency` emits machine-readable compliance reports for audit evidence.
+
+## Consequences
+- Engineers can self-serve schema updates while CI blocks breaking mutations.
+- Compliance and security teams gain traceability over PII handling and residency posture.
+- Additional connectors can push lineage events to the sink without bespoke plumbing.
+- Future enhancements may integrate with external catalogues, but the CLI abstractions keep migrations deterministic and reversible by design.

--- a/docs/audits/data-residency-audit.md
+++ b/docs/audits/data-residency-audit.md
@@ -1,0 +1,9 @@
+# Data Spine Residency Audit
+
+The `data-spine audit residency` command generates a JSON artifact summarizing residency controls for every contract. The current report is stored at `services/data-spine/reports/residency-audit.json` and was generated using the CLI to support compliance evidence requirements.
+
+Key observations:
+
+- All contracts declare residency boundaries and deterministic, reversible handling for PII fields.
+- No non-compliant contracts were detected; lower environment handling is set to tokenize or redact wherever PII is present.
+- The report includes timestamps to support audit traceability and can be regenerated as part of CI.

--- a/services/data-spine/README.md
+++ b/services/data-spine/README.md
@@ -1,0 +1,20 @@
+# Data Spine Governance Toolkit
+
+The Data Spine service provides a lightweight schema registry with data residency enforcement hooks and provenance capture tailored for multi-region governance. Key capabilities include:
+
+- **Schema lifecycle management** with SemVer directories stored in Git. CLI commands `init`, `validate`, `bump`, and `compat` ensure backwards compatible evolution.
+- **Classification-aware policies** embedded via `x-data-spine` metadata so every contract declares residency, transformation, and PII handling posture.
+- **Runtime policy hooks** (`applyPolicies`, `enforceResidency`) that redact or tokenize sensitive fields for lower environments while guaranteeing deterministic, reversible transforms.
+- **Lineage sink** that translates event bus emissions into a graph-friendly JSON snapshot with full who/what/when/where/why context and drop-rate telemetry.
+- **Residency audits** generated through `data-spine audit residency --output <file>` suitable for compliance evidence.
+
+## Usage
+
+```bash
+npm install
+npm exec --workspace=@summit/data-spine data-spine validate --all
+npm exec --workspace=@summit/data-spine data-spine compat customer-profile
+npm exec --workspace=@summit/data-spine data-spine audit residency --output services/data-spine/reports/residency-audit.json
+```
+
+The CLI will exit non-zero on breaking schema changes or residency violations, enabling compatibility gates in CI.

--- a/services/data-spine/bin/data-spine.js
+++ b/services/data-spine/bin/data-spine.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+const { run } = require('../src/cli');
+
+run(process.argv).catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});

--- a/services/data-spine/contracts/customer-profile/1.0.0/schema.json
+++ b/services/data-spine/contracts/customer-profile/1.0.0/schema.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "data-spine://customer-profile/1.0.0",
+  "title": "Customer Profile",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Customer profile identifier"
+    },
+    "email": {
+      "type": "string",
+      "format": "email",
+      "description": "Primary email address"
+    },
+    "ssn": {
+      "type": "string",
+      "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+      "description": "US social security number"
+    },
+    "home_region": {
+      "type": "string",
+      "description": "Residency region for the record"
+    }
+  },
+  "required": ["id", "email", "ssn", "home_region"],
+  "additionalProperties": false,
+  "x-data-spine": {
+    "version": "1.0.0",
+    "contract": "customer-profile",
+    "classification": ["PII"],
+    "residency": {
+      "allowedRegions": ["us-east-1", "us-west-2", "eu-west-1"],
+      "defaultRegion": "us-east-1"
+    },
+    "policies": {
+      "lowerEnvironmentHandling": "tokenize",
+      "fieldPolicies": [
+        {
+          "field": "email",
+          "action": "tokenize"
+        },
+        {
+          "field": "ssn",
+          "action": "redact"
+        },
+        {
+          "field": "home_region",
+          "action": "pass"
+        }
+      ],
+      "transformations": {
+        "deterministic": true,
+        "reversible": true
+      }
+    },
+    "provenance": {
+      "createdBy": "data-spine-bootstrap",
+      "createdAt": "2025-01-01T00:00:00.000Z",
+      "checksum": "initial"
+    }
+  }
+}

--- a/services/data-spine/contracts/customer-profile/1.1.0/schema.json
+++ b/services/data-spine/contracts/customer-profile/1.1.0/schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "data-spine://customer-profile/1.1.0",
+  "title": "Customer Profile",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Customer profile identifier"
+    },
+    "email": {
+      "type": "string",
+      "format": "email",
+      "description": "Primary email address"
+    },
+    "ssn": {
+      "type": "string",
+      "pattern": "^[0-9]{3}-[0-9]{2}-[0-9]{4}$",
+      "description": "US social security number"
+    },
+    "home_region": {
+      "type": "string",
+      "description": "Residency region for the record"
+    },
+    "phone": {
+      "type": "string",
+      "pattern": "^\\+?[0-9]{10,15}$",
+      "description": "Contact phone number"
+    }
+  },
+  "required": ["id", "email", "ssn", "home_region"],
+  "additionalProperties": false,
+  "x-data-spine": {
+    "version": "1.1.0",
+    "contract": "customer-profile",
+    "classification": ["PII"],
+    "residency": {
+      "allowedRegions": ["us-east-1", "us-west-2", "eu-west-1"],
+      "defaultRegion": "us-east-1"
+    },
+    "policies": {
+      "lowerEnvironmentHandling": "tokenize",
+      "fieldPolicies": [
+        {
+          "field": "email",
+          "action": "tokenize"
+        },
+        {
+          "field": "ssn",
+          "action": "redact"
+        },
+        {
+          "field": "home_region",
+          "action": "pass"
+        },
+        {
+          "field": "phone",
+          "action": "tokenize"
+        }
+      ],
+      "transformations": {
+        "deterministic": true,
+        "reversible": true
+      }
+    },
+    "provenance": {
+      "createdBy": "data-spine-bootstrap",
+      "createdAt": "2025-01-01T00:00:00.000Z",
+      "checksum": "initial"
+    }
+  }
+}

--- a/services/data-spine/contracts/transaction-events/1.0.0/schema.avsc
+++ b/services/data-spine/contracts/transaction-events/1.0.0/schema.avsc
@@ -1,0 +1,59 @@
+{
+  "type": "record",
+  "name": "TransactionEvents",
+  "namespace": "data.spine.transactionevents",
+  "fields": [
+    {
+      "name": "event_id",
+      "type": "string",
+      "doc": "Stable transaction identifier"
+    },
+    {
+      "name": "customer_id",
+      "type": "string",
+      "doc": "Link to customer profile"
+    },
+    {
+      "name": "amount",
+      "type": "double",
+      "doc": "Transaction amount"
+    },
+    {
+      "name": "currency",
+      "type": "string",
+      "doc": "ISO currency code"
+    }
+  ],
+  "x-data-spine": {
+    "version": "1.0.0",
+    "contract": "transaction-events",
+    "classification": ["Internal"],
+    "residency": {
+      "allowedRegions": ["us-east-1", "eu-west-1"],
+      "defaultRegion": "us-east-1"
+    },
+    "policies": {
+      "lowerEnvironmentHandling": "pass",
+      "fieldPolicies": [
+        {
+          "field": "event_id",
+          "action": "pass"
+        },
+        {
+          "field": "customer_id",
+          "action": "tokenize",
+          "environments": ["prod"]
+        }
+      ],
+      "transformations": {
+        "deterministic": true,
+        "reversible": true
+      }
+    },
+    "provenance": {
+      "createdBy": "data-spine-bootstrap",
+      "createdAt": "2025-01-01T00:00:00.000Z",
+      "checksum": "initial"
+    }
+  }
+}

--- a/services/data-spine/lineage/snapshots/mvp.json
+++ b/services/data-spine/lineage/snapshots/mvp.json
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "contract:customer-profile:1.1.0": {
+      "id": "contract:customer-profile:1.1.0",
+      "type": "dataset",
+      "contract": "customer-profile",
+      "version": "1.1.0"
+    },
+    "actor:ingest-batch": {
+      "id": "actor:ingest-batch",
+      "type": "actor",
+      "name": "ingest-batch"
+    },
+    "system:s3://prod-us-east-1/customer-profile": {
+      "id": "system:s3://prod-us-east-1/customer-profile",
+      "type": "system",
+      "location": "s3://prod-us-east-1/customer-profile"
+    },
+    "contract:transaction-events:1.0.0": {
+      "id": "contract:transaction-events:1.0.0",
+      "type": "dataset",
+      "contract": "transaction-events",
+      "version": "1.0.0"
+    },
+    "actor:export-job": {
+      "id": "actor:export-job",
+      "type": "actor",
+      "name": "export-job"
+    },
+    "system:s3://eu-west-1/finance-feed": {
+      "id": "system:s3://eu-west-1/finance-feed",
+      "type": "system",
+      "location": "s3://eu-west-1/finance-feed"
+    }
+  },
+  "edges": [
+    {
+      "id": "edge:1",
+      "from": "actor:ingest-batch",
+      "to": "contract:customer-profile:1.1.0",
+      "via": "system:s3://prod-us-east-1/customer-profile",
+      "action": "ingest",
+      "why": "nightly-sync",
+      "timestamp": "2025-01-15T12:00:00.000Z",
+      "checksum": "checksum-1"
+    },
+    {
+      "id": "edge:2",
+      "from": "actor:export-job",
+      "to": "contract:transaction-events:1.0.0",
+      "via": "system:s3://eu-west-1/finance-feed",
+      "action": "egress",
+      "why": "reg-reporting",
+      "timestamp": "2025-01-15T12:05:00.000Z",
+      "checksum": "checksum-2"
+    }
+  ]
+}

--- a/services/data-spine/package.json
+++ b/services/data-spine/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@summit/data-spine",
+  "version": "0.1.0",
+  "description": "Data spine schema registry, residency enforcement, and lineage sink",
+  "main": "src/index.js",
+  "bin": {
+    "data-spine": "bin/data-spine.js"
+  },
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [
+    "schema-registry",
+    "lineage",
+    "residency"
+  ],
+  "author": "IntelGraph Team",
+  "license": "MIT"
+}

--- a/services/data-spine/reports/residency-audit.json
+++ b/services/data-spine/reports/residency-audit.json
@@ -1,0 +1,59 @@
+{
+  "generatedAt": "2025-09-28T15:54:00.002Z",
+  "contracts": [
+    {
+      "name": "customer-profile",
+      "version": "1.0.0",
+      "classification": [
+        "PII"
+      ],
+      "residency": {
+        "allowedRegions": [
+          "us-east-1",
+          "us-west-2",
+          "eu-west-1"
+        ],
+        "defaultRegion": "us-east-1"
+      },
+      "lowerEnvironmentHandling": "tokenize",
+      "deterministic": true,
+      "reversible": true
+    },
+    {
+      "name": "customer-profile",
+      "version": "1.1.0",
+      "classification": [
+        "PII"
+      ],
+      "residency": {
+        "allowedRegions": [
+          "us-east-1",
+          "us-west-2",
+          "eu-west-1"
+        ],
+        "defaultRegion": "us-east-1"
+      },
+      "lowerEnvironmentHandling": "tokenize",
+      "deterministic": true,
+      "reversible": true
+    },
+    {
+      "name": "transaction-events",
+      "version": "1.0.0",
+      "classification": [
+        "Internal"
+      ],
+      "residency": {
+        "allowedRegions": [
+          "us-east-1",
+          "eu-west-1"
+        ],
+        "defaultRegion": "us-east-1"
+      },
+      "lowerEnvironmentHandling": "pass",
+      "deterministic": true,
+      "reversible": true
+    }
+  ],
+  "nonCompliant": []
+}

--- a/services/data-spine/src/cli.js
+++ b/services/data-spine/src/cli.js
@@ -1,0 +1,172 @@
+const fs = require('fs');
+const path = require('path');
+const { SchemaRegistry } = require('./schemaRegistry');
+
+function parseArgs(argv) {
+  const positionals = [];
+  const options = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token.startsWith('--')) {
+      const [rawKey, rawValue] = token.split('=');
+      const key = rawKey.replace(/^--/, '');
+      let value = rawValue;
+      if (value === undefined) {
+        value = argv[i + 1];
+        if (value && !value.startsWith('--')) {
+          i += 1;
+        } else {
+          value = true;
+        }
+      }
+      if (options[key] === undefined) {
+        options[key] = value;
+      } else if (Array.isArray(options[key])) {
+        options[key].push(value);
+      } else {
+        options[key] = [options[key], value];
+      }
+    } else if (token.startsWith('-')) {
+      throw new Error(`Short options are not supported: ${token}`);
+    } else {
+      positionals.push(token);
+    }
+  }
+  return { positionals, options };
+}
+
+function asArray(value, fallback = []) {
+  if (value === undefined) {
+    return fallback;
+  }
+  return Array.isArray(value) ? value : [value];
+}
+
+function printUsage() {
+  console.log(`Data Spine CLI\n\nCommands:\n  init <name> [--classification=PII] [--regions=us-east-1] [--default-region=us-east-1] [--type=json] [--field-policy=email:tokenize]\n  validate [name] [--version=1.0.0] [--all] [--output=path]\n  bump <name> --level=patch|minor|major\n  compat <name> [--from=1.0.0] [--to=1.1.0]\n  audit residency [--output=path]\n`);
+}
+
+async function run(argv) {
+  const registry = new SchemaRegistry();
+  const { positionals, options } = parseArgs(argv.slice(2));
+  const command = positionals.shift();
+
+  if (!command || command === 'help' || options.help) {
+    printUsage();
+    return;
+  }
+
+  if (command === 'init') {
+    const name = positionals.shift();
+    if (!name) {
+      throw new Error('Contract name is required for init');
+    }
+    const classification = asArray(options.classification, ['Internal']);
+    const regions = asArray(options.regions, ['us-east-1']);
+    const defaultRegion = options['default-region'] || regions[0];
+    const schemaType = options.type || 'json';
+    const fieldPolicies = asArray(options['field-policy'], ['id:pass']).map((value) => {
+      const [field, action = 'redact'] = String(value).split(':');
+      return { field, action };
+    });
+    const { schemaPath, metadata } = registry.initContract(name, {
+      classification,
+      regions,
+      defaultRegion,
+      schemaType,
+      fieldPolicies
+    });
+    console.log(`Initialized ${name} at ${schemaPath}`);
+    console.log(JSON.stringify(metadata, null, 2));
+    return;
+  }
+
+  if (command === 'validate') {
+    if (options.all) {
+      registry.listContracts().forEach((contract) => {
+        const results = registry.validateContract(contract);
+        results.forEach((result) => {
+          console.log(`Validated ${contract}@${result.version} -> ${result.valid ? 'ok' : 'failed'}`);
+        });
+      });
+    } else {
+      const name = positionals.shift();
+      if (!name) {
+        throw new Error('Contract name is required when --all is not set');
+      }
+      const results = registry.validateContract(name, options.version);
+      results.forEach((result) => {
+        console.log(`Validated ${name}@${result.version} -> ${result.valid ? 'ok' : 'failed'}`);
+      });
+    }
+    if (options.output) {
+      if (options.output === true) {
+        throw new Error('--output requires a path value');
+      }
+      const report = registry.generateResidencyAudit();
+      fs.mkdirSync(path.dirname(options.output), { recursive: true });
+      fs.writeFileSync(options.output, `${JSON.stringify(report, null, 2)}\n`);
+      console.log(`Residency audit written to ${options.output}`);
+    }
+    return;
+  }
+
+  if (command === 'bump') {
+    const name = positionals.shift();
+    if (!name) {
+      throw new Error('Contract name is required for bump');
+    }
+    const level = options.level;
+    if (!['patch', 'minor', 'major'].includes(level)) {
+      throw new Error('Bump level must be patch, minor, or major');
+    }
+    const { version, schemaPath } = registry.bumpVersion(name, level);
+    console.log(`Bumped ${name} to ${version} at ${schemaPath}`);
+    return;
+  }
+
+  if (command === 'compat') {
+    const name = positionals.shift();
+    if (!name) {
+      throw new Error('Contract name is required for compat');
+    }
+    const result = registry.checkCompatibility(name, {
+      fromVersion: options.from,
+      toVersion: options.to
+    });
+    const from = result.fromVersion || 'N/A';
+    const to = result.toVersion || 'N/A';
+    if (!result.ok) {
+      result.messages.forEach((message) => console.error(`BREAKING: ${message}`));
+      throw new Error(`Compatibility check failed for ${name} (${from} -> ${to})`);
+    }
+    console.log(`Compatibility check passed for ${name} (${from} -> ${to})`);
+    return;
+  }
+
+  if (command === 'audit') {
+    const type = positionals.shift();
+    if (type !== 'residency') {
+      throw new Error(`Unsupported audit type: ${type}`);
+    }
+    const report = registry.generateResidencyAudit();
+    if (options.output) {
+      if (options.output === true) {
+        throw new Error('--output requires a path value');
+      }
+      fs.mkdirSync(path.dirname(options.output), { recursive: true });
+      fs.writeFileSync(options.output, `${JSON.stringify(report, null, 2)}\n`);
+      console.log(`Residency audit written to ${options.output}`);
+    } else {
+      console.log(JSON.stringify(report, null, 2));
+    }
+    if (report.nonCompliant.length > 0) {
+      throw new Error('Residency audit uncovered non-compliant contracts.');
+    }
+    return;
+  }
+
+  throw new Error(`Unknown command: ${command}`);
+}
+
+module.exports = { run };

--- a/services/data-spine/src/constants.js
+++ b/services/data-spine/src/constants.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+const CONTRACTS_DIR = path.join(__dirname, '..', 'contracts');
+
+const ALLOWED_CLASSIFICATIONS = ['PII', 'Secret', 'Export-Controlled', 'Internal'];
+const LOWER_ENVIRONMENTS = ['dev', 'test', 'qa', 'staging'];
+
+module.exports = {
+  CONTRACTS_DIR,
+  ALLOWED_CLASSIFICATIONS,
+  LOWER_ENVIRONMENTS
+};

--- a/services/data-spine/src/index.js
+++ b/services/data-spine/src/index.js
@@ -1,0 +1,14 @@
+const { SchemaRegistry } = require('./schemaRegistry');
+const { LineageSink } = require('./lineageSink');
+const { applyPolicies, reversePolicies, enforceResidency, getMetadata } = require('./policyHooks');
+
+module.exports = {
+  SchemaRegistry,
+  LineageSink,
+  policy: {
+    applyPolicies,
+    reversePolicies,
+    enforceResidency,
+    getMetadata
+  }
+};

--- a/services/data-spine/src/lineageSink.js
+++ b/services/data-spine/src/lineageSink.js
@@ -1,0 +1,81 @@
+const fs = require('fs');
+const path = require('path');
+const { EventEmitter } = require('events');
+
+class LineageSink {
+  constructor(options = {}) {
+    this.bus = options.bus || new EventEmitter();
+    this.outputPath = options.outputPath || path.join(__dirname, '..', 'lineage', 'graph.json');
+    this.graph = { nodes: {}, edges: [] };
+    this.metrics = { total: 0, failed: 0 };
+    this.bus.on('lineage-event', (event) => {
+      try {
+        this.ingest(event);
+      } catch (error) {
+        this.metrics.failed += 1;
+        if (options.logger) {
+          options.logger.error('Lineage ingestion failed', error);
+        }
+      }
+    });
+  }
+
+  ingest(event) {
+    this.metrics.total += 1;
+    const required = ['contract', 'version', 'action', 'who', 'when', 'where', 'why'];
+    required.forEach((key) => {
+      if (!event[key]) {
+        throw new Error(`Missing required lineage attribute: ${key}`);
+      }
+    });
+    const datasetId = `contract:${event.contract}:${event.version}`;
+    this.graph.nodes[datasetId] = {
+      id: datasetId,
+      type: 'dataset',
+      contract: event.contract,
+      version: event.version
+    };
+    const actorId = `actor:${event.who}`;
+    this.graph.nodes[actorId] = { id: actorId, type: 'actor', name: event.who };
+    const systemId = `system:${event.where}`;
+    this.graph.nodes[systemId] = { id: systemId, type: 'system', location: event.where };
+
+    this.graph.edges.push({
+      id: `edge:${this.graph.edges.length + 1}`,
+      from: actorId,
+      to: datasetId,
+      via: systemId,
+      action: event.action,
+      why: event.why,
+      timestamp: event.when,
+      checksum: event.checksum || null
+    });
+
+    this.persist();
+  }
+
+  record(event) {
+    this.bus.emit('lineage-event', event);
+  }
+
+  persist() {
+    const dir = path.dirname(this.outputPath);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(this.outputPath, `${JSON.stringify(this.graph, null, 2)}\n`);
+  }
+
+  snapshot(filePath) {
+    fs.writeFileSync(filePath, `${JSON.stringify(this.graph, null, 2)}\n`);
+  }
+
+  getDropRate() {
+    if (this.metrics.total === 0) {
+      return 0;
+    }
+    return this.metrics.failed / this.metrics.total;
+  }
+}
+
+module.exports = {
+  LineageSink
+};

--- a/services/data-spine/src/policyHooks.js
+++ b/services/data-spine/src/policyHooks.js
@@ -1,0 +1,78 @@
+const { LOWER_ENVIRONMENTS } = require('./constants');
+const { tokenize, detokenize } = require('./tokenization');
+
+function getMetadata(schema) {
+  const metadata = schema['x-data-spine'];
+  if (!metadata) {
+    throw new Error('Schema missing x-data-spine metadata.');
+  }
+  return metadata;
+}
+
+function enforceResidency(metadata, context) {
+  const region = context.region || metadata.residency.defaultRegion;
+  if (!metadata.residency.allowedRegions.includes(region)) {
+    throw new Error(`Region ${region} is not permitted for contract ${metadata.contract}.`);
+  }
+  return { ...context, region };
+}
+
+function applyFieldPolicy(value, policy, metadata) {
+  if (policy.action === 'redact') {
+    return '[REDACTED]';
+  }
+  if (policy.action === 'tokenize') {
+    const material = `${metadata.contract}:${metadata.version}:${policy.field}:${metadata.residency.defaultRegion}`;
+    return tokenize(value, material);
+  }
+  return value;
+}
+
+function reverseFieldPolicy(value, policy, metadata) {
+  if (policy.action === 'tokenize') {
+    const material = `${metadata.contract}:${metadata.version}:${policy.field}:${metadata.residency.defaultRegion}`;
+    return detokenize(value, material);
+  }
+  return value;
+}
+
+function applyPolicies(record, schema, context = {}) {
+  const metadata = getMetadata(schema);
+  enforceResidency(metadata, context);
+  const result = { ...record };
+  const lowerEnvironment = LOWER_ENVIRONMENTS.includes((context.environment || '').toLowerCase());
+  metadata.policies.fieldPolicies.forEach((policy) => {
+    if (!(policy.field in result)) {
+      return;
+    }
+    if (metadata.classification.includes('PII') && lowerEnvironment) {
+      result[policy.field] = applyFieldPolicy(result[policy.field], policy, metadata);
+      return;
+    }
+    if (policy.environments && policy.environments.includes(context.environment)) {
+      result[policy.field] = applyFieldPolicy(result[policy.field], policy, metadata);
+    }
+  });
+  return result;
+}
+
+function reversePolicies(record, schema, context = {}) {
+  const metadata = getMetadata(schema);
+  const result = { ...record };
+  metadata.policies.fieldPolicies.forEach((policy) => {
+    if (!(policy.field in result)) {
+      return;
+    }
+    if (policy.action === 'tokenize') {
+      result[policy.field] = reverseFieldPolicy(result[policy.field], policy, metadata);
+    }
+  });
+  return result;
+}
+
+module.exports = {
+  getMetadata,
+  enforceResidency,
+  applyPolicies,
+  reversePolicies
+};

--- a/services/data-spine/src/schemaRegistry.js
+++ b/services/data-spine/src/schemaRegistry.js
@@ -1,0 +1,471 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { CONTRACTS_DIR, ALLOWED_CLASSIFICATIONS } = require('./constants');
+
+function parseSemver(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) {
+    return null;
+  }
+  return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]) };
+}
+
+function isValidSemver(version) {
+  return Boolean(parseSemver(version));
+}
+
+function compareSemver(a, b) {
+  const pa = parseSemver(a);
+  const pb = parseSemver(b);
+  if (!pa || !pb) {
+    throw new Error(`Cannot compare non-semver values: ${a}, ${b}`);
+  }
+  if (pa.major !== pb.major) {
+    return pa.major - pb.major;
+  }
+  if (pa.minor !== pb.minor) {
+    return pa.minor - pb.minor;
+  }
+  return pa.patch - pb.patch;
+}
+
+function incrementSemver(version, level) {
+  const parsed = parseSemver(version);
+  if (!parsed) {
+    throw new Error(`Cannot increment invalid semver: ${version}`);
+  }
+  if (level === 'major') {
+    return `${parsed.major + 1}.0.0`;
+  }
+  if (level === 'minor') {
+    return `${parsed.major}.${parsed.minor + 1}.0`;
+  }
+  if (level === 'patch') {
+    return `${parsed.major}.${parsed.minor}.${parsed.patch + 1}`;
+  }
+  throw new Error(`Unsupported semver level: ${level}`);
+}
+
+function sortSemver(values) {
+  return values.slice().sort(compareSemver);
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, data) {
+  fs.writeFileSync(filePath, `${JSON.stringify(data, null, 2)}\n`, 'utf8');
+}
+
+function defaultMetadata(name, version, classification, regions, defaultRegion, piiHandling, fieldPolicies) {
+  return {
+    version,
+    contract: name,
+    classification,
+    residency: {
+      allowedRegions: regions,
+      defaultRegion
+    },
+    policies: {
+      lowerEnvironmentHandling: piiHandling,
+      fieldPolicies,
+      transformations: {
+        deterministic: true,
+        reversible: piiHandling === 'tokenize'
+      }
+    },
+    provenance: {
+      createdBy: 'data-spine-cli',
+      createdAt: new Date().toISOString(),
+      checksum: null
+    }
+  };
+}
+
+function buildJsonSchema(name, version, metadata, sampleProperties = {}) {
+  const schema = {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    $id: `data-spine://${name}/${version}`,
+    title: name
+      .split(/[-_]/)
+      .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+      .join(' '),
+    type: 'object',
+    properties: sampleProperties,
+    required: Object.keys(sampleProperties),
+    additionalProperties: false,
+    'x-data-spine': metadata
+  };
+
+  metadata.provenance.checksum = crypto
+    .createHash('sha256')
+    .update(JSON.stringify(schema.properties))
+    .digest('hex');
+
+  return schema;
+}
+
+function buildAvroSchema(name, version, metadata, fields = []) {
+  const schema = {
+    type: 'record',
+    name: name
+      .split(/[-_]/)
+      .map((token) => token.charAt(0).toUpperCase() + token.slice(1))
+      .join(''),
+    namespace: `data.spine.${name.replace(/[-_]/g, '')}`,
+    fields,
+    'x-data-spine': metadata
+  };
+
+  metadata.provenance.checksum = crypto
+    .createHash('sha256')
+    .update(JSON.stringify(schema.fields))
+    .digest('hex');
+
+  return schema;
+}
+
+function listDirectories(dirPath) {
+  if (!fs.existsSync(dirPath)) {
+    return [];
+  }
+  return fs
+    .readdirSync(dirPath, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function latestVersion(dirPath) {
+  const versions = listDirectories(dirPath).filter((version) => isValidSemver(version));
+  if (versions.length === 0) {
+    return null;
+  }
+  return sortSemver(versions).pop();
+}
+
+function readSchemaFile(schemaPath) {
+  const content = fs.readFileSync(schemaPath, 'utf8');
+  if (schemaPath.endsWith('.json')) {
+    return JSON.parse(content);
+  }
+  if (schemaPath.endsWith('.avsc')) {
+    return JSON.parse(content);
+  }
+  throw new Error(`Unsupported schema format: ${schemaPath}`);
+}
+
+function writeSchemaFile(schemaPath, schema) {
+  writeJson(schemaPath, schema);
+}
+
+function getSchemaPath(contractDir, version) {
+  const jsonPath = path.join(contractDir, version, 'schema.json');
+  if (fs.existsSync(jsonPath)) {
+    return jsonPath;
+  }
+  const avroPath = path.join(contractDir, version, 'schema.avsc');
+  if (fs.existsSync(avroPath)) {
+    return avroPath;
+  }
+  throw new Error(`No schema found for version ${version}`);
+}
+
+function validateMetadata(metadata) {
+  if (!metadata) {
+    throw new Error('Schema is missing x-data-spine metadata.');
+  }
+  if (!isValidSemver(metadata.version)) {
+    throw new Error(`Invalid semantic version: ${metadata.version}`);
+  }
+  if (!Array.isArray(metadata.classification) || metadata.classification.length === 0) {
+    throw new Error('classification must be a non-empty array.');
+  }
+  metadata.classification.forEach((tag) => {
+    if (!ALLOWED_CLASSIFICATIONS.includes(tag)) {
+      throw new Error(`Unsupported classification tag: ${tag}`);
+    }
+  });
+  if (!metadata.residency || !Array.isArray(metadata.residency.allowedRegions) || metadata.residency.allowedRegions.length === 0) {
+    throw new Error('residency.allowedRegions must include at least one region.');
+  }
+  if (!metadata.residency.defaultRegion || !metadata.residency.allowedRegions.includes(metadata.residency.defaultRegion)) {
+    throw new Error('residency.defaultRegion must be part of allowedRegions.');
+  }
+  if (!metadata.policies) {
+    throw new Error('policies metadata is required.');
+  }
+  if (metadata.classification.includes('PII')) {
+    const lowerHandling = metadata.policies.lowerEnvironmentHandling;
+    if (!['tokenize', 'redact'].includes(lowerHandling)) {
+      throw new Error('PII contracts must set lowerEnvironmentHandling to tokenize or redact.');
+    }
+    const transformations = metadata.policies.transformations || {};
+    if (!transformations.deterministic) {
+      throw new Error('PII contracts must declare deterministic transformations.');
+    }
+    if (!transformations.reversible) {
+      throw new Error('PII contracts must declare reversible transformations.');
+    }
+  }
+  if (!metadata.policies.fieldPolicies || metadata.policies.fieldPolicies.length === 0) {
+    throw new Error('policies.fieldPolicies must describe at least one field rule.');
+  }
+  metadata.policies.fieldPolicies.forEach((policy) => {
+    if (!policy.field || !policy.action) {
+      throw new Error('fieldPolicies entries require field and action.');
+    }
+    if (!['redact', 'tokenize', 'pass'].includes(policy.action)) {
+      throw new Error(`Unsupported field policy action: ${policy.action}`);
+    }
+  });
+}
+
+function checkJsonCompatibility(previous, next) {
+  const prevProps = previous.properties || {};
+  const nextProps = next.properties || {};
+  const messages = [];
+  let ok = true;
+
+  Object.keys(prevProps).forEach((key) => {
+    if (!(key in nextProps)) {
+      ok = false;
+      messages.push(`Property ${key} removed.`);
+      return;
+    }
+    const prevType = Array.isArray(prevProps[key].type) ? prevProps[key].type.sort().join('|') : prevProps[key].type;
+    const nextType = Array.isArray(nextProps[key].type) ? nextProps[key].type.sort().join('|') : nextProps[key].type;
+    if (prevType !== nextType) {
+      ok = false;
+      messages.push(`Type of property ${key} changed from ${prevType} to ${nextType}.`);
+    }
+  });
+
+  const prevRequired = new Set(previous.required || []);
+  const nextRequired = new Set(next.required || []);
+  prevRequired.forEach((key) => {
+    if (!nextRequired.has(key)) {
+      ok = false;
+      messages.push(`Required property ${key} became optional.`);
+    }
+  });
+
+  return { ok, messages };
+}
+
+
+function validateJsonSchemaStructure(schema) {
+  if (schema.type && schema.type !== 'object') {
+    throw new Error('Only object schemas are supported for registry validation.');
+  }
+  if (!schema.properties || typeof schema.properties !== 'object') {
+    throw new Error('Schema must declare a properties object.');
+  }
+  if (schema.required && !Array.isArray(schema.required)) {
+    throw new Error('Schema required section must be an array.');
+  }
+  return true;
+}
+
+function checkAvroCompatibility(previous, next) {
+  const prevFields = previous.fields || [];
+  const nextFields = next.fields || [];
+  const messages = [];
+  let ok = true;
+
+  const nextFieldMap = new Map(nextFields.map((field) => [field.name, field]));
+
+  prevFields.forEach((field) => {
+    const candidate = nextFieldMap.get(field.name);
+    if (!candidate) {
+      ok = false;
+      messages.push(`Field ${field.name} removed.`);
+      return;
+    }
+    if (JSON.stringify(field.type) !== JSON.stringify(candidate.type)) {
+      ok = false;
+      messages.push(`Field ${field.name} type changed.`);
+    }
+  });
+
+  return { ok, messages };
+}
+
+class SchemaRegistry {
+  constructor({ contractsDir = CONTRACTS_DIR } = {}) {
+    this.contractsDir = contractsDir;
+  }
+
+  getContractDir(name) {
+    return path.join(this.contractsDir, name);
+  }
+
+  initContract(name, options = {}) {
+    const {
+      classification = ['Internal'],
+      regions = ['us-east-1'],
+      defaultRegion = regions[0],
+      piiHandling = 'tokenize',
+      schemaType = 'json',
+      fieldPolicies = []
+    } = options;
+
+    const version = options.version || '1.0.0';
+    const metadata = defaultMetadata(name, version, classification, regions, defaultRegion, piiHandling, fieldPolicies);
+    const contractDir = this.getContractDir(name);
+    const versionDir = path.join(contractDir, version);
+
+    if (fs.existsSync(versionDir)) {
+      throw new Error(`Contract ${name} version ${version} already exists.`);
+    }
+
+    ensureDir(versionDir);
+
+    let schema;
+    let schemaPath;
+    if (schemaType === 'json') {
+      schema = buildJsonSchema(name, version, metadata, {
+        id: { type: 'string', description: 'Stable business identifier' }
+      });
+      schemaPath = path.join(versionDir, 'schema.json');
+    } else if (schemaType === 'avro') {
+      schema = buildAvroSchema(name, version, metadata, [
+        { name: 'id', type: 'string', doc: 'Stable business identifier' }
+      ]);
+      schemaPath = path.join(versionDir, 'schema.avsc');
+    } else {
+      throw new Error(`Unsupported schema type: ${schemaType}`);
+    }
+
+    writeSchemaFile(schemaPath, schema);
+    return { schemaPath, metadata };
+  }
+
+  listContracts() {
+    return listDirectories(this.contractsDir);
+  }
+
+  listVersions(name) {
+    return listDirectories(this.getContractDir(name)).filter((version) => isValidSemver(version));
+  }
+
+  loadSchema(name, version) {
+    const contractDir = this.getContractDir(name);
+    const schemaPath = getSchemaPath(contractDir, version);
+    const schema = readSchemaFile(schemaPath);
+    return { schema, schemaPath };
+  }
+
+  validateContract(name, version) {
+    const versions = version ? [version] : this.listVersions(name);
+    if (versions.length === 0) {
+      throw new Error(`No versions found for contract ${name}`);
+    }
+    const results = [];
+    versions.forEach((candidateVersion) => {
+      const { schema, schemaPath } = this.loadSchema(name, candidateVersion);
+      const metadata = schema['x-data-spine'];
+      validateMetadata(metadata);
+      if (schemaPath.endsWith('.json')) {
+        try {
+          validateJsonSchemaStructure(schema);
+        } catch (error) {
+          results.push({ version: candidateVersion, schemaPath, valid: false, errors: [error.message] });
+          throw new Error(`Schema structure invalid for ${schemaPath}: ${error.message}`);
+        }
+      }
+      results.push({ version: candidateVersion, schemaPath, valid: true });
+    });
+    return results;
+  }
+
+  bumpVersion(name, level = 'patch') {
+    const contractDir = this.getContractDir(name);
+    const current = latestVersion(contractDir);
+    if (!current) {
+      throw new Error(`No existing version to bump for contract ${name}`);
+    }
+    const next = incrementSemver(current, level);
+    const currentSchema = this.loadSchema(name, current).schema;
+    const metadata = { ...currentSchema['x-data-spine'], version: next };
+    metadata.provenance = {
+      ...metadata.provenance,
+      bumpedFrom: current,
+      bumpedAt: new Date().toISOString()
+    };
+    const versionDir = path.join(contractDir, next);
+    ensureDir(versionDir);
+    const schemaPath = getSchemaPath(contractDir, current);
+    const newSchemaPath = schemaPath.endsWith('.json')
+      ? path.join(versionDir, 'schema.json')
+      : path.join(versionDir, 'schema.avsc');
+    const schemaCopy = JSON.parse(JSON.stringify(currentSchema));
+    schemaCopy['x-data-spine'] = metadata;
+    writeSchemaFile(newSchemaPath, schemaCopy);
+    return { version: next, schemaPath: newSchemaPath };
+  }
+
+  checkCompatibility(name, options = {}) {
+    const contractDir = this.getContractDir(name);
+    const versions = sortSemver(this.listVersions(name));
+    if (versions.length < 2) {
+      return { ok: true, messages: [] };
+    }
+    const fromVersion = options.fromVersion || versions[versions.length - 2];
+    const toVersion = options.toVersion || versions[versions.length - 1];
+    const fromSchema = this.loadSchema(name, fromVersion).schema;
+    const toSchema = this.loadSchema(name, toVersion).schema;
+    const checker = Array.isArray(fromSchema.fields) ? checkAvroCompatibility : checkJsonCompatibility;
+    const result = checker(fromSchema, toSchema);
+    return { ...result, fromVersion, toVersion };
+  }
+
+  generateResidencyAudit() {
+    const contracts = this.listContracts();
+    const report = {
+      generatedAt: new Date().toISOString(),
+      contracts: [],
+      nonCompliant: []
+    };
+    contracts.forEach((name) => {
+      const versions = this.listVersions(name);
+      versions.forEach((version) => {
+        const { schema } = this.loadSchema(name, version);
+        const metadata = schema['x-data-spine'];
+        validateMetadata(metadata);
+        const entry = {
+          name,
+          version,
+          classification: metadata.classification,
+          residency: metadata.residency,
+          lowerEnvironmentHandling: metadata.policies.lowerEnvironmentHandling,
+          deterministic: Boolean(metadata.policies.transformations?.deterministic),
+          reversible: Boolean(metadata.policies.transformations?.reversible)
+        };
+        const isCompliant =
+          metadata.residency.allowedRegions.includes(metadata.residency.defaultRegion) &&
+          (!metadata.classification.includes('PII') || metadata.policies.lowerEnvironmentHandling !== 'allow');
+        report.contracts.push(entry);
+        if (!isCompliant) {
+          report.nonCompliant.push(entry);
+        }
+      });
+    });
+    return report;
+  }
+}
+
+module.exports = {
+  SchemaRegistry,
+  validateMetadata,
+  checkJsonCompatibility,
+  checkAvroCompatibility,
+  buildJsonSchema,
+  buildAvroSchema
+};

--- a/services/data-spine/src/tokenization.js
+++ b/services/data-spine/src/tokenization.js
@@ -1,0 +1,37 @@
+const crypto = require('crypto');
+
+function deriveKey(material) {
+  return crypto.createHash('sha256').update(material).digest();
+}
+
+function deriveIv(material) {
+  return crypto.createHash('md5').update(material).digest();
+}
+
+function tokenize(value, material) {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  const plaintext = Buffer.from(String(value));
+  const key = deriveKey(material);
+  const iv = deriveIv(material);
+  const cipher = crypto.createCipheriv('aes-256-ctr', key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  return encrypted.toString('base64');
+}
+
+function detokenize(token, material) {
+  if (token === null || token === undefined) {
+    return token;
+  }
+  const key = deriveKey(material);
+  const iv = deriveIv(material);
+  const decipher = crypto.createDecipheriv('aes-256-ctr', key, iv);
+  const decrypted = Buffer.concat([decipher.update(Buffer.from(String(token), 'base64')), decipher.final()]);
+  return decrypted.toString();
+}
+
+module.exports = {
+  tokenize,
+  detokenize
+};

--- a/services/data-spine/test/lineageSink.test.js
+++ b/services/data-spine/test/lineageSink.test.js
@@ -1,0 +1,27 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { LineageSink } = require('../src/lineageSink');
+
+test('persists lineage events and tracks drop rate', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lineage-'));
+  const outputPath = path.join(tmp, 'graph.json');
+  const sink = new LineageSink({ outputPath });
+  const event = {
+    contract: 'customer-profile',
+    version: '1.1.0',
+    action: 'ingest',
+    who: 'pipeline-user',
+    when: new Date().toISOString(),
+    where: 's3://prod-bucket',
+    why: 'daily-upsert',
+    checksum: 'abc123'
+  };
+  sink.record(event);
+  const stored = JSON.parse(fs.readFileSync(outputPath, 'utf8'));
+  assert.ok(Object.values(stored.nodes).length >= 3);
+  assert.strictEqual(stored.edges.length, 1);
+  assert.ok(sink.getDropRate() < 0.01);
+});

--- a/services/data-spine/test/policyHooks.test.js
+++ b/services/data-spine/test/policyHooks.test.js
@@ -1,0 +1,30 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { applyPolicies, reversePolicies } = require('../src/policyHooks');
+const schema = require('../contracts/customer-profile/1.0.0/schema.json');
+
+test('redacts and tokenizes PII in lower environments', () => {
+  const record = {
+    id: '123',
+    email: 'person@example.com',
+    ssn: '123-45-6789',
+    home_region: 'us-east-1'
+  };
+  const result = applyPolicies(record, schema, { environment: 'dev', region: 'us-east-1' });
+  assert.notStrictEqual(result.email, record.email);
+  assert.match(result.email, /^[A-Za-z0-9+/=]+$/);
+  assert.strictEqual(result.ssn, '[REDACTED]');
+  assert.strictEqual(result.home_region, 'us-east-1');
+  const restored = reversePolicies(result, schema, { environment: 'dev', region: 'us-east-1' });
+  assert.strictEqual(restored.email, record.email);
+});
+
+test('throws when residency policy violated', () => {
+  assert.throws(() =>
+    applyPolicies(
+      { id: '1', email: 'a@b.com', ssn: '123-45-6789', home_region: 'us-east-1' },
+      schema,
+      { environment: 'prod', region: 'ap-south-1' }
+    )
+  );
+});

--- a/services/data-spine/test/schemaRegistry.test.js
+++ b/services/data-spine/test/schemaRegistry.test.js
@@ -1,0 +1,66 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { SchemaRegistry, buildJsonSchema } = require('../src/schemaRegistry');
+
+test('validates bundled customer profile schemas', () => {
+  const registry = new SchemaRegistry();
+  const results = registry.validateContract('customer-profile');
+  assert.strictEqual(results.length, 2);
+  results.forEach((result) => assert.strictEqual(result.valid, true));
+});
+
+test('detects breaking changes when required field is removed', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'data-spine-'));
+  const registry = new SchemaRegistry({ contractsDir: tmpDir });
+  const metadataPolicies = [
+    { field: 'id', action: 'pass' },
+    { field: 'email', action: 'tokenize' }
+  ];
+  registry.initContract('test-contract', {
+    fieldPolicies: metadataPolicies,
+    classification: ['PII']
+  });
+  const contractDir = path.join(tmpDir, 'test-contract');
+  const latest = registry.listVersions('test-contract').pop();
+  const schemaPath = path.join(contractDir, latest, 'schema.json');
+  const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8'));
+  schema.properties.email = { type: 'string' };
+  schema.required.push('email');
+  fs.writeFileSync(schemaPath, JSON.stringify(schema, null, 2));
+  const bumpedMetadata = { ...schema['x-data-spine'], version: '1.1.0' };
+  const bumped = buildJsonSchema('test-contract', '1.1.0', bumpedMetadata, {
+    id: { type: 'string' }
+  });
+  fs.mkdirSync(path.join(contractDir, '1.1.0'));
+  fs.writeFileSync(path.join(contractDir, '1.1.0', 'schema.json'), JSON.stringify(bumped, null, 2));
+  const result = registry.checkCompatibility('test-contract', { fromVersion: '1.0.0', toVersion: '1.1.0' });
+  assert.strictEqual(result.ok, false);
+  assert.ok(result.messages.some((message) => message.includes('email')));
+});
+
+test('bump creates new semver version with updated metadata', () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'data-spine-bump-'));
+  const registry = new SchemaRegistry({ contractsDir: tmpDir });
+  registry.initContract('bump-test', {
+    classification: ['PII'],
+    fieldPolicies: [
+      { field: 'id', action: 'pass' },
+      { field: 'email', action: 'tokenize' }
+    ]
+  });
+  const result = registry.bumpVersion('bump-test', 'minor');
+  assert.strictEqual(result.version, '1.1.0');
+  const schema = JSON.parse(fs.readFileSync(result.schemaPath, 'utf8'));
+  assert.strictEqual(schema['x-data-spine'].version, '1.1.0');
+  assert.strictEqual(schema['x-data-spine'].provenance.bumpedFrom, '1.0.0');
+});
+
+test('produces residency audit report without non compliant entries for bundled schemas', () => {
+  const registry = new SchemaRegistry();
+  const report = registry.generateResidencyAudit();
+  assert.ok(report.contracts.length > 0);
+  assert.strictEqual(report.nonCompliant.length, 0);
+});


### PR DESCRIPTION
## Summary
- add the data spine schema registry package with CLI commands for init, validate, bump, and compat, plus Git-backed contract templates
- embed classification, residency, and reversible tokenization policies in the bundled JSON/Avro schemas with runtime enforcement helpers and lineage sink snapshots
- wire up a governance workflow in CI to run unit tests, residency audits, and compatibility gates on every change

## Testing
- node --test services/data-spine/test/*.test.js
- node services/data-spine/bin/data-spine.js validate --all --output services/data-spine/reports/cli-residency-audit.json
- node services/data-spine/bin/data-spine.js compat customer-profile

------
https://chatgpt.com/codex/tasks/task_e_68d9576248688333a1b0d43463d23cfd