### PR TITLE
feat: add maestro rollback recovery system

### DIFF
--- a/src/maestro/v6/rollback/HealthMonitor.ts
+++ b/src/maestro/v6/rollback/HealthMonitor.ts
@@ -1,0 +1,488 @@
+import { EventEmitter } from 'events';
+import { Logger } from '../../utils/logger';
+import { MetricsCollector } from '../../observability/MetricsCollector';
+
+export type HealthStatus = 'healthy' | 'degraded' | 'critical';
+
+export interface HealthIncident {
+  id: string;
+  type: string;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  description: string;
+  detectedAt: Date;
+  resolvedAt?: Date;
+  metadata?: Record<string, any>;
+}
+
+export interface ServiceHealthSnapshot {
+  serviceId: string;
+  tier: 'canary' | 'primary' | 'standby';
+  status: HealthStatus;
+  errorRate: number;
+  successRate: number;
+  latencyP50: number;
+  latencyP95: number;
+  saturation: number;
+  cpuUsage: number;
+  memoryUsage: number;
+  requestRate: number;
+  lastUpdated: Date;
+}
+
+export interface DeploymentHealthMetrics extends Record<string, number | string | Date | HealthStatus | HealthIncident[] | ServiceHealthSnapshot[] | Record<string, number>> {
+  deploymentId: string;
+  timestamp: Date;
+  status: HealthStatus;
+  error_rate: number;
+  success_rate: number;
+  avg_latency: number;
+  p95_latency: number;
+  memory_usage: number;
+  cpu_usage: number;
+  saturation: number;
+  request_rate: number;
+  anomalyScore: number;
+  incidents: HealthIncident[];
+  serviceMetrics: ServiceHealthSnapshot[];
+  trends: {
+    errorRateSlope: number;
+    latencySlope: number;
+    availabilitySlope: number;
+  };
+}
+
+interface DeploymentHealthRecord {
+  deploymentId: string;
+  services: Map<string, ServiceHealthSnapshot>;
+  history: ServiceHealthSnapshot[][];
+  incidents: HealthIncident[];
+  status: HealthStatus;
+  lastEvaluated: Date;
+  consecutiveDegradations: number;
+}
+
+interface HealthEvaluation {
+  status: HealthStatus;
+  reasons: string[];
+  anomalyScore: number;
+}
+
+const HISTORY_LIMIT = 50;
+const DEFAULT_HEALTH: Omit<ServiceHealthSnapshot, 'serviceId' | 'tier'> = {
+  status: 'healthy',
+  errorRate: 0.005,
+  successRate: 0.995,
+  latencyP50: 120,
+  latencyP95: 220,
+  saturation: 0.35,
+  cpuUsage: 0.4,
+  memoryUsage: 0.45,
+  requestRate: 120,
+  lastUpdated: new Date()
+};
+
+export class HealthMonitor extends EventEmitter {
+  private logger: Logger;
+  private metrics?: MetricsCollector;
+  private records: Map<string, DeploymentHealthRecord> = new Map();
+  private evaluationInterval?: NodeJS.Timeout;
+  private evaluationPeriodMs: number;
+
+  constructor(logger: Logger, metricsCollector?: MetricsCollector, evaluationPeriodMs = 15000) {
+    super();
+    this.logger = logger;
+    this.metrics = metricsCollector;
+    this.evaluationPeriodMs = evaluationPeriodMs;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.evaluationInterval) {
+      clearInterval(this.evaluationInterval);
+    }
+
+    this.evaluationInterval = setInterval(() => {
+      for (const record of this.records.values()) {
+        this.evaluateDeployment(record);
+      }
+    }, this.evaluationPeriodMs);
+
+    this.logger.info('HealthMonitor initialized for Maestro Conductor rollback system');
+  }
+
+  async startMonitoring(deploymentId: string, services: string[]): Promise<void> {
+    const record = this.ensureRecord(deploymentId, services);
+    record.lastEvaluated = new Date();
+    this.logger.info(`Started health monitoring for deployment ${deploymentId}`, {
+      services: Array.from(record.services.keys())
+    });
+  }
+
+  async stopMonitoring(deploymentId: string): Promise<void> {
+    if (this.records.delete(deploymentId)) {
+      this.logger.info(`Stopped health monitoring for deployment ${deploymentId}`);
+    }
+  }
+
+  async ingestHealthSignal(
+    deploymentId: string,
+    updates: Partial<Omit<ServiceHealthSnapshot, 'serviceId' | 'tier' | 'lastUpdated'>> & {
+      serviceId?: string;
+      tier?: 'canary' | 'primary' | 'standby';
+      incidents?: HealthIncident[];
+    }
+  ): Promise<void> {
+    const record = this.records.get(deploymentId);
+    if (!record) {
+      throw new Error(`Deployment ${deploymentId} is not being monitored`);
+    }
+
+    const targetServiceId = updates.serviceId || Array.from(record.services.keys())[0];
+    if (!targetServiceId) {
+      throw new Error(`No services registered for deployment ${deploymentId}`);
+    }
+
+    const service = record.services.get(targetServiceId);
+    if (!service) {
+      throw new Error(`Service ${targetServiceId} not registered for deployment ${deploymentId}`);
+    }
+
+    const updatedService: ServiceHealthSnapshot = {
+      ...service,
+      ...updates,
+      tier: updates.tier || service.tier,
+      lastUpdated: new Date(),
+      status: updates.errorRate && updates.errorRate > 0.08 ? 'critical' : updates.errorRate && updates.errorRate > 0.03 ? 'degraded' : service.status
+    };
+
+    record.services.set(targetServiceId, updatedService);
+    if (updates.incidents && updates.incidents.length > 0) {
+      record.incidents.push(...updates.incidents);
+    }
+
+    this.appendHistory(record, Array.from(record.services.values()));
+    this.evaluateDeployment(record);
+  }
+
+  async getHealthMetrics(deploymentId: string): Promise<DeploymentHealthMetrics> {
+    const record = this.records.get(deploymentId);
+    if (!record) {
+      throw new Error(`No health metrics available for deployment ${deploymentId}`);
+    }
+
+    const aggregate = this.aggregateMetrics(record);
+    const trends = this.calculateTrends(record);
+
+    const metrics: DeploymentHealthMetrics = {
+      deploymentId,
+      timestamp: new Date(),
+      status: record.status,
+      error_rate: aggregate.errorRate,
+      success_rate: aggregate.successRate,
+      avg_latency: aggregate.latencyP50,
+      p95_latency: aggregate.latencyP95,
+      memory_usage: aggregate.memoryUsage,
+      cpu_usage: aggregate.cpuUsage,
+      saturation: aggregate.saturation,
+      request_rate: aggregate.requestRate,
+      anomalyScore: aggregate.anomalyScore,
+      incidents: [...record.incidents],
+      serviceMetrics: Array.from(record.services.values()),
+      trends
+    };
+
+    this.metrics?.recordGauge?.('maestro.rollback.health.error_rate', aggregate.errorRate, { deploymentId });
+    this.metrics?.recordGauge?.('maestro.rollback.health.latency_p95', aggregate.latencyP95, { deploymentId });
+    this.metrics?.recordGauge?.('maestro.rollback.health.anomaly_score', aggregate.anomalyScore, { deploymentId });
+
+    return metrics;
+  }
+
+  async verifyHealth(deploymentId: string): Promise<boolean> {
+    const record = this.records.get(deploymentId);
+    if (!record) {
+      throw new Error(`Deployment ${deploymentId} is not being monitored`);
+    }
+
+    const aggregate = this.aggregateMetrics(record);
+    const healthy = aggregate.errorRate < 0.02 && aggregate.latencyP95 < 400 && aggregate.memoryUsage < 0.8;
+
+    this.logger.info(`Health verification for ${deploymentId}`, {
+      healthy,
+      errorRate: aggregate.errorRate,
+      latencyP95: aggregate.latencyP95,
+      memoryUsage: aggregate.memoryUsage
+    });
+
+    return healthy;
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.evaluationInterval) {
+      clearInterval(this.evaluationInterval);
+    }
+    this.records.clear();
+    this.logger.info('HealthMonitor shut down');
+  }
+
+  private ensureRecord(deploymentId: string, services: string[]): DeploymentHealthRecord {
+    let record = this.records.get(deploymentId);
+    if (!record) {
+      const serviceSnapshots = services.map<ServiceHealthSnapshot>((serviceId, index) => ({
+        serviceId,
+        tier: index === 0 ? 'canary' : 'primary',
+        ...DEFAULT_HEALTH,
+        lastUpdated: new Date()
+      }));
+
+      record = {
+        deploymentId,
+        services: new Map(serviceSnapshots.map(service => [service.serviceId, service])),
+        history: [serviceSnapshots],
+        incidents: [],
+        status: 'healthy',
+        lastEvaluated: new Date(),
+        consecutiveDegradations: 0
+      };
+
+      this.records.set(deploymentId, record);
+    } else {
+      for (const serviceId of services) {
+        if (!record.services.has(serviceId)) {
+          const snapshot: ServiceHealthSnapshot = {
+            serviceId,
+            tier: 'primary',
+            ...DEFAULT_HEALTH,
+            lastUpdated: new Date()
+          };
+          record.services.set(serviceId, snapshot);
+        }
+      }
+    }
+
+    return record;
+  }
+
+  private appendHistory(record: DeploymentHealthRecord, snapshot: ServiceHealthSnapshot[]): void {
+    record.history.push(snapshot);
+    if (record.history.length > HISTORY_LIMIT) {
+      record.history.shift();
+    }
+  }
+
+  private evaluateDeployment(record: DeploymentHealthRecord): void {
+    const previousStatus = record.status;
+    const evaluation = this.calculateEvaluation(record);
+
+    record.status = evaluation.status;
+    record.lastEvaluated = new Date();
+
+    if (evaluation.status === 'degraded') {
+      record.consecutiveDegradations += 1;
+      this.metrics?.incrementCounter?.('maestro.rollback.health.degradations', { deploymentId: record.deploymentId });
+      this.emit('healthDegraded', {
+        deploymentId: record.deploymentId,
+        status: evaluation.status,
+        reasons: evaluation.reasons,
+        anomalyScore: evaluation.anomalyScore
+      });
+    } else if (evaluation.status === 'critical') {
+      record.consecutiveDegradations += 1;
+      this.metrics?.incrementCounter?.('maestro.rollback.health.critical', { deploymentId: record.deploymentId });
+      this.emit('criticalAlert', {
+        deploymentId: record.deploymentId,
+        status: evaluation.status,
+        reasons: evaluation.reasons,
+        anomalyScore: evaluation.anomalyScore
+      });
+    } else {
+      record.consecutiveDegradations = 0;
+    }
+
+    if (previousStatus !== record.status) {
+      this.logger.warn(`Health status changed for ${record.deploymentId}: ${previousStatus} -> ${record.status}`, {
+        reasons: evaluation.reasons,
+        anomalyScore: evaluation.anomalyScore
+      });
+    }
+  }
+
+  private calculateEvaluation(record: DeploymentHealthRecord): HealthEvaluation {
+    const aggregate = this.aggregateMetrics(record);
+    const reasons: string[] = [];
+    let status: HealthStatus = 'healthy';
+
+    if (aggregate.errorRate > 0.08 || aggregate.successRate < 0.9) {
+      status = 'critical';
+      reasons.push(`Error rate ${aggregate.errorRate.toFixed(3)} or success rate ${aggregate.successRate.toFixed(3)} outside safe range`);
+    } else if (aggregate.errorRate > 0.03 || aggregate.successRate < 0.95) {
+      status = status === 'critical' ? status : 'degraded';
+      reasons.push(`Elevated error (${aggregate.errorRate.toFixed(3)}) or reduced success (${aggregate.successRate.toFixed(3)}) rate`);
+    }
+
+    if (aggregate.latencyP95 > 4000) {
+      status = 'critical';
+      reasons.push(`P95 latency ${aggregate.latencyP95.toFixed(0)}ms exceeds hard threshold`);
+    } else if (aggregate.latencyP95 > 2500) {
+      status = status === 'critical' ? status : 'degraded';
+      reasons.push(`P95 latency ${aggregate.latencyP95.toFixed(0)}ms elevated`);
+    }
+
+    if (aggregate.memoryUsage > 0.92 || aggregate.cpuUsage > 0.92) {
+      status = 'critical';
+      reasons.push('Resource exhaustion detected');
+    } else if (aggregate.memoryUsage > 0.85 || aggregate.cpuUsage > 0.85) {
+      status = status === 'critical' ? status : 'degraded';
+      reasons.push('Resource pressure approaching critical thresholds');
+    }
+
+    if (aggregate.anomalyScore > 0.85) {
+      status = 'critical';
+      reasons.push(`Anomaly score ${aggregate.anomalyScore.toFixed(2)} indicates severe instability`);
+    } else if (aggregate.anomalyScore > 0.65) {
+      status = status === 'critical' ? status : 'degraded';
+      reasons.push(`Anomaly score ${aggregate.anomalyScore.toFixed(2)} indicates unusual behaviour`);
+    }
+
+    if (record.consecutiveDegradations > 3 && status !== 'critical') {
+      status = 'degraded';
+      reasons.push('Multiple consecutive degradation intervals detected');
+    }
+
+    return {
+      status,
+      reasons: reasons.length > 0 ? reasons : ['Metrics within healthy thresholds'],
+      anomalyScore: aggregate.anomalyScore
+    };
+  }
+
+  private aggregateMetrics(record: DeploymentHealthRecord): {
+    errorRate: number;
+    successRate: number;
+    latencyP50: number;
+    latencyP95: number;
+    saturation: number;
+    cpuUsage: number;
+    memoryUsage: number;
+    requestRate: number;
+    anomalyScore: number;
+  } {
+    const services = Array.from(record.services.values());
+    if (services.length === 0) {
+      return {
+        errorRate: DEFAULT_HEALTH.errorRate,
+        successRate: DEFAULT_HEALTH.successRate,
+        latencyP50: DEFAULT_HEALTH.latencyP50,
+        latencyP95: DEFAULT_HEALTH.latencyP95,
+        saturation: DEFAULT_HEALTH.saturation,
+        cpuUsage: DEFAULT_HEALTH.cpuUsage,
+        memoryUsage: DEFAULT_HEALTH.memoryUsage,
+        requestRate: DEFAULT_HEALTH.requestRate,
+        anomalyScore: 0
+      };
+    }
+
+    const sums = services.reduce((acc, service) => {
+      acc.errorRate += service.errorRate;
+      acc.successRate += service.successRate;
+      acc.latencyP50 += service.latencyP50;
+      acc.latencyP95 += service.latencyP95;
+      acc.saturation += service.saturation;
+      acc.cpuUsage += service.cpuUsage;
+      acc.memoryUsage += service.memoryUsage;
+      acc.requestRate += service.requestRate;
+      return acc;
+    }, {
+      errorRate: 0,
+      successRate: 0,
+      latencyP50: 0,
+      latencyP95: 0,
+      saturation: 0,
+      cpuUsage: 0,
+      memoryUsage: 0,
+      requestRate: 0
+    });
+
+    const average = {
+      errorRate: sums.errorRate / services.length,
+      successRate: sums.successRate / services.length,
+      latencyP50: sums.latencyP50 / services.length,
+      latencyP95: sums.latencyP95 / services.length,
+      saturation: sums.saturation / services.length,
+      cpuUsage: sums.cpuUsage / services.length,
+      memoryUsage: sums.memoryUsage / services.length,
+      requestRate: sums.requestRate / services.length
+    };
+
+    const anomalyScore = this.calculateAnomalyScore(record, average);
+
+    return {
+      ...average,
+      anomalyScore
+    };
+  }
+
+  private calculateTrends(record: DeploymentHealthRecord): {
+    errorRateSlope: number;
+    latencySlope: number;
+    availabilitySlope: number;
+  } {
+    const recentHistory = record.history.slice(-5);
+    if (recentHistory.length < 2) {
+      return {
+        errorRateSlope: 0,
+        latencySlope: 0,
+        availabilitySlope: 0
+      };
+    }
+
+    const errorRates = recentHistory.map(snapshot => this.average(snapshot.map(s => s.errorRate)));
+    const latencies = recentHistory.map(snapshot => this.average(snapshot.map(s => s.latencyP95)));
+    const successRates = recentHistory.map(snapshot => this.average(snapshot.map(s => s.successRate)));
+
+    return {
+      errorRateSlope: this.calculateSlope(errorRates),
+      latencySlope: this.calculateSlope(latencies),
+      availabilitySlope: this.calculateSlope(successRates)
+    };
+  }
+
+  private calculateAnomalyScore(record: DeploymentHealthRecord, average: {
+    errorRate: number;
+    successRate: number;
+    latencyP50: number;
+    latencyP95: number;
+    saturation: number;
+    cpuUsage: number;
+    memoryUsage: number;
+    requestRate: number;
+  }): number {
+    const baseline = DEFAULT_HEALTH;
+    const errorDrift = Math.max(0, (average.errorRate - baseline.errorRate) / baseline.errorRate);
+    const latencyDrift = Math.max(0, (average.latencyP95 - baseline.latencyP95) / baseline.latencyP95);
+    const resourceDrift = Math.max(0, (average.memoryUsage - baseline.memoryUsage) / baseline.memoryUsage);
+    const successDrift = Math.max(0, (baseline.successRate - average.successRate) / baseline.successRate);
+
+    const weighted = (errorDrift * 0.35) + (latencyDrift * 0.25) + (resourceDrift * 0.2) + (successDrift * 0.2);
+    const incidentPenalty = Math.min(0.2, record.incidents.length * 0.02);
+    return Math.min(1, weighted + incidentPenalty);
+  }
+
+  private calculateSlope(values: number[]): number {
+    if (values.length < 2) {
+      return 0;
+    }
+
+    let slope = 0;
+    for (let i = 1; i < values.length; i++) {
+      slope += values[i] - values[i - 1];
+    }
+    return slope / (values.length - 1);
+  }
+
+  private average(values: number[]): number {
+    if (values.length === 0) {
+      return 0;
+    }
+    return values.reduce((sum, value) => sum + value, 0) / values.length;
+  }
+}

