### PR TITLE
docs: add fast-ship sku one-pager and order forms

### DIFF
--- a/docs/sales/fast-ship-top6-one-pager.md
+++ b/docs/sales/fast-ship-top6-one-pager.md
@@ -1,0 +1,28 @@
+# Fast-Ship Revenue Plays: Top 6 SKUs
+
+_Standard: ≤14 days to first proof, crisp ICP targeting, and clear attach paths._
+
+| SKU | Problem Solved | 14-Day Proof Plan | Commercials | Ideal Customer Profile | Attach / Upsell Hooks |
+| --- | --- | --- | --- | --- | --- |
+| **FIN-01**<br>FinOps Guard for LLM & GPU | AI experimentation creates surprise cloud bills. | Day 3 budgets + guardrails live, Day 7 dashboards with cost/request view, Day 14 anomaly ping + savings attestation. | $2k setup<br>$1k/mo<br>10% of savings (cap $3k/mo). | Eng/Data teams piloting LLM or GPU workloads with <$100k/mo spend. | Eval Harness (AIE-01), Audit Trail (AIG-01). |
+| **AIS-RT-01**<br>Prompt Injection Red-Team Lite | Prompt attacks stall launches and trust. | Day 2 kick-off + attack library, Day 7 findings mapped to decision tree, Day 14 mitigation checklist delivered. | $5k fixed (2-week sprint). | Product or platform owners shipping user-generated prompts to LLMs. | Policy Bundle (POL-01), Privacy Gateway (PRIV-01). |
+| **AIS-GUARD-01**<br>Prompt Safelist & Output Guard | Unstable or unsafe LLM outputs in production. | Day 5 safelist/denylist deployed, Day 10 grounded claims chips surfaced, Day 14 fallback runbook validated. | $3k setup<br>$1.5k/mo. | LLM features embedded in customer-facing UIs with compliance stakes. | Audit Trail (AIG-01), Eval Harness (AIE-01). |
+| **RES-01**<br>Data Residency & Lineage Auditor | Lack of proof on data location and handling. | Day 4 data flow tagging, Day 9 lineage export with violations, Day 14 remediation memo ready for auditor. | $4k setup<br>$1.5k/mo. | EU/CA-exposed SaaS platforms needing residency assurance. | Privacy Gateway (PRIV-01), DPIA Helper (GRC-03). |
+| **GH-CERT-01**<br>GitHub Compliance Badges | Buyers demand compliance proof before POC. | Day 5 repo scan + SBOM badge, Day 10 SLSA signature + canary rules, Day 14 access review badge live. | $1.5k setup<br>$600/mo per repo. | Dev-led SaaS teams needing a shareable trust page. | SBOM/SLSA (SEC-02), Disclosure Pack (DP-01). |
+| **RBC-01**<br>Runbook-as-Code Starter | Tribal ops knowledge blocks scale and audits. | Day 3 YAML skeletons, Day 8 Maestro execution wired, Day 14 evidence export showing traceable ops. | $2k setup<br>$800/mo. | Infra/SRE-light teams formalizing incident response. | Incident Pack (INC-01), SLO Guardrails (SRE-01). |
+
+## Packaging Notes
+
+- **Proof Window:** Every SKU commits to visible value and an executive-ready artifact inside 14 days.
+- **Margins:** Setup fees cover delivery hours; recurring fees land ≥60% margin with light-touch ops.
+- **Playbook:** Lead with the problem narrative, show the 14-day proof plan, land the upsell path before close.
+- **Bundles to Pitch:**
+  - _Trust-in-Two Weeks:_ Pair GH-CERT-01 with DP-01 and SEC-02 when buyers need pre-POC proof.
+  - _LLM Risk Basic:_ Sequence AIS-RT-01 → AIS-GUARD-01 → AIG-01 for shipping LLM features safely.
+  - _Ops Confidence:_ Attach RBC-01 to DR-01 and INC-01 for resilience stories.
+
+## Call-to-Action Script Snippets
+
+1. **“Day 14 receipt” close:** “We’ll stand up the controls, ship the proof pack, and hand you the attestation inside two weeks. If we miss, pause the subscription.”
+2. **“Attach now” close:** “Teams that buy FinOps Guard often green-light Eval Harness right after the first anomaly catch—let’s add it to the order while procurement is warm.”
+3. **“Pilot-to-production bridge” close:** “These runbooks and badges become the backbone of the production SOW; this order form keeps you in the express lane.”

