### PR TITLE
feat: add distributed configuration management service

### DIFF
--- a/docs/distributed-config-management.md
+++ b/docs/distributed-config-management.md
@@ -1,0 +1,87 @@
+# Distributed Configuration Management Service
+
+## Overview
+The distributed configuration management service introduces a production-ready control plane for managing runtime configuration across Summit services. The service focuses on safety-critical concerns including deterministic rollouts, auditability, rapid recovery, and seamless integrations with existing operational tooling.
+
+## Capabilities
+- **Versioned configuration history** with immutable audit records and commit metadata.
+- **Environment-specific overrides** that layer on top of baseline configuration values.
+- **Secret resolution** via pluggable resolvers (e.g., KeyVault) supporting nested secret references.
+- **Dynamic reload** support through watcher callbacks and event emitters that downstream services can subscribe to.
+- **Schema validation** using Zod to enforce contract safety before changes are persisted.
+- **A/B experimentation and canary rollouts** with deterministic hashing for traffic splitting.
+- **Feature flag integration** using the existing MVP feature infrastructure or a custom adapter.
+- **Drift detection and applied state tracking** to identify divergence between desired and actual runtime configuration.
+- **Rollback workflows** that promote any historical version while preserving metadata and auditing trail entries.
+
+## Architecture
+```
+┌────────────────────────────┐
+│  DistributedConfigService  │
+├──────────────┬─────────────┤
+│ Schema Guard │ Watchers    │
+├──────────────┼─────────────┤
+│ Secret Hook  │ FeatureFlag │
+├──────────────┴─────────────┤
+│ InMemoryConfigRepository   │
+└────────────────────────────┘
+```
+- **DistributedConfigService** orchestrates validation, versioning, rollout logic, and integrations.
+- **InMemoryConfigRepository** persists configuration histories, audit logs, and applied state. It is easily replaceable with a database-backed repository when available.
+- **Secret and feature-flag adapters** allow integration with KeyVaultService, LaunchDarkly, or existing Summit feature toggles.
+
+## Usage
+```ts
+import {
+  DistributedConfigService,
+  InMemoryConfigRepository,
+} from '../config/distributed';
+import { z } from 'zod';
+
+const schema = z.object({
+  endpoint: z.string().url(),
+  retries: z.number().int().min(0),
+});
+
+const repository = new InMemoryConfigRepository();
+const service = new DistributedConfigService(repository, {
+  secretResolver: {
+    resolve: async ({ provider, key }) => mySecretClient.read(provider, key),
+  },
+});
+
+service.registerSchema('notification-service', schema);
+await service.createOrUpdate('notification-service', {
+  config: { endpoint: 'https://api', retries: 3 },
+  metadata: { actor: 'deploy-bot', message: 'baseline' },
+  overrides: {
+    production: { retries: 5 },
+  },
+  canary: {
+    environment: 'production',
+    trafficPercent: 10,
+    config: { retries: 6 },
+    startAt: new Date(),
+  },
+});
+
+const { effectiveConfig } = await service.getConfig('notification-service', {
+  environment: 'production',
+  resolveSecrets: true,
+  assignmentValue: 0.05,
+});
+```
+
+## Testing Strategy
+New Jest integration tests cover the following scenarios:
+- Environment override layering and watcher notifications.
+- Secret resolution, AB testing, canary rollouts, and rollback flows.
+- Drift detection output and feature flag adapter hand-offs.
+
+Run the suite via `cd server && npm test -- distributed-config-service`.
+
+## Operational Guidance
+- Subscribe to the `config:updated` event emitter or register watchers to trigger hot reloads.
+- Call `recordApplied` after propagating configuration to capture applied checksums for drift comparison.
+- Use `detectDrift` during health checks to flag configuration divergence early.
+- Replace the in-memory repository with a persistence layer (e.g., Postgres) by implementing the `RepositoryWriter` interface.

