### PR TITLE
feat: add influence mining extractor pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
     "db:knex:smoke": "knex migrate:down && knex migrate:up",
     "prov:dev": "ts-node packages/prov-ledger/src/server.ts",
     "lac:compile": "ts-node packages/lac/src/compiler.ts",
-    "kpw:dev": "node packages/kpw-media/dist/server.js"
+    "kpw:dev": "node packages/kpw-media/dist/server.js",
+    "extract": "npm run --workspace=packages/influence-mining extract --"
   },
   "keywords": [
     "intelligence-analysis",

--- a/packages/influence-mining/README.md
+++ b/packages/influence-mining/README.md
@@ -1,0 +1,26 @@
+# Influence Mining
+
+The **Influence Mining** package extracts, enriches, and ranks influence networks from multi-modal social data sources.
+
+## Usage
+
+```bash
+npm run extract -- --input packages/influence-mining/test-data/sample-social-posts.json --output /tmp/network.json
+```
+
+The command ingests the supplied dataset, constructs the influence network, enriches it with adversarial motif detection, ranks the entities, and writes the resulting JSON network to the provided path.
+
+## Development
+
+- `npm run --workspace=packages/influence-mining build` – compile the TypeScript sources.
+- `npm run --workspace=packages/influence-mining test` – run the Jest test-suite for the package.
+
+The library exposes the following primary classes:
+
+- `InfluenceNetworkExtractor`
+- `RelationshipDetector`
+- `GraphBuilder`
+- `MotifAnalyzer`
+- `DataIngester`
+
+Refer to the tests for end-to-end examples of the extraction pipeline.

--- a/packages/influence-mining/package.json
+++ b/packages/influence-mining/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@intelgraph/influence-mining",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "influence-extract": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "preextract": "npm run build",
+    "extract": "node dist/cli.js",
+    "test": "jest"
+  }
+}

--- a/packages/influence-mining/src/DataIngester.ts
+++ b/packages/influence-mining/src/DataIngester.ts
@@ -1,0 +1,118 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  Entity,
+  IngestResult,
+  Relationship,
+  SocialPost,
+  SourceData,
+  TextDocument,
+} from './types.js';
+import { RelationshipDetector } from './RelationshipDetector.js';
+
+export class DataIngester {
+  constructor(private readonly relationshipDetector: RelationshipDetector) {}
+
+  ingest(sources: SourceData[]): { result: IngestResult; relationships: Relationship[] } {
+    const posts: SocialPost[] = [];
+    const documents: TextDocument[] = [];
+    const entities = new Map<string, Entity>();
+    const relationships: Relationship[] = [];
+
+    for (const source of sources) {
+      if (source.kind === 'social') {
+        const sourcePosts: SocialPost[] = [];
+        for (const post of source.posts) {
+          const normalized = this.normalizePost(post);
+          sourcePosts.push(normalized);
+          posts.push(normalized);
+          entities.set(normalized.author.toLowerCase(), {
+            id: normalized.author.toLowerCase(),
+            type: 'actor',
+            label: normalized.author,
+          });
+
+          const mentions = normalized.mentions ?? [];
+          for (const mention of mentions) {
+            entities.set(mention.toLowerCase(), {
+              id: mention.toLowerCase(),
+              type: 'actor',
+              label: mention,
+            });
+          }
+
+          if (normalized.inReplyTo) {
+            entities.set(normalized.inReplyTo.toLowerCase(), {
+              id: normalized.inReplyTo.toLowerCase(),
+              type: 'actor',
+              label: normalized.inReplyTo,
+            });
+          }
+
+          if (normalized.sharedFrom) {
+            entities.set(normalized.sharedFrom.toLowerCase(), {
+              id: normalized.sharedFrom.toLowerCase(),
+              type: 'actor',
+              label: normalized.sharedFrom,
+            });
+          }
+        }
+
+        relationships.push(...this.relationshipDetector.detectFromSocial(sourcePosts));
+      } else if (source.kind === 'text') {
+        for (const doc of source.documents) {
+          const normalizedDoc: TextDocument = {
+            ...doc,
+            id: doc.id,
+            text: doc.text,
+            primaryActor: doc.primaryActor.toLowerCase(),
+          };
+          documents.push(normalizedDoc);
+          entities.set(normalizedDoc.primaryActor, {
+            id: normalizedDoc.primaryActor,
+            type: 'actor',
+            label: doc.primaryActor,
+          });
+          const textRelationships = this.relationshipDetector.detectFromText(doc.text);
+          relationships.push(...textRelationships);
+          for (const rel of textRelationships) {
+            if (!entities.has(rel.from)) {
+              entities.set(rel.from, { id: rel.from, type: 'actor' });
+            }
+            if (!entities.has(rel.to)) {
+              entities.set(rel.to, { id: rel.to, type: 'actor' });
+            }
+          }
+        }
+      }
+    }
+
+    return {
+      result: {
+        posts,
+        documents,
+        entities: Array.from(entities.values()),
+      },
+      relationships,
+    };
+  }
+
+  loadSocialPostsFromFile(filePath: string): SocialPost[] {
+    const resolved = path.resolve(filePath);
+    const raw = fs.readFileSync(resolved, 'utf-8');
+    const data = JSON.parse(raw) as SocialPost[];
+    return data.map((post) => this.normalizePost(post));
+  }
+
+  private normalizePost(post: SocialPost): SocialPost {
+    const mentions = post.mentions ?? [...post.text.matchAll(/@([a-zA-Z0-9_\-]+)/g)].map((match) => match[1].toLowerCase());
+    return {
+      ...post,
+      author: post.author.toLowerCase(),
+      mentions: mentions.map((mention) => mention.toLowerCase()),
+      inReplyTo: post.inReplyTo ? post.inReplyTo.toLowerCase() : undefined,
+      sharedFrom: post.sharedFrom ? post.sharedFrom.toLowerCase() : undefined,
+    };
+  }
+}

--- a/packages/influence-mining/src/GraphBuilder.ts
+++ b/packages/influence-mining/src/GraphBuilder.ts
@@ -1,0 +1,64 @@
+import { Entity, Graph, GraphEdge, RelationshipType } from './types.js';
+
+export class GraphBuilder {
+  private readonly nodes = new Map<string, Entity>();
+  private readonly edgeMap = new Map<string, GraphEdge>();
+
+  addNode(entity: Entity): void {
+    const existing = this.nodes.get(entity.id);
+    if (existing) {
+      this.nodes.set(entity.id, { ...existing, ...entity });
+      return;
+    }
+
+    this.nodes.set(entity.id, { ...entity });
+  }
+
+  addEdge(from: Entity, to: Entity, weight: number, type: RelationshipType = 'interaction'): void {
+    if (!this.nodes.has(from.id)) {
+      this.addNode(from);
+    }
+    if (!this.nodes.has(to.id)) {
+      this.addNode(to);
+    }
+
+    const key = `${from.id}->${to.id}`;
+    const existing = this.edgeMap.get(key);
+    if (existing) {
+      existing.weight += weight;
+      if (!existing.types.includes(type)) {
+        existing.types.push(type);
+      }
+      this.edgeMap.set(key, existing);
+      return;
+    }
+
+    this.edgeMap.set(key, {
+      from: from.id,
+      to: to.id,
+      weight,
+      types: [type],
+    });
+  }
+
+  build(): Graph {
+    const adjacency: Record<string, Record<string, number>> = {};
+    for (const edge of this.edgeMap.values()) {
+      if (!adjacency[edge.from]) {
+        adjacency[edge.from] = {};
+      }
+      adjacency[edge.from][edge.to] = edge.weight;
+    }
+
+    return {
+      nodes: Array.from(this.nodes.values()),
+      edges: Array.from(this.edgeMap.values()).sort((a, b) => {
+        if (a.weight === b.weight) {
+          return a.to.localeCompare(b.to);
+        }
+        return b.weight - a.weight;
+      }),
+      adjacency,
+    };
+  }
+}