--- a/docs/sales/order-forms/AIS-GUARD-01-order-form.md
+++ b/docs/sales/order-forms/AIS-GUARD-01-order-form.md
@@ -1,0 +1,47 @@
+# Order Form – AIS-GUARD-01 Prompt Safelist & Output Guard
+
+**Customer:** _________________________________________  
+**Date:** _________________________________________  
+**Prepared by:** Summit Revenue Ops  
+**Engagement Term:** Initial 90-day subscription (auto-renews monthly).
+
+## Scope of Work
+
+### Objectives
+- Stabilize LLM outputs in production with enforceable safelists and fallbacks.
+- Provide compliance-ready evidence that safeguards are live within 14 days.
+
+### Day-14 Proof Plan
+1. **Day 0–4:** Inventory target prompts/output types; configure allow/deny pattern rules and monitoring hooks.
+2. **Day 5–10:** Deploy grounded claim chips and implement human-in-the-loop fallback workflows.
+3. **Day 11–14:** Run live fire-drills on high-risk flows, capture evidence, publish guardrail attestation.
+
+### Ongoing Delivery (Post Day 14)
+- Continuous tuning of safelist/denylist patterns with weekly review.
+- Monthly guardrail performance report and exception log.
+- Recommendations for connecting Audit Trail (AIG-01) and Eval Harness (AIE-01).
+
+## Commercials
+- **Setup Fee:** $3,000 due at signing (non-refundable).
+- **Subscription:** $1,500 per month, invoiced in advance starting Day 14.
+- **Payment Terms:** Net 15 days from invoice.
+
+## Success Criteria
+- Safelist/denylist policies active in production-equivalent environment within 10 days.
+- Documented fallback execution with resolution metrics before Day 14.
+- Guardrail attestation delivered and accepted by product/compliance lead.
+
+## Assumptions & Dependencies
+- Customer supplies API access, prompt templates, and sample transcripts within 3 business days.
+- Engineering counterpart available for two integration working sessions (60 minutes each).
+- Customer maintains incident response contact for real-time escalation.
+
+## Change Requests
+Enhancements beyond described safeguards or expansion to additional products require mutual written change order.
+
+## Acceptance
+
+| Role | Name | Signature | Date |
+| --- | --- | --- | --- |
+| Customer Authorized Signer |  |  |  |
+| Summit Authorized Signer |  |  |  |

--- a/docs/sales/order-forms/AIS-RT-01-order-form.md
+++ b/docs/sales/order-forms/AIS-RT-01-order-form.md
@@ -1,0 +1,47 @@
+# Order Form – AIS-RT-01 Prompt Injection Red-Team Lite
+
+**Customer:** _________________________________________  
+**Date:** _________________________________________  
+**Prepared by:** Summit Revenue Ops  
+**Engagement Term:** Fixed 2-week engagement.
+
+## Scope of Work
+
+### Objectives
+- Identify and prioritize prompt injection risks that block launch readiness.
+- Hand off actionable mitigations mapped to decision nodes and policy levers.
+
+### Day-14 Proof Plan
+1. **Day 0–2:** Kickoff workshop, environment access, baseline target personas, finalize red-team rules of engagement.
+2. **Day 3–7:** Execute curated safe attack set against staging/prod-like environment, log impact, capture evidence.
+3. **Day 8–14:** Consolidate findings into decision-tree heatmap and mitigation checklist; deliver playback to stakeholders.
+
+### Deliverables
+- Findings report with severity, exploit path, and recommended mitigations.
+- Decision-node coverage matrix aligned to product flows.
+- Mitigation checklist with owner, effort, and acceptance criteria.
+- Optional executive summary slide for leadership readout.
+
+## Commercials
+- **Engagement Fee:** $5,000 fixed, 50% due at signing and 50% at Day 14 delivery.
+- **Payment Terms:** Net 15 on each invoice.
+
+## Success Criteria
+- Attack library executed with documented outcomes within the 2-week window.
+- At least five high-priority decision nodes mapped with mitigation guidance.
+- Stakeholder playback completed and sign-off on remediation backlog.
+
+## Assumptions & Dependencies
+- Customer grants non-production access suitable for simulated attacks within 3 business days.
+- Customer provides a security/product owner for daily stand-up (15 minutes) during active testing.
+- Summit operates under mutually agreed safe-list to avoid live customer impact.
+
+## Change Requests
+Additional attack scenarios or environment builds beyond scope require a new order form or change order.
+
+## Acceptance
+
+| Role | Name | Signature | Date |
+| --- | --- | --- | --- |
+| Customer Authorized Signer |  |  |  |
+| Summit Authorized Signer |  |  |  |

