### PR TITLE
feat: introduce migratevet migration linter

### DIFF
--- a/tools/migratevet/__init__.py
+++ b/tools/migratevet/__init__.py
@@ -1,0 +1,5 @@
+"""MigrateVet SQL migration linter."""
+
+from .cli import main
+
+__all__ = ["main"]

--- a/tools/migratevet/cli.py
+++ b/tools/migratevet/cli.py
@@ -1,0 +1,79 @@
+"""Command line interface for the MigrateVet SQL migration linter."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from .scanner import scan_directory
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="migratevet", description="Safe DB migration linter")
+    subparsers = parser.add_subparsers(dest="command")
+
+    check_parser = subparsers.add_parser("check", help="Run migration checks")
+    check_parser.add_argument("--dir", required=True, help="Directory containing SQL migrations")
+    check_parser.add_argument("--dialect", required=True, help="SQL dialect (e.g. postgres)")
+    check_parser.add_argument(
+        "--enforce",
+        action="store_true",
+        help="Fail with a non-zero exit code on findings (defaults to warn-only).",
+    )
+    check_parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="Force warn-only mode even if MIGRATEVET_ENFORCE is set.",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.command == "check":
+        return _run_check(args)
+
+    parser.print_help()
+    return 0
+
+
+def _run_check(args: argparse.Namespace) -> int:
+    root = Path(args.dir)
+    if not root.exists():
+        print(f"No such directory: {root}", file=sys.stderr)
+        return 2
+
+    dialect = args.dialect.lower()
+    enforce_env = os.environ.get("MIGRATEVET_ENFORCE", "").lower() in {"1", "true", "yes"}
+    enforce = (args.enforce or enforce_env) and not args.warn_only
+
+    try:
+        issues = scan_directory(root, dialect)
+    except ValueError as exc:  # Unsupported dialect
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    severity = "ERROR" if enforce else "WARN"
+    issues = sorted(issues, key=lambda item: (str(item.file_path), item.line, item.code))
+    if issues:
+        for issue in issues:
+            print(issue.format(severity=severity))
+        unique_files = {issue.file_path for issue in issues}
+        mode = "enforce" if enforce else "warn-only"
+        print(
+            f"Found {len(issues)} issue(s) across {len(unique_files)} file(s) (mode: {mode}).",
+            file=sys.stderr,
+        )
+        return 1 if enforce else 0
+
+    print(f"No issues found for dialect '{dialect}' in {root}.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tools/migratevet/models.py
+++ b/tools/migratevet/models.py
@@ -1,0 +1,57 @@
+"""Shared dataclasses for MigrateVet."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+@dataclass(frozen=True)
+class Issue:
+    file_path: Path
+    line: int
+    code: str
+    message: str
+    hint: str
+
+    def format(self, severity: str = "WARN") -> str:
+        location = f"{self.file_path}:{self.line}"
+        return f"{severity}: {location}: [{self.code}] {self.message}\n    Hint: {self.hint}"
+
+
+@dataclass(frozen=True)
+class Statement:
+    text: str
+    upper: str
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class FileContext:
+    path: Path
+    source_text: str
+    sanitized_text: str
+    line_offsets: Sequence[int]
+
+    def line_for_offset(self, offset: int) -> int:
+        if offset < 0:
+            offset = 0
+        if offset >= len(self.source_text):
+            return len(self.line_offsets)
+        lo, hi = 0, len(self.line_offsets) - 1
+        while lo <= hi:
+            mid = (lo + hi) // 2
+            start = self.line_offsets[mid]
+            if mid + 1 < len(self.line_offsets):
+                end = self.line_offsets[mid + 1]
+            else:
+                end = len(self.source_text) + 1
+            if start <= offset < end:
+                return mid + 1
+            if offset < start:
+                hi = mid - 1
+            else:
+                lo = mid + 1
+        return len(self.line_offsets)

