### PR TITLE
feat: add data retention policy engine

### DIFF
--- a/docs/legal/DATA_RETENTION_ENGINE_COMPLIANCE.md
+++ b/docs/legal/DATA_RETENTION_ENGINE_COMPLIANCE.md
@@ -1,0 +1,47 @@
+# Data Retention Engine Compliance Overview
+
+## Scope
+The data retention engine governs lifecycle management for structured (PostgreSQL), graph (Neo4j), and object storage datasets that flow through IntelGraph services. It enforces retention rules, legal holds, archival controls, and evidentiary audit trails for all registered datasets.
+
+## Capabilities
+- **Policy Template Library** – Curated templates encode default retention periods, safeguards, and storage targets for regulated audit evidence, personal data, telemetry, ML training artifacts, and public intelligence datasets.
+- **Automated Classification** – Dataset metadata (sensitivity markers, jurisdictions, data type, and tags) drive automatic selection of the correct template and classification level.
+- **Lifecycle Enforcement** – Scheduled purges delete expired records from PostgreSQL tables and Neo4j labels while respecting legal holds and purge grace periods.
+- **Legal Hold Integration** – Full or scoped legal holds block purges until released or expired, generating audit evidence for each action.
+- **Archival Workflow** – Datasets can be promoted to archival tiers with immutable history and storage-tier updates in graph nodes.
+- **Compliance Reporting** – Summaries surface overdue purges, legal hold counts, and archival activity for internal and external attestations.
+- **Audit Logging** – Every policy change, purge, legal hold, and archival event is emitted to the governance audit channel (pino logger or Advanced Audit System adapter).
+
+## Controls Mapping
+| Control Area | Implementation Detail |
+| --- | --- |
+| SOC 2 CC6 / CC7 | Scheduled purges with audit logging provide change and activity monitoring. |
+| SOC 2 CC8 / CC9 | Legal holds prevent unauthorized disposal of evidence. |
+| GDPR Art. 5 & 17 | Automated classification, DSAR-ready templates, and purge enforcement support storage limitation and right-to-erasure. |
+| HIPAA §164.316 | Archival workflows capture immutable histories for PHI datasets with regulated templates. |
+
+## Operational Runbook
+1. **Registration** – Services register datasets with metadata (owner, storage targets, classification hints).
+2. **Template Resolution** – The engine assigns an appropriate template and stores the applied policy record.
+3. **Scheduling** – Purge intervals are scheduled per dataset; scheduler telemetry is exported for monitoring.
+4. **Monitoring** – Compliance reports highlight datasets approaching SLA breaches; alerts integrate with observability pipelines.
+5. **Legal Holds** – Legal, compliance, or incident response can apply or release holds via governance APIs.
+6. **Archival** – Operators initiate archival workflows for long-lived or decommissioned datasets.
+
+## Evidence Artifacts
+- Policy application and updates (`policy.applied`, `policy.updated` events)
+- Purge executions and skips (`purge.executed`, `purge.skipped` events)
+- Legal hold lifecycle (`legal-hold.applied`, `legal-hold.released` events)
+- Archival completion logs (`archive.completed` events)
+- Compliance reports generated for audit attestation
+
+## Testing & Validation
+- Unit tests cover policy assignment, legal holds, scheduled purges, compliance reporting, and archival workflows.
+- Scheduled purge simulations validate interaction with PostgreSQL and Neo4j adapters using safe mocks.
+- Repository persistence degrades gracefully when control tables are absent, preserving functionality in lower environments.
+
+## Deployment Considerations
+- Provision PostgreSQL table `data_retention_records` (JSONB columns) and configure retention-friendly indices.
+- Ensure Neo4j datasets include `datasetId` and `retentionExpiresAt`/`archivedAt` attributes for lifecycle queries.
+- Wire audit logger to the Advanced Audit System for tamper-evident compliance evidence in regulated environments.
+- Enable scheduler monitoring to alert on overdue datasets and purge failures.

--- a/server/src/governance/retention/auditLogger.ts
+++ b/server/src/governance/retention/auditLogger.ts
@@ -1,0 +1,67 @@
+import pino from 'pino';
+import { RetentionAuditEvent } from './types.js';
+
+export interface RetentionAuditLogger {
+  log(event: RetentionAuditEvent): Promise<void>;
+}
+
+const logger = pino({ name: 'data-retention' });
+
+export class PinoRetentionAuditLogger implements RetentionAuditLogger {
+  async log(event: RetentionAuditEvent): Promise<void> {
+    const logMethod = event.severity === 'error'
+      ? logger.error.bind(logger)
+      : event.severity === 'warn'
+        ? logger.warn.bind(logger)
+        : logger.info.bind(logger);
+
+    logMethod({
+      datasetId: event.datasetId,
+      policyId: event.policyId,
+      metadata: event.metadata
+    }, event.message);
+  }
+}
+
+export class AdvancedAuditSystemAdapter implements RetentionAuditLogger {
+  private readonly auditSystem: { recordEvent: (event: Record<string, any>) => Promise<string> };
+
+  constructor(auditSystem: { recordEvent: (event: Record<string, any>) => Promise<string> }) {
+    this.auditSystem = auditSystem;
+  }
+
+  async log(event: RetentionAuditEvent): Promise<void> {
+    await this.auditSystem.recordEvent({
+      eventType: `retention.${event.event}`,
+      level: event.severity === 'error' ? 'error' : event.severity === 'warn' ? 'warn' : 'info',
+      tenantId: event.metadata?.tenantId || 'global',
+      serviceId: 'data-retention-engine',
+      action: event.event,
+      outcome: event.severity === 'error' ? 'failure' : 'success',
+      message: event.message,
+      details: {
+        datasetId: event.datasetId,
+        policyId: event.policyId,
+        ...event.metadata
+      },
+      complianceRelevant: true,
+      complianceFrameworks: ['SOC2', 'GDPR'],
+      correlationId: event.metadata?.correlationId || event.datasetId,
+      userId: event.metadata?.userId,
+      resourceType: event.metadata?.resourceType || 'dataset',
+      resourceId: event.datasetId
+    });
+  }
+}
+
+export class CompositeRetentionAuditLogger implements RetentionAuditLogger {
+  private readonly loggers: RetentionAuditLogger[];
+
+  constructor(...loggers: RetentionAuditLogger[]) {
+    this.loggers = loggers;
+  }
+
+  async log(event: RetentionAuditEvent): Promise<void> {
+    await Promise.all(this.loggers.map(logger => logger.log(event)));
+  }
+}