--- a/docs/sales/order-forms/FIN-01-order-form.md
+++ b/docs/sales/order-forms/FIN-01-order-form.md
@@ -1,0 +1,49 @@
+# Order Form – FIN-01 FinOps Guard for LLM & GPU
+
+**Customer:** _________________________________________  
+**Date:** _________________________________________  
+**Prepared by:** Summit Revenue Ops  
+**Engagement Term:** Month-to-month with 30-day cancellation notice.
+
+## Scope of Work
+
+### Objectives
+- Stop surprise LLM/GPU cloud spend during pilot and pre-production phases.
+- Deliver executive-ready cost transparency and enforced guardrails inside 14 days.
+
+### Day-14 Proof Plan
+1. **Day 0–3:** Connect billing sources (AWS/Azure/GCP), set per-project budget caps, configure cost-per-request tagging.
+2. **Day 4–7:** Launch live dashboards (per model, per workspace) and enable anomaly detection thresholds.
+3. **Day 8–14:** Trigger simulated overage, deliver anomaly alert with recommended action, publish monthly attestation pack.
+
+### Ongoing Delivery (Post Day 14)
+- Maintain dashboards, update budget caps, refine anomaly thresholds.
+- Issue monthly cost attestation and savings summary.
+- Surface upsell recommendations (Eval Harness AIE-01, Audit Trail AIG-01).
+
+## Commercials
+- **Setup Fee:** $2,000 due at signing (non-refundable).
+- **Subscription:** $1,000 per month, invoiced in advance.
+- **Savings Share:** 10% of verified monthly savings, capped at $3,000 per month.
+- **Payment Terms:** Net 15 days from invoice date.
+
+## Success Criteria
+- Cost guardrails active and tested within 14 days of kickoff.
+- Dashboard adoption: at least two stakeholder logins recorded by Day 14.
+- Documented anomaly alert and remediation recommendation delivered.
+- Monthly attestation accepted by customer FinOps or engineering lead.
+
+## Assumptions & Dependencies
+- Customer provides read-only access to relevant cloud billing accounts within 2 business days.
+- Customer designates a FinOps/engineering owner for weekly 30-minute syncs.
+- Summit will leverage existing tagging/metadata; new tagging support is out of scope beyond advisory.
+
+## Change Requests
+Adjustments beyond the defined deliverables require a written change order and may impact pricing and timeline.
+
+## Acceptance
+
+| Role | Name | Signature | Date |
+| --- | --- | --- | --- |
+| Customer Authorized Signer |  |  |  |
+| Summit Authorized Signer |  |  |  |

--- a/docs/sales/order-forms/GH-CERT-01-order-form.md
+++ b/docs/sales/order-forms/GH-CERT-01-order-form.md
@@ -1,0 +1,47 @@
+# Order Form – GH-CERT-01 GitHub Compliance Badges
+
+**Customer:** _________________________________________  
+**Date:** _________________________________________  
+**Prepared by:** Summit Revenue Ops  
+**Engagement Term:** Initial 12-month subscription (renews monthly thereafter).
+
+## Scope of Work
+
+### Objectives
+- Provide verifiable compliance evidence for GitHub repos prior to POC/security reviews.
+- Publish badge page covering SBOM presence, SLSA signatures, canary rules, and access reviews within 14 days.
+
+### Day-14 Proof Plan
+1. **Day 0–5:** Repository intake, run SBOM scan, configure badge page shell.
+2. **Day 6–10:** Enable SLSA signing pipeline, validate canary branch protection, capture access review log.
+3. **Day 11–14:** Launch public/private badge page, deliver attestation packet, train team on updates.
+
+### Ongoing Delivery (Post Day 14)
+- Monthly badge refresh with automated SBOM + SLSA verification.
+- Quarterly access review reminders and evidence upload.
+- Upsell briefing for SBOM/SLSA (SEC-02) and Disclosure Pack (DP-01).
+
+## Commercials
+- **Setup Fee:** $1,500 per repo due at signing (non-refundable).
+- **Subscription:** $600 per month per repo, invoiced in advance.
+- **Payment Terms:** Net 15 days from invoice.
+
+## Success Criteria
+- Badge page live with all four controls validated inside 14 days.
+- First attestation packet accepted by customer security lead.
+- Internal champion enabled to self-service badge refreshes with Summit support.
+
+## Assumptions & Dependencies
+- Customer provides admin access or automation token to target repositories within 2 business days.
+- Customer schedules 1-hour badge review session before Day 14.
+- Summit scope limited to designated repositories; additional repos require separate order forms.
+
+## Change Requests
+Additional compliance controls or integrations beyond defined scope require a mutually agreed change order.
+
+## Acceptance
+
+| Role | Name | Signature | Date |
+| --- | --- | --- | --- |
+| Customer Authorized Signer |  |  |  |
+| Summit Authorized Signer |  |  |  |