--- a/packages/influence-mining/src/InfluenceNetworkExtractor.ts
+++ b/packages/influence-mining/src/InfluenceNetworkExtractor.ts
@@ -1,0 +1,108 @@
+import { DataIngester } from './DataIngester.js';
+import { GraphBuilder } from './GraphBuilder.js';
+import { MotifAnalyzer } from './MotifAnalyzer.js';
+import { RelationshipDetector } from './RelationshipDetector.js';
+import {
+  EnrichedNetwork,
+  Entity,
+  InfluenceNetwork,
+  NodeRanking,
+  RankedNetwork,
+  SourceData,
+} from './types.js';
+
+export class InfluenceNetworkExtractor {
+  private readonly relationshipDetector: RelationshipDetector;
+  private readonly dataIngester: DataIngester;
+  private readonly motifAnalyzer: MotifAnalyzer;
+
+  constructor(
+    relationshipDetector = new RelationshipDetector(),
+    dataIngester = new DataIngester(relationshipDetector),
+    motifAnalyzer = new MotifAnalyzer(),
+  ) {
+    this.relationshipDetector = relationshipDetector;
+    this.dataIngester = dataIngester;
+    this.motifAnalyzer = motifAnalyzer;
+  }
+
+  extract(data: SourceData[]): InfluenceNetwork {
+    const ingestion = this.dataIngester.ingest(data);
+    const initialRelationships = this.relationshipDetector.mergeRelationships([
+      ...ingestion.relationships,
+    ]);
+
+    const graphBuilder = new GraphBuilder();
+    const entityMap = new Map<string, Entity>();
+
+    for (const entity of ingestion.result.entities) {
+      entityMap.set(entity.id, entity);
+      graphBuilder.addNode(entity);
+    }
+
+    for (const relationship of initialRelationships) {
+      const from = entityMap.get(relationship.from) ?? {
+        id: relationship.from,
+        type: 'actor',
+      };
+      const to = entityMap.get(relationship.to) ?? {
+        id: relationship.to,
+        type: 'actor',
+      };
+      graphBuilder.addNode(from);
+      graphBuilder.addNode(to);
+      graphBuilder.addEdge(from, to, relationship.weight, relationship.type);
+    }
+
+    const graph = graphBuilder.build();
+    const entities = Array.from(new Map(graph.nodes.map((entity) => [entity.id, entity])).values());
+
+    return {
+      graph,
+      entities,
+      relationships: initialRelationships,
+    };
+  }
+
+  enrich(network: InfluenceNetwork): EnrichedNetwork {
+    const motifs = {
+      botNetworks: this.motifAnalyzer.detectBotNetworks(network.graph),
+      amplifierClusters: this.motifAnalyzer.findAmplifierClusters(network.graph),
+      coordinatedBehaviors: this.motifAnalyzer.identifyCoordinatedBehavior(network.graph),
+    };
+
+    return {
+      ...network,
+      motifs,
+    };
+  }
+
+  rankNodes(network: InfluenceNetwork): RankedNetwork {
+    const inbound = new Map<string, number>();
+    const outbound = new Map<string, number>();
+
+    for (const relationship of network.relationships) {
+      outbound.set(relationship.from, (outbound.get(relationship.from) ?? 0) + relationship.weight);
+      inbound.set(relationship.to, (inbound.get(relationship.to) ?? 0) + relationship.weight);
+    }
+
+    const rankings: NodeRanking[] = network.graph.nodes.map((entity) => {
+      const inWeight = inbound.get(entity.id) ?? 0;
+      const outWeight = outbound.get(entity.id) ?? 0;
+      const score = inWeight * 1.2 + outWeight;
+      return {
+        entity,
+        score,
+        inboundWeight: inWeight,
+        outboundWeight: outWeight,
+      };
+    });
+
+    rankings.sort((a, b) => b.score - a.score || a.entity.id.localeCompare(b.entity.id));
+
+    return {
+      ...network,
+      rankings,
+    };
+  }
+}

--- a/packages/influence-mining/src/MotifAnalyzer.ts
+++ b/packages/influence-mining/src/MotifAnalyzer.ts
@@ -1,0 +1,123 @@
+import { BotCluster, Cluster, Graph, Pattern, RelationshipType } from './types.js';
+
+const SHARE_TYPE: RelationshipType = 'share';
+const MENTION_TYPE: RelationshipType = 'mention';
+
+export class MotifAnalyzer {
+  detectBotNetworks(graph: Graph): BotCluster[] {
+    const clusters: BotCluster[] = [];
+    const shareTargets = new Map<string, Map<string, number>>();
+
+    for (const edge of graph.edges) {
+      if (!edge.types.includes(SHARE_TYPE)) {
+        continue;
+      }
+      const from = edge.from;
+      const target = edge.to;
+      if (!shareTargets.has(target)) {
+        shareTargets.set(target, new Map());
+      }
+      const members = shareTargets.get(target)!;
+      members.set(from, edge.weight + (members.get(from) ?? 0));
+    }
+
+    for (const [target, members] of shareTargets.entries()) {
+      const activeMembers = Array.from(members.entries()).filter(([, weight]) => weight >= 2);
+      if (activeMembers.length >= 3) {
+        const activityScore = activeMembers.reduce((acc, [, weight]) => acc + weight, 0);
+        clusters.push({
+          label: `Coordinated share burst targeting ${target}`,
+          members: activeMembers.map(([member]) => member),
+          activityScore,
+          evidence: [SHARE_TYPE],
+        });
+      }
+    }
+
+    return clusters;
+  }
+
+  findAmplifierClusters(graph: Graph): Cluster[] {
+    const amplificationByNode = new Map<string, number>();
+
+    for (const edge of graph.edges) {
+      if (edge.types.includes(SHARE_TYPE)) {
+        amplificationByNode.set(edge.from, (amplificationByNode.get(edge.from) ?? 0) + edge.weight);
+      }
+      if (edge.types.includes(MENTION_TYPE)) {
+        amplificationByNode.set(edge.from, (amplificationByNode.get(edge.from) ?? 0) + edge.weight * 0.5);
+      }
+    }
+
+    const clusters: Cluster[] = [];
+    const sorted = Array.from(amplificationByNode.entries()).sort((a, b) => b[1] - a[1]);
+    const topNodes = sorted.filter(([, score]) => score >= 3);
+    if (topNodes.length > 0) {
+      clusters.push({
+        nodes: topNodes.map(([node]) => node),
+        amplificationScore: topNodes.reduce((acc, [, score]) => acc + score, 0),
+      });
+    }
+
+    return clusters;
+  }
+
+  identifyCoordinatedBehavior(graph: Graph): Pattern[] {
+    const patterns: Pattern[] = [];
+    const neighborMap = new Map<string, Map<string, { weight: number; types: RelationshipType[] }>>();
+
+    for (const edge of graph.edges) {
+      if (!neighborMap.has(edge.from)) {
+        neighborMap.set(edge.from, new Map());
+      }
+      neighborMap.get(edge.from)!.set(edge.to, { weight: edge.weight, types: edge.types });
+    }
+
+    const visitedPairs = new Set<string>();
+    const nodes = Array.from(neighborMap.keys());
+
+    for (let i = 0; i < nodes.length; i += 1) {
+      for (let j = i + 1; j < nodes.length; j += 1) {
+        const a = nodes[i];
+        const b = nodes[j];
+        const key = `${a}|${b}`;
+        if (visitedPairs.has(key)) {
+          continue;
+        }
+        visitedPairs.add(key);
+
+        const neighborsA = neighborMap.get(a);
+        const neighborsB = neighborMap.get(b);
+        if (!neighborsA || !neighborsB) {
+          continue;
+        }
+
+        const sharedTargets: string[] = [];
+        for (const [target, infoA] of neighborsA.entries()) {
+          const infoB = neighborsB.get(target);
+          if (!infoB) {
+            continue;
+          }
+          const hasCoordinatedType = infoA.types.some((type) => infoB.types.includes(type));
+          if (!hasCoordinatedType) {
+            continue;
+          }
+          const combinedWeight = infoA.weight + infoB.weight;
+          if (combinedWeight >= 3) {
+            sharedTargets.push(target);
+          }
+        }
+
+        if (sharedTargets.length >= 2) {
+          patterns.push({
+            description: `Coordinated engagement by ${a} and ${b} on ${sharedTargets.length} shared targets`,
+            participants: [a, b],
+            support: sharedTargets.length,
+          });
+        }
+      }
+    }
+
+    return patterns;
+  }
+}

--- a/packages/influence-mining/src/RelationshipDetector.ts
+++ b/packages/influence-mining/src/RelationshipDetector.ts
@@ -1,0 +1,138 @@
+import { Relationship, RelationshipType, SocialPost } from './types.js';
+
+const mentionRegex = /@([a-zA-Z0-9_\-]+)/g;
+
+export class RelationshipDetector {
+  detectFromText(text: string): Relationship[] {
+    const relationships: Relationship[] = [];
+    const normalized = text.toLowerCase();
+    const mentionMatches = [...normalized.matchAll(mentionRegex)];
+
+    if (mentionMatches.length > 1) {
+      const primary = mentionMatches[0][1];
+      for (let i = 1; i < mentionMatches.length; i += 1) {
+        const target = mentionMatches[i][1];
+        relationships.push({
+          from: primary,
+          to: target,
+          type: 'mention',
+          weight: 1,
+          metadata: { source: 'text' },
+        });
+      }
+      return relationships;
+    }
+
+    const patterns: Array<{ regex: RegExp; type: RelationshipType }> = [
+      { regex: /(\w+)\s+mentions\s+(\w+)/gi, type: 'mention' },
+      { regex: /(\w+)\s+replies\s+to\s+(\w+)/gi, type: 'reply' },
+      { regex: /(\w+)\s+shares\s+(\w+)/gi, type: 'share' },
+    ];
+
+    for (const { regex, type } of patterns) {
+      let match = regex.exec(text);
+      while (match) {
+        const [, from, to] = match;
+        relationships.push({
+          from: from.toLowerCase(),
+          to: to.toLowerCase(),
+          type,
+          weight: 1,
+          metadata: { source: 'text-pattern' },
+        });
+        match = regex.exec(text);
+      }
+    }
+
+    return relationships;
+  }
+
+  detectFromSocial(posts: SocialPost[]): Relationship[] {
+    const relationships: Relationship[] = [];
+
+    for (const post of posts) {
+      const author = post.author.toLowerCase();
+      const timestamp = post.timestamp;
+
+      const mentions = post.mentions ?? [...post.text.matchAll(mentionRegex)].map((match) => match[1].toLowerCase());
+      for (const mention of mentions) {
+        if (mention === author) {
+          continue;
+        }
+        relationships.push({
+          from: author,
+          to: mention,
+          type: 'mention',
+          weight: 1,
+          metadata: { postId: post.id, timestamp },
+        });
+      }
+
+      if (post.inReplyTo) {
+        relationships.push({
+          from: author,
+          to: post.inReplyTo.toLowerCase(),
+          type: 'reply',
+          weight: 1,
+          metadata: { postId: post.id, timestamp },
+        });
+      }
+
+      if (post.sharedFrom) {
+        relationships.push({
+          from: author,
+          to: post.sharedFrom.toLowerCase(),
+          type: 'share',
+          weight: 1,
+          metadata: { postId: post.id, timestamp },
+        });
+      }
+    }
+
+    return relationships;
+  }
+
+  mergeRelationships(rels: Relationship[]): Relationship[] {
+    const merged = new Map<string, Relationship>();
+
+    for (const rel of rels) {
+      const key = `${rel.from}->${rel.to}->${rel.type}`;
+      const existing = merged.get(key);
+      if (existing) {
+        existing.weight += rel.weight;
+        existing.metadata = {
+          occurrences: (existing.metadata?.occurrences as number | undefined ?? 1) + 1,
+          sources: [
+            ...(existing.metadata?.sources as string[] | undefined ?? []),
+            rel.metadata?.postId ? `post:${rel.metadata.postId}` : rel.metadata?.source,
+          ].filter(Boolean),
+        };
+        merged.set(key, existing);
+        continue;
+      }
+
+      merged.set(key, {
+        ...rel,
+        metadata: {
+          ...rel.metadata,
+          occurrences: 1,
+          sources: rel.metadata?.postId
+            ? [`post:${rel.metadata.postId}`]
+            : rel.metadata?.source
+              ? [rel.metadata.source as string]
+              : [],
+        },
+      });
+    }
+
+    return Array.from(merged.values()).sort((a, b) => {
+      if (a.weight === b.weight) {
+        if (a.from === b.from) {
+          return a.to.localeCompare(b.to);
+        }
+        return a.from.localeCompare(b.from);
+      }
+      return b.weight - a.weight;
+    });
+  }
+}