--- a/server/src/governance/retention/dataRetentionEngine.ts
+++ b/server/src/governance/retention/dataRetentionEngine.ts
@@ -1,0 +1,429 @@
+import { Pool } from 'pg';
+import pino from 'pino';
+import { runCypher } from '../../graph/neo4j.js';
+import { DataRetentionRepository } from './repository.js';
+import { RetentionScheduler } from './scheduler.js';
+import {
+  AppliedRetentionPolicy,
+  ArchivalWorkflow,
+  ClassificationResult,
+  DatasetMetadata,
+  LegalHold,
+  RetentionRecord,
+  RetentionSchedule
+} from './types.js';
+import { POLICY_TEMPLATE_LIBRARY, selectTemplateForDataset, getPolicyTemplateById, resolveClassification } from './policyTemplates.js';
+import { PinoRetentionAuditLogger, RetentionAuditLogger } from './auditLogger.js';
+
+export interface DataRetentionEngineOptions {
+  pool: Pool;
+  auditLogger?: RetentionAuditLogger;
+  scheduler?: RetentionScheduler;
+  repository?: DataRetentionRepository;
+  runCypher?: (cypher: string, params?: Record<string, any>) => Promise<any>;
+}
+
+interface ComplianceReportRow {
+  datasetId: string;
+  datasetName: string;
+  classification: string;
+  policyId: string;
+  retentionDays: number;
+  onLegalHold: boolean;
+  nextPurge?: Date;
+  lastRun?: Date;
+  archivedCount: number;
+}
+
+export interface ComplianceReportSummary {
+  generatedAt: Date;
+  totalDatasets: number;
+  datasetsOnLegalHold: number;
+  overdueDatasets: number;
+  archivedInPeriod: number;
+  details: ComplianceReportRow[];
+}
+
+export class DataRetentionEngine {
+  private readonly logger = pino({ name: 'data-retention-engine' });
+  private readonly pool: Pool;
+  private readonly repository: DataRetentionRepository;
+  private readonly scheduler: RetentionScheduler;
+  private readonly auditLogger: RetentionAuditLogger;
+  private readonly cypherRunner: (cypher: string, params?: Record<string, any>) => Promise<any>;
+
+  constructor(options: DataRetentionEngineOptions) {
+    this.pool = options.pool;
+    this.repository = options.repository ?? new DataRetentionRepository(options.pool);
+    this.scheduler = options.scheduler ?? new RetentionScheduler();
+    this.auditLogger = options.auditLogger ?? new PinoRetentionAuditLogger();
+    this.cypherRunner = options.runCypher ?? runCypher;
+  }
+
+  listPolicyTemplates() {
+    return POLICY_TEMPLATE_LIBRARY;
+  }
+
+  getRecord(datasetId: string): RetentionRecord | undefined {
+    return this.repository.getRecord(datasetId);
+  }
+
+  classifyDataset(metadata: DatasetMetadata): ClassificationResult {
+    const { level, rationale } = resolveClassification(metadata);
+    const templateSelection = selectTemplateForDataset(metadata);
+    return {
+      level,
+      recommendedTemplateId: templateSelection.template.id,
+      rationale
+    };
+  }
+
+  async registerDataset(metadata: DatasetMetadata, appliedBy: string): Promise<RetentionRecord> {
+    const { template, rationale } = selectTemplateForDataset(metadata);
+    const policy: AppliedRetentionPolicy = {
+      datasetId: metadata.datasetId,
+      templateId: template.id,
+      retentionDays: template.retentionDays,
+      purgeGraceDays: template.purgeGraceDays,
+      legalHoldAllowed: template.legalHoldAllowed,
+      storageTargets: template.storageTargets,
+      classificationLevel: template.classificationLevel,
+      safeguards: template.defaultSafeguards,
+      appliedAt: new Date(),
+      appliedBy
+    };
+
+    const record: RetentionRecord = {
+      metadata,
+      policy,
+      legalHold: undefined,
+      schedule: undefined,
+      archiveHistory: [],
+      lastEvaluatedAt: new Date()
+    };
+
+    await this.repository.upsertRecord(record);
+
+    await this.auditLogger.log({
+      event: 'policy.applied',
+      datasetId: metadata.datasetId,
+      policyId: policy.templateId,
+      severity: 'info',
+      message: `Applied template ${template.id} (${template.name})`,
+      metadata: { rationale, appliedBy },
+      timestamp: new Date()
+    });
+
+    return record;
+  }
+
+  async applyCustomPolicy(datasetId: string, overrides: Partial<AppliedRetentionPolicy>): Promise<AppliedRetentionPolicy> {
+    const record = this.repository.getRecord(datasetId);
+    if (!record) {
+      throw new Error(`Unknown dataset ${datasetId}`);
+    }
+
+    const template = getPolicyTemplateById(overrides.templateId ?? record.policy.templateId);
+    if (!template) {
+      throw new Error(`Unknown retention template ${overrides.templateId}`);
+    }
+
+    const policy: AppliedRetentionPolicy = {
+      ...record.policy,
+      ...overrides,
+      templateId: template.id,
+      retentionDays: overrides.retentionDays ?? template.retentionDays,
+      purgeGraceDays: overrides.purgeGraceDays ?? template.purgeGraceDays,
+      legalHoldAllowed: overrides.legalHoldAllowed ?? template.legalHoldAllowed,
+      storageTargets: overrides.storageTargets ?? template.storageTargets,
+      classificationLevel: overrides.classificationLevel ?? template.classificationLevel,
+      safeguards: overrides.safeguards ?? template.defaultSafeguards,
+      appliedAt: new Date(),
+      appliedBy: overrides.appliedBy ?? record.policy.appliedBy
+    };
+
+    await this.repository.updatePolicy(datasetId, policy);
+
+    await this.auditLogger.log({
+      event: 'policy.updated',
+      datasetId,
+      policyId: policy.templateId,
+      severity: 'info',
+      message: 'Retention policy updated',
+      metadata: { overrides },
+      timestamp: new Date()
+    });
+
+    return policy;
+  }
+
+  async schedulePurge(datasetId: string, intervalMs: number): Promise<RetentionSchedule> {
+    const record = this.repository.getRecord(datasetId);
+    if (!record) {
+      throw new Error(`Unknown dataset ${datasetId}`);
+    }
+
+    const nextRun = new Date(Date.now() + intervalMs);
+    const schedule: RetentionSchedule = {
+      datasetId,
+      intervalMs,
+      nextRun,
+      lastRun: record.schedule?.lastRun,
+      policyId: record.policy.templateId
+    };
+
+    this.scheduler.register(schedule, async () => {
+      await this.purgeDataset(datasetId, 'scheduler');
+      const updated = this.scheduler.getSchedule(datasetId);
+      if (updated) {
+        await this.repository.setSchedule(datasetId, updated);
+      }
+    });
+
+    this.scheduler.start();
+    await this.repository.setSchedule(datasetId, schedule);
+
+    await this.auditLogger.log({
+      event: 'purge.scheduled',
+      datasetId,
+      policyId: record.policy.templateId,
+      severity: 'info',
+      message: `Scheduled purge every ${intervalMs / 1000} seconds`,
+      metadata: { intervalMs },
+      timestamp: new Date()
+    });
+
+    return schedule;
+  }
+
+  async purgeDataset(datasetId: string, trigger: 'manual' | 'scheduler' | 'compliance' = 'manual'): Promise<void> {
+    const record = this.repository.getRecord(datasetId);
+    if (!record) {
+      throw new Error(`Unknown dataset ${datasetId}`);
+    }
+
+    if (record.legalHold) {
+      const expiresAt = record.legalHold.expiresAt;
+      if (!expiresAt || expiresAt > new Date()) {
+        await this.auditLogger.log({
+          event: 'purge.skipped',
+          datasetId,
+          policyId: record.policy.templateId,
+          severity: 'warn',
+          message: 'Purge skipped due to active legal hold',
+          metadata: { trigger, legalHold: record.legalHold },
+          timestamp: new Date()
+        });
+        return;
+      }
+
+      await this.repository.setLegalHold(datasetId, undefined);
+    }
+
+    await this.performPostgresPurge(record);
+    await this.performNeo4jPurge(record);
+
+    await this.auditLogger.log({
+      event: 'purge.executed',
+      datasetId,
+      policyId: record.policy.templateId,
+      severity: 'info',
+      message: `Dataset purged via ${trigger}`,
+      metadata: { trigger },
+      timestamp: new Date()
+    });
+  }
+
+  async applyLegalHold(datasetId: string, legalHold: LegalHold): Promise<void> {
+    const record = this.repository.getRecord(datasetId);
+    if (!record) {
+      throw new Error(`Unknown dataset ${datasetId}`);
+    }
+
+    if (!record.policy.legalHoldAllowed && legalHold.scope === 'full') {
+      throw new Error('Policy does not allow full legal holds');
+    }
+
+    await this.repository.setLegalHold(datasetId, legalHold);
+
+    await this.auditLogger.log({
+      event: 'legal-hold.applied',
+      datasetId,
+      policyId: record.policy.templateId,
+      severity: 'warn',
+      message: 'Legal hold applied to dataset',
+      metadata: { legalHold },
+      timestamp: new Date()
+    });
+  }
+
+  async releaseLegalHold(datasetId: string, releasedBy: string): Promise<void> {
+    const record = this.repository.getRecord(datasetId);
+    if (!record?.legalHold) {
+      return;
+    }
+
+    await this.repository.setLegalHold(datasetId, undefined);
+
+    await this.auditLogger.log({
+      event: 'legal-hold.released',
+      datasetId,
+      policyId: record.policy.templateId,
+      severity: 'info',
+      message: 'Legal hold released',
+      metadata: { releasedBy },
+      timestamp: new Date()
+    });
+  }
+
+  async archiveDataset(datasetId: string, initiatedBy: string, targetLocation: string): Promise<ArchivalWorkflow> {
+    const record = this.repository.getRecord(datasetId);
+    if (!record) {
+      throw new Error(`Unknown dataset ${datasetId}`);
+    }
+
+    const workflow: ArchivalWorkflow = {
+      datasetId,
+      initiatedBy,
+      initiatedAt: new Date(),
+      targetLocation,
+      status: 'in-progress'
+    };
+
+    await this.repository.appendArchivalEvent(datasetId, workflow);
+
+    try {
+      await this.performArchival(record, targetLocation);
+      workflow.status = 'completed';
+    } catch (error) {
+      workflow.status = 'failed';
+      workflow.details = { error: (error as Error).message };
+      throw error;
+    } finally {
+      await this.repository.appendArchivalEvent(datasetId, workflow);
+    }
+
+    await this.auditLogger.log({
+      event: 'archive.completed',
+      datasetId,
+      policyId: record.policy.templateId,
+      severity: workflow.status === 'completed' ? 'info' : 'error',
+      message: `Archival workflow ${workflow.status}`,
+      metadata: { targetLocation, initiatedBy },
+      timestamp: new Date()
+    });
+
+    return workflow;
+  }
+
+  generateComplianceReport(start: Date, end: Date): ComplianceReportSummary {
+    const records = this.repository.getAllRecords();
+    const rows: ComplianceReportRow[] = records.map(record => {
+      const schedule = record.schedule;
+      const archivedCount = record.archiveHistory.filter(entry => entry.initiatedAt >= start && entry.initiatedAt <= end).length;
+      return {
+        datasetId: record.metadata.datasetId,
+        datasetName: record.metadata.name,
+        classification: record.policy.classificationLevel,
+        policyId: record.policy.templateId,
+        retentionDays: record.policy.retentionDays,
+        onLegalHold: Boolean(record.legalHold && (!record.legalHold.expiresAt || record.legalHold.expiresAt > new Date())),
+        nextPurge: schedule?.nextRun,
+        lastRun: schedule?.lastRun,
+        archivedCount
+      };
+    });
+
+    const overdueDatasets = rows.filter(row => {
+      if (!row.nextPurge) {
+        return false;
+      }
+      return row.nextPurge < new Date();
+    }).length;
+
+    const report: ComplianceReportSummary = {
+      generatedAt: new Date(),
+      totalDatasets: rows.length,
+      datasetsOnLegalHold: rows.filter(row => row.onLegalHold).length,
+      overdueDatasets,
+      archivedInPeriod: rows.reduce((count, row) => count + row.archivedCount, 0),
+      details: rows
+    };
+
+    return report;
+  }
+
+  private async performPostgresPurge(record: RetentionRecord): Promise<void> {
+    if (!record.policy.storageTargets.includes('postgres')) {
+      return;
+    }
+
+    const tableTags = record.metadata.tags.filter(tag => tag.startsWith('postgres:table:'));
+    const tables = tableTags
+      .map(tag => tag.replace('postgres:table:', ''))
+      .filter(table => /^[a-zA-Z0-9_]+$/.test(table));
+
+    for (const table of tables) {
+      try {
+        await this.pool.query(
+          `DELETE FROM ${table} WHERE dataset_id = $1 AND (retention_expires_at IS NULL OR retention_expires_at < now())`,
+          [record.metadata.datasetId]
+        );
+      } catch (error: any) {
+        if (error.code === '42P01') {
+          this.logger.warn({ table }, 'Postgres purge skipped because table is missing.');
+          continue;
+        }
+        throw error;
+      }
+    }
+  }
+
+  private async performNeo4jPurge(record: RetentionRecord): Promise<void> {
+    if (!record.policy.storageTargets.includes('neo4j')) {
+      return;
+    }
+
+    const labelTags = record.metadata.tags.filter(tag => tag.startsWith('neo4j:label:'));
+    const labels = labelTags
+      .map(tag => tag.replace('neo4j:label:', ''))
+      .filter(label => /^[A-Za-z0-9_]+$/.test(label));
+
+    for (const label of labels) {
+      await this.cypherRunner(
+        `MATCH (n:${label} { datasetId: $datasetId })
+         WHERE coalesce(n.retentionExpiresAt, datetime()) <= datetime()
+         DETACH DELETE n`,
+        { datasetId: record.metadata.datasetId }
+      );
+    }
+  }
+
+  private async performArchival(record: RetentionRecord, targetLocation: string): Promise<void> {
+    if (record.policy.storageTargets.includes('postgres')) {
+      try {
+        await this.pool.query(
+          `UPDATE data_retention_records
+           SET archive_history = coalesce(archive_history, '[]'::jsonb) || $2::jsonb
+           WHERE dataset_id = $1`,
+          [
+            record.metadata.datasetId,
+            JSON.stringify({ targetLocation, archivedAt: new Date().toISOString() })
+          ]
+        );
+      } catch (error: any) {
+        if (error.code !== '42P01') {
+          throw error;
+        }
+      }
+    }
+
+    if (record.policy.storageTargets.includes('neo4j')) {
+      await this.cypherRunner(
+        `MATCH (n { datasetId: $datasetId })
+         SET n.storageTier = 'archive', n.archivedAt = datetime()`,
+        { datasetId: record.metadata.datasetId }
+      );
+    }
+  }
+}

