### PR TITLE
feat: add gatekeeper policy linter

### DIFF
--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts and packages for Summit tooling."""

--- a/tools/gatekeeper/__init__.py
+++ b/tools/gatekeeper/__init__.py
@@ -1,0 +1,5 @@
+"""Gatekeeper RBAC policy linting package."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/tools/gatekeeper/__main__.py
+++ b/tools/gatekeeper/__main__.py
@@ -1,0 +1,6 @@
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+
+    sys.exit(main())

--- a/tools/gatekeeper/cli.py
+++ b/tools/gatekeeper/cli.py
@@ -1,0 +1,78 @@
+"""Command line interface for the Gatekeeper RBAC policy linter."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List
+
+from .lint import LintIssue, expand_policy_globs, lint_policies, lint_roles
+from .reporting import ConsoleReporter, JunitReporter
+
+
+DEFAULT_JUNIT_PATH = Path("gatekeeper-report.xml")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="gatekeeper", description="RBAC policy linter")
+    subparsers = parser.add_subparsers(dest="command")
+
+    check = subparsers.add_parser("check", help="Lint Rego policies and role maps")
+    check.add_argument(
+        "--policies",
+        nargs="+",
+        required=True,
+        help="Glob patterns to locate policy files (e.g. policies/**/*.rego)",
+    )
+    check.add_argument(
+        "--roles",
+        required=True,
+        help="Path to roles YAML map.",
+    )
+    check.add_argument(
+        "--junit",
+        default=str(DEFAULT_JUNIT_PATH),
+        help="Output path for generated JUnit report.",
+    )
+    check.add_argument(
+        "--fix",
+        action="store_true",
+        help="Normalize the roles map in-place.",
+    )
+
+    return parser
+
+
+def _run_check(args: argparse.Namespace) -> int:
+    policy_paths = expand_policy_globs(args.policies)
+    policy_result = lint_policies(policy_paths)
+
+    roles_path = Path(args.roles)
+    role_result = lint_roles(roles_path, normalize=args.fix)
+
+    issues: List[LintIssue] = list(policy_result.issues) + list(role_result.issues)
+
+    if args.fix and role_result.normalized is not None:
+        roles_path.write_text(role_result.normalized, encoding="utf-8")
+
+    junit_path = Path(args.junit)
+    JunitReporter().write(issues, output=junit_path)
+    ConsoleReporter().render(issues, checked_files=len(policy_result.checked_files), junit_path=junit_path)
+
+    has_errors = any(issue.severity != "warning" for issue in issues)
+    return 1 if has_errors else 0
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "check":
+        return _run_check(args)
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    sys.exit(main())

--- a/tools/gatekeeper/lint.py
+++ b/tools/gatekeeper/lint.py
@@ -1,0 +1,365 @@
+"""Static linting utilities for Gatekeeper RBAC policies and role maps."""
+from __future__ import annotations
+
+import glob
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+try:  # pragma: no cover - optional dependency guard
+    import yaml
+except ImportError as exc:  # pragma: no cover
+    raise RuntimeError("PyYAML is required to run gatekeeper checks") from exc
+
+
+@dataclass
+class LintIssue:
+    """Structured representation of a linting finding."""
+
+    file: str
+    line: int
+    rule: str
+    message: str
+    severity: str = "error"
+
+    def sort_key(self) -> Tuple[str, int, str]:
+        return (self.file, self.line, self.rule)
+
+
+BROAD_WILDCARD_PATTERN = re.compile(r'"([^"\\]*\\.)*[^"\\]*\*[^"\\]*"')
+RULE_DEFINITION_PATTERN = re.compile(r"^(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*(?:\[[^\]]+\])?\s*{", re.MULTILINE)
+COMMENT_PATTERN = re.compile(r"^\s*#")
+
+
+class PolicyLintResult:
+    """Container for policy linting output."""
+
+    def __init__(self, issues: Sequence[LintIssue], checked_files: Sequence[Path]):
+        self.issues = list(issues)
+        self.checked_files = list(checked_files)
+
+
+class RoleLintResult:
+    """Container for role map linting output and optional normalization."""
+
+    def __init__(self, issues: Sequence[LintIssue], normalized: Optional[str] = None):
+        self.issues = list(issues)
+        self.normalized = normalized
+
+
+def expand_policy_globs(patterns: Sequence[str]) -> List[Path]:
+    """Expand the provided glob patterns into an ordered list of policy paths."""
+
+    paths: List[Path] = []
+    for pattern in patterns:
+        for match in sorted(glob.glob(pattern, recursive=True)):
+            path = Path(match)
+            if path.is_file():
+                paths.append(path)
+    return paths
+
+
+def lint_policies(paths: Sequence[Path]) -> PolicyLintResult:
+    """Lint the provided Rego policy files for common safety violations."""
+
+    issues: List[LintIssue] = []
+    checked: List[Path] = []
+
+    for path in paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            continue
+
+        checked.append(path)
+        stripped_lines = text.splitlines()
+
+        # Broad wildcard detection ("*") inside string literals
+        for match in BROAD_WILDCARD_PATTERN.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            # Skip comments entirely containing the match
+            line_text = stripped_lines[line - 1] if 0 <= line - 1 < len(stripped_lines) else ""
+            if COMMENT_PATTERN.match(line_text):
+                continue
+            issues.append(
+                LintIssue(
+                    file=str(path),
+                    line=line,
+                    rule="broad-wildcard",
+                    message="Avoid broad wildcard match in policy string literal.",
+                )
+            )
+
+        # Unreachable rule detection: rules never referenced outside their definition
+        rule_references: Dict[str, int] = {}
+        for match in RULE_DEFINITION_PATTERN.finditer(text):
+            name = match.group("name")
+            line = text.count("\n", 0, match.start()) + 1
+            if name.startswith("_"):
+                # private helper rule, skip
+                continue
+            occurrences = len(re.findall(rf"\b{name}\b", text))
+            rule_references[name] = occurrences
+            if occurrences <= 1:
+                issues.append(
+                    LintIssue(
+                        file=str(path),
+                        line=line,
+                        rule="unreachable-rule",
+                        message=f"Rule '{name}' is never referenced and may be dead code.",
+                        severity="warning",
+                    )
+                )
+
+        # Missing tests: policy file without *_test.rego companion in the same directory
+        if not path.name.endswith("_test.rego"):
+            test_files = list(path.parent.glob("*_test.rego"))
+            if not test_files:
+                issues.append(
+                    LintIssue(
+                        file=str(path),
+                        line=1,
+                        rule="missing-tests",
+                        message="Policy lacks matching *_test.rego fixture in directory.",
+                    )
+                )
+
+    return PolicyLintResult(issues=issues, checked_files=checked)
+
+
+def lint_roles(path: Path, *, normalize: bool = False) -> RoleLintResult:
+    """Lint a YAML role map for RBAC safety issues."""
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return RoleLintResult(
+            [
+                LintIssue(
+                    file=str(path),
+                    line=1,
+                    rule="missing-file",
+                    message="Roles file not found.",
+                )
+            ]
+        )
+
+    try:
+        data = yaml.safe_load(text) or {}
+    except yaml.YAMLError as exc:
+        return RoleLintResult(
+            [
+                LintIssue(
+                    file=str(path),
+                    line=1,
+                    rule="invalid-yaml",
+                    message=f"Unable to parse roles file: {exc}",
+                )
+            ]
+        )
+
+    issues: List[LintIssue] = []
+    normalized_text: Optional[str] = None
+
+    role_entries = _extract_role_entries(data)
+
+    if not role_entries:
+        issues.append(
+            LintIssue(
+                file=str(path),
+                line=1,
+                rule="no-roles",
+                message="No roles defined in roles map.",
+                severity="warning",
+            )
+        )
+    else:
+        for role in role_entries:
+            issues.extend(_lint_role(role, path))
+
+    if normalize and role_entries:
+        normalized_data, changed = _normalize_roles(data)
+        if changed:
+            normalized_text = yaml.safe_dump(
+                normalized_data,
+                sort_keys=False,
+                default_flow_style=False,
+            )
+
+    return RoleLintResult(issues=issues, normalized=normalized_text)
+
+
+def _extract_role_entries(data: object) -> List[Dict[str, object]]:
+    """Locate role entries within the loaded YAML structure."""
+
+    if isinstance(data, dict):
+        for key in ("roles", "role_map", "roleMap"):
+            roles = data.get(key)
+            if isinstance(roles, list):
+                return [role for role in roles if isinstance(role, dict)]
+    elif isinstance(data, list):
+        return [role for role in data if isinstance(role, dict)]
+    return []
+
+
+def _lint_role(role: Dict[str, object], path: Path) -> List[LintIssue]:
+    issues: List[LintIssue] = []
+    role_name = str(role.get("name", role.get("id", "<unnamed>")))
+    permissions = role.get("permissions")
+
+    if not isinstance(permissions, list) or not permissions:
+        issues.append(
+            LintIssue(
+                file=str(path),
+                line=1,
+                rule="missing-permissions",
+                message=f"Role '{role_name}' has no permissions defined.",
+            )
+        )
+        return issues
+
+    seen: Dict[Tuple[str, Tuple[str, ...]], int] = {}
+    for idx, perm in enumerate(permissions):
+        if not isinstance(perm, dict):
+            issues.append(
+                LintIssue(
+                    file=str(path),
+                    line=1,
+                    rule="invalid-permission",
+                    message=f"Role '{role_name}' permission #{idx + 1} is not a mapping.",
+                )
+            )
+            continue
+
+        resource = str(perm.get("resource", ""))
+        actions = perm.get("actions")
+        if isinstance(actions, str):
+            actions_list = [actions]
+        elif isinstance(actions, list):
+            actions_list = [str(action) for action in actions]
+        else:
+            actions_list = []
+
+        if resource == "*":
+            issues.append(
+                LintIssue(
+                    file=str(path),
+                    line=1,
+                    rule="broad-wildcard",
+                    message=f"Role '{role_name}' grants wildcard resource access.",
+                )
+            )
+
+        if any(action == "*" for action in actions_list):
+            issues.append(
+                LintIssue(
+                    file=str(path),
+                    line=1,
+                    rule="broad-wildcard",
+                    message=f"Role '{role_name}' grants wildcard action access.",
+                )
+            )
+
+        key = (resource, tuple(sorted(actions_list)))
+        if key in seen:
+            issues.append(
+                LintIssue(
+                    file=str(path),
+                    line=1,
+                    rule="shadowed-permission",
+                    message=(
+                        f"Role '{role_name}' permission for '{resource}' with actions "
+                        f"{sorted(actions_list)} is duplicated."
+                    ),
+                )
+            )
+        else:
+            seen[key] = idx
+
+        if not actions_list:
+            issues.append(
+                LintIssue(
+                    file=str(path),
+                    line=1,
+                    rule="missing-actions",
+                    message=f"Role '{role_name}' permission for '{resource}' lacks actions.",
+                )
+            )
+
+    return issues
+
+
+def _normalize_roles(data: object) -> Tuple[object, bool]:
+    """Return a normalized copy of the roles structure for deterministic output."""
+
+    changed = False
+
+    if isinstance(data, dict):
+        for key in ("roles", "role_map", "roleMap"):
+            roles = data.get(key)
+            if isinstance(roles, list):
+                normalized_roles = []
+                for role in roles:
+                    if isinstance(role, dict):
+                        normalized_role, role_changed = _normalize_role(role)
+                        changed = changed or role_changed
+                        normalized_roles.append(normalized_role)
+                    else:
+                        normalized_roles.append(role)
+                sorted_roles = sorted(
+                    normalized_roles,
+                    key=lambda item: str(item.get("name", item.get("id", "")))
+                    if isinstance(item, dict)
+                    else str(item),
+                )
+                if roles != sorted_roles:
+                    changed = True
+                data = {**data, key: sorted_roles}
+                break
+    elif isinstance(data, list):
+        normalized_roles = []
+        for role in data:
+            if isinstance(role, dict):
+                normalized_role, role_changed = _normalize_role(role)
+                changed = changed or role_changed
+                normalized_roles.append(normalized_role)
+            else:
+                normalized_roles.append(role)
+        sorted_roles = sorted(
+            normalized_roles,
+            key=lambda item: str(item.get("name", item.get("id", "")))
+            if isinstance(item, dict)
+            else str(item),
+        )
+        if data != sorted_roles:
+            changed = True
+        data = sorted_roles
+
+    return data, changed
+
+
+def _normalize_role(role: Dict[str, object]) -> Tuple[Dict[str, object], bool]:
+    changed = False
+    permissions = role.get("permissions")
+    if isinstance(permissions, list):
+        normalized_permissions = []
+        for perm in permissions:
+            if isinstance(perm, dict):
+                actions = perm.get("actions")
+                if isinstance(actions, list):
+                    sorted_actions = sorted(str(action) for action in actions)
+                    if actions != sorted_actions:
+                        perm = {**perm, "actions": sorted_actions}
+                        changed = True
+                normalized_permissions.append(perm)
+            else:
+                normalized_permissions.append(perm)
+        sorted_permissions = sorted(
+            normalized_permissions,
+            key=lambda item: str(item.get("resource", "")) if isinstance(item, dict) else str(item),
+        )
+        if permissions != sorted_permissions:
+            changed = True
+        role = {**role, "permissions": sorted_permissions}
+    return role, changed

--- a/tools/gatekeeper/reporting.py
+++ b/tools/gatekeeper/reporting.py
@@ -1,0 +1,68 @@
+"""Reporting utilities for Gatekeeper lint results."""
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Sequence
+import xml.etree.ElementTree as ET
+
+from .lint import LintIssue
+
+
+class ConsoleReporter:
+    """Render lint issues as a human-friendly console report."""
+
+    def render(self, issues: Sequence[LintIssue], *, checked_files: int, junit_path: Path) -> None:
+        if not issues:
+            print("Gatekeeper: no issues detected across", checked_files, "policy files.")
+            print(f"JUnit report written to {junit_path}")
+            return
+
+        print("Gatekeeper lint results:")
+        for issue in sorted(issues, key=lambda i: i.sort_key()):
+            location = f"{issue.file}:{issue.line}" if issue.line else issue.file
+            print(f"  {issue.severity.upper():<7} {location} [{issue.rule}] {issue.message}")
+
+        counts = Counter(issue.severity for issue in issues)
+        total = len(issues)
+        summary_parts = [f"{total} issues"] + [f"{count} {severity}" for severity, count in counts.items()]
+        print("Summary:", ", ".join(summary_parts))
+        print(f"JUnit report written to {junit_path}")
+
+
+class JunitReporter:
+    """Persist lint issues in JUnit XML format for CI consumption."""
+
+    def write(self, issues: Sequence[LintIssue], *, output: Path) -> None:
+        testsuite = ET.Element("testsuite", name="gatekeeper", tests=str(len(issues) or 1))
+
+        if issues:
+            testsuite.set("failures", str(len(issues)))
+            for issue in issues:
+                testcase = ET.SubElement(
+                    testsuite,
+                    "testcase",
+                    classname=issue.file,
+                    name=issue.rule,
+                )
+                failure = ET.SubElement(
+                    testcase,
+                    "failure",
+                    message=issue.message,
+                    type=issue.severity,
+                )
+                failure.text = issue.message
+        else:
+            ET.SubElement(
+                testsuite,
+                "testcase",
+                classname="gatekeeper",
+                name="lint",
+            )
+
+        tree = ET.ElementTree(testsuite)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        tree.write(output, encoding="utf-8", xml_declaration=True)
+
+
+__all__ = ["ConsoleReporter", "JunitReporter"]

--- a/tools/gatekeeper/tests/test_cli.py
+++ b/tools/gatekeeper/tests/test_cli.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import yaml
+
+from tools.gatekeeper.cli import main
+
+
+def write_file(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_check_reports_policy_and_role_issues(tmp_path, capsys):
+    policies_dir = tmp_path / "policies"
+    write_file(
+        policies_dir / "bad.rego",
+        """
+        package example
+
+        allow {
+            input.resource == "*"
+        }
+        """.strip()
+    )
+
+    roles_path = write_file(
+        tmp_path / "roles.yaml",
+        yaml.safe_dump(
+            {
+                "roles": [
+                    {
+                        "name": "admin",
+                        "permissions": [
+                            {"resource": "*", "actions": ["read", "write"]},
+                            {"resource": "projects", "actions": ["*"]},
+                            {"resource": "projects", "actions": ["read"]},
+                            {"resource": "projects", "actions": ["read"]},
+                        ],
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+    )
+
+    exit_code = main(
+        [
+            "check",
+            "--policies",
+            str(policies_dir / "**" / "*.rego"),
+            "--roles",
+            str(roles_path),
+            "--junit",
+            str(tmp_path / "report.xml"),
+        ]
+    )
+
+    assert exit_code == 1
+
+    stdout = capsys.readouterr().out
+    assert "broad-wildcard" in stdout
+    assert "missing-tests" in stdout
+    assert "shadowed-permission" in stdout
+
+    junit_path = tmp_path / "report.xml"
+    assert junit_path.exists()
+    assert "testsuite" in junit_path.read_text(encoding="utf-8")
+
+
+def test_check_fix_normalizes_roles(tmp_path):
+    policies_dir = tmp_path / "policies"
+    write_file(
+        policies_dir / "rule.rego",
+        """
+        package example
+
+        default allow = false
+
+        allow {
+            true
+        }
+        """.strip()
+    )
+    write_file(
+        policies_dir / "rule_test.rego",
+        """
+        package example
+
+        test_allow {
+            allow
+        }
+        """.strip()
+    )
+
+    roles_content = {
+        "roles": [
+            {
+                "name": "developer",
+                "permissions": [
+                    {"resource": "projects", "actions": ["write", "read"]},
+                    {"resource": "artifacts", "actions": ["publish", "read"]},
+                ],
+            },
+            {
+                "name": "admin",
+                "permissions": [
+                    {"resource": "system", "actions": ["manage"]},
+                ],
+            },
+        ]
+    }
+    roles_path = write_file(tmp_path / "roles.yaml", yaml.safe_dump(roles_content, sort_keys=False))
+
+    exit_code = main(
+        [
+            "check",
+            "--policies",
+            str(policies_dir / "**" / "*.rego"),
+            "--roles",
+            str(roles_path),
+            "--fix",
+            "--junit",
+            str(tmp_path / "report.xml"),
+        ]
+    )
+
+    assert exit_code == 0
+
+    normalized = yaml.safe_load(roles_path.read_text(encoding="utf-8"))
+    role_names = [role["name"] for role in normalized["roles"]]
+    assert role_names == ["admin", "developer"]
+    dev_role = next(role for role in normalized["roles"] if role["name"] == "developer")
+    dev_projects = next(perm for perm in dev_role["permissions"] if perm["resource"] == "projects")
+    assert dev_projects["actions"] == ["read", "write"]
+
+    junit_path = tmp_path / "report.xml"
+    assert junit_path.exists()


### PR DESCRIPTION
## Summary
- add a `gatekeeper` CLI with a `check` command to lint Rego policies and RBAC role maps
- implement lint rules for wildcard access, dead rules, missing tests, duplicate permissions, and optional role normalization with console + JUnit reports
- cover the new workflow with pytest fixtures and make `tools` importable as a package

## Testing
- pytest --override-ini addopts='' tools/gatekeeper/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d961d0e9148333b608980a79624202