--- a/packages/influence-mining/src/cli.ts
+++ b/packages/influence-mining/src/cli.ts
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { InfluenceNetworkExtractor } from './InfluenceNetworkExtractor.js';
+import { SourceData, SocialPost } from './types.js';
+
+interface CliArgs {
+  input: string;
+  output: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const part = argv[i];
+    if (part.startsWith('--')) {
+      const key = part.slice(2);
+      const value = argv[i + 1];
+      if (!value || value.startsWith('--')) {
+        throw new Error(`Missing value for --${key}`);
+      }
+      args[key] = value;
+      i += 1;
+    }
+  }
+
+  const input = args.input ?? args.i;
+  const output = args.output ?? args.o;
+  if (!input || !output) {
+    throw new Error('Usage: npm run extract -- --input <file> --output <file>');
+  }
+
+  return { input, output };
+}
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = path.resolve(packageRoot, '..', '..');
+
+function resolveInputPath(filePath: string): string {
+  const candidates = [
+    path.resolve(process.cwd(), filePath),
+    path.resolve(packageRoot, filePath),
+    path.resolve(repoRoot, filePath),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  return candidates[0];
+}
+
+function loadSourceData(filePath: string): SourceData[] {
+  const resolved = resolveInputPath(filePath);
+  if (!fs.existsSync(resolved)) {
+    throw new Error(`Input file not found: ${resolved}`);
+  }
+
+  const ext = path.extname(resolved).toLowerCase();
+  if (ext === '.json') {
+    const raw = fs.readFileSync(resolved, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return [{ kind: 'social', posts: parsed as SocialPost[] }];
+    }
+    if (parsed.kind) {
+      return [parsed as SourceData];
+    }
+    if (parsed.posts || parsed.documents) {
+      const sources: SourceData[] = [];
+      if (parsed.posts) {
+        sources.push({ kind: 'social', posts: parsed.posts });
+      }
+      if (parsed.documents) {
+        sources.push({ kind: 'text', documents: parsed.documents });
+      }
+      return sources;
+    }
+    throw new Error('Unsupported JSON structure for input data');
+  }
+
+  if (ext === '.csv') {
+    const raw = fs.readFileSync(resolved, 'utf-8');
+    const [header, ...rows] = raw.split(/\r?\n/).filter(Boolean);
+    const columns = header.split(',').map((col) => col.trim());
+    const posts: SocialPost[] = rows.map((row, index) => {
+      const values = row.split(',').map((value) => value.trim());
+      const record: Record<string, string> = {};
+      columns.forEach((col, colIndex) => {
+        record[col] = values[colIndex] ?? '';
+      });
+      return {
+        id: record.id ?? `row-${index}`,
+        author: record.author ?? 'unknown',
+        text: record.text ?? '',
+        timestamp: record.timestamp ?? new Date().toISOString(),
+        inReplyTo: record.inReplyTo || undefined,
+        sharedFrom: record.sharedFrom || undefined,
+      };
+    });
+    return [{ kind: 'social', posts }];
+  }
+
+  throw new Error(`Unsupported input format: ${ext}`);
+}
+
+function main(): void {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    const sources = loadSourceData(args.input);
+    const extractor = new InfluenceNetworkExtractor();
+    const network = extractor.extract(sources);
+    const enriched = extractor.enrich(network);
+    const ranked = extractor.rankNodes(enriched);
+    const output = { ...enriched, rankings: ranked.rankings };
+    fs.writeFileSync(path.resolve(args.output), JSON.stringify(output, null, 2));
+    // eslint-disable-next-line no-console
+    console.log(`Wrote influence network to ${path.resolve(args.output)}`);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    // eslint-disable-next-line no-console
+    console.error(message);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/packages/influence-mining/src/index.ts
+++ b/packages/influence-mining/src/index.ts
@@ -1,0 +1,6 @@
+export * from './types.js';
+export * from './InfluenceNetworkExtractor.js';
+export * from './GraphBuilder.js';
+export * from './RelationshipDetector.js';
+export * from './MotifAnalyzer.js';
+export * from './DataIngester.js';

--- a/packages/influence-mining/src/types.ts
+++ b/packages/influence-mining/src/types.ts
@@ -1,0 +1,98 @@
+export type RelationshipType = 'mention' | 'reply' | 'share' | string;
+
+export interface Entity {
+  id: string;
+  type: string;
+  label?: string;
+  attributes?: Record<string, unknown>;
+}
+
+export interface Relationship {
+  from: string;
+  to: string;
+  type: RelationshipType;
+  weight: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface GraphEdge {
+  from: string;
+  to: string;
+  weight: number;
+  types: RelationshipType[];
+}
+
+export interface Graph {
+  nodes: Entity[];
+  edges: GraphEdge[];
+  adjacency: Record<string, Record<string, number>>;
+}
+
+export interface BotCluster {
+  label: string;
+  members: string[];
+  activityScore: number;
+  evidence: RelationshipType[];
+}
+
+export interface Cluster {
+  nodes: string[];
+  amplificationScore: number;
+}
+
+export interface Pattern {
+  description: string;
+  participants: string[];
+  support: number;
+}
+
+export interface InfluenceNetwork {
+  graph: Graph;
+  entities: Entity[];
+  relationships: Relationship[];
+}
+
+export interface EnrichedNetwork extends InfluenceNetwork {
+  motifs: {
+    botNetworks: BotCluster[];
+    amplifierClusters: Cluster[];
+    coordinatedBehaviors: Pattern[];
+  };
+}
+
+export interface NodeRanking {
+  entity: Entity;
+  score: number;
+  inboundWeight: number;
+  outboundWeight: number;
+}
+
+export interface RankedNetwork extends InfluenceNetwork {
+  rankings: NodeRanking[];
+}
+
+export interface SocialPost {
+  id: string;
+  author: string;
+  text: string;
+  timestamp: string;
+  inReplyTo?: string | null;
+  sharedFrom?: string | null;
+  mentions?: string[];
+}
+
+export interface TextDocument {
+  id: string;
+  text: string;
+  primaryActor: string;
+}
+
+export type SourceData =
+  | { kind: 'social'; posts: SocialPost[] }
+  | { kind: 'text'; documents: TextDocument[] };
+
+export interface IngestResult {
+  posts: SocialPost[];
+  documents: TextDocument[];
+  entities: Entity[];
+}

--- a/packages/influence-mining/test-data/expected-network.json
+++ b/packages/influence-mining/test-data/expected-network.json
@@ -1,0 +1,1028 @@
+{
+  "graph": {
+    "nodes": [
+      {
+        "id": "alice",
+        "type": "actor",
+        "label": "alice"
+      },
+      {
+        "id": "bob",
+        "type": "actor",
+        "label": "bob"
+      },
+      {
+        "id": "carol",
+        "type": "actor",
+        "label": "carol"
+      },
+      {
+        "id": "newsdesk",
+        "type": "actor",
+        "label": "newsdesk"
+      },
+      {
+        "id": "dave",
+        "type": "actor",
+        "label": "dave"
+      },
+      {
+        "id": "erin",
+        "type": "actor",
+        "label": "erin"
+      },
+      {
+        "id": "frank",
+        "type": "actor",
+        "label": "frank"
+      },
+      {
+        "id": "grace",
+        "type": "actor",
+        "label": "grace"
+      },
+      {
+        "id": "henry",
+        "type": "actor",
+        "label": "henry"
+      },
+      {
+        "id": "ivy",
+        "type": "actor",
+        "label": "ivy"
+      },
+      {
+        "id": "judy",
+        "type": "actor",
+        "label": "judy"
+      },
+      {
+        "id": "bot1",
+        "type": "actor",
+        "label": "bot1"
+      },
+      {
+        "id": "propagandahub",
+        "type": "actor",
+        "label": "propagandahub"
+      },
+      {
+        "id": "bot2",
+        "type": "actor",
+        "label": "bot2"
+      },
+      {
+        "id": "bot3",
+        "type": "actor",
+        "label": "bot3"
+      }
+    ],
+    "edges": [
+      {
+        "from": "bot1",
+        "to": "propagandahub",
+        "weight": 16,
+        "types": [
+          "mention",
+          "share"
+        ]
+      },
+      {
+        "from": "bot2",
+        "to": "propagandahub",
+        "weight": 16,
+        "types": [
+          "mention",
+          "share"
+        ]
+      },
+      {
+        "from": "bot3",
+        "to": "propagandahub",
+        "weight": 14,
+        "types": [
+          "mention",
+          "share"
+        ]
+      },
+      {
+        "from": "bob",
+        "to": "alice",
+        "weight": 12,
+        "types": [
+          "reply",
+          "mention"
+        ]
+      },
+      {
+        "from": "alice",
+        "to": "bob",
+        "weight": 10,
+        "types": [
+          "mention"
+        ]
+      },
+      {
+        "from": "alice",
+        "to": "carol",
+        "weight": 10,
+        "types": [
+          "mention"
+        ]
+      },
+      {
+        "from": "carol",
+        "to": "alice",
+        "weight": 8,
+        "types": [
+          "mention",
+          "share"
+        ]
+      },
+      {
+        "from": "carol",
+        "to": "newsdesk",
+        "weight": 8,
+        "types": [
+          "mention",
+          "share"
+        ]
+      },
+      {
+        "from": "bob",
+        "to": "carol",
+        "weight": 6,
+        "types": [
+          "mention"
+        ]
+      },
+      {
+        "from": "erin",
+        "to": "dave",
+        "weight": 6,
+        "types": [
+          "reply",
+          "mention"
+        ]
+      },
+      {
+        "from": "grace",
+        "to": "newsdesk",
+        "weight": 6,
+        "types": [
+          "share"
+        ]
+      },
+      {
+        "from": "henry",
+        "to": "newsdesk",
+        "weight": 6,
+        "types": [
+          "share"
+        ]
+      },
+      {
+        "from": "ivy",
+        "to": "newsdesk",
+        "weight": 6,
+        "types": [
+          "share"
+        ]
+      },
+      {
+        "from": "judy",
+        "to": "alice",
+        "weight": 5,
+        "types": [
+          "mention"
+        ]
+      },
+      {
+        "from": "alice",
+        "to": "newsdesk",
+        "weight": 5,
+        "types": [
+          "share"
+        ]
+      },
+      {
+        "from": "dave",
+        "to": "erin",
+        "weight": 4,
+        "types": [
+          "mention"
+        ]
+      },
+      {
+        "from": "erin",
+        "to": "alice",
+        "weight": 3,
+        "types": [
+          "mention"
+        ]
+      },
+      {
+        "from": "frank",
+        "to": "dave",
+        "weight": 3,
+        "types": [
+          "mention"
+        ]
+      },
+      {
+        "from": "dave",
+        "to": "newsdesk",
+        "weight": 3,
+        "types": [
+          "share"
+        ]
+      },
+      {
+        "from": "frank",
+        "to": "newsdesk",
+        "weight": 3,
+        "types": [
+          "share"
+        ]
+      }
+    ],
+    "adjacency": {
+      "alice": {
+        "bob": 10,
+        "carol": 10,
+        "newsdesk": 5
+      },
+      "bot1": {
+        "propagandahub": 16
+      },
+      "bot2": {
+        "propagandahub": 16
+      },
+      "bot3": {
+        "propagandahub": 14
+      },
+      "bob": {
+        "alice": 12,
+        "carol": 6
+      },
+      "grace": {
+        "newsdesk": 6
+      },
+      "henry": {
+        "newsdesk": 6
+      },
+      "ivy": {
+        "newsdesk": 6
+      },
+      "judy": {
+        "alice": 5
+      },
+      "carol": {
+        "alice": 8,
+        "newsdesk": 8
+      },
+      "dave": {
+        "erin": 4,
+        "newsdesk": 3
+      },
+      "erin": {
+        "alice": 3,
+        "dave": 6
+      },
+      "frank": {
+        "dave": 3,
+        "newsdesk": 3
+      }
+    }
+  },
+  "entities": [
+    {
+      "id": "alice",
+      "type": "actor",
+      "label": "alice"
+    },
+    {
+      "id": "bob",
+      "type": "actor",
+      "label": "bob"
+    },
+    {
+      "id": "carol",
+      "type": "actor",
+      "label": "carol"
+    },
+    {
+      "id": "newsdesk",
+      "type": "actor",
+      "label": "newsdesk"
+    },
+    {
+      "id": "dave",
+      "type": "actor",
+      "label": "dave"
+    },
+    {
+      "id": "erin",
+      "type": "actor",
+      "label": "erin"
+    },
+    {
+      "id": "frank",
+      "type": "actor",
+      "label": "frank"
+    },
+    {
+      "id": "grace",
+      "type": "actor",
+      "label": "grace"
+    },
+    {
+      "id": "henry",
+      "type": "actor",
+      "label": "henry"
+    },
+    {
+      "id": "ivy",
+      "type": "actor",
+      "label": "ivy"
+    },
+    {
+      "id": "judy",
+      "type": "actor",
+      "label": "judy"
+    },
+    {
+      "id": "bot1",
+      "type": "actor",
+      "label": "bot1"
+    },
+    {
+      "id": "propagandahub",
+      "type": "actor",
+      "label": "propagandahub"
+    },
+    {
+      "id": "bot2",
+      "type": "actor",
+      "label": "bot2"
+    },
+    {
+      "id": "bot3",
+      "type": "actor",
+      "label": "bot3"
+    }
+  ],
+  "relationships": [
+    {
+      "from": "alice",
+      "to": "bob",
+      "type": "mention",
+      "weight": 10,
+      "metadata": {
+        "occurrences": 10,
+        "sources": [
+          "post:alice-001",
+          "post:alice-002",
+          "post:alice-003",
+          "post:alice-004",
+          "post:alice-005",
+          "post:alice-006",
+          "post:alice-007",
+          "post:alice-008",
+          "post:alice-009",
+          "post:alice-010"
+        ]
+      }
+    },
+    {
+      "from": "alice",
+      "to": "carol",
+      "type": "mention",
+      "weight": 10,
+      "metadata": {
+        "occurrences": 10,
+        "sources": [
+          "post:alice-001",
+          "post:alice-002",
+          "post:alice-003",
+          "post:alice-004",
+          "post:alice-005",
+          "post:alice-006",
+          "post:alice-007",
+          "post:alice-008",
+          "post:alice-009",
+          "post:alice-010"
+        ]
+      }
+    },
+    {
+      "from": "bot1",
+      "to": "propagandahub",
+      "type": "mention",
+      "weight": 8,
+      "metadata": {
+        "occurrences": 8,
+        "sources": [
+          "post:bot1-078",
+          "post:bot1-079",
+          "post:bot1-080",
+          "post:bot1-081",
+          "post:bot1-082",
+          "post:bot1-083",
+          "post:bot1-084",
+          "post:bot1-085"
+        ]
+      }
+    },
+    {
+      "from": "bot1",
+      "to": "propagandahub",
+      "type": "share",
+      "weight": 8,
+      "metadata": {
+        "occurrences": 8,
+        "sources": [
+          "post:bot1-078",
+          "post:bot1-079",
+          "post:bot1-080",
+          "post:bot1-081",
+          "post:bot1-082",
+          "post:bot1-083",
+          "post:bot1-084",
+          "post:bot1-085"
+        ]
+      }
+    },
+    {
+      "from": "bot2",
+      "to": "propagandahub",
+      "type": "mention",
+      "weight": 8,
+      "metadata": {
+        "occurrences": 8,
+        "sources": [
+          "post:bot2-086",
+          "post:bot2-087",
+          "post:bot2-088",
+          "post:bot2-089",
+          "post:bot2-090",
+          "post:bot2-091",
+          "post:bot2-092",
+          "post:bot2-093"
+        ]
+      }
+    },
+    {
+      "from": "bot2",
+      "to": "propagandahub",
+      "type": "share",
+      "weight": 8,
+      "metadata": {
+        "occurrences": 8,
+        "sources": [
+          "post:bot2-086",
+          "post:bot2-087",
+          "post:bot2-088",
+          "post:bot2-089",
+          "post:bot2-090",
+          "post:bot2-091",
+          "post:bot2-092",
+          "post:bot2-093"
+        ]
+      }
+    },
+    {
+      "from": "bot3",
+      "to": "propagandahub",
+      "type": "mention",
+      "weight": 7,
+      "metadata": {
+        "occurrences": 7,
+        "sources": [
+          "post:bot3-094",
+          "post:bot3-095",
+          "post:bot3-096",
+          "post:bot3-097",
+          "post:bot3-098",
+          "post:bot3-099",
+          "post:bot3-100"
+        ]
+      }
+    },
+    {
+      "from": "bot3",
+      "to": "propagandahub",
+      "type": "share",
+      "weight": 7,
+      "metadata": {
+        "occurrences": 7,
+        "sources": [
+          "post:bot3-094",
+          "post:bot3-095",
+          "post:bot3-096",
+          "post:bot3-097",
+          "post:bot3-098",
+          "post:bot3-099",
+          "post:bot3-100"
+        ]
+      }
+    },
+    {
+      "from": "bob",
+      "to": "alice",
+      "type": "reply",
+      "weight": 6,
+      "metadata": {
+        "occurrences": 6,
+        "sources": [
+          "post:bob-016",
+          "post:bob-017",
+          "post:bob-018",
+          "post:bob-019",
+          "post:bob-020",
+          "post:bob-021"
+        ]
+      }
+    },
+    {
+      "from": "bob",
+      "to": "alice",
+      "type": "mention",
+      "weight": 6,
+      "metadata": {
+        "occurrences": 6,
+        "sources": [
+          "post:bob-022",
+          "post:bob-023",
+          "post:bob-024",
+          "post:bob-025",
+          "post:bob-026",
+          "post:bob-027"
+        ]
+      }
+    },
+    {
+      "from": "bob",
+      "to": "carol",
+      "type": "mention",
+      "weight": 6,
+      "metadata": {
+        "occurrences": 6,
+        "sources": [
+          "post:bob-022",
+          "post:bob-023",
+          "post:bob-024",
+          "post:bob-025",
+          "post:bob-026",
+          "post:bob-027"
+        ]
+      }
+    },
+    {
+      "from": "grace",
+      "to": "newsdesk",
+      "type": "share",
+      "weight": 6,
+      "metadata": {
+        "occurrences": 6,
+        "sources": [
+          "post:grace-055",
+          "post:grace-056",
+          "post:grace-057",
+          "post:grace-058",
+          "post:grace-059",
+          "post:grace-060"
+        ]
+      }
+    },
+    {
+      "from": "henry",
+      "to": "newsdesk",
+      "type": "share",
+      "weight": 6,
+      "metadata": {
+        "occurrences": 6,
+        "sources": [
+          "post:henry-061",
+          "post:henry-062",
+          "post:henry-063",
+          "post:henry-064",
+          "post:henry-065",
+          "post:henry-066"
+        ]
+      }
+    },
+    {
+      "from": "ivy",
+      "to": "newsdesk",
+      "type": "share",
+      "weight": 6,
+      "metadata": {
+        "occurrences": 6,
+        "sources": [
+          "post:ivy-067",
+          "post:ivy-068",
+          "post:ivy-069",
+          "post:ivy-070",
+          "post:ivy-071",
+          "post:ivy-072"
+        ]
+      }
+    },
+    {
+      "from": "alice",
+      "to": "newsdesk",
+      "type": "share",
+      "weight": 5,
+      "metadata": {
+        "occurrences": 5,
+        "sources": [
+          "post:alice-011",
+          "post:alice-012",
+          "post:alice-013",
+          "post:alice-014",
+          "post:alice-015"
+        ]
+      }
+    },
+    {
+      "from": "judy",
+      "to": "alice",
+      "type": "mention",
+      "weight": 5,
+      "metadata": {
+        "occurrences": 5,
+        "sources": [
+          "post:judy-073",
+          "post:judy-074",
+          "post:judy-075",
+          "post:judy-076",
+          "post:judy-077"
+        ]
+      }
+    },
+    {
+      "from": "carol",
+      "to": "alice",
+      "type": "mention",
+      "weight": 4,
+      "metadata": {
+        "occurrences": 4,
+        "sources": [
+          "post:carol-028",
+          "post:carol-029",
+          "post:carol-030",
+          "post:carol-031"
+        ]
+      }
+    },
+    {
+      "from": "carol",
+      "to": "alice",
+      "type": "share",
+      "weight": 4,
+      "metadata": {
+        "occurrences": 4,
+        "sources": [
+          "post:carol-028",
+          "post:carol-029",
+          "post:carol-030",
+          "post:carol-031"
+        ]
+      }
+    },
+    {
+      "from": "carol",
+      "to": "newsdesk",
+      "type": "mention",
+      "weight": 4,
+      "metadata": {
+        "occurrences": 4,
+        "sources": [
+          "post:carol-032",
+          "post:carol-033",
+          "post:carol-034",
+          "post:carol-035"
+        ]
+      }
+    },
+    {
+      "from": "carol",
+      "to": "newsdesk",
+      "type": "share",
+      "weight": 4,
+      "metadata": {
+        "occurrences": 4,
+        "sources": [
+          "post:carol-032",
+          "post:carol-033",
+          "post:carol-034",
+          "post:carol-035"
+        ]
+      }
+    },
+    {
+      "from": "dave",
+      "to": "erin",
+      "type": "mention",
+      "weight": 4,
+      "metadata": {
+        "occurrences": 4,
+        "sources": [
+          "post:dave-036",
+          "post:dave-037",
+          "post:dave-038",
+          "post:dave-039"
+        ]
+      }
+    },
+    {
+      "from": "dave",
+      "to": "newsdesk",
+      "type": "share",
+      "weight": 3,
+      "metadata": {
+        "occurrences": 3,
+        "sources": [
+          "post:dave-040",
+          "post:dave-041",
+          "post:dave-042"
+        ]
+      }
+    },
+    {
+      "from": "erin",
+      "to": "alice",
+      "type": "mention",
+      "weight": 3,
+      "metadata": {
+        "occurrences": 3,
+        "sources": [
+          "post:erin-046",
+          "post:erin-047",
+          "post:erin-048"
+        ]
+      }
+    },
+    {
+      "from": "erin",
+      "to": "dave",
+      "type": "reply",
+      "weight": 3,
+      "metadata": {
+        "occurrences": 3,
+        "sources": [
+          "post:erin-043",
+          "post:erin-044",
+          "post:erin-045"
+        ]
+      }
+    },
+    {
+      "from": "erin",
+      "to": "dave",
+      "type": "mention",
+      "weight": 3,
+      "metadata": {
+        "occurrences": 3,
+        "sources": [
+          "post:erin-046",
+          "post:erin-047",
+          "post:erin-048"
+        ]
+      }
+    },
+    {
+      "from": "frank",
+      "to": "dave",
+      "type": "mention",
+      "weight": 3,
+      "metadata": {
+        "occurrences": 3,
+        "sources": [
+          "post:frank-049",
+          "post:frank-050",
+          "post:frank-051"
+        ]
+      }
+    },
+    {
+      "from": "frank",
+      "to": "newsdesk",
+      "type": "share",
+      "weight": 3,
+      "metadata": {
+        "occurrences": 3,
+        "sources": [
+          "post:frank-052",
+          "post:frank-053",
+          "post:frank-054"
+        ]
+      }
+    }
+  ],
+  "motifs": {
+    "botNetworks": [
+      {
+        "label": "Coordinated share burst targeting propagandahub",
+        "members": [
+          "bot1",
+          "bot2",
+          "bot3"
+        ],
+        "activityScore": 46,
+        "evidence": [
+          "share"
+        ]
+      },
+      {
+        "label": "Coordinated share burst targeting newsdesk",
+        "members": [
+          "carol",
+          "grace",
+          "henry",
+          "ivy",
+          "alice",
+          "dave",
+          "frank"
+        ],
+        "activityScore": 37,
+        "evidence": [
+          "share"
+        ]
+      }
+    ],
+    "amplifierClusters": [
+      {
+        "nodes": [
+          "bot1",
+          "bot2",
+          "carol",
+          "bot3",
+          "alice",
+          "bob",
+          "grace",
+          "henry",
+          "ivy",
+          "dave",
+          "erin",
+          "frank"
+        ],
+        "amplificationScore": 149
+      }
+    ],
+    "coordinatedBehaviors": []
+  },
+  "rankings": [
+    {
+      "entity": {
+        "id": "alice",
+        "type": "actor",
+        "label": "alice"
+      },
+      "score": 58.6,
+      "inboundWeight": 28,
+      "outboundWeight": 25
+    },
+    {
+      "entity": {
+        "id": "propagandahub",
+        "type": "actor",
+        "label": "propagandahub"
+      },
+      "score": 55.199999999999996,
+      "inboundWeight": 46,
+      "outboundWeight": 0
+    },
+    {
+      "entity": {
+        "id": "newsdesk",
+        "type": "actor",
+        "label": "newsdesk"
+      },
+      "score": 44.4,
+      "inboundWeight": 37,
+      "outboundWeight": 0
+    },
+    {
+      "entity": {
+        "id": "carol",
+        "type": "actor",
+        "label": "carol"
+      },
+      "score": 35.2,
+      "inboundWeight": 16,
+      "outboundWeight": 16
+    },
+    {
+      "entity": {
+        "id": "bob",
+        "type": "actor",
+        "label": "bob"
+      },
+      "score": 30,
+      "inboundWeight": 10,
+      "outboundWeight": 18
+    },
+    {
+      "entity": {
+        "id": "dave",
+        "type": "actor",
+        "label": "dave"
+      },
+      "score": 17.799999999999997,
+      "inboundWeight": 9,
+      "outboundWeight": 7
+    },
+    {
+      "entity": {
+        "id": "bot1",
+        "type": "actor",
+        "label": "bot1"
+      },
+      "score": 16,
+      "inboundWeight": 0,
+      "outboundWeight": 16
+    },
+    {
+      "entity": {
+        "id": "bot2",
+        "type": "actor",
+        "label": "bot2"
+      },
+      "score": 16,
+      "inboundWeight": 0,
+      "outboundWeight": 16
+    },
+    {
+      "entity": {
+        "id": "bot3",
+        "type": "actor",
+        "label": "bot3"
+      },
+      "score": 14,
+      "inboundWeight": 0,
+      "outboundWeight": 14
+    },
+    {
+      "entity": {
+        "id": "erin",
+        "type": "actor",
+        "label": "erin"
+      },
+      "score": 13.8,
+      "inboundWeight": 4,
+      "outboundWeight": 9
+    },
+    {
+      "entity": {
+        "id": "frank",
+        "type": "actor",
+        "label": "frank"
+      },
+      "score": 6,
+      "inboundWeight": 0,
+      "outboundWeight": 6
+    },
+    {
+      "entity": {
+        "id": "grace",
+        "type": "actor",
+        "label": "grace"
+      },
+      "score": 6,
+      "inboundWeight": 0,
+      "outboundWeight": 6
+    },
+    {
+      "entity": {
+        "id": "henry",
+        "type": "actor",
+        "label": "henry"
+      },
+      "score": 6,
+      "inboundWeight": 0,
+      "outboundWeight": 6
+    },
+    {
+      "entity": {
+        "id": "ivy",
+        "type": "actor",
+        "label": "ivy"
+      },
+      "score": 6,
+      "inboundWeight": 0,
+      "outboundWeight": 6
+    },
+    {
+      "entity": {
+        "id": "judy",
+        "type": "actor",
+        "label": "judy"
+      },
+      "score": 5,
+      "inboundWeight": 0,
+      "outboundWeight": 5
+    }
+  ]
+}

--- a/packages/influence-mining/test-data/sample-social-posts.json
+++ b/packages/influence-mining/test-data/sample-social-posts.json
@@ -1,0 +1,802 @@
+[
+  {
+    "id": "alice-001",
+    "author": "Alice",
+    "text": "Collaborating with @Bob and @Carol on brief 0",
+    "timestamp": "2024-01-01T00:00:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "alice-002",
+    "author": "Alice",
+    "text": "Collaborating with @Bob and @Carol on brief 1",
+    "timestamp": "2024-01-01T00:01:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "alice-003",
+    "author": "Alice",
+    "text": "Collaborating with @Bob and @Carol on brief 2",
+    "timestamp": "2024-01-01T00:02:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "alice-004",
+    "author": "Alice",
+    "text": "Collaborating with @Bob and @Carol on brief 3",
+    "timestamp": "2024-01-01T00:03:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "alice-005",
+    "author": "Alice",
+    "text": "Collaborating with @Bob and @Carol on brief 4",
+    "timestamp": "2024-01-01T00:04:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "alice-006",
+    "author": "Alice",
+    "text": "Collaborating with @Bob and @Carol on brief 5",
+    "timestamp": "2024-01-01T00:05:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "alice-007",
+    "author": "Alice",
+    "text": "Collaborating with @Bob and @Carol on brief 6",
+    "timestamp": "2024-01-01T00:06:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "alice-008",
+    "author": "Alice",
+    "text": "Collaborating with @Bob and @Carol on brief 7",
+    "timestamp": "2024-01-01T00:07:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "alice-009",
+    "author": "Alice",
+    "text": "Collaborating with @Bob and @Carol on brief 8",
+    "timestamp": "2024-01-01T00:08:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "alice-010",
+    "author": "Alice",
+    "text": "Collaborating with @Bob and @Carol on brief 9",
+    "timestamp": "2024-01-01T00:09:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "alice-011",
+    "author": "Alice",
+    "text": "Boosting newsroom insights 0",
+    "timestamp": "2024-01-01T00:10:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "alice-012",
+    "author": "Alice",
+    "text": "Boosting newsroom insights 1",
+    "timestamp": "2024-01-01T00:11:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "alice-013",
+    "author": "Alice",
+    "text": "Boosting newsroom insights 2",
+    "timestamp": "2024-01-01T00:12:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "alice-014",
+    "author": "Alice",
+    "text": "Boosting newsroom insights 3",
+    "timestamp": "2024-01-01T00:13:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "alice-015",
+    "author": "Alice",
+    "text": "Boosting newsroom insights 4",
+    "timestamp": "2024-01-01T00:14:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "bob-016",
+    "author": "Bob",
+    "text": "Replying to Alice update 0",
+    "timestamp": "2024-01-01T00:15:00Z",
+    "inReplyTo": "Alice",
+    "sharedFrom": null
+  },
+  {
+    "id": "bob-017",
+    "author": "Bob",
+    "text": "Replying to Alice update 1",
+    "timestamp": "2024-01-01T00:16:00Z",
+    "inReplyTo": "Alice",
+    "sharedFrom": null
+  },
+  {
+    "id": "bob-018",
+    "author": "Bob",
+    "text": "Replying to Alice update 2",
+    "timestamp": "2024-01-01T00:17:00Z",
+    "inReplyTo": "Alice",
+    "sharedFrom": null
+  },
+  {
+    "id": "bob-019",
+    "author": "Bob",
+    "text": "Replying to Alice update 3",
+    "timestamp": "2024-01-01T00:18:00Z",
+    "inReplyTo": "Alice",
+    "sharedFrom": null
+  },
+  {
+    "id": "bob-020",
+    "author": "Bob",
+    "text": "Replying to Alice update 4",
+    "timestamp": "2024-01-01T00:19:00Z",
+    "inReplyTo": "Alice",
+    "sharedFrom": null
+  },
+  {
+    "id": "bob-021",
+    "author": "Bob",
+    "text": "Replying to Alice update 5",
+    "timestamp": "2024-01-01T00:20:00Z",
+    "inReplyTo": "Alice",
+    "sharedFrom": null
+  },
+  {
+    "id": "bob-022",
+    "author": "Bob",
+    "text": "Sharing intel with @Carol and @Alice 0",
+    "timestamp": "2024-01-01T00:21:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "bob-023",
+    "author": "Bob",
+    "text": "Sharing intel with @Carol and @Alice 1",
+    "timestamp": "2024-01-01T00:22:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "bob-024",
+    "author": "Bob",
+    "text": "Sharing intel with @Carol and @Alice 2",
+    "timestamp": "2024-01-01T00:23:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "bob-025",
+    "author": "Bob",
+    "text": "Sharing intel with @Carol and @Alice 3",
+    "timestamp": "2024-01-01T00:24:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "bob-026",
+    "author": "Bob",
+    "text": "Sharing intel with @Carol and @Alice 4",
+    "timestamp": "2024-01-01T00:25:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "bob-027",
+    "author": "Bob",
+    "text": "Sharing intel with @Carol and @Alice 5",
+    "timestamp": "2024-01-01T00:26:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "carol-028",
+    "author": "Carol",
+    "text": "Amplifying @Alice analysis 0",
+    "timestamp": "2024-01-01T00:27:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "Alice"
+  },
+  {
+    "id": "carol-029",
+    "author": "Carol",
+    "text": "Amplifying @Alice analysis 1",
+    "timestamp": "2024-01-01T00:28:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "Alice"
+  },
+  {
+    "id": "carol-030",
+    "author": "Carol",
+    "text": "Amplifying @Alice analysis 2",
+    "timestamp": "2024-01-01T00:29:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "Alice"
+  },
+  {
+    "id": "carol-031",
+    "author": "Carol",
+    "text": "Amplifying @Alice analysis 3",
+    "timestamp": "2024-01-01T00:30:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "Alice"
+  },
+  {
+    "id": "carol-032",
+    "author": "Carol",
+    "text": "Highlighting @NewsDesk scoop 0",
+    "timestamp": "2024-01-01T00:31:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "carol-033",
+    "author": "Carol",
+    "text": "Highlighting @NewsDesk scoop 1",
+    "timestamp": "2024-01-01T00:32:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "carol-034",
+    "author": "Carol",
+    "text": "Highlighting @NewsDesk scoop 2",
+    "timestamp": "2024-01-01T00:33:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "carol-035",
+    "author": "Carol",
+    "text": "Highlighting @NewsDesk scoop 3",
+    "timestamp": "2024-01-01T00:34:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "dave-036",
+    "author": "Dave",
+    "text": "Coordinating with @Erin on logistics 0",
+    "timestamp": "2024-01-01T00:35:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "dave-037",
+    "author": "Dave",
+    "text": "Coordinating with @Erin on logistics 1",
+    "timestamp": "2024-01-01T00:36:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "dave-038",
+    "author": "Dave",
+    "text": "Coordinating with @Erin on logistics 2",
+    "timestamp": "2024-01-01T00:37:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "dave-039",
+    "author": "Dave",
+    "text": "Coordinating with @Erin on logistics 3",
+    "timestamp": "2024-01-01T00:38:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "dave-040",
+    "author": "Dave",
+    "text": "Forwarding newsroom alert 0",
+    "timestamp": "2024-01-01T00:39:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "dave-041",
+    "author": "Dave",
+    "text": "Forwarding newsroom alert 1",
+    "timestamp": "2024-01-01T00:40:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "dave-042",
+    "author": "Dave",
+    "text": "Forwarding newsroom alert 2",
+    "timestamp": "2024-01-01T00:41:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "erin-043",
+    "author": "Erin",
+    "text": "Replying to Dave thread 0",
+    "timestamp": "2024-01-01T00:42:00Z",
+    "inReplyTo": "Dave",
+    "sharedFrom": null
+  },
+  {
+    "id": "erin-044",
+    "author": "Erin",
+    "text": "Replying to Dave thread 1",
+    "timestamp": "2024-01-01T00:43:00Z",
+    "inReplyTo": "Dave",
+    "sharedFrom": null
+  },
+  {
+    "id": "erin-045",
+    "author": "Erin",
+    "text": "Replying to Dave thread 2",
+    "timestamp": "2024-01-01T00:44:00Z",
+    "inReplyTo": "Dave",
+    "sharedFrom": null
+  },
+  {
+    "id": "erin-046",
+    "author": "Erin",
+    "text": "Agree with @Alice and @Dave 0",
+    "timestamp": "2024-01-01T00:45:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "erin-047",
+    "author": "Erin",
+    "text": "Agree with @Alice and @Dave 1",
+    "timestamp": "2024-01-01T00:46:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "erin-048",
+    "author": "Erin",
+    "text": "Agree with @Alice and @Dave 2",
+    "timestamp": "2024-01-01T00:47:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "frank-049",
+    "author": "Frank",
+    "text": "Checking with @Dave about rollout 0",
+    "timestamp": "2024-01-01T00:48:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "frank-050",
+    "author": "Frank",
+    "text": "Checking with @Dave about rollout 1",
+    "timestamp": "2024-01-01T00:49:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "frank-051",
+    "author": "Frank",
+    "text": "Checking with @Dave about rollout 2",
+    "timestamp": "2024-01-01T00:50:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "frank-052",
+    "author": "Frank",
+    "text": "Sharing newsroom digest 0",
+    "timestamp": "2024-01-01T00:51:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "frank-053",
+    "author": "Frank",
+    "text": "Sharing newsroom digest 1",
+    "timestamp": "2024-01-01T00:52:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "frank-054",
+    "author": "Frank",
+    "text": "Sharing newsroom digest 2",
+    "timestamp": "2024-01-01T00:53:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "grace-055",
+    "author": "Grace",
+    "text": "Signal boost for NewsDesk story 0",
+    "timestamp": "2024-01-01T00:54:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "grace-056",
+    "author": "Grace",
+    "text": "Signal boost for NewsDesk story 1",
+    "timestamp": "2024-01-01T00:55:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "grace-057",
+    "author": "Grace",
+    "text": "Signal boost for NewsDesk story 2",
+    "timestamp": "2024-01-01T00:56:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "grace-058",
+    "author": "Grace",
+    "text": "Signal boost for NewsDesk story 3",
+    "timestamp": "2024-01-01T00:57:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "grace-059",
+    "author": "Grace",
+    "text": "Signal boost for NewsDesk story 4",
+    "timestamp": "2024-01-01T00:58:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "grace-060",
+    "author": "Grace",
+    "text": "Signal boost for NewsDesk story 5",
+    "timestamp": "2024-01-01T00:59:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "henry-061",
+    "author": "Henry",
+    "text": "Resharing NewsDesk report 0",
+    "timestamp": "2024-01-01T01:00:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "henry-062",
+    "author": "Henry",
+    "text": "Resharing NewsDesk report 1",
+    "timestamp": "2024-01-01T01:01:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "henry-063",
+    "author": "Henry",
+    "text": "Resharing NewsDesk report 2",
+    "timestamp": "2024-01-01T01:02:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "henry-064",
+    "author": "Henry",
+    "text": "Resharing NewsDesk report 3",
+    "timestamp": "2024-01-01T01:03:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "henry-065",
+    "author": "Henry",
+    "text": "Resharing NewsDesk report 4",
+    "timestamp": "2024-01-01T01:04:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "henry-066",
+    "author": "Henry",
+    "text": "Resharing NewsDesk report 5",
+    "timestamp": "2024-01-01T01:05:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "ivy-067",
+    "author": "Ivy",
+    "text": "NewsDesk coverage worth reading 0",
+    "timestamp": "2024-01-01T01:06:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "ivy-068",
+    "author": "Ivy",
+    "text": "NewsDesk coverage worth reading 1",
+    "timestamp": "2024-01-01T01:07:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "ivy-069",
+    "author": "Ivy",
+    "text": "NewsDesk coverage worth reading 2",
+    "timestamp": "2024-01-01T01:08:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "ivy-070",
+    "author": "Ivy",
+    "text": "NewsDesk coverage worth reading 3",
+    "timestamp": "2024-01-01T01:09:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "ivy-071",
+    "author": "Ivy",
+    "text": "NewsDesk coverage worth reading 4",
+    "timestamp": "2024-01-01T01:10:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "ivy-072",
+    "author": "Ivy",
+    "text": "NewsDesk coverage worth reading 5",
+    "timestamp": "2024-01-01T01:11:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "NewsDesk"
+  },
+  {
+    "id": "judy-073",
+    "author": "Judy",
+    "text": "Great perspective from @Alice on topic 0",
+    "timestamp": "2024-01-01T01:12:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "judy-074",
+    "author": "Judy",
+    "text": "Great perspective from @Alice on topic 1",
+    "timestamp": "2024-01-01T01:13:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "judy-075",
+    "author": "Judy",
+    "text": "Great perspective from @Alice on topic 2",
+    "timestamp": "2024-01-01T01:14:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "judy-076",
+    "author": "Judy",
+    "text": "Great perspective from @Alice on topic 3",
+    "timestamp": "2024-01-01T01:15:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "judy-077",
+    "author": "Judy",
+    "text": "Great perspective from @Alice on topic 4",
+    "timestamp": "2024-01-01T01:16:00Z",
+    "inReplyTo": null,
+    "sharedFrom": null
+  },
+  {
+    "id": "bot1-078",
+    "author": "Bot1",
+    "text": "Push @PropagandaHub narrative 0",
+    "timestamp": "2024-01-01T01:17:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot1-079",
+    "author": "Bot1",
+    "text": "Push @PropagandaHub narrative 1",
+    "timestamp": "2024-01-01T01:18:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot1-080",
+    "author": "Bot1",
+    "text": "Push @PropagandaHub narrative 2",
+    "timestamp": "2024-01-01T01:19:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot1-081",
+    "author": "Bot1",
+    "text": "Push @PropagandaHub narrative 3",
+    "timestamp": "2024-01-01T01:20:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot1-082",
+    "author": "Bot1",
+    "text": "Push @PropagandaHub narrative 4",
+    "timestamp": "2024-01-01T01:21:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot1-083",
+    "author": "Bot1",
+    "text": "Push @PropagandaHub narrative 5",
+    "timestamp": "2024-01-01T01:22:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot1-084",
+    "author": "Bot1",
+    "text": "Push @PropagandaHub narrative 6",
+    "timestamp": "2024-01-01T01:23:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot1-085",
+    "author": "Bot1",
+    "text": "Push @PropagandaHub narrative 7",
+    "timestamp": "2024-01-01T01:24:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot2-086",
+    "author": "Bot2",
+    "text": "Echo @PropagandaHub broadcast 0",
+    "timestamp": "2024-01-01T01:25:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot2-087",
+    "author": "Bot2",
+    "text": "Echo @PropagandaHub broadcast 1",
+    "timestamp": "2024-01-01T01:26:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot2-088",
+    "author": "Bot2",
+    "text": "Echo @PropagandaHub broadcast 2",
+    "timestamp": "2024-01-01T01:27:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot2-089",
+    "author": "Bot2",
+    "text": "Echo @PropagandaHub broadcast 3",
+    "timestamp": "2024-01-01T01:28:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot2-090",
+    "author": "Bot2",
+    "text": "Echo @PropagandaHub broadcast 4",
+    "timestamp": "2024-01-01T01:29:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot2-091",
+    "author": "Bot2",
+    "text": "Echo @PropagandaHub broadcast 5",
+    "timestamp": "2024-01-01T01:30:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot2-092",
+    "author": "Bot2",
+    "text": "Echo @PropagandaHub broadcast 6",
+    "timestamp": "2024-01-01T01:31:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot2-093",
+    "author": "Bot2",
+    "text": "Echo @PropagandaHub broadcast 7",
+    "timestamp": "2024-01-01T01:32:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot3-094",
+    "author": "Bot3",
+    "text": "Relay @PropagandaHub message 0",
+    "timestamp": "2024-01-01T01:33:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot3-095",
+    "author": "Bot3",
+    "text": "Relay @PropagandaHub message 1",
+    "timestamp": "2024-01-01T01:34:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot3-096",
+    "author": "Bot3",
+    "text": "Relay @PropagandaHub message 2",
+    "timestamp": "2024-01-01T01:35:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot3-097",
+    "author": "Bot3",
+    "text": "Relay @PropagandaHub message 3",
+    "timestamp": "2024-01-01T01:36:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot3-098",
+    "author": "Bot3",
+    "text": "Relay @PropagandaHub message 4",
+    "timestamp": "2024-01-01T01:37:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot3-099",
+    "author": "Bot3",
+    "text": "Relay @PropagandaHub message 5",
+    "timestamp": "2024-01-01T01:38:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  },
+  {
+    "id": "bot3-100",
+    "author": "Bot3",
+    "text": "Relay @PropagandaHub message 6",
+    "timestamp": "2024-01-01T01:39:00Z",
+    "inReplyTo": null,
+    "sharedFrom": "PropagandaHub"
+  }
+]

--- a/packages/influence-mining/tests/InfluenceNetworkExtractor.test.ts
+++ b/packages/influence-mining/tests/InfluenceNetworkExtractor.test.ts
@@ -1,0 +1,124 @@
+import { InfluenceNetworkExtractor } from '../src/InfluenceNetworkExtractor.js';
+import { SourceData } from '../src/types.js';
+
+describe('InfluenceNetworkExtractor', () => {
+  const buildExtractor = () => new InfluenceNetworkExtractor();
+
+  it('extracts relationships and builds a weighted graph', () => {
+    const dataset: SourceData[] = [
+      {
+        kind: 'social',
+        posts: [
+          {
+            id: 'p1',
+            author: 'Alice',
+            text: 'Working with @Bob on the latest report',
+            timestamp: '2024-01-01T00:00:00Z',
+          },
+          {
+            id: 'p2',
+            author: 'Alice',
+            text: 'Follow up with @Bob ASAP',
+            timestamp: '2024-01-01T00:01:00Z',
+          },
+          {
+            id: 'p3',
+            author: 'Bob',
+            text: 'Replying to Alice',
+            timestamp: '2024-01-01T00:02:00Z',
+            inReplyTo: 'Alice',
+          },
+          {
+            id: 'p4',
+            author: 'Carol',
+            text: 'Sharing Alice update',
+            timestamp: '2024-01-01T00:03:00Z',
+            sharedFrom: 'Alice',
+          },
+        ],
+      },
+    ];
+
+    const extractor = buildExtractor();
+    const network = extractor.extract(dataset);
+
+    const mentionRel = network.relationships.find(
+      (rel) => rel.type === 'mention' && rel.from === 'alice' && rel.to === 'bob',
+    );
+    expect(mentionRel?.weight).toBe(2);
+
+    const replyRel = network.relationships.find(
+      (rel) => rel.type === 'reply' && rel.from === 'bob' && rel.to === 'alice',
+    );
+    expect(replyRel).toBeDefined();
+
+    const shareRel = network.relationships.find(
+      (rel) => rel.type === 'share' && rel.from === 'carol' && rel.to === 'alice',
+    );
+    expect(shareRel).toBeDefined();
+
+    const aliceEdges = network.graph.edges.filter((edge) => edge.from === 'alice');
+    expect(aliceEdges[0]?.weight).toBeGreaterThanOrEqual(2);
+  });
+
+  it('enriches the network with motif analytics', () => {
+    const dataset: SourceData[] = [
+      {
+        kind: 'social',
+        posts: [
+          { id: 'b1', author: 'bot1', text: 'Boost @target', timestamp: '2024-01-02T00:00:00Z', sharedFrom: 'target' },
+          { id: 'b2', author: 'bot1', text: 'Boost again @target', timestamp: '2024-01-02T00:05:00Z', sharedFrom: 'target' },
+          { id: 'b3', author: 'bot2', text: 'Boost @target', timestamp: '2024-01-02T00:01:00Z', sharedFrom: 'target' },
+          { id: 'b4', author: 'bot2', text: 'Boost again', timestamp: '2024-01-02T00:06:00Z', sharedFrom: 'target' },
+          { id: 'b5', author: 'bot3', text: 'Boost', timestamp: '2024-01-02T00:02:00Z', sharedFrom: 'target' },
+          { id: 'b6', author: 'bot3', text: 'Boost again', timestamp: '2024-01-02T00:07:00Z', sharedFrom: 'target' },
+          { id: 'c1', author: 'analyst1', text: '@target interesting', timestamp: '2024-01-02T00:03:00Z' },
+          { id: 'c2', author: 'analyst2', text: '@target insights', timestamp: '2024-01-02T00:04:00Z' },
+        ],
+      },
+    ];
+
+    const extractor = buildExtractor();
+    const enriched = extractor.enrich(extractor.extract(dataset));
+
+    expect(enriched.motifs.botNetworks.length).toBeGreaterThan(0);
+    expect(enriched.motifs.amplifierClusters[0]?.nodes).toContain('bot1');
+    expect(enriched.motifs.coordinatedBehaviors.length).toBeGreaterThanOrEqual(0);
+  });
+
+  it('ranks nodes by weighted influence', () => {
+    const dataset: SourceData[] = [
+      {
+        kind: 'social',
+        posts: [
+          {
+            id: 'r1',
+            author: 'AnalystA',
+            text: '@Leader sharing update',
+            timestamp: '2024-01-03T00:00:00Z',
+            sharedFrom: 'Leader',
+          },
+          {
+            id: 'r2',
+            author: 'Leader',
+            text: 'Thanks @AnalystA',
+            timestamp: '2024-01-03T00:01:00Z',
+          },
+          {
+            id: 'r3',
+            author: 'Leader',
+            text: 'Reply to AnalystA',
+            timestamp: '2024-01-03T00:02:00Z',
+            inReplyTo: 'AnalystA',
+          },
+        ],
+      },
+    ];
+
+    const extractor = buildExtractor();
+    const ranked = extractor.rankNodes(extractor.extract(dataset));
+
+    expect(ranked.rankings[0]?.score).toBeGreaterThanOrEqual(ranked.rankings[1]?.score ?? 0);
+    expect(ranked.rankings.find((item) => item.entity.id === 'leader')).toBeDefined();
+  });
+});

--- a/packages/influence-mining/tests/integration/extraction-pipeline.test.ts
+++ b/packages/influence-mining/tests/integration/extraction-pipeline.test.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { InfluenceNetworkExtractor } from '../../src/InfluenceNetworkExtractor.js';
+import { SourceData } from '../../src/types.js';
+
+describe('Influence network extraction pipeline', () => {
+  const __filename = fileURLToPath(import.meta.url);
+  const __dirname = path.dirname(__filename);
+  const dataPath = path.resolve(__dirname, '../../test-data/sample-social-posts.json');
+  const expectedPath = path.resolve(__dirname, '../../test-data/expected-network.json');
+
+  it('reproduces the expected network structure from sample data', () => {
+    const posts = JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
+    const expected = JSON.parse(fs.readFileSync(expectedPath, 'utf-8'));
+
+    const extractor = new InfluenceNetworkExtractor();
+    const sources: SourceData[] = [{ kind: 'social', posts }];
+    const network = extractor.extract(sources);
+    const enriched = extractor.enrich(network);
+    const ranked = extractor.rankNodes(enriched);
+    const actual = { ...enriched, rankings: ranked.rankings };
+
+    const normalizeGraph = (graph: typeof actual.graph) => ({
+      nodes: [...graph.nodes].sort((a, b) => a.id.localeCompare(b.id)),
+      edges: [...graph.edges].sort((a, b) => {
+        if (a.from === b.from) {
+          if (a.to === b.to) {
+            return a.weight - b.weight;
+          }
+          return a.to.localeCompare(b.to);
+        }
+        return a.from.localeCompare(b.from);
+      }),
+      adjacency: graph.adjacency,
+    });
+
+    const normalisedActual = {
+      ...actual,
+      graph: normalizeGraph(actual.graph),
+      relationships: [...actual.relationships].sort((a, b) => {
+        if (a.type === b.type) {
+          if (a.from === b.from) {
+            return a.to.localeCompare(b.to);
+          }
+          return a.from.localeCompare(b.from);
+        }
+        return a.type.localeCompare(b.type);
+      }),
+      entities: [...actual.entities].sort((a, b) => a.id.localeCompare(b.id)),
+      rankings: [...actual.rankings].sort((a, b) => b.score - a.score || a.entity.id.localeCompare(b.entity.id)),
+      motifs: {
+        botNetworks: [...actual.motifs.botNetworks].sort((a, b) => b.activityScore - a.activityScore),
+        amplifierClusters: [...actual.motifs.amplifierClusters].sort(
+          (a, b) => b.amplificationScore - a.amplificationScore,
+        ),
+        coordinatedBehaviors: [...actual.motifs.coordinatedBehaviors].sort(
+          (a, b) => b.support - a.support,
+        ),
+      },
+    };
+
+    const normalisedExpected = {
+      ...expected,
+      graph: normalizeGraph(expected.graph),
+      relationships: [...expected.relationships].sort((a, b) => {
+        if (a.type === b.type) {
+          if (a.from === b.from) {
+            return a.to.localeCompare(b.to);
+          }
+          return a.from.localeCompare(b.from);
+        }
+        return a.type.localeCompare(b.type);
+      }),
+      entities: [...expected.entities].sort((a, b) => a.id.localeCompare(b.id)),
+      rankings: [...expected.rankings].sort((a, b) => b.score - a.score || a.entity.id.localeCompare(b.entity.id)),
+      motifs: {
+        botNetworks: [...expected.motifs.botNetworks].sort((a, b) => b.activityScore - a.activityScore),
+        amplifierClusters: [...expected.motifs.amplifierClusters].sort(
+          (a, b) => b.amplificationScore - a.amplificationScore,
+        ),
+        coordinatedBehaviors: [...expected.motifs.coordinatedBehaviors].sort((a, b) => b.support - a.support),
+      },
+    };
+
+    expect(normalisedActual).toEqual(normalisedExpected);
+    expect(normalisedActual.motifs.botNetworks.length).toBeGreaterThan(0);
+    expect(normalisedActual.relationships.some((rel) => rel.type === 'share')).toBe(true);
+    expect(normalisedActual.relationships.some((rel) => rel.type === 'reply')).toBe(true);
+    expect(normalisedActual.relationships.some((rel) => rel.type === 'mention')).toBe(true);
+  });
+});

--- a/packages/influence-mining/tsconfig.json
+++ b/packages/influence-mining/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "module": "ESNext",
+    "target": "ES2022",
+    "moduleResolution": "Bundler",
+    "declarationMap": true,
+    "sourceMap": true,
+    "types": ["node"],
+    "lib": ["ES2022"],
+    "allowImportingTsExtensions": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "tests", "test-data"]
+}


### PR DESCRIPTION
## Summary
- implement an influence network extraction pipeline with ingestion, relationship detection, graph construction, enrichment, and ranking components
- add a CLI entry point plus sample social data and expected output fixtures for end-to-end extraction runs
- create unit and integration coverage to validate relationship aggregation, motif detection, and the generated network snapshot

## Testing
- npm run extract -- --input packages/influence-mining/test-data/sample-social-posts.json --output /tmp/network.json
- npm run test -- --runTestsByPath packages/influence-mining/tests/InfluenceNetworkExtractor.test.ts packages/influence-mining/tests/integration/extraction-pipeline.test.ts *(fails: jest-environment-jsdom module unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e36fc4648333b80817d8ce6df6bb