--- a/server/src/governance/retention/policyTemplates.ts
+++ b/server/src/governance/retention/policyTemplates.ts
@@ -1,0 +1,153 @@
+import { DatasetMetadata, RetentionPolicyTemplate, DataClassificationLevel } from './types.js';
+
+export const POLICY_TEMPLATE_LIBRARY: RetentionPolicyTemplate[] = [
+  {
+    id: 'audit-7y',
+    name: 'Regulated Audit Evidence - 7 Years',
+    description: 'Write-once storage with seven year retention for audit evidence and regulator-mandated records.',
+    classificationLevel: 'regulated',
+    retentionDays: 2555,
+    legalHoldAllowed: true,
+    purgeGraceDays: 30,
+    storageTargets: ['postgres', 's3'],
+    defaultSafeguards: [
+      'immutable-storage',
+      'dual-control-delete',
+      'evidence-chain-verification',
+      'tamper-evident-hash'
+    ],
+    applicableDataTypes: ['audit', 'analytics']
+  },
+  {
+    id: 'pii-365d',
+    name: 'Personal Data - 365 Days',
+    description: 'Standard one year retention for personal data with privacy review and DSAR support.',
+    classificationLevel: 'restricted',
+    retentionDays: 365,
+    legalHoldAllowed: true,
+    purgeGraceDays: 14,
+    storageTargets: ['postgres', 'neo4j'],
+    defaultSafeguards: [
+      'pii-tokenization',
+      'regional-access-controls',
+      'dsar-ready-export'
+    ],
+    applicableDataTypes: ['communications', 'analytics', 'telemetry']
+  },
+  {
+    id: 'telemetry-90d',
+    name: 'Telemetry - 90 Days',
+    description: 'Operational telemetry retained for ninety days to support investigations and trend analysis.',
+    classificationLevel: 'internal',
+    retentionDays: 90,
+    legalHoldAllowed: false,
+    purgeGraceDays: 7,
+    storageTargets: ['postgres', 'elasticsearch'],
+    defaultSafeguards: [
+      'anonymized-identifiers',
+      'usage-bounded-access'
+    ],
+    applicableDataTypes: ['telemetry', 'analytics']
+  },
+  {
+    id: 'ml-training-30d',
+    name: 'ML Training Artifacts - 30 Days',
+    description: 'Short lived retention for ML feature stores and training extracts pending model promotion.',
+    classificationLevel: 'internal',
+    retentionDays: 30,
+    legalHoldAllowed: true,
+    purgeGraceDays: 5,
+    storageTargets: ['s3', 'object-store'],
+    defaultSafeguards: [
+      'model-version-linkage',
+      'anonymized-sampling'
+    ],
+    applicableDataTypes: ['ml-training']
+  },
+  {
+    id: 'public-180d',
+    name: 'Open Intelligence - 180 Days',
+    description: 'Retention for open-source intelligence artifacts and derived analytics.',
+    classificationLevel: 'public',
+    retentionDays: 180,
+    legalHoldAllowed: false,
+    purgeGraceDays: 10,
+    storageTargets: ['neo4j', 'postgres'],
+    defaultSafeguards: [
+      'integrity-checkpoints'
+    ],
+    applicableDataTypes: ['analytics', 'custom']
+  }
+];
+
+export function getPolicyTemplateById(templateId: string): RetentionPolicyTemplate | undefined {
+  return POLICY_TEMPLATE_LIBRARY.find(template => template.id === templateId);
+}
+
+export function resolveClassification(metadata: DatasetMetadata): {
+  level: DataClassificationLevel;
+  rationale: string[];
+} {
+  const rationale: string[] = [];
+  let level: DataClassificationLevel = 'internal';
+
+  if (metadata.containsPersonalData) {
+    rationale.push('Contains personal data requiring restricted handling.');
+    level = 'restricted';
+  }
+
+  if (metadata.containsFinancialData) {
+    rationale.push('Contains financial attributes requiring regulatory retention.');
+    level = 'regulated';
+  }
+
+  if (metadata.containsHealthData) {
+    rationale.push('Contains health information subject to HIPAA-equivalent retention.');
+    level = 'regulated';
+  }
+
+  if (metadata.dataType === 'audit') {
+    rationale.push('Audit datasets inherit regulated classification.');
+    level = 'regulated';
+  }
+
+  if (metadata.tags.includes('public-intel')) {
+    rationale.push('Tagged as public intelligence.');
+    if (level !== 'regulated' && level !== 'restricted') {
+      level = 'public';
+    }
+  }
+
+  if (metadata.tags.includes('internal-only') && level === 'public') {
+    level = 'internal';
+  }
+
+  if (rationale.length === 0) {
+    rationale.push('No sensitive markers detected; defaulting to internal.');
+  }
+
+  return { level, rationale };
+}
+
+export function selectTemplateForDataset(metadata: DatasetMetadata): {
+  template: RetentionPolicyTemplate;
+  rationale: string[];
+} {
+  const classification = resolveClassification(metadata);
+  const applicableTemplates = POLICY_TEMPLATE_LIBRARY.filter(template => {
+    const levelMatch = template.classificationLevel === classification.level
+      || (classification.level === 'regulated' && template.classificationLevel === 'restricted');
+    const typeMatch = template.applicableDataTypes.includes(metadata.dataType)
+      || template.applicableDataTypes.includes('custom');
+    return levelMatch && typeMatch;
+  });
+
+  if (applicableTemplates.length > 0) {
+    return { template: applicableTemplates[0], rationale: classification.rationale };
+  }
+
+  return {
+    template: POLICY_TEMPLATE_LIBRARY[0],
+    rationale: [...classification.rationale, 'Falling back to default regulated template.']
+  };
+}