--- a/tools/migratevet/postgres_rules.py
+++ b/tools/migratevet/postgres_rules.py
@@ -1,0 +1,89 @@
+"""Postgres-specific lint rules for MigrateVet."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+from .models import FileContext, Issue, Statement
+
+
+@dataclass(frozen=True)
+class Rule:
+    code: str
+    message: str
+    hint: str
+
+
+FULL_TABLE_REWRITE = Rule(
+    code="MIGRATEVET001",
+    message="ALTER COLUMN TYPE rewrites the entire table.",
+    hint="Perform the rewrite in a batched migration or use a USING clause with a shadow table.",
+)
+
+DROP_COLUMN_GUARD = Rule(
+    code="MIGRATEVET002",
+    message="DROP COLUMN without IF EXISTS can fail on repeated deploys.",
+    hint="Add IF EXISTS to the DROP COLUMN clause to make it idempotent.",
+)
+
+ALTER_TYPE_GUARD = Rule(
+    code="MIGRATEVET003",
+    message="ALTER TYPE operations require special handling to avoid blocking.",
+    hint="Prefer ADD VALUE IF NOT EXISTS or create a new type and migrate data incrementally.",
+)
+
+INDEX_CONCURRENTLY = Rule(
+    code="MIGRATEVET004",
+    message="CREATE INDEX without CONCURRENTLY can lock writes for long periods.",
+    hint="Use CREATE INDEX CONCURRENTLY (or drop/recreate concurrently) to avoid blocking writes.",
+)
+
+
+def evaluate(statements: Iterable[Statement], context: FileContext) -> List[Issue]:
+    """Run postgres rules for the given statements."""
+    issues: List[Issue] = []
+    for stmt in statements:
+        issues.extend(_check_statement(stmt, context))
+    return issues
+
+
+def _check_statement(stmt: Statement, context: FileContext) -> List[Issue]:
+    upper = stmt.upper
+    stripped_upper = upper.strip()
+    issues: List[Issue] = []
+
+    if "ALTER TABLE" in upper and "ALTER COLUMN" in upper:
+        if " TYPE" in upper or " SET DATA TYPE" in upper:
+            idx = upper.find("ALTER COLUMN")
+            issues.append(_make_issue(context, stmt, idx if idx != -1 else 0, FULL_TABLE_REWRITE))
+
+    if "ALTER TABLE" in upper and "DROP COLUMN" in upper:
+        drop_idx = upper.find("DROP COLUMN")
+        if drop_idx != -1:
+            guard_segment = upper[drop_idx : drop_idx + 80]
+            if "DROP COLUMN IF EXISTS" not in guard_segment:
+                issues.append(_make_issue(context, stmt, drop_idx, DROP_COLUMN_GUARD))
+
+    if "ALTER TYPE" in upper:
+        idx = upper.find("ALTER TYPE")
+        guard_segment = upper[idx : idx + 120] if idx != -1 else upper
+        if "ADD VALUE IF NOT EXISTS" in guard_segment:
+            pass
+        else:
+            issues.append(_make_issue(context, stmt, idx if idx != -1 else 0, ALTER_TYPE_GUARD))
+
+    # CREATE INDEX checks.
+    leading = stripped_upper
+    if leading.startswith("CREATE INDEX") or leading.startswith("CREATE UNIQUE INDEX"):
+        if "CONCURRENTLY" not in upper:
+            idx = upper.find("CREATE")
+            issues.append(_make_issue(context, stmt, idx if idx != -1 else 0, INDEX_CONCURRENTLY))
+
+    return issues
+
+
+def _make_issue(context: FileContext, stmt: Statement, relative_offset: int, rule: Rule) -> Issue:
+    offset = stmt.start + max(relative_offset, 0)
+    line = context.line_for_offset(offset)
+    return Issue(file_path=context.path, line=line, code=rule.code, message=rule.message, hint=rule.hint)

--- a/tools/migratevet/scanner.py
+++ b/tools/migratevet/scanner.py
@@ -1,0 +1,211 @@
+"""Core scanning utilities for the MigrateVet CLI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+from . import postgres_rules
+from .models import FileContext, Issue, Statement
+
+
+SUPPORTED_DIALECTS = {"postgres"}
+
+
+def scan_directory(root: Path, dialect: str) -> List[Issue]:
+    """Scan all SQL files under ``root`` for the given dialect."""
+    if dialect not in SUPPORTED_DIALECTS:
+        raise ValueError(f"Unsupported dialect '{dialect}'. Supported dialects: {sorted(SUPPORTED_DIALECTS)}")
+
+    issues: List[Issue] = []
+    for path in sorted(root.rglob("*.sql")):
+        issues.extend(scan_file(path, dialect))
+    return issues
+
+
+def scan_file(path: Path, dialect: str) -> List[Issue]:
+    """Scan an individual SQL file."""
+    text = path.read_text(encoding="utf-8")
+    sanitized = _strip_sql_comments(text)
+    statements = list(_extract_statements(sanitized))
+    context = FileContext(path=path, source_text=text, sanitized_text=sanitized, line_offsets=_compute_line_offsets(text))
+
+    if dialect == "postgres":
+        return postgres_rules.evaluate(statements, context)
+    raise ValueError(f"Unsupported dialect '{dialect}'")
+
+
+def _compute_line_offsets(text: str) -> List[int]:
+    offsets = [0]
+    for idx, char in enumerate(text):
+        if char == "\n":
+            offsets.append(idx + 1)
+    return offsets
+
+
+def _strip_sql_comments(text: str) -> str:
+    """Return ``text`` with SQL comments replaced by spaces, preserving length."""
+    result: List[str] = []
+    length = len(text)
+    i = 0
+    in_single = False
+    in_double = False
+    dollar_tag: str | None = None
+    in_block_comment = False
+
+    while i < length:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < length else ""
+
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                result.append("  ")
+                i += 2
+                in_block_comment = False
+            else:
+                result.append("\n" if ch == "\n" else " ")
+                i += 1
+            continue
+
+        if dollar_tag is not None:
+            if ch == "$" and text.startswith(dollar_tag, i):
+                tag_len = len(dollar_tag)
+                result.append(text[i : i + tag_len])
+                i += tag_len
+                dollar_tag = None
+            else:
+                result.append(ch)
+                i += 1
+            continue
+
+        if in_single:
+            result.append(ch)
+            i += 1
+            if ch == "'":
+                if nxt == "'":
+                    result.append("'")
+                    i += 1
+                else:
+                    in_single = False
+            continue
+
+        if in_double:
+            result.append(ch)
+            i += 1
+            if ch == '"':
+                in_double = False
+            continue
+
+        # Not in any quoted section.
+        if ch == "-" and nxt == "-":
+            # Single-line comment.
+            while i < length and text[i] != "\n":
+                result.append(" ")
+                i += 1
+            if i < length:
+                result.append("\n")
+                i += 1
+            continue
+
+        if ch == "/" and nxt == "*":
+            in_block_comment = True
+            result.append("  ")
+            i += 2
+            continue
+
+        if ch == "'":
+            in_single = True
+            result.append(ch)
+            i += 1
+            continue
+
+        if ch == '"':
+            in_double = True
+            result.append(ch)
+            i += 1
+            continue
+
+        if ch == "$":
+            tag_end = text.find("$", i + 1)
+            if tag_end != -1:
+                tag = text[i : tag_end + 1]
+                # Ensure the tag is alphanumeric or underscore.
+                if all(c.isalnum() or c == "_" for c in tag[1:-1]):
+                    dollar_tag = tag
+                    result.append(tag)
+                    i += len(tag)
+                    continue
+            result.append(ch)
+            i += 1
+            continue
+
+        result.append(ch)
+        i += 1
+
+    return "".join(result)
+
+
+def _extract_statements(sanitized_text: str) -> Iterable[Statement]:
+    start = 0
+    in_single = False
+    in_double = False
+    dollar_tag: str | None = None
+    length = len(sanitized_text)
+
+    for idx, ch in enumerate(sanitized_text):
+        if dollar_tag is not None:
+            if ch == "$" and sanitized_text.startswith(dollar_tag, idx):
+                dollar_tag = None
+            continue
+
+        if in_single:
+            if ch == "'":
+                nxt = sanitized_text[idx + 1] if idx + 1 < length else ""
+                if nxt == "'":
+                    continue
+                in_single = False
+            continue
+
+        if in_double:
+            if ch == '"':
+                in_double = False
+            continue
+
+        if ch == "'":
+            in_single = True
+            continue
+
+        if ch == '"':
+            in_double = True
+            continue
+
+        if ch == "$":
+            tag_end = _find_dollar_tag_end(sanitized_text, idx)
+            if tag_end is not None:
+                dollar_tag = sanitized_text[idx : tag_end + 1]
+            continue
+
+        if ch == ";":
+            segment = sanitized_text[start : idx + 1]
+            if segment.strip():
+                upper = segment.upper()
+                yield Statement(text=segment, upper=upper, start=start, end=idx + 1)
+            start = idx + 1
+
+    if start < length:
+        segment = sanitized_text[start:length]
+        if segment.strip():
+            upper = segment.upper()
+            yield Statement(text=segment, upper=upper, start=start, end=length)
+
+
+def _find_dollar_tag_end(text: str, start: int) -> int | None:
+    tag_end = text.find("$", start + 1)
+    if tag_end == -1:
+        return None
+    tag = text[start : tag_end + 1]
+    if not tag or tag.count("$") != 2:
+        return None
+    if all(c.isalnum() or c == "_" for c in tag[1:-1]):
+        return tag_end
+    return None