--- a/docs/sales/order-forms/RBC-01-order-form.md
+++ b/docs/sales/order-forms/RBC-01-order-form.md
@@ -1,0 +1,47 @@
+# Order Form – RBC-01 Runbook-as-Code Starter
+
+**Customer:** _________________________________________  
+**Date:** _________________________________________  
+**Prepared by:** Summit Revenue Ops  
+**Engagement Term:** Initial 6-month subscription (renews monthly thereafter).
+
+## Scope of Work
+
+### Objectives
+- Codify tribal operational knowledge into executable YAML runbooks.
+- Demonstrate Maestro-run evidence trail within 14 days.
+
+### Day-14 Proof Plan
+1. **Day 0–3:** Capture top 3 operational scenarios, translate into YAML templates, validate with customer SMEs.
+2. **Day 4–8:** Integrate runbooks with Maestro executions, configure evidence capture, run dry-runs.
+3. **Day 9–14:** Execute live scenario, export evidence pack, train customer operators.
+
+### Ongoing Delivery (Post Day 14)
+- Monthly runbook review and update cycle (up to 3 scenarios/month).
+- Evidence exports for audits and retrospectives.
+- Recommendations to attach Incident Pack (INC-01) and SLO Guardrails (SRE-01).
+
+## Commercials
+- **Setup Fee:** $2,000 due at signing (non-refundable).
+- **Subscription:** $800 per month, invoiced in advance.
+- **Payment Terms:** Net 15 days from invoice.
+
+## Success Criteria
+- Minimum of three YAML runbooks published and version-controlled by Day 7.
+- Maestro execution logged with evidence export prior to Day 14.
+- Customer operators trained (at least two attendees) and sign-off on adoption checklist.
+
+## Assumptions & Dependencies
+- Customer provides subject matter experts for two 60-minute working sessions during Week 1.
+- Customer grants access to existing tooling needed for automation hooks.
+- Summit scope limited to defined scenarios; additional scenarios require new scoping.
+
+## Change Requests
+Expanding beyond agreed scenarios or integrating new systems requires a change order.
+
+## Acceptance
+
+| Role | Name | Signature | Date |
+| --- | --- | --- | --- |
+| Customer Authorized Signer |  |  |  |
+| Summit Authorized Signer |  |  |  |

--- a/docs/sales/order-forms/RES-01-order-form.md
+++ b/docs/sales/order-forms/RES-01-order-form.md
@@ -1,0 +1,47 @@
+# Order Form – RES-01 Data Residency & Lineage Auditor
+
+**Customer:** _________________________________________  
+**Date:** _________________________________________  
+**Prepared by:** Summit Revenue Ops  
+**Engagement Term:** Initial 6-month subscription (renews monthly thereafter).
+
+## Scope of Work
+
+### Objectives
+- Provide defensible evidence of data residency and lineage for EU/CA stakeholders.
+- Surface violations and remediation guidance within the first 14 days.
+
+### Day-14 Proof Plan
+1. **Day 0–4:** Intake system inventory, tag data flows by region and sensitivity, configure lineage tracing connectors.
+2. **Day 5–9:** Generate residency map, identify policy breaches, draft remediation options.
+3. **Day 10–14:** Deliver auditor-ready export (violations + fixes) and executive memo summarizing risk posture.
+
+### Ongoing Delivery (Post Day 14)
+- Monthly lineage export with variance tracking and remediation status.
+- Advisory office hours for regulatory questions (up to 2 hours/month).
+- Privacy Gateway (PRIV-01) and DPIA Helper (GRC-03) attach recommendations.
+
+## Commercials
+- **Setup Fee:** $4,000 due at signing (non-refundable).
+- **Subscription:** $1,500 per month, invoiced in advance.
+- **Payment Terms:** Net 15 days from invoice.
+
+## Success Criteria
+- Residency tagging completed across agreed systems inside 14 days.
+- Auditor export delivered and accepted by customer compliance owner.
+- At least one remediation path documented per identified violation.
+
+## Assumptions & Dependencies
+- Customer provides architecture diagrams and access to data flow metadata within 3 business days.
+- Customer designates compliance/engineering stakeholders for twice-weekly checkpoints.
+- Summit access limited to metadata; raw data copies remain in customer environment.
+
+## Change Requests
+Expansion to additional regions, systems, or custom automation requires a written change order.
+
+## Acceptance
+
+| Role | Name | Signature | Date |
+| --- | --- | --- | --- |
+| Customer Authorized Signer |  |  |  |
+| Summit Authorized Signer |  |  |  |


### PR DESCRIPTION
## Summary
- add a fast-ship portfolio one-pager highlighting the six priority SKUs and their 14-day proof plans
- provide click-to-order statements of work for FIN-01, AIS-RT-01, AIS-GUARD-01, RES-01, GH-CERT-01, and RBC-01

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e07fa7a1ac8333beefde15f1ba0795