--- a/server/src/governance/retention/repository.ts
+++ b/server/src/governance/retention/repository.ts
@@ -1,0 +1,145 @@
+import { Pool } from 'pg';
+import pino from 'pino';
+import {
+  AppliedRetentionPolicy,
+  ArchivalWorkflow,
+  DatasetMetadata,
+  LegalHold,
+  RetentionRecord,
+  RetentionSchedule
+} from './types.js';
+
+export class DataRetentionRepository {
+  private readonly pool: Pool;
+  private readonly logger = pino({ name: 'data-retention-repository' });
+  private readonly records = new Map<string, RetentionRecord>();
+
+  constructor(pool: Pool) {
+    this.pool = pool;
+  }
+
+  getAllRecords(): RetentionRecord[] {
+    return Array.from(this.records.values());
+  }
+
+  getRecord(datasetId: string): RetentionRecord | undefined {
+    return this.records.get(datasetId);
+  }
+
+  async upsertRecord(record: RetentionRecord): Promise<void> {
+    this.records.set(record.metadata.datasetId, record);
+    await this.persistRecord(record);
+  }
+
+  async updatePolicy(datasetId: string, policy: AppliedRetentionPolicy): Promise<void> {
+    const record = this.records.get(datasetId);
+    if (!record) {
+      throw new Error(`Unknown dataset ${datasetId}`);
+    }
+
+    record.policy = policy;
+    record.lastEvaluatedAt = new Date();
+    await this.persistRecord(record);
+  }
+
+  async updateMetadata(datasetId: string, metadata: DatasetMetadata): Promise<void> {
+    const record = this.records.get(datasetId);
+    if (!record) {
+      throw new Error(`Unknown dataset ${datasetId}`);
+    }
+
+    record.metadata = metadata;
+    record.lastEvaluatedAt = new Date();
+    await this.persistRecord(record);
+  }
+
+  async setLegalHold(datasetId: string, legalHold?: LegalHold): Promise<void> {
+    const record = this.records.get(datasetId);
+    if (!record) {
+      throw new Error(`Unknown dataset ${datasetId}`);
+    }
+
+    record.legalHold = legalHold;
+    record.lastEvaluatedAt = new Date();
+    await this.persistRecord(record);
+  }
+
+  async setSchedule(datasetId: string, schedule?: RetentionSchedule): Promise<void> {
+    const record = this.records.get(datasetId);
+    if (!record) {
+      throw new Error(`Unknown dataset ${datasetId}`);
+    }
+
+    record.schedule = schedule;
+    await this.persistRecord(record);
+  }
+
+  async appendArchivalEvent(datasetId: string, workflow: ArchivalWorkflow): Promise<void> {
+    const record = this.records.get(datasetId);
+    if (!record) {
+      throw new Error(`Unknown dataset ${datasetId}`);
+    }
+
+    record.archiveHistory.push(workflow);
+    await this.persistRecord(record);
+  }
+
+  private async persistRecord(record: RetentionRecord): Promise<void> {
+    try {
+      await this.pool.query(
+        `INSERT INTO data_retention_records (
+          dataset_id,
+          metadata,
+          policy,
+          legal_hold,
+          schedule,
+          archive_history,
+          last_evaluated_at,
+          updated_at
+        ) VALUES ($1, $2::jsonb, $3::jsonb, $4::jsonb, $5::jsonb, $6::jsonb, $7, now())
+        ON CONFLICT (dataset_id)
+        DO UPDATE SET
+          metadata = EXCLUDED.metadata,
+          policy = EXCLUDED.policy,
+          legal_hold = EXCLUDED.legal_hold,
+          schedule = EXCLUDED.schedule,
+          archive_history = EXCLUDED.archive_history,
+          last_evaluated_at = EXCLUDED.last_evaluated_at,
+          updated_at = now()`,
+        [
+          record.metadata.datasetId,
+          JSON.stringify(record.metadata),
+          JSON.stringify(record.policy),
+          record.legalHold ? JSON.stringify(record.legalHold) : null,
+          record.schedule ? JSON.stringify(record.schedule) : null,
+          JSON.stringify(record.archiveHistory),
+          record.lastEvaluatedAt
+        ]
+      );
+    } catch (error: any) {
+      if (this.isIgnorablePersistenceError(error)) {
+        this.logger.debug({ error: error.message }, 'Falling back to in-memory retention repository.');
+        return;
+      }
+
+      this.logger.error({ error }, 'Failed to persist data retention record.');
+      throw error;
+    }
+  }
+
+  private isIgnorablePersistenceError(error: any): boolean {
+    if (!error) {
+      return false;
+    }
+
+    if (error.code === '42P01') {
+      return true;
+    }
+
+    if (typeof error.message === 'string' && error.message.includes('does not exist')) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/server/src/governance/retention/scheduler.ts
+++ b/server/src/governance/retention/scheduler.ts
@@ -1,0 +1,64 @@
+import { EventEmitter } from 'events';
+import { RetentionSchedule } from './types.js';
+
+type ScheduledHandler = () => Promise<void>;
+
+interface ScheduledTask {
+  schedule: RetentionSchedule;
+  handler: ScheduledHandler;
+}
+
+export class RetentionScheduler extends EventEmitter {
+  private readonly tasks = new Map<string, ScheduledTask>();
+  private readonly tickIntervalMs: number;
+  private timer?: NodeJS.Timeout;
+
+  constructor(tickIntervalMs = 60000) {
+    super();
+    this.tickIntervalMs = tickIntervalMs;
+  }
+
+  register(schedule: RetentionSchedule, handler: ScheduledHandler): void {
+    this.tasks.set(schedule.datasetId, { schedule, handler });
+  }
+
+  unregister(datasetId: string): void {
+    this.tasks.delete(datasetId);
+  }
+
+  getSchedule(datasetId: string): RetentionSchedule | undefined {
+    return this.tasks.get(datasetId)?.schedule;
+  }
+
+  start(): void {
+    if (this.timer) {
+      return;
+    }
+
+    this.timer = setInterval(() => {
+      void this.runDueTasks();
+    }, this.tickIntervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+
+  async runDueTasks(referenceTime: Date = new Date()): Promise<void> {
+    for (const [datasetId, task] of this.tasks.entries()) {
+      if (task.schedule.nextRun <= referenceTime) {
+        try {
+          await task.handler();
+          task.schedule.lastRun = referenceTime;
+          task.schedule.nextRun = new Date(referenceTime.getTime() + task.schedule.intervalMs);
+          this.emit('taskCompleted', { datasetId, schedule: task.schedule });
+        } catch (error) {
+          this.emit('taskFailed', { datasetId, error });
+        }
+      }
+    }
+  }
+}

--- a/server/src/governance/retention/types.ts
+++ b/server/src/governance/retention/types.ts
@@ -1,0 +1,101 @@
+export type StorageSystem = 'postgres' | 'neo4j' | 's3' | 'object-store' | 'elasticsearch' | 'blob';
+
+export type DataClassificationLevel =
+  | 'public'
+  | 'internal'
+  | 'confidential'
+  | 'restricted'
+  | 'regulated';
+
+export interface DatasetMetadata {
+  datasetId: string;
+  name: string;
+  description?: string;
+  dataType: 'audit' | 'analytics' | 'telemetry' | 'communications' | 'ml-training' | 'custom';
+  containsPersonalData: boolean;
+  containsFinancialData?: boolean;
+  containsHealthData?: boolean;
+  jurisdictions: string[];
+  tags: string[];
+  storageSystems: StorageSystem[];
+  owner: string;
+  createdAt: Date;
+  recordCount?: number;
+}
+
+export interface RetentionPolicyTemplate {
+  id: string;
+  name: string;
+  description: string;
+  classificationLevel: DataClassificationLevel;
+  retentionDays: number;
+  legalHoldAllowed: boolean;
+  purgeGraceDays: number;
+  storageTargets: StorageSystem[];
+  defaultSafeguards: string[];
+  applicableDataTypes: DatasetMetadata['dataType'][];
+}
+
+export interface ClassificationResult {
+  level: DataClassificationLevel;
+  recommendedTemplateId: string;
+  rationale: string[];
+}
+
+export interface AppliedRetentionPolicy {
+  datasetId: string;
+  templateId: string;
+  retentionDays: number;
+  purgeGraceDays: number;
+  legalHoldAllowed: boolean;
+  storageTargets: StorageSystem[];
+  classificationLevel: DataClassificationLevel;
+  safeguards: string[];
+  appliedAt: Date;
+  appliedBy: string;
+}
+
+export interface LegalHold {
+  datasetId: string;
+  reason: string;
+  requestedBy: string;
+  createdAt: Date;
+  expiresAt?: Date;
+  scope: 'full' | 'partial';
+}
+
+export interface RetentionSchedule {
+  datasetId: string;
+  intervalMs: number;
+  nextRun: Date;
+  lastRun?: Date;
+  policyId: string;
+}
+
+export interface ArchivalWorkflow {
+  datasetId: string;
+  initiatedBy: string;
+  initiatedAt: Date;
+  targetLocation: string;
+  status: 'pending' | 'in-progress' | 'completed' | 'failed';
+  details?: Record<string, any>;
+}
+
+export interface RetentionAuditEvent {
+  event: string;
+  datasetId: string;
+  policyId?: string;
+  severity: 'info' | 'warn' | 'error';
+  message: string;
+  metadata?: Record<string, any>;
+  timestamp: Date;
+}
+
+export interface RetentionRecord {
+  metadata: DatasetMetadata;
+  policy: AppliedRetentionPolicy;
+  legalHold?: LegalHold;
+  schedule?: RetentionSchedule;
+  archiveHistory: ArchivalWorkflow[];
+  lastEvaluatedAt: Date;
+}

--- a/server/src/jobs/retention.ts
+++ b/server/src/jobs/retention.ts
@@ -1,11 +1,50 @@
-import { runCypher } from '../graph/neo4j';
-export async function purgeOldSuggestions(days = 90) {
-  await runCypher(
-    `
-    MATCH (s:AISuggestion)
-    WHERE datetime(s.createdAt) < datetime() - duration({days:$days})
-    DETACH DELETE s
-  `,
-    { days },
-  );
+import { getPostgresPool } from '../db/postgres.js';
+import { DataRetentionEngine } from '../governance/retention/dataRetentionEngine.js';
+import { RetentionScheduler } from '../governance/retention/scheduler.js';
+import { DatasetMetadata } from '../governance/retention/types.js';
+
+const pool = getPostgresPool();
+const scheduler = new RetentionScheduler(60000);
+export const retentionEngine = new DataRetentionEngine({ pool, scheduler });
+
+const AI_SUGGESTION_DATASET_ID = 'ai-suggestions';
+
+async function ensureAiSuggestionDataset(days: number): Promise<void> {
+  const existing = retentionEngine.getRecord(AI_SUGGESTION_DATASET_ID);
+  const intervalMs = days * 24 * 60 * 60 * 1000;
+
+  if (!existing) {
+    const metadata: DatasetMetadata = {
+      datasetId: AI_SUGGESTION_DATASET_ID,
+      name: 'AI Investigative Suggestions',
+      description: 'Graph-native AI assistance content surfaced to analysts.',
+      dataType: 'analytics',
+      containsPersonalData: true,
+      containsFinancialData: false,
+      containsHealthData: false,
+      jurisdictions: ['global'],
+      tags: ['neo4j:label:AISuggestion', 'retention:auto', 'postgres:table:ai_suggestions_shadow'],
+      storageSystems: ['neo4j', 'postgres'],
+      owner: 'governance@intelgraph.dev',
+      createdAt: new Date(),
+      recordCount: undefined
+    };
+
+    await retentionEngine.registerDataset(metadata, 'system');
+    await retentionEngine.schedulePurge(AI_SUGGESTION_DATASET_ID, intervalMs);
+    return;
+  }
+
+  if (!existing.schedule) {
+    await retentionEngine.schedulePurge(AI_SUGGESTION_DATASET_ID, intervalMs);
+  }
+}
+
+export async function purgeOldSuggestions(days = 90): Promise<void> {
+  await ensureAiSuggestionDataset(days);
+  await retentionEngine.purgeDataset(AI_SUGGESTION_DATASET_ID, 'manual');
+}
+
+export async function initializeDataRetentionPolicies(): Promise<void> {
+  await ensureAiSuggestionDataset(90);
 }

--- a/server/src/tests/dataRetentionEngine.test.ts
+++ b/server/src/tests/dataRetentionEngine.test.ts
@@ -1,0 +1,161 @@
+import { Pool } from 'pg';
+import { DataRetentionEngine } from '../governance/retention/dataRetentionEngine.js';
+import { RetentionScheduler } from '../governance/retention/scheduler.js';
+import { DatasetMetadata, LegalHold } from '../governance/retention/types.js';
+import { RetentionAuditLogger } from '../governance/retention/auditLogger.js';
+
+function createMockPool() {
+  return {
+    query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 })
+  } as unknown as Pool;
+}
+
+function createAuditLogger(): RetentionAuditLogger {
+  return {
+    log: jest.fn().mockResolvedValue(undefined)
+  };
+}
+
+function createMetadata(overrides: Partial<DatasetMetadata> = {}): DatasetMetadata {
+  return {
+    datasetId: overrides.datasetId ?? `dataset-${Math.random().toString(36).slice(2)}`,
+    name: overrides.name ?? 'Test Dataset',
+    description: overrides.description,
+    dataType: overrides.dataType ?? 'communications',
+    containsPersonalData: overrides.containsPersonalData ?? true,
+    containsFinancialData: overrides.containsFinancialData ?? false,
+    containsHealthData: overrides.containsHealthData ?? false,
+    jurisdictions: overrides.jurisdictions ?? ['us'],
+    tags: overrides.tags ?? ['neo4j:label:TestLabel', 'postgres:table:test_table'],
+    storageSystems: overrides.storageSystems ?? ['neo4j', 'postgres'],
+    owner: overrides.owner ?? 'tester@intelgraph.dev',
+    createdAt: overrides.createdAt ?? new Date(),
+    recordCount: overrides.recordCount
+  };
+}
+
+describe('DataRetentionEngine', () => {
+  it('applies policy templates automatically during registration', async () => {
+    const pool = createMockPool();
+    const scheduler = new RetentionScheduler(1000);
+    const auditLogger = createAuditLogger();
+    const runCypher = jest.fn().mockResolvedValue([]);
+    const engine = new DataRetentionEngine({ pool, scheduler, auditLogger, runCypher });
+
+    const metadata = createMetadata();
+    const record = await engine.registerDataset(metadata, 'tester');
+
+    expect(record.policy.templateId).toBe('pii-365d');
+    expect(record.policy.retentionDays).toBe(365);
+    expect((auditLogger.log as jest.Mock).mock.calls[0][0].event).toBe('policy.applied');
+
+    scheduler.stop();
+  });
+
+  it('prevents purges when a legal hold is active', async () => {
+    const pool = createMockPool();
+    const scheduler = new RetentionScheduler(1000);
+    const auditLogger = createAuditLogger();
+    const runCypher = jest.fn().mockResolvedValue([]);
+    const engine = new DataRetentionEngine({ pool, scheduler, auditLogger, runCypher });
+
+    const metadata = createMetadata({ datasetId: 'legal-hold-test' });
+    await engine.registerDataset(metadata, 'tester');
+
+    const legalHold: LegalHold = {
+      datasetId: 'legal-hold-test',
+      reason: 'Pending litigation',
+      requestedBy: 'legal@intelgraph.dev',
+      createdAt: new Date(),
+      scope: 'full'
+    };
+
+    await engine.applyLegalHold('legal-hold-test', legalHold);
+    await engine.purgeDataset('legal-hold-test', 'manual');
+
+    expect((auditLogger.log as jest.Mock)).toHaveBeenCalledWith(expect.objectContaining({ event: 'purge.skipped' }));
+
+    scheduler.stop();
+  });
+
+  it('executes scheduled purges across storage backends', async () => {
+    const pool = createMockPool();
+    const scheduler = new RetentionScheduler(5);
+    const auditLogger = createAuditLogger();
+    const runCypher = jest.fn().mockResolvedValue([]);
+    const engine = new DataRetentionEngine({ pool, scheduler, auditLogger, runCypher });
+
+    const metadata = createMetadata({
+      datasetId: 'scheduled-dataset',
+      dataType: 'analytics',
+      containsPersonalData: false,
+      tags: ['neo4j:label:RetentionNode', 'postgres:table:retention_table', 'public-intel'],
+      storageSystems: ['neo4j', 'postgres']
+    });
+
+    await engine.registerDataset(metadata, 'scheduler');
+    await engine.schedulePurge('scheduled-dataset', 10);
+
+    await scheduler.runDueTasks(new Date(Date.now() + 20));
+
+    expect((pool.query as unknown as jest.Mock)).toHaveBeenCalledWith(
+      expect.stringContaining('DELETE FROM retention_table'),
+      ['scheduled-dataset']
+    );
+    expect(runCypher).toHaveBeenCalled();
+
+    scheduler.stop();
+  });
+
+  it('generates compliance reports with legal hold visibility', async () => {
+    const pool = createMockPool();
+    const scheduler = new RetentionScheduler(1000);
+    const auditLogger = createAuditLogger();
+    const runCypher = jest.fn().mockResolvedValue([]);
+    const engine = new DataRetentionEngine({ pool, scheduler, auditLogger, runCypher });
+
+    const metadata = createMetadata({ datasetId: 'report-dataset' });
+    await engine.registerDataset(metadata, 'compliance');
+
+    await engine.applyLegalHold('report-dataset', {
+      datasetId: 'report-dataset',
+      reason: 'Regulatory request',
+      requestedBy: 'compliance@intelgraph.dev',
+      createdAt: new Date(),
+      scope: 'full'
+    });
+
+    const report = engine.generateComplianceReport(new Date(Date.now() - 1000), new Date(Date.now() + 1000));
+
+    expect(report.totalDatasets).toBeGreaterThanOrEqual(1);
+    expect(report.datasetsOnLegalHold).toBeGreaterThanOrEqual(1);
+    expect(report.details[0].policyId).toBeDefined();
+
+    scheduler.stop();
+  });
+
+  it('archives datasets and records audit events', async () => {
+    const pool = createMockPool();
+    const scheduler = new RetentionScheduler(1000);
+    const auditLogger = createAuditLogger();
+    const runCypher = jest.fn().mockResolvedValue([]);
+    const engine = new DataRetentionEngine({ pool, scheduler, auditLogger, runCypher });
+
+    const metadata = createMetadata({ datasetId: 'archive-dataset' });
+    await engine.registerDataset(metadata, 'archiver');
+
+    await engine.archiveDataset('archive-dataset', 'archiver', 'glacier://intelgraph/archive-dataset');
+
+    expect((pool.query as unknown as jest.Mock)).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE data_retention_records'),
+      expect.any(Array)
+    );
+    expect(runCypher).toHaveBeenCalledWith(
+      expect.stringContaining('MATCH (n { datasetId: $datasetId })'),
+      expect.objectContaining({ datasetId: 'archive-dataset' })
+    );
+    expect((auditLogger.log as jest.Mock)).toHaveBeenCalledWith(expect.objectContaining({ event: 'archive.completed' }));
+
+    scheduler.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- build a reusable data retention engine with policy templates, automated classification, legal hold enforcement, scheduled purges, archival workflows, and compliance reporting
- add repository, scheduler, and audit logging adapters plus integrate the engine with the AI suggestion retention job
- document compliance posture and add targeted unit tests for lifecycle, legal hold, reporting, and archival scenarios

## Testing
- npm test -- --config jest.config.ts dataRetentionEngine *(fails: jest configuration expects jest-extended/all which is unavailable in this environment due to native build prerequisites)*

------
https://chatgpt.com/codex/tasks/task_e_68e09b0287a48333a5c371b0b97bfa5e