--- a/server/src/config/distributed/__tests__/distributed-config-service.test.ts
+++ b/server/src/config/distributed/__tests__/distributed-config-service.test.ts
@@ -1,0 +1,211 @@
+import { z } from 'zod';
+import DistributedConfigService from '../distributed-config-service';
+import InMemoryConfigRepository from '../repository';
+import { FeatureFlagAdapter, SecretResolver } from '../types';
+
+describe('DistributedConfigService', () => {
+  const schema = z.object({
+    endpoint: z.string().url(),
+    retries: z.number().int().min(0),
+    features: z.object({
+      enableCaching: z.boolean(),
+      enableStreaming: z.boolean(),
+    }),
+    database: z.object({
+      host: z.string(),
+      password: z.union([
+        z.string(),
+        z.object({
+          __secretRef: z.object({
+            provider: z.string(),
+            key: z.string(),
+            path: z.string().optional(),
+          }),
+        }),
+      ]),
+    }),
+  });
+
+  const baseConfig = {
+    endpoint: 'https://api.example.com',
+    retries: 3,
+    features: {
+      enableCaching: true,
+      enableStreaming: false,
+    },
+    database: {
+      host: 'config-db',
+      password: {
+        __secretRef: { provider: 'vault', key: 'database/password' },
+      },
+    },
+  };
+
+  let repository: InMemoryConfigRepository<typeof baseConfig>;
+  let secretResolver: { resolve: jest.Mock };
+  let featureFlagAdapter: { updateFlags: jest.Mock };
+  let service: DistributedConfigService<typeof baseConfig>;
+
+  beforeEach(() => {
+    repository = new InMemoryConfigRepository(() => new Date('2024-01-01T00:00:00Z'));
+    secretResolver = {
+      resolve: jest.fn(async ({ provider, key }) => `${provider}:${key}:resolved`),
+    };
+    featureFlagAdapter = {
+      updateFlags: jest.fn(async () => undefined),
+    };
+
+    service = new DistributedConfigService(repository, {
+      secretResolver: secretResolver as unknown as SecretResolver,
+      featureFlagAdapter: featureFlagAdapter as unknown as FeatureFlagAdapter,
+      clock: () => new Date('2024-01-01T00:00:00Z'),
+    });
+    service.registerSchema('service-core', schema);
+  });
+
+  it('creates versions with overrides and resolves environment-specific config', async () => {
+    await service.createOrUpdate('service-core', {
+      config: baseConfig,
+      overrides: {
+        staging: {
+          endpoint: 'https://staging.example.com',
+          features: { enableStreaming: true },
+        },
+      },
+      metadata: { actor: 'alice' },
+    });
+
+    const resolved = await service.getConfig('service-core', { environment: 'staging' });
+    expect(resolved.version.metadata.version).toBe(1);
+    expect(resolved.effectiveConfig.endpoint).toBe('https://staging.example.com');
+    expect(resolved.effectiveConfig.features.enableStreaming).toBe(true);
+  });
+
+  it('supports dynamic watchers and audit trail entries', async () => {
+    const watcher = jest.fn();
+    service.registerWatcher('service-core', async ({ version }) => {
+      watcher(version.metadata.version);
+    });
+
+    await service.createOrUpdate('service-core', {
+      config: baseConfig,
+      metadata: { actor: 'bob', message: 'initial' },
+    });
+
+    expect(watcher).toHaveBeenCalledWith(1);
+    const audit = await service.getAuditTrail('service-core');
+    expect(audit).toHaveLength(1);
+    expect(audit[0]).toMatchObject({ actor: 'bob', message: 'initial' });
+  });
+
+  it('resolves secrets through the configured resolver', async () => {
+    await service.createOrUpdate('service-core', {
+      config: baseConfig,
+      metadata: { actor: 'carol' },
+    });
+
+    const resolved = await service.getConfig('service-core', {
+      environment: 'production',
+      resolveSecrets: true,
+    });
+
+    expect(secretResolver.resolve).toHaveBeenCalledWith({
+      provider: 'vault',
+      key: 'database/password',
+    });
+    expect(resolved.effectiveConfig.database.password).toBe('vault:database/password:resolved');
+  });
+
+  it('supports canary releases and deterministic assignment', async () => {
+    await service.createOrUpdate('service-core', {
+      config: baseConfig,
+      canary: {
+        environment: 'production',
+        trafficPercent: 50,
+        config: { features: { enableStreaming: true } },
+        startAt: new Date('2023-12-31T23:00:00Z'),
+      },
+      metadata: { actor: 'dan' },
+    });
+
+    const included = await service.getConfig('service-core', {
+      environment: 'production',
+      assignmentValue: 0.25,
+    });
+    expect(included.effectiveConfig.features.enableStreaming).toBe(true);
+
+    const excluded = await service.getConfig('service-core', {
+      environment: 'production',
+      assignmentValue: 0.75,
+    });
+    expect(excluded.effectiveConfig.features.enableStreaming).toBe(false);
+  });
+
+  it('selects AB test variants deterministically', async () => {
+    await service.createOrUpdate('service-core', {
+      config: baseConfig,
+      abTest: {
+        experimentId: 'streaming-toggle',
+        variants: [
+          { name: 'control', weight: 1, config: {} },
+          { name: 'variant', weight: 1, config: { features: { enableStreaming: true } } },
+        ],
+        startAt: new Date('2023-12-31T23:00:00Z'),
+      },
+      metadata: { actor: 'erin' },
+    });
+
+    const control = await service.getConfig('service-core', {
+      environment: 'production',
+      assignmentValue: 0.1,
+    });
+    expect(control.effectiveConfig.features.enableStreaming).toBe(false);
+
+    const variant = await service.getConfig('service-core', {
+      environment: 'production',
+      assignmentValue: 0.7,
+    });
+    expect(variant.effectiveConfig.features.enableStreaming).toBe(true);
+  });
+
+  it('supports rollback and feature flag synchronization', async () => {
+    await service.createOrUpdate('service-core', {
+      config: baseConfig,
+      metadata: { actor: 'frank' },
+    });
+    await service.createOrUpdate('service-core', {
+      config: { ...baseConfig, retries: 5 },
+      metadata: { actor: 'frank', message: 'increase retries' },
+      featureFlags: { STREAMING_BETA: true },
+    });
+
+    expect(featureFlagAdapter.updateFlags).toHaveBeenCalledWith({ STREAMING_BETA: true });
+
+    const rolledBack = await service.rollback('service-core', 1, 'grace', 'revert retries');
+    expect(rolledBack.metadata.version).toBe(3);
+
+    const resolved = await service.getConfig('service-core');
+    expect(resolved.effectiveConfig.retries).toBe(3);
+  });
+
+  it('detects configuration drift with detailed deltas', async () => {
+    await service.createOrUpdate('service-core', {
+      config: baseConfig,
+      metadata: { actor: 'henry' },
+    });
+
+    const drift = await service.detectDrift('service-core', 'production', {
+      ...baseConfig,
+      retries: 4,
+      database: { ...baseConfig.database, host: 'drifted' },
+    });
+
+    expect(drift.driftDetected).toBe(true);
+    expect(drift.deltas).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: 'retries' }),
+        expect.objectContaining({ path: 'database.host' }),
+      ]),
+    );
+  });
+});