--- a/tools/migratevet/tests/fixtures/postgres/bad/001_risky_ops.sql
+++ b/tools/migratevet/tests/fixtures/postgres/bad/001_risky_ops.sql
@@ -1,0 +1,11 @@
+-- Full table rewrite without guard
+ALTER TABLE customers
+    ALTER COLUMN last_login TYPE TIMESTAMPTZ;
+
+/* Drop column without IF EXISTS */
+ALTER TABLE customers
+    DROP COLUMN legacy_flag;
+
+ALTER TYPE status ADD VALUE 'archived';
+
+CREATE INDEX idx_customers_last_login ON customers (last_login);

--- a/tools/migratevet/tests/fixtures/postgres/good/001_create_table.sql
+++ b/tools/migratevet/tests/fixtures/postgres/good/001_create_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE accounts (
+    id BIGSERIAL PRIMARY KEY,
+    email TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_accounts_email ON accounts (email);

--- a/tools/migratevet/tests/test_cli.py
+++ b/tools/migratevet/tests/test_cli.py
@@ -1,0 +1,95 @@
+"""Tests for the MigrateVet CLI."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from tools.migratevet.scanner import scan_directory
+
+FIXTURES = Path(__file__).parent / "fixtures" / "postgres"
+
+
+class MigrateVetCLITests(unittest.TestCase):
+    def test_postgres_good_fixture_clean(self) -> None:
+        good_dir = FIXTURES / "good"
+        issues = scan_directory(good_dir, "postgres")
+        self.assertEqual([], issues)
+
+    def test_postgres_bad_fixture_reports_expected_rules(self) -> None:
+        bad_dir = FIXTURES / "bad"
+        issues = scan_directory(bad_dir, "postgres")
+        codes = sorted(issue.code for issue in issues)
+        self.assertEqual(
+            [
+                "MIGRATEVET001",
+                "MIGRATEVET002",
+                "MIGRATEVET003",
+                "MIGRATEVET004",
+            ],
+            codes,
+        )
+
+    def test_cli_warn_mode_exits_zero(self) -> None:
+        bad_dir = FIXTURES / "bad"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tools.migratevet.cli",
+                "check",
+                "--dir",
+                str(bad_dir),
+                "--dialect",
+                "postgres",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(0, result.returncode)
+        self.assertIn("WARN", result.stdout)
+        self.assertIn("warn-only", result.stderr)
+
+    def test_cli_enforce_mode_exits_one(self) -> None:
+        bad_dir = FIXTURES / "bad"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "tools.migratevet.cli",
+                "check",
+                "--dir",
+                str(bad_dir),
+                "--dialect",
+                "postgres",
+                "--enforce",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(1, result.returncode)
+        self.assertIn("ERROR", result.stdout)
+        self.assertIn("mode: enforce", result.stderr)
+
+    def test_large_file_budget(self) -> None:
+        statement = "INSERT INTO audit_log (id, payload) VALUES (1, '{}'::jsonb);\n"
+        repetitions = 4000
+        with TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+            sql_path = tmp_path / "large_fixture.sql"
+            sql_path.write_text(statement * repetitions, encoding="utf-8")
+            start = time.perf_counter()
+            issues = scan_directory(tmp_path, "postgres")
+            duration = time.perf_counter() - start
+        self.assertEqual([], issues)
+        self.assertLess(duration, 0.5, f"scan exceeded timing budget: {duration:.3f}s")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add the migratevet CLI to scan SQL migration directories in warn or enforce modes
- implement postgres rules for table rewrites, unsafe drops, alter type usage, and non-concurrent indexes
- add fixtures and unit tests, including a timing budget check for large files

## Testing
- python -m unittest tools.migratevet.tests.test_cli

------
https://chatgpt.com/codex/tasks/task_e_68d960d127508333bd1f8c8913edc271