### PR TITLE
feat: visualize MC execution progress timeline

### DIFF
--- a/ga-graphai/packages/common-types/src/index.ts
+++ b/ga-graphai/packages/common-types/src/index.ts
@@ -988,6 +988,21 @@ export interface WorkflowEstimates {
   criticalPath: string[];
 }
 
+export interface TimelineStatusCounts {
+  total: number;
+  completed: number;
+  succeeded: number;
+  skipped: number;
+  failed: number;
+  running: number;
+  queued: number;
+}
+
+export interface TimelineDelta {
+  nodeId: string;
+  status: NodeRunStatus;
+}
+
 export interface ObserverTimelineFrame {
   index: number;
   timestamp: string;
@@ -995,6 +1010,9 @@ export interface ObserverTimelineFrame {
   costUSD?: number;
   latencyMs?: number;
   criticalPath?: string[];
+  statusCounts: TimelineStatusCounts;
+  progressPercent: number;
+  delta?: TimelineDelta;
 }
 
 export interface ObserverTimeline {


### PR DESCRIPTION
## Summary
- augment observer timeline frames with per-status counts, deltas, and progress percentages for real-time MC execution tracking
- add dependency graph snapshot builder to surface node blocking, critical paths, and status-aware edges in the MC canvas
- extend canvas unit tests to cover progress metadata and dependency graph snapshots

## Testing
- npm test (ga-graphai/packages/common-types) *(fails: existing suite expects helper exports not present in repository)*
- npm test (ga-graphai/packages/web)

------
https://chatgpt.com/codex/tasks/task_e_68e0b16de3808333aba003cbe6148ae9