--- a/server/src/config/distributed/distributed-config-service.ts
+++ b/server/src/config/distributed/distributed-config-service.ts
@@ -1,0 +1,443 @@
+import { createHash } from 'crypto';
+import { EventEmitter } from 'events';
+import { z } from 'zod';
+import { updateFeatureFlags } from '../mvp1-features';
+import {
+  ABTestConfig,
+  ABTestVariant,
+  AppliedState,
+  AuditEntry,
+  CanaryConfig,
+  ConfigSchema,
+  ConfigVersion,
+  ConfigWatcher,
+  DriftDelta,
+  DriftReport,
+  EnvironmentName,
+  FeatureFlagAdapter,
+  FeatureFlagBindings,
+  RepositoryWriter,
+  SecretReference,
+  SecretResolver,
+} from './types';
+
+const SECRET_REFERENCE_KEY = '__secretRef';
+
+interface CreateOrUpdateOptions<TConfig> {
+  config: TConfig;
+  overrides?: Partial<Record<EnvironmentName, Partial<TConfig>>>;
+  metadata: {
+    actor: string;
+    message?: string;
+    source?: string;
+    commitId?: string;
+  };
+  abTest?: ABTestConfig<TConfig>;
+  canary?: CanaryConfig<TConfig>;
+  featureFlags?: FeatureFlagBindings;
+}
+
+interface GetConfigOptions {
+  environment?: EnvironmentName;
+  resolveSecrets?: boolean;
+  abTestVariant?: string;
+  actorId?: string;
+  requestId?: string;
+  assignmentValue?: number;
+}
+
+interface ResolvedConfig<TConfig> {
+  version: ConfigVersion<TConfig>;
+  effectiveConfig: TConfig;
+}
+
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function isSecretReference(value: unknown): value is { [SECRET_REFERENCE_KEY]: SecretReference } {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      SECRET_REFERENCE_KEY in (value as Record<string, unknown>) &&
+      typeof (value as Record<string, unknown>)[SECRET_REFERENCE_KEY] === 'object',
+  );
+}
+
+function deepMerge<TConfig>(base: TConfig, override?: Partial<TConfig>): TConfig {
+  if (!override) {
+    return base;
+  }
+  const result: any = Array.isArray(base) ? [...(base as any[])] : { ...base };
+  for (const [key, value] of Object.entries(override as Record<string, unknown>)) {
+    if (value === undefined) {
+      continue;
+    }
+    if (
+      value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      base &&
+      typeof (base as any)[key] === 'object' &&
+      !Array.isArray((base as any)[key])
+    ) {
+      result[key] = deepMerge((base as any)[key], value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result as TConfig;
+}
+
+function collectDiffs(expected: unknown, actual: unknown, path: string[] = []): DriftDelta[] {
+  if (JSON.stringify(expected) === JSON.stringify(actual)) {
+    return [];
+  }
+
+  if (typeof expected !== 'object' || expected === null || typeof actual !== 'object' || actual === null) {
+    return [
+      {
+        path: path.join('.') || 'root',
+        expected,
+        actual,
+      },
+    ];
+  }
+
+  const keys = new Set([
+    ...Object.keys(expected as Record<string, unknown>),
+    ...Object.keys(actual as Record<string, unknown>),
+  ]);
+  const deltas: DriftDelta[] = [];
+  for (const key of keys) {
+    deltas.push(...collectDiffs((expected as any)[key], (actual as any)[key], [...path, key]));
+  }
+  return deltas;
+}
+
+function selectVariant<TConfig>(
+  abTest: ABTestConfig<TConfig>,
+  identifier: string,
+  assignmentValue?: number,
+): ABTestVariant<TConfig> | undefined {
+  if (abTest.endAt && abTest.endAt.getTime() < Date.now()) {
+    return undefined;
+  }
+  const totalWeight = abTest.variants.reduce((sum, variant) => sum + variant.weight, 0);
+  if (totalWeight <= 0) {
+    return undefined;
+  }
+  const normalized = abTest.variants.map((variant) => ({
+    ...variant,
+    weight: variant.weight / totalWeight,
+  }));
+  const value =
+    assignmentValue !== undefined
+      ? assignmentValue
+      : parseInt(createHash('sha1').update(identifier).digest('hex').slice(0, 8), 16) / 0xffffffff;
+
+  let cumulative = 0;
+  for (const variant of normalized) {
+    cumulative += variant.weight;
+    if (value <= cumulative) {
+      return variant;
+    }
+  }
+  return normalized[normalized.length - 1];
+}
+
+export class DistributedConfigService<TConfig = Record<string, any>> {
+  private readonly schemas = new Map<string, ConfigSchema>();
+  private readonly watchers = new Map<string, Set<ConfigWatcher<TConfig>>>();
+  private readonly events = new EventEmitter();
+  private readonly clock: () => Date;
+
+  constructor(
+    private readonly repository: RepositoryWriter<TConfig>,
+    private readonly options: {
+      secretResolver?: SecretResolver;
+      featureFlagAdapter?: FeatureFlagAdapter;
+      clock?: () => Date;
+    } = {},
+  ) {
+    this.clock = options.clock ?? (() => new Date());
+  }
+
+  registerSchema(configId: string, schema: ConfigSchema): void {
+    this.schemas.set(configId, schema);
+  }
+
+  async createOrUpdate(configId: string, options: CreateOrUpdateOptions<TConfig>): Promise<ConfigVersion<TConfig>> {
+    const schema = this.schemas.get(configId);
+    if (schema) {
+      schema.parse(options.config);
+      if (options.overrides) {
+        for (const override of Object.values(options.overrides)) {
+          if (override) {
+            schema.partial().parse(override);
+          }
+        }
+      }
+      if (options.abTest) {
+        z
+          .object({
+            experimentId: z.string(),
+            variants: z.array(
+              z.object({
+                name: z.string(),
+                weight: z.number().positive(),
+                config: schema.partial(),
+              }),
+            ),
+            startAt: z.date(),
+            endAt: z.date().optional(),
+            targetingRules: z.record(z.any()).optional(),
+          })
+          .parse(options.abTest);
+      }
+      if (options.canary) {
+        z
+          .object({
+            environment: z.string(),
+            trafficPercent: z.number().min(0).max(100),
+            config: schema.partial(),
+            startAt: z.date(),
+            endAt: z.date().optional(),
+            guardRailMetrics: z.array(z.string()).optional(),
+          })
+          .parse(options.canary);
+      }
+    }
+
+    const latest = await this.repository.getLatestVersion(configId);
+    const nextVersionNumber = latest ? latest.metadata.version + 1 : 1;
+    const metadata = {
+      version: nextVersionNumber,
+      createdAt: this.clock(),
+      createdBy: options.metadata.actor,
+      message: options.metadata.message,
+      source: options.metadata.source,
+      commitId: options.metadata.commitId,
+    };
+
+    const payload: ConfigVersion<TConfig> = {
+      id: configId,
+      config: deepClone(options.config),
+      overrides: deepClone(options.overrides ?? {}),
+      metadata,
+      checksum: this.computeChecksum(options.config, options.overrides, options.abTest, options.canary),
+      abTest: options.abTest,
+      canary: options.canary,
+      featureFlags: options.featureFlags,
+    };
+
+    const auditEntry: AuditEntry = {
+      version: metadata.version,
+      actor: options.metadata.actor,
+      timestamp: metadata.createdAt,
+      message: options.metadata.message,
+      changes: this.computeChanges(latest?.config ?? {}, options.config),
+    };
+
+    await this.repository.saveVersion(configId, payload, auditEntry);
+
+    if (payload.featureFlags) {
+      await this.syncFeatureFlags(payload.featureFlags);
+    }
+
+    await this.notifyWatchers(configId, payload);
+    return payload;
+  }
+
+  async getConfig(configId: string, options: GetConfigOptions = {}): Promise<ResolvedConfig<TConfig>> {
+    const version = await this.repository.getLatestVersion(configId);
+    if (!version) {
+      throw new Error(`Config ${configId} not found`);
+    }
+
+    let effectiveConfig: TConfig = deepClone(version.config);
+
+    if (options.environment && version.overrides[options.environment]) {
+      effectiveConfig = deepMerge(effectiveConfig, version.overrides[options.environment]);
+    }
+
+    if (version.canary && this.isCanaryActive(version.canary, options.environment)) {
+      const sample = options.assignmentValue ?? this.hashAssignment(options.actorId ?? options.requestId);
+      if (sample <= version.canary.trafficPercent / 100) {
+        effectiveConfig = deepMerge(effectiveConfig, version.canary.config);
+      }
+    }
+
+    if (version.abTest && this.isABTestActive(version.abTest)) {
+      const identifier = options.actorId ?? options.requestId ?? 'anonymous';
+      const variant =
+        options.abTestVariant &&
+        version.abTest.variants.find((entry) => entry.name === options.abTestVariant)
+          ? version.abTest.variants.find((entry) => entry.name === options.abTestVariant)
+          : selectVariant(version.abTest, identifier, options.assignmentValue);
+      if (variant) {
+        effectiveConfig = deepMerge(effectiveConfig, variant.config as Partial<TConfig>);
+      }
+    }
+
+    if (options.resolveSecrets) {
+      effectiveConfig = await this.resolveSecrets(effectiveConfig);
+    }
+
+    return { version, effectiveConfig };
+  }
+
+  async rollback(configId: string, versionNumber: number, actor: string, message?: string): Promise<ConfigVersion<TConfig>> {
+    const target = await this.repository.getVersion(configId, versionNumber);
+    if (!target) {
+      throw new Error(`Version ${versionNumber} for ${configId} not found`);
+    }
+    return this.createOrUpdate(configId, {
+      config: target.config,
+      overrides: target.overrides,
+      metadata: { actor, message: message ?? `Rollback to ${versionNumber}` },
+      abTest: target.abTest,
+      canary: target.canary,
+      featureFlags: target.featureFlags,
+    });
+  }
+
+  async detectDrift(
+    configId: string,
+    environment: EnvironmentName,
+    actualConfig: TConfig,
+  ): Promise<DriftReport> {
+    const { version, effectiveConfig } = await this.getConfig(configId, { environment });
+    const deltas = collectDiffs(effectiveConfig, actualConfig);
+    return {
+      configId,
+      environment,
+      version: version.metadata.version,
+      driftDetected: deltas.length > 0,
+      deltas,
+      generatedAt: this.clock(),
+    };
+  }
+
+  async recordApplied(configId: string, environment: EnvironmentName): Promise<AppliedState> {
+    const version = await this.repository.getLatestVersion(configId);
+    if (!version) {
+      throw new Error(`Config ${configId} not found`);
+    }
+    const state: AppliedState = {
+      environment,
+      version: version.metadata.version,
+      checksum: version.checksum,
+      appliedAt: this.clock(),
+    };
+    await this.repository.recordAppliedState(configId, state);
+    return state;
+  }
+
+  async getAuditTrail(configId: string): Promise<AuditEntry[]> {
+    return this.repository.getAuditTrail(configId);
+  }
+
+  registerWatcher(configId: string, watcher: ConfigWatcher<TConfig>): () => void {
+    const watchers = this.watchers.get(configId) ?? new Set<ConfigWatcher<TConfig>>();
+    watchers.add(watcher);
+    this.watchers.set(configId, watchers);
+    return () => {
+      watchers.delete(watcher);
+      if (watchers.size === 0) {
+        this.watchers.delete(configId);
+      }
+    };
+  }
+
+  on(event: 'config:updated', listener: (payload: ConfigVersion<TConfig>) => void): void {
+    this.events.on(event, listener);
+  }
+
+  private async notifyWatchers(configId: string, version: ConfigVersion<TConfig>): Promise<void> {
+    const watchers = this.watchers.get(configId);
+    if (watchers) {
+      for (const watcher of watchers) {
+        await watcher({ configId, version });
+      }
+    }
+    this.events.emit('config:updated', version);
+  }
+
+  private computeChecksum(
+    config: TConfig,
+    overrides?: Partial<Record<EnvironmentName, Partial<TConfig>>>,
+    abTest?: ABTestConfig<TConfig>,
+    canary?: CanaryConfig<TConfig>,
+  ): string {
+    return createHash('sha256')
+      .update(JSON.stringify({ config, overrides, abTest, canary }))
+      .digest('hex');
+  }
+
+  private computeChanges(prevConfig: TConfig, nextConfig: TConfig): string[] {
+    const deltas = collectDiffs(prevConfig, nextConfig);
+    return deltas.map((delta) => delta.path);
+  }
+
+  private async resolveSecrets(config: TConfig): Promise<TConfig> {
+    if (!this.options.secretResolver) {
+      return config;
+    }
+    const traverse = async (value: any): Promise<any> => {
+      if (Array.isArray(value)) {
+        return Promise.all(value.map((item) => traverse(item)));
+      }
+      if (isSecretReference(value)) {
+        const resolved = await this.options.secretResolver!.resolve(
+          value[SECRET_REFERENCE_KEY] as SecretReference,
+        );
+        return resolved;
+      }
+      if (value && typeof value === 'object') {
+        const entries = await Promise.all(
+          Object.entries(value).map(async ([key, val]) => [key, await traverse(val)]),
+        );
+        return Object.fromEntries(entries);
+      }
+      return value;
+    };
+    return (await traverse(config)) as TConfig;
+  }
+
+  private hashAssignment(identifier?: string): number {
+    if (!identifier) {
+      return Math.random();
+    }
+    return parseInt(createHash('sha1').update(identifier).digest('hex').slice(0, 8), 16) / 0xffffffff;
+  }
+
+  private isCanaryActive(canary: CanaryConfig<TConfig>, environment?: EnvironmentName): boolean {
+    if (!environment || canary.environment !== environment) {
+      return false;
+    }
+    const now = this.clock().getTime();
+    if (canary.startAt.getTime() > now) {
+      return false;
+    }
+    if (canary.endAt && canary.endAt.getTime() < now) {
+      return false;
+    }
+    return canary.trafficPercent > 0;
+  }
+
+  private isABTestActive(abTest: ABTestConfig<TConfig>): boolean {
+    const now = this.clock().getTime();
+    return abTest.startAt.getTime() <= now && (!abTest.endAt || abTest.endAt.getTime() >= now);
+  }
+
+  private async syncFeatureFlags(flags: FeatureFlagBindings): Promise<void> {
+    if (this.options.featureFlagAdapter) {
+      await this.options.featureFlagAdapter.updateFlags(flags);
+    } else {
+      updateFeatureFlags(flags);
+    }
+  }
+}
+
+export default DistributedConfigService;

--- a/server/src/config/distributed/index.ts
+++ b/server/src/config/distributed/index.ts
@@ -1,0 +1,3 @@
+export { DistributedConfigService } from './distributed-config-service';
+export { InMemoryConfigRepository } from './repository';
+export * from './types';

--- a/server/src/config/distributed/repository.ts
+++ b/server/src/config/distributed/repository.ts
@@ -1,0 +1,78 @@
+import {
+  AppliedState,
+  AuditEntry,
+  ConfigVersion,
+  EnvironmentName,
+  RepositoryWriter,
+} from './types';
+
+interface ConfigHistory<TConfig> {
+  versions: ConfigVersion<TConfig>[];
+  audit: AuditEntry[];
+  applied: Map<EnvironmentName, AppliedState>;
+}
+
+export class InMemoryConfigRepository<TConfig = Record<string, any>> implements RepositoryWriter<TConfig> {
+  private histories = new Map<string, ConfigHistory<TConfig>>();
+
+  constructor(private readonly clock: () => Date = () => new Date()) {}
+
+  private ensureHistory(configId: string): ConfigHistory<TConfig> {
+    const history = this.histories.get(configId);
+    if (history) {
+      return history;
+    }
+    const created: ConfigHistory<TConfig> = {
+      versions: [],
+      audit: [],
+      applied: new Map(),
+    };
+    this.histories.set(configId, created);
+    return created;
+  }
+
+  async saveVersion(
+    configId: string,
+    version: ConfigVersion<TConfig>,
+    auditEntry: AuditEntry,
+  ): Promise<void> {
+    const history = this.ensureHistory(configId);
+    history.versions.push(version);
+    history.audit.push(auditEntry);
+  }
+
+  async getLatestVersion(configId: string): Promise<ConfigVersion<TConfig> | undefined> {
+    const history = this.histories.get(configId);
+    if (!history || history.versions.length === 0) {
+      return undefined;
+    }
+    return history.versions[history.versions.length - 1];
+  }
+
+  async getVersion(configId: string, versionNumber: number): Promise<ConfigVersion<TConfig> | undefined> {
+    const history = this.histories.get(configId);
+    return history?.versions.find((entry) => entry.metadata.version === versionNumber);
+  }
+
+  async listVersions(configId: string): Promise<ConfigVersion<TConfig>[]> {
+    const history = this.histories.get(configId);
+    return history ? [...history.versions] : [];
+  }
+
+  async recordAppliedState(configId: string, state: AppliedState): Promise<void> {
+    const history = this.ensureHistory(configId);
+    history.applied.set(state.environment, { ...state, appliedAt: state.appliedAt ?? this.clock() });
+  }
+
+  async getAppliedState(configId: string, environment: EnvironmentName): Promise<AppliedState | undefined> {
+    const history = this.histories.get(configId);
+    return history?.applied.get(environment);
+  }
+
+  async getAuditTrail(configId: string): Promise<AuditEntry[]> {
+    const history = this.histories.get(configId);
+    return history ? [...history.audit] : [];
+  }
+}
+
+export default InMemoryConfigRepository;

--- a/server/src/config/distributed/types.ts
+++ b/server/src/config/distributed/types.ts
@@ -1,0 +1,111 @@
+import { z } from 'zod';
+
+export type EnvironmentName = 'development' | 'staging' | 'qa' | 'production' | string;
+
+export interface SecretReference {
+  provider: string;
+  key: string;
+  path?: string;
+}
+
+export interface ConfigMetadata {
+  version: number;
+  createdAt: Date;
+  createdBy: string;
+  message?: string;
+  source?: string;
+  commitId?: string;
+}
+
+export interface AuditEntry {
+  version: number;
+  actor: string;
+  timestamp: Date;
+  message?: string;
+  changes?: string[];
+}
+
+export interface AppliedState {
+  environment: EnvironmentName;
+  version: number;
+  checksum: string;
+  appliedAt: Date;
+}
+
+export interface ABTestVariant<TConfig> {
+  name: string;
+  config: Partial<TConfig>;
+  weight: number;
+}
+
+export interface ABTestConfig<TConfig> {
+  experimentId: string;
+  variants: ABTestVariant<TConfig>[];
+  startAt: Date;
+  endAt?: Date;
+  targetingRules?: Record<string, unknown>;
+}
+
+export interface CanaryConfig<TConfig> {
+  environment: EnvironmentName;
+  trafficPercent: number;
+  config: Partial<TConfig>;
+  startAt: Date;
+  endAt?: Date;
+  guardRailMetrics?: string[];
+}
+
+export interface FeatureFlagBindings {
+  [flagName: string]: boolean;
+}
+
+export interface ConfigVersion<TConfig = Record<string, any>> {
+  id: string;
+  config: TConfig;
+  overrides: Partial<Record<EnvironmentName, Partial<TConfig>>>;
+  metadata: ConfigMetadata;
+  checksum: string;
+  abTest?: ABTestConfig<TConfig>;
+  canary?: CanaryConfig<TConfig>;
+  featureFlags?: FeatureFlagBindings;
+}
+
+export interface DriftDelta {
+  path: string;
+  expected: unknown;
+  actual: unknown;
+}
+
+export interface DriftReport {
+  configId: string;
+  environment: EnvironmentName;
+  version: number;
+  driftDetected: boolean;
+  deltas: DriftDelta[];
+  generatedAt: Date;
+}
+
+export type ConfigSchema = z.ZodTypeAny;
+
+export type ConfigWatcher<TConfig = Record<string, any>> = (payload: {
+  configId: string;
+  version: ConfigVersion<TConfig>;
+}) => void | Promise<void>;
+
+export interface SecretResolver {
+  resolve(reference: SecretReference): Promise<string>;
+}
+
+export interface FeatureFlagAdapter {
+  updateFlags(flags: FeatureFlagBindings): Promise<void>;
+}
+
+export interface RepositoryWriter<TConfig = Record<string, any>> {
+  saveVersion(configId: string, version: ConfigVersion<TConfig>, auditEntry: AuditEntry): Promise<void>;
+  getLatestVersion(configId: string): Promise<ConfigVersion<TConfig> | undefined>;
+  getVersion(configId: string, versionNumber: number): Promise<ConfigVersion<TConfig> | undefined>;
+  listVersions(configId: string): Promise<ConfigVersion<TConfig>[]>;
+  recordAppliedState(configId: string, state: AppliedState): Promise<void>;
+  getAppliedState(configId: string, environment: EnvironmentName): Promise<AppliedState | undefined>;
+  getAuditTrail(configId: string): Promise<AuditEntry[]>;
+}


### PR DESCRIPTION
## Summary
- add a distributed configuration management module with versioning, audit logging, rollbacks, canary and A/B support
- integrate schema validation, secret resolution hooks, feature-flag syncing, and drift detection utilities
- provide comprehensive documentation and targeted Jest coverage for the new service

## Testing
- npm test -- distributed-config-service *(fails: jest missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e09d0478088333978bd9a6e52026fd