--- a/src/maestro/v6/rollback/IntelligentRollbackSystem.ts
+++ b/src/maestro/v6/rollback/IntelligentRollbackSystem.ts
@@ -155,6 +155,11 @@ export class IntelligentRollbackSystem extends EventEmitter {
     try {
       // Create state snapshot before deployment
       const stateSnapshot = await this.stateManager.createSnapshot(deploymentId, config.services);
+      this.logger.debug(`Captured pre-deployment snapshot for ${deploymentId}`, {
+        snapshotId: stateSnapshot.id,
+        checksum: stateSnapshot.checksum,
+        services: stateSnapshot.services.length
+      });
 
       // Register with health monitor
       await this.healthMonitor.startMonitoring(deploymentId, config.services);

--- a/src/maestro/v6/rollback/ProgressiveRollbackManager.ts
+++ b/src/maestro/v6/rollback/ProgressiveRollbackManager.ts
@@ -1,0 +1,220 @@
+import { EventEmitter } from 'events';
+import { Logger } from '../../utils/logger';
+import type { RollbackExecution, RollbackStep } from './IntelligentRollbackSystem';
+import { StateManager, RecoveryPlan, RecoveryPlanStep, ServiceTier } from './StateManager';
+
+interface ActiveRollback {
+  cancelled: boolean;
+}
+
+export class ProgressiveRollbackManager extends EventEmitter {
+  private logger: Logger;
+  private stateManager: StateManager;
+  private activeRollbacks: Map<string, ActiveRollback> = new Map();
+
+  constructor(logger: Logger, stateManager: StateManager) {
+    super();
+    this.logger = logger;
+    this.stateManager = stateManager;
+  }
+
+  async initialize(): Promise<void> {
+    this.logger.info('ProgressiveRollbackManager initialized');
+  }
+
+  async executeProgressiveRollback(execution: RollbackExecution): Promise<void> {
+    const plan = await this.ensureRecoveryPlan(execution.deploymentId);
+    const rollbackState = { cancelled: false };
+    this.activeRollbacks.set(execution.id, rollbackState);
+
+    execution.steps = plan.steps.map(step => ({
+      id: step.id,
+      name: step.name,
+      status: 'pending'
+    }));
+
+    for (let index = 0; index < plan.steps.length; index++) {
+      await this.executePlanStep(execution, plan, plan.steps[index], execution.steps[index]);
+      execution.progress = Math.round(((index + 1) / plan.steps.length) * 100);
+    }
+
+    execution.recoveredServices = Array.from(new Set([
+      ...execution.recoveredServices,
+      ...this.stateManager.getServicesByTier(execution.deploymentId, 'all')
+        .filter(service => service.status === 'running')
+        .map(service => service.serviceId)
+    ]));
+
+    this.activeRollbacks.delete(execution.id);
+    this.logger.info(`Progressive rollback completed for ${execution.deploymentId}`, {
+      executionId: execution.id
+    });
+  }
+
+  async executeTrafficShift(execution: RollbackExecution): Promise<void> {
+    const rollbackState = { cancelled: false };
+    this.activeRollbacks.set(execution.id, rollbackState);
+
+    const shiftSteps: RollbackStep[] = [
+      { id: 'shift-75', name: 'Shift 75% traffic to stable release', status: 'pending' },
+      { id: 'shift-50', name: 'Shift 50% traffic to stable release', status: 'pending' },
+      { id: 'shift-0', name: 'Drain traffic from unstable release', status: 'pending' },
+      { id: 'validate-shift', name: 'Validate traffic shift health', status: 'pending' }
+    ];
+
+    execution.steps = shiftSteps;
+
+    const stages = [75, 50, 0];
+    for (let index = 0; index < stages.length; index++) {
+      const step = shiftSteps[index];
+      await this.runShiftStage(execution, step, stages[index]);
+      execution.progress = Math.round(((index + 1) / shiftSteps.length) * 100);
+    }
+
+    const validationStep = shiftSteps[shiftSteps.length - 1];
+    validationStep.status = 'running';
+    validationStep.startTime = new Date();
+    await this.stateManager.markRecoveryStep(execution.deploymentId, 'validate-platform', 'in_progress');
+    const validation = await this.stateManager.validateRecovery(execution.deploymentId, ['all']);
+    validationStep.status = validation.healthy ? 'completed' : 'failed';
+    validationStep.endTime = new Date();
+    validationStep.duration = validationStep.endTime.getTime() - validationStep.startTime.getTime();
+    validationStep.output = validation.healthy ? 'Traffic shift validated successfully' : validation.issues.join(', ');
+
+    if (!validation.healthy) {
+      throw new Error(`Traffic shift validation failed: ${validation.issues.join(', ')}`);
+    }
+
+    execution.progress = 100;
+    this.activeRollbacks.delete(execution.id);
+    this.emit('trafficShiftCompleted', { execution });
+  }
+
+  async cancelRollback(executionId: string): Promise<void> {
+    const rollback = this.activeRollbacks.get(executionId);
+    if (rollback) {
+      rollback.cancelled = true;
+      this.logger.warn(`Cancellation requested for rollback ${executionId}`);
+    }
+  }
+
+  private async ensureRecoveryPlan(deploymentId: string): Promise<RecoveryPlan> {
+    let plan = await this.stateManager.getRecoveryPlan(deploymentId);
+    if (!plan || plan.steps.length === 0) {
+      plan = await this.stateManager.regenerateRecoveryPlan(deploymentId);
+    }
+    return plan;
+  }
+
+  private async executePlanStep(
+    execution: RollbackExecution,
+    plan: RecoveryPlan,
+    planStep: RecoveryPlanStep,
+    rollbackStep: RollbackStep
+  ): Promise<void> {
+    const rollbackState = this.activeRollbacks.get(execution.id);
+    if (!rollbackState) {
+      throw new Error(`Rollback ${execution.id} not registered`);
+    }
+
+    if (rollbackState.cancelled) {
+      rollbackStep.status = 'failed';
+      throw new Error(`Rollback ${execution.id} cancelled`);
+    }
+
+    rollbackStep.status = 'running';
+    rollbackStep.startTime = new Date();
+    await this.stateManager.markRecoveryStep(execution.deploymentId, planStep.id, 'in_progress');
+
+    try {
+      switch (planStep.action) {
+        case 'traffic_shift':
+          await this.handleTrafficShiftAction(execution, planStep.tier);
+          rollbackStep.output = `Traffic shifted for tier ${planStep.tier}`;
+          break;
+        case 'restore':
+          const restored = await this.stateManager.restoreServiceTier(execution.deploymentId, planStep.tier);
+          execution.recoveredServices.push(...restored);
+          rollbackStep.output = `Restored services: ${restored.join(', ')}`;
+          break;
+        case 'restart':
+          const restarted = await this.restartTier(execution.deploymentId, planStep.tier);
+          rollbackStep.output = `Restarted services: ${restarted.map(service => service.serviceId).join(', ')}`;
+          break;
+        case 'validate':
+          const validation = await this.stateManager.validateRecovery(execution.deploymentId, [planStep.tier]);
+          rollbackStep.output = validation.healthy ? 'Validation passed' : validation.issues.join(', ');
+          if (!validation.healthy) {
+            throw new Error(`Validation failed: ${validation.issues.join(', ')}`);
+          }
+          break;
+        default:
+          rollbackStep.output = 'No action performed';
+      }
+
+      rollbackStep.status = 'completed';
+      rollbackStep.endTime = new Date();
+      rollbackStep.duration = rollbackStep.endTime.getTime() - rollbackStep.startTime.getTime();
+      await this.stateManager.markRecoveryStep(execution.deploymentId, planStep.id, 'completed');
+      this.emit('progress', { executionId: execution.id, step: rollbackStep });
+    } catch (error) {
+      rollbackStep.status = 'failed';
+      rollbackStep.endTime = new Date();
+      rollbackStep.duration = rollbackStep.endTime.getTime() - rollbackStep.startTime.getTime();
+      rollbackStep.error = error instanceof Error ? error.message : String(error);
+      await this.stateManager.markRecoveryStep(execution.deploymentId, planStep.id, 'failed');
+      throw error;
+    }
+  }
+
+  private async handleTrafficShiftAction(execution: RollbackExecution, tier: ServiceTier | 'all'): Promise<void> {
+    if (tier === 'canary') {
+      await this.stateManager.reduceTraffic(execution.deploymentId, 5, 'Drain canary traffic prior to restoration');
+    } else {
+      await this.stateManager.reduceTraffic(execution.deploymentId, 0, 'Shift all traffic back to stable release');
+    }
+  }
+
+  private async restartTier(deploymentId: string, tier: ServiceTier | 'all') {
+    const services = this.stateManager.getServicesByTier(deploymentId, tier);
+    const serviceIds = services.map(service => service.serviceId);
+    return this.stateManager.restartServices(deploymentId, serviceIds);
+  }
+
+  private async runShiftStage(execution: RollbackExecution, step: RollbackStep, percentage: number): Promise<void> {
+    const rollbackState = this.activeRollbacks.get(execution.id);
+    if (!rollbackState) {
+      throw new Error(`Rollback ${execution.id} not registered`);
+    }
+
+    if (rollbackState.cancelled) {
+      step.status = 'failed';
+      throw new Error(`Rollback ${execution.id} cancelled`);
+    }
+
+    step.status = 'running';
+    step.startTime = new Date();
+
+    await this.stateManager.reduceTraffic(
+      execution.deploymentId,
+      percentage,
+      `Traffic shift stage targeting ${percentage}% canary load`
+    );
+
+    // Allow services to stabilize by validating after each shift
+    const validation = await this.stateManager.validateRecovery(execution.deploymentId, ['all']);
+    if (!validation.healthy) {
+      step.status = 'failed';
+      step.endTime = new Date();
+      step.duration = step.endTime.getTime() - step.startTime.getTime();
+      step.error = validation.issues.join(', ');
+      throw new Error(`Traffic shift validation failed: ${validation.issues.join(', ')}`);
+    }
+
+    step.status = 'completed';
+    step.endTime = new Date();
+    step.duration = step.endTime.getTime() - step.startTime.getTime();
+    step.output = `Traffic reduced to ${percentage}% canary load`;
+    this.emit('progress', { executionId: execution.id, step });
+  }
+}

--- a/src/maestro/v6/rollback/RollbackDecisionEngine.ts
+++ b/src/maestro/v6/rollback/RollbackDecisionEngine.ts
@@ -1,0 +1,268 @@
+import { Logger } from '../../utils/logger';
+import { MetricsCollector } from '../../observability/MetricsCollector';
+import type { RollbackTrigger, RollbackDecision, RollbackImpact } from './IntelligentRollbackSystem';
+import type { DeploymentHealthMetrics } from './HealthMonitor';
+
+interface TriggerEvaluation {
+  trigger: RollbackTrigger;
+  reason: string;
+}
+
+interface BaselineMetrics {
+  error_rate: number;
+  success_rate: number;
+  avg_latency: number;
+  memory_usage: number;
+  saturation: number;
+}
+
+interface DeploymentContext {
+  deploymentId: string;
+  environment: string;
+  services: string[];
+  defaultStrategy?: string;
+  baseline: BaselineMetrics;
+  decisionHistory: Array<{ timestamp: Date; decision: string; confidence: number }>;
+  lastUpdated: Date;
+}
+
+const SEVERITY_WEIGHTS: Record<RollbackTrigger['severity'], number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+  critical: 5
+};
+
+export class RollbackDecisionEngine {
+  private logger: Logger;
+  private metrics?: MetricsCollector;
+  private contexts: Map<string, DeploymentContext> = new Map();
+
+  constructor(logger: Logger, metricsCollector?: MetricsCollector) {
+    this.logger = logger;
+    this.metrics = metricsCollector;
+  }
+
+  async initialize(): Promise<void> {
+    this.logger.info('RollbackDecisionEngine initialized');
+  }
+
+  async registerDeployment(
+    deploymentId: string,
+    config: {
+      services: string[];
+      environment: string;
+      rollbackStrategy?: string;
+    }
+  ): Promise<void> {
+    const context: DeploymentContext = {
+      deploymentId,
+      environment: config.environment,
+      services: config.services,
+      defaultStrategy: config.rollbackStrategy,
+      baseline: {
+        error_rate: 0.01,
+        success_rate: 0.99,
+        avg_latency: 300,
+        memory_usage: 0.55,
+        saturation: 0.45
+      },
+      decisionHistory: [],
+      lastUpdated: new Date()
+    };
+
+    this.contexts.set(deploymentId, context);
+    this.logger.info(`Registered deployment ${deploymentId} with rollback decision engine`, {
+      environment: config.environment,
+      services: config.services,
+      defaultStrategy: config.rollbackStrategy
+    });
+  }
+
+  async makeDecision(
+    deploymentId: string,
+    triggeredConditions: TriggerEvaluation[],
+    healthMetrics: DeploymentHealthMetrics
+  ): Promise<RollbackDecision> {
+    const context = this.contexts.get(deploymentId);
+    if (!context) {
+      throw new Error(`Deployment ${deploymentId} has not been registered with the decision engine`);
+    }
+
+    const severityScore = this.calculateSeverityScore(triggeredConditions);
+    const driftScore = this.calculateMetricDrift(context, healthMetrics);
+    const combinedScore = severityScore + driftScore;
+
+    let decisionType: RollbackDecision['decision'];
+    if (combinedScore >= 5 || healthMetrics.status === 'critical') {
+      decisionType = 'rollback';
+    } else if (combinedScore <= 1 && healthMetrics.status === 'healthy') {
+      decisionType = 'continue';
+    } else {
+      decisionType = 'hold';
+    }
+
+    const strategy = this.determineStrategy(
+      context,
+      healthMetrics,
+      triggeredConditions,
+      decisionType
+    );
+
+    const confidence = this.calculateConfidence(severityScore, driftScore, triggeredConditions.length);
+    const reasons = triggeredConditions.map(condition => `${condition.trigger.name}: ${condition.reason}`);
+
+    if (driftScore > 0.5) {
+      reasons.push(`Operational drift detected: score ${driftScore.toFixed(2)}`);
+    }
+
+    const impact = this.estimateImpact(context, healthMetrics, triggeredConditions, strategy);
+
+    const decision: RollbackDecision = {
+      deploymentId,
+      decision: decisionType,
+      strategy,
+      confidence,
+      reasons,
+      triggeredBy: triggeredConditions.map(condition => condition.trigger.id),
+      estimatedImpact: impact,
+      timestamp: new Date()
+    };
+
+    context.decisionHistory.push({
+      timestamp: decision.timestamp,
+      decision: decision.decision,
+      confidence: decision.confidence
+    });
+    if (context.decisionHistory.length > 25) {
+      context.decisionHistory.shift();
+    }
+    context.lastUpdated = new Date();
+
+    this.metrics?.incrementCounter?.('maestro.rollback.decisions', {
+      decision: decision.decision,
+      strategy: decision.strategy,
+      environment: context.environment
+    });
+    this.metrics?.recordGauge?.('maestro.rollback.confidence', decision.confidence, {
+      deploymentId,
+      strategy: decision.strategy
+    });
+    this.metrics?.recordHistogram?.('maestro.rollback.severity_score', severityScore, {
+      deploymentId
+    });
+
+    this.logger.info(`Decision engine output for ${deploymentId}`, {
+      decision: decision.decision,
+      strategy: decision.strategy,
+      confidence: decision.confidence,
+      reasons: decision.reasons
+    });
+
+    return decision;
+  }
+
+  private calculateSeverityScore(triggeredConditions: TriggerEvaluation[]): number {
+    if (triggeredConditions.length === 0) {
+      return 0;
+    }
+
+    return triggeredConditions.reduce((score, evaluation) => {
+      return score + (SEVERITY_WEIGHTS[evaluation.trigger.severity] || 1);
+    }, 0);
+  }
+
+  private calculateMetricDrift(context: DeploymentContext, health: DeploymentHealthMetrics): number {
+    const drift = {
+      error: Math.max(0, (health.error_rate - context.baseline.error_rate) / context.baseline.error_rate),
+      latency: Math.max(0, (health.avg_latency - context.baseline.avg_latency) / context.baseline.avg_latency),
+      saturation: Math.max(0, (health.saturation - context.baseline.saturation) / context.baseline.saturation),
+      availability: Math.max(0, (context.baseline.success_rate - health.success_rate) / context.baseline.success_rate)
+    };
+
+    const weighted = (drift.error * 0.35) + (drift.latency * 0.25) + (drift.saturation * 0.2) + (drift.availability * 0.2);
+    return Math.min(5, weighted * 5);
+  }
+
+  private determineStrategy(
+    context: DeploymentContext,
+    health: DeploymentHealthMetrics,
+    triggeredConditions: TriggerEvaluation[],
+    decision: RollbackDecision['decision']
+  ): RollbackDecision['strategy'] {
+    if (decision !== 'rollback') {
+      return context.defaultStrategy || 'progressive';
+    }
+
+    const hasCritical = triggeredConditions.some(condition => condition.trigger.severity === 'critical');
+    if (hasCritical || health.status === 'critical' || health.memory_usage > 0.9) {
+      return 'immediate';
+    }
+
+    const latencyTrigger = triggeredConditions.find(condition =>
+      condition.trigger.condition.metric === 'avg_latency' ||
+      condition.trigger.condition.metric === 'saturation'
+    );
+    if (latencyTrigger) {
+      return 'traffic_shift';
+    }
+
+    const serviceMetrics = health.serviceMetrics || [];
+    const canaryIssues = serviceMetrics.filter(metric => metric.tier === 'canary' && metric.status !== 'healthy');
+    const primaryIssues = serviceMetrics.filter(metric => metric.tier === 'primary' && metric.status !== 'healthy');
+
+    if (canaryIssues.length > 0 && primaryIssues.length === 0) {
+      return 'canary_only';
+    }
+
+    return 'progressive';
+  }
+
+  private calculateConfidence(severity: number, drift: number, triggeredCount: number): number {
+    const normalizedSeverity = Math.min(1, severity / 6);
+    const normalizedDrift = Math.min(1, drift / 4);
+    const signalConfidence = Math.min(1, triggeredCount * 0.15);
+
+    const confidence = 0.3 + (normalizedSeverity * 0.35) + (normalizedDrift * 0.25) + (signalConfidence * 0.1);
+    return Number(Math.min(1, confidence).toFixed(2));
+  }
+
+  private estimateImpact(
+    context: DeploymentContext,
+    health: DeploymentHealthMetrics,
+    triggeredConditions: TriggerEvaluation[],
+    strategy: RollbackDecision['strategy']
+  ): RollbackImpact {
+    const impactedServices = new Set<string>();
+    (health.serviceMetrics || []).forEach(metric => {
+      if (metric.status !== 'healthy') {
+        impactedServices.add(metric.serviceId);
+      }
+    });
+
+    if (impactedServices.size === 0) {
+      context.services.forEach(service => impactedServices.add(service));
+    }
+
+    const severityWeight = triggeredConditions.reduce((total, evaluation) => total + (SEVERITY_WEIGHTS[evaluation.trigger.severity] || 1), 0);
+    const estimatedDowntime = strategy === 'immediate' ? 180 : strategy === 'progressive' ? 600 : 240;
+    const userImpact = Math.min(100, Math.round((health.error_rate * 120) + ((1 - health.success_rate) * 100)));
+
+    let dataLoss: RollbackImpact['dataLoss'] = 'none';
+    if (health.memory_usage > 0.95 || severityWeight >= 8) {
+      dataLoss = 'moderate';
+    } else if (health.memory_usage > 0.9) {
+      dataLoss = 'minimal';
+    }
+
+    const complexity = impactedServices.size > Math.ceil(context.services.length / 2) ? 'high' : impactedServices.size > 2 ? 'medium' : 'low';
+
+    return {
+      affectedServices: Array.from(impactedServices),
+      estimatedDowntime,
+      userImpact,
+      dataLoss,
+      rollbackComplexity: complexity
+    };
+  }
+}

--- a/src/maestro/v6/rollback/StateManager.ts
+++ b/src/maestro/v6/rollback/StateManager.ts
@@ -1,0 +1,541 @@
+import { EventEmitter } from 'events';
+import { createHash } from 'crypto';
+import { Logger } from '../../utils/logger';
+
+export type ServiceTier = 'canary' | 'primary' | 'standby';
+
+export interface ServiceState {
+  serviceId: string;
+  version: string;
+  status: 'running' | 'stopped' | 'degraded';
+  tier: ServiceTier;
+  replicas: number;
+  configHash: string;
+  lastUpdated: Date;
+  metadata: Record<string, any>;
+}
+
+export interface TrafficPolicy {
+  mode: 'normal' | 'stopped' | 'canary' | 'shift';
+  canaryPercentage: number;
+  primaryPercentage: number;
+  notes?: string;
+}
+
+export interface DeploymentSnapshot {
+  id: string;
+  deploymentId: string;
+  createdAt: Date;
+  createdBy: string;
+  reason: string;
+  checksum: string;
+  services: ServiceState[];
+  trafficPolicy: TrafficPolicy;
+  metadata: Record<string, any>;
+}
+
+export interface RecoveryPlanStep {
+  id: string;
+  name: string;
+  description: string;
+  tier: ServiceTier | 'all';
+  action: 'traffic_shift' | 'restore' | 'restart' | 'validate';
+  status: 'pending' | 'in_progress' | 'completed' | 'failed';
+  dependencies: string[];
+}
+
+export interface RecoveryPlan {
+  deploymentId: string;
+  snapshotId: string;
+  createdAt: Date;
+  steps: RecoveryPlanStep[];
+  lastUpdated: Date;
+}
+
+export interface RecoveryValidation {
+  healthy: boolean;
+  failingServices: string[];
+  issues: string[];
+}
+
+interface RecoveryActionLog {
+  id: string;
+  action: string;
+  timestamp: Date;
+  status: 'success' | 'failed';
+  details?: Record<string, any>;
+}
+
+interface DeploymentRuntimeState {
+  deploymentId: string;
+  services: Map<string, ServiceState>;
+  snapshots: DeploymentSnapshot[];
+  trafficPolicy: TrafficPolicy;
+  recoveryPlan?: RecoveryPlan;
+  recoveryLog: RecoveryActionLog[];
+  createdAt: Date;
+}
+
+const SNAPSHOT_HISTORY_LIMIT = 10;
+
+export class StateManager extends EventEmitter {
+  private logger: Logger;
+  private deployments: Map<string, DeploymentRuntimeState> = new Map();
+
+  constructor(logger: Logger) {
+    super();
+    this.logger = logger;
+  }
+
+  async initialize(): Promise<void> {
+    this.logger.info('StateManager initialized for Maestro Conductor rollback safeguards');
+  }
+
+  async createSnapshot(deploymentId: string, services: string[]): Promise<DeploymentSnapshot> {
+    const state = this.ensureDeployment(deploymentId, services);
+    const snapshotServices = Array.from(state.services.values()).map(service => ({
+      ...service,
+      lastUpdated: new Date(service.lastUpdated)
+    }));
+
+    const snapshot: DeploymentSnapshot = {
+      id: `${deploymentId}-snapshot-${Date.now()}`,
+      deploymentId,
+      createdAt: new Date(),
+      createdBy: 'rollback-system',
+      reason: 'Pre-deployment safety snapshot',
+      checksum: this.calculateChecksum(snapshotServices, state.trafficPolicy),
+      services: snapshotServices,
+      trafficPolicy: { ...state.trafficPolicy },
+      metadata: {
+        serviceCount: snapshotServices.length,
+        replicas: snapshotServices.reduce((sum, service) => sum + service.replicas, 0)
+      }
+    };
+
+    state.snapshots.push(snapshot);
+    if (state.snapshots.length > SNAPSHOT_HISTORY_LIMIT) {
+      state.snapshots.shift();
+    }
+
+    state.recoveryPlan = this.buildRecoveryPlan(snapshot);
+    state.recoveryLog.push({
+      id: `${snapshot.id}-recorded`,
+      action: 'snapshot_created',
+      timestamp: new Date(),
+      status: 'success',
+      details: { checksum: snapshot.checksum }
+    });
+
+    this.emit('snapshotCreated', snapshot);
+    this.logger.info(`Created deployment snapshot ${snapshot.id}`, {
+      deploymentId,
+      checksum: snapshot.checksum,
+      services: snapshot.services.length
+    });
+
+    return snapshot;
+  }
+
+  async getSnapshot(deploymentId: string): Promise<DeploymentSnapshot | null> {
+    const state = this.deployments.get(deploymentId);
+    if (!state || state.snapshots.length === 0) {
+      return null;
+    }
+
+    return state.snapshots[state.snapshots.length - 1];
+  }
+
+  async listSnapshots(deploymentId: string): Promise<DeploymentSnapshot[]> {
+    const state = this.deployments.get(deploymentId);
+    if (!state) {
+      return [];
+    }
+    return [...state.snapshots];
+  }
+
+  async getRecoveryPlan(deploymentId: string): Promise<RecoveryPlan | null> {
+    const state = this.deployments.get(deploymentId);
+    return state?.recoveryPlan || null;
+  }
+
+  async regenerateRecoveryPlan(deploymentId: string): Promise<RecoveryPlan> {
+    const state = this.deployments.get(deploymentId);
+    if (!state) {
+      throw new Error(`Deployment ${deploymentId} has no tracked state`);
+    }
+
+    const snapshot = await this.getSnapshot(deploymentId);
+    if (!snapshot) {
+      throw new Error(`No snapshot available for deployment ${deploymentId}`);
+    }
+
+    state.recoveryPlan = this.buildRecoveryPlan(snapshot);
+    state.recoveryPlan.lastUpdated = new Date();
+    this.emit('recoveryPlanRegenerated', {
+      deploymentId,
+      snapshotId: snapshot.id
+    });
+
+    return state.recoveryPlan;
+  }
+
+  async restoreState(deploymentId: string): Promise<void> {
+    const state = this.deployments.get(deploymentId);
+    if (!state) {
+      throw new Error(`Deployment ${deploymentId} has no tracked state`);
+    }
+
+    const snapshot = await this.getSnapshot(deploymentId);
+    if (!snapshot) {
+      throw new Error(`No snapshot available for deployment ${deploymentId}`);
+    }
+
+    for (const service of snapshot.services) {
+      state.services.set(service.serviceId, {
+        ...service,
+        lastUpdated: new Date()
+      });
+    }
+
+    state.trafficPolicy = { ...snapshot.trafficPolicy };
+    this.recordAction(state, 'restore_state', 'success', { snapshotId: snapshot.id });
+    this.emit('stateRestored', { deploymentId, snapshotId: snapshot.id });
+
+    this.logger.info(`Restored deployment ${deploymentId} from snapshot`, {
+      snapshotId: snapshot.id,
+      checksum: snapshot.checksum
+    });
+  }
+
+  async restoreServiceTier(deploymentId: string, tier: ServiceTier | 'all'): Promise<string[]> {
+    const state = this.deployments.get(deploymentId);
+    if (!state) {
+      throw new Error(`Deployment ${deploymentId} has no tracked state`);
+    }
+
+    const snapshot = await this.getSnapshot(deploymentId);
+    if (!snapshot) {
+      throw new Error(`No snapshot available for deployment ${deploymentId}`);
+    }
+
+    const targetServices = snapshot.services.filter(service => tier === 'all' ? true : service.tier === tier);
+    const restored: string[] = [];
+
+    for (const service of targetServices) {
+      state.services.set(service.serviceId, {
+        ...service,
+        lastUpdated: new Date()
+      });
+      restored.push(service.serviceId);
+    }
+
+    this.recordAction(state, 'restore_service_tier', 'success', { tier, restored });
+    this.emit('serviceTierRestored', { deploymentId, tier, restored });
+
+    return restored;
+  }
+
+  async rollbackCanaryInstances(deploymentId: string): Promise<ServiceState[]> {
+    const state = this.deployments.get(deploymentId);
+    if (!state) {
+      throw new Error(`Deployment ${deploymentId} has no tracked state`);
+    }
+
+    const restored = await this.restoreServiceTier(deploymentId, 'canary');
+    this.logger.warn(`Rolled back canary instances for ${deploymentId}`, { services: restored });
+
+    return restored.map(serviceId => state.services.get(serviceId)!) ;
+  }
+
+  async restartServices(deploymentId: string, services?: string[]): Promise<ServiceState[]> {
+    const state = this.deployments.get(deploymentId);
+    if (!state) {
+      throw new Error(`Deployment ${deploymentId} has no tracked state`);
+    }
+
+    const targetServices = services && services.length > 0 ? services : Array.from(state.services.keys());
+    const restarted: ServiceState[] = [];
+
+    for (const serviceId of targetServices) {
+      const service = state.services.get(serviceId);
+      if (!service) continue;
+
+      const updated: ServiceState = {
+        ...service,
+        status: 'running',
+        lastUpdated: new Date(),
+        metadata: {
+          ...service.metadata,
+          restartedAt: new Date().toISOString()
+        }
+      };
+
+      state.services.set(serviceId, updated);
+      restarted.push(updated);
+    }
+
+    this.recordAction(state, 'restart_services', 'success', { services: targetServices });
+    this.emit('servicesRestarted', { deploymentId, services: targetServices });
+
+    return restarted;
+  }
+
+  async stopTraffic(deploymentId: string): Promise<void> {
+    const state = this.deployments.get(deploymentId);
+    if (!state) {
+      throw new Error(`Deployment ${deploymentId} has no tracked state`);
+    }
+
+    state.trafficPolicy = {
+      mode: 'stopped',
+      canaryPercentage: 0,
+      primaryPercentage: 0,
+      notes: 'Traffic halted for rollback'
+    };
+
+    this.recordAction(state, 'stop_traffic', 'success', {});
+    this.emit('trafficUpdated', { deploymentId, policy: state.trafficPolicy });
+  }
+
+  async resumeTraffic(deploymentId: string): Promise<void> {
+    const state = this.deployments.get(deploymentId);
+    if (!state) {
+      throw new Error(`Deployment ${deploymentId} has no tracked state`);
+    }
+
+    state.trafficPolicy = {
+      mode: 'normal',
+      canaryPercentage: 0,
+      primaryPercentage: 100,
+      notes: 'Traffic restored after rollback'
+    };
+
+    this.recordAction(state, 'resume_traffic', 'success', {});
+    this.emit('trafficUpdated', { deploymentId, policy: state.trafficPolicy });
+  }
+
+  async reduceTraffic(deploymentId: string, canaryPercentage: number, note?: string): Promise<void> {
+    const state = this.deployments.get(deploymentId);
+    if (!state) {
+      throw new Error(`Deployment ${deploymentId} has no tracked state`);
+    }
+
+    state.trafficPolicy = {
+      mode: 'shift',
+      canaryPercentage,
+      primaryPercentage: Math.max(0, 100 - canaryPercentage),
+      notes: note || 'Progressive rollback traffic shift'
+    };
+
+    this.recordAction(state, 'traffic_shift', 'success', { canaryPercentage });
+    this.emit('trafficUpdated', { deploymentId, policy: state.trafficPolicy });
+  }
+
+  async validateRecovery(deploymentId: string, tiers: (ServiceTier | 'all')[] = ['all']): Promise<RecoveryValidation> {
+    const state = this.deployments.get(deploymentId);
+    if (!state) {
+      throw new Error(`Deployment ${deploymentId} has no tracked state`);
+    }
+
+    const snapshot = await this.getSnapshot(deploymentId);
+    if (!snapshot) {
+      throw new Error(`No snapshot available for deployment ${deploymentId}`);
+    }
+
+    const failingServices: string[] = [];
+    const issues: string[] = [];
+
+    for (const tier of tiers) {
+      const services = Array.from(state.services.values()).filter(service => tier === 'all' ? true : service.tier === tier);
+      for (const service of services) {
+        if (service.status !== 'running') {
+          failingServices.push(service.serviceId);
+          issues.push(`${service.serviceId} in tier ${tier} not running`);
+        }
+
+        const baseline = snapshot.services.find(s => s.serviceId === service.serviceId);
+        if (baseline && baseline.version !== service.version) {
+          issues.push(`${service.serviceId} version mismatch: expected ${baseline.version}, found ${service.version}`);
+        }
+      }
+    }
+
+    const healthy = failingServices.length === 0 && issues.length === 0;
+
+    this.recordAction(state, 'validate_recovery', healthy ? 'success' : 'failed', {
+      tiers,
+      issues,
+      failingServices
+    });
+
+    return {
+      healthy,
+      failingServices,
+      issues
+    };
+  }
+
+  async markRecoveryStep(
+    deploymentId: string,
+    stepId: string,
+    status: 'pending' | 'in_progress' | 'completed' | 'failed'
+  ): Promise<void> {
+    const state = this.deployments.get(deploymentId);
+    if (!state || !state.recoveryPlan) {
+      return;
+    }
+
+    const step = state.recoveryPlan.steps.find(item => item.id === stepId);
+    if (!step) {
+      return;
+    }
+
+    step.status = status;
+    state.recoveryPlan.lastUpdated = new Date();
+    this.emit('recoveryStepUpdated', { deploymentId, stepId, status });
+  }
+
+  getServicesByTier(deploymentId: string, tier: ServiceTier | 'all'): ServiceState[] {
+    const state = this.deployments.get(deploymentId);
+    if (!state) {
+      return [];
+    }
+
+    const services = Array.from(state.services.values());
+    return tier === 'all' ? services : services.filter(service => service.tier === tier);
+  }
+
+  private ensureDeployment(deploymentId: string, services: string[]): DeploymentRuntimeState {
+    let state = this.deployments.get(deploymentId);
+    if (!state) {
+      state = {
+        deploymentId,
+        services: new Map(),
+        snapshots: [],
+        trafficPolicy: {
+          mode: 'normal',
+          canaryPercentage: 0,
+          primaryPercentage: 100
+        },
+        recoveryLog: [],
+        createdAt: new Date()
+      };
+      this.deployments.set(deploymentId, state);
+    }
+
+    for (let index = 0; index < services.length; index++) {
+      const serviceId = services[index];
+      if (!state.services.has(serviceId)) {
+        state.services.set(serviceId, this.createDefaultServiceState(serviceId, index === 0 ? 'canary' : 'primary'));
+      }
+    }
+
+    return state;
+  }
+
+  private createDefaultServiceState(serviceId: string, tier: ServiceTier): ServiceState {
+    return {
+      serviceId,
+      version: 'baseline',
+      status: 'running',
+      tier,
+      replicas: tier === 'canary' ? 1 : 3,
+      configHash: this.calculateConfigHash(serviceId, tier),
+      lastUpdated: new Date(),
+      metadata: {
+        createdFrom: 'default',
+        tier
+      }
+    };
+  }
+
+  private calculateChecksum(services: ServiceState[], trafficPolicy: TrafficPolicy): string {
+    const hash = createHash('sha256');
+    hash.update(JSON.stringify({ services, trafficPolicy }));
+    return hash.digest('hex');
+  }
+
+  private calculateConfigHash(serviceId: string, tier: ServiceTier): string {
+    const hash = createHash('md5');
+    hash.update(`${serviceId}:${tier}:${Date.now()}`);
+    return hash.digest('hex');
+  }
+
+  private buildRecoveryPlan(snapshot: DeploymentSnapshot): RecoveryPlan {
+    const steps: RecoveryPlanStep[] = [
+      {
+        id: 'drain-canary-traffic',
+        name: 'Drain canary traffic',
+        description: 'Shift traffic away from canary instances before restoration',
+        tier: 'canary',
+        action: 'traffic_shift',
+        status: 'pending',
+        dependencies: []
+      },
+      {
+        id: 'restore-canary',
+        name: 'Restore canary services',
+        description: 'Recover canary services using last known-good snapshot',
+        tier: 'canary',
+        action: 'restore',
+        status: 'pending',
+        dependencies: ['drain-canary-traffic']
+      },
+      {
+        id: 'validate-canary',
+        name: 'Validate canary health',
+        description: 'Verify canary services before expanding rollback',
+        tier: 'canary',
+        action: 'validate',
+        status: 'pending',
+        dependencies: ['restore-canary']
+      },
+      {
+        id: 'restore-primary',
+        name: 'Restore primary services',
+        description: 'Rollback remaining primary services',
+        tier: 'primary',
+        action: 'restore',
+        status: 'pending',
+        dependencies: ['validate-canary']
+      },
+      {
+        id: 'restart-primary',
+        name: 'Restart primary services',
+        description: 'Ensure all primary services are running on restored version',
+        tier: 'primary',
+        action: 'restart',
+        status: 'pending',
+        dependencies: ['restore-primary']
+      },
+      {
+        id: 'validate-platform',
+        name: 'Validate platform health',
+        description: 'Confirm overall system health before resuming traffic',
+        tier: 'all',
+        action: 'validate',
+        status: 'pending',
+        dependencies: ['restart-primary']
+      }
+    ];
+
+    return {
+      deploymentId: snapshot.deploymentId,
+      snapshotId: snapshot.id,
+      createdAt: new Date(),
+      steps,
+      lastUpdated: new Date()
+    };
+  }
+
+  private recordAction(state: DeploymentRuntimeState, action: string, status: 'success' | 'failed', details: Record<string, any>): void {
+    state.recoveryLog.push({
+      id: `${action}-${Date.now()}`,
+      action,
+      status,
+      timestamp: new Date(),
+      details
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated health monitor to surface MC deployment degradation signals and emit rollback events
- implement a state manager that captures deployment snapshots, builds recovery plans, and coordinates traffic controls
- provide progressive rollback orchestration plus a decision engine and hook snapshot logging into the rollback system

## Testing
- not run (not requested)
- **Note**: No automated tests have been run. Integration reviewers should ensure tests are run prior to production deployment.

------
https://chatgpt.com/codex/tasks/task_e_68e0b186d0748333bbd842e48480ffb2