### PR TITLE
feat: add PerfTrace Jira automation toolkit

### DIFF
--- a/packages/jira-integration/README.md
+++ b/packages/jira-integration/README.md
@@ -1,0 +1,105 @@
+# PerfTrace Jira Integration
+
+The `@summit/jira-integration` package automates PerfTrace ticket creation and lifecycle management in Jira. It provides opinionated helpers for applying Summit workflow conventions, enforcing custom field mappings, and capturing audit trails for every Jira interaction.
+
+## Features
+
+- **Automated ticket creation** – Build PerfTrace issues with consistent custom field mappings, severity tagging, and owner assignment.
+- **Priority & severity governance** – Translate PerfTrace severity levels into Jira priorities and severity custom fields.
+- **Workflow automation** – Perform workflow transitions and synchronize ticket state based on Summit-specific mappings.
+- **Bulk operations** – Create batches of PerfTrace tickets with resilient error handling and audit logging.
+- **Attachment & link handling** – Upload performance artifacts and link to related incidents or follow-up work.
+- **Webhook processing** – React to Jira webhook payloads for downstream automation.
+- **Audit-ready logging** – Capture structured audit events for every Jira request and integration action.
+
+## Getting Started
+
+```bash
+# install dependencies from the monorepo root
+npm install
+
+# run tests with coverage
+npx jest packages/jira-integration --coverage
+
+# build the package
+npm run --workspace=@summit/jira-integration build
+```
+
+### Configuration
+
+```ts
+import { JiraIntegrationService, JiraApiClient, InMemoryAuditLogger } from '@summit/jira-integration';
+
+const config = {
+  baseUrl: 'https://your-domain.atlassian.net',
+  email: process.env.JIRA_EMAIL!,
+  apiToken: process.env.JIRA_TOKEN!,
+  projectKey: 'PERF',
+  issueTypeId: '12345',
+  customFieldMap: {
+    environment: 'customfield_10100',
+    regressionWindow: 'customfield_10101',
+    owners: 'customfield_10102',
+    perfMetric: 'customfield_10103',
+    baselineValue: 'customfield_10104',
+    currentValue: 'customfield_10105'
+  },
+  priorityMapping: {
+    blocker: { priorityId: '1', severityFieldId: 'customfield_10200', severityValue: 'Blocker' },
+    critical: { priorityId: '2', severityFieldId: 'customfield_10200', severityValue: 'Critical' },
+    high: { priorityId: '3', severityFieldId: 'customfield_10200', severityValue: 'High' },
+    medium: { priorityId: '4', severityFieldId: 'customfield_10200', severityValue: 'Medium' },
+    low: { priorityId: '5', severityFieldId: 'customfield_10200', severityValue: 'Low' },
+    info: { priorityId: '6', severityFieldId: 'customfield_10200', severityValue: 'Informational' }
+  },
+  workflowTransitions: {
+    Triaged: 'In Progress',
+    'Ready for QA': 'QA In Progress',
+    Resolved: 'Validation'
+  }
+};
+
+const auditLogger = new InMemoryAuditLogger();
+const client = new JiraApiClient(config, auditLogger);
+const integration = new JiraIntegrationService(config, client, auditLogger);
+```
+
+### Creating a PerfTrace Ticket
+
+```ts
+await integration.createPerfTraceTicket({
+  summary: 'Perf regression detected in checkout latency',
+  description: 'p95 response time exceeded baseline for 5 consecutive minutes.',
+  severity: 'critical',
+  environment: 'prod',
+  regressionWindow: '24h',
+  owners: ['account-id-1'],
+  perfMetric: 'checkout_latency_p95',
+  baselineValue: 120,
+  currentValue: 210,
+  labels: ['perftrace'],
+  relatedIssueKeys: ['PLAT-21']
+});
+```
+
+### Webhook Handling
+
+```ts
+export const onJiraWebhook = (event: JiraWebhookEvent) => {
+  const result = integration.handleWebhook(event);
+  if (result?.transitioned) {
+    // enqueue downstream updates or notifications
+  }
+};
+```
+
+## Documentation
+
+- [Integration Guide](./docs/integration-guide.md)
+- [PerfTrace Ticket Templates](./docs/templates/perftrace-ticket-templates.md)
+
+## Testing & Quality Gates
+
+- **TypeScript strict mode** is enforced via the package `tsconfig.json`.
+- Run `npm run lint` at the repository root to ensure ESLint validation.
+- Unit tests target >80% coverage; see `npm run test --workspace=@summit/jira-integration` for package-only execution.

--- a/packages/jira-integration/__tests__/client.test.ts
+++ b/packages/jira-integration/__tests__/client.test.ts
@@ -1,0 +1,57 @@
+import { jest } from '@jest/globals';
+import { InMemoryAuditLogger } from '../src/logger.js';
+import { JiraApiClient, JiraApiError } from '../src/client.js';
+import { JiraIntegrationConfig } from '../src/types.js';
+
+describe('JiraApiClient', () => {
+  const config: JiraIntegrationConfig = {
+    baseUrl: 'https://example.atlassian.net',
+    email: 'bot@example.com',
+    apiToken: 'token',
+    projectKey: 'PERF',
+    issueTypeId: '10001',
+    customFieldMap: {
+      environment: 'env',
+      regressionWindow: 'regression',
+      owners: 'owners',
+      perfMetric: 'metric',
+      baselineValue: 'baseline',
+      currentValue: 'current'
+    },
+    priorityMapping: {
+      blocker: { priorityId: '1', severityFieldId: 'sev', severityValue: 'Blocker' },
+      critical: { priorityId: '2', severityFieldId: 'sev', severityValue: 'Critical' },
+      high: { priorityId: '3', severityFieldId: 'sev', severityValue: 'High' },
+      medium: { priorityId: '4', severityFieldId: 'sev', severityValue: 'Medium' },
+      low: { priorityId: '5', severityFieldId: 'sev', severityValue: 'Low' },
+      info: { priorityId: '6', severityFieldId: 'sev', severityValue: 'Info' }
+    },
+    workflowTransitions: {},
+    maxRetries: 2,
+    retryDelayMs: 1
+  };
+
+  it('retries failed requests and eventually succeeds', async () => {
+    const auditLogger = new InMemoryAuditLogger();
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500, text: async () => 'error' })
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({ id: '1' }) });
+
+    const client = new JiraApiClient(config, auditLogger, fetchMock as unknown as typeof fetch);
+    const response = await client.request<{ id: string }>('/rest/api/3/issue', { method: 'GET' });
+
+    expect(response.id).toBe('1');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(auditLogger.getAll().length).toBeGreaterThan(0);
+  });
+
+  it('throws JiraApiError when retries exhausted', async () => {
+    const auditLogger = new InMemoryAuditLogger();
+    const fetchMock = jest.fn().mockResolvedValue({ ok: false, status: 500, text: async () => 'error' });
+
+    const client = new JiraApiClient(config, auditLogger, fetchMock as unknown as typeof fetch);
+    await expect(client.request('/rest/api/3/issue', { method: 'GET' })).rejects.toBeInstanceOf(JiraApiError);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/jira-integration/__tests__/jiraIntegration.test.ts
+++ b/packages/jira-integration/__tests__/jiraIntegration.test.ts
@@ -1,0 +1,168 @@
+import { jest } from '@jest/globals';
+import { InMemoryAuditLogger } from '../src/logger.js';
+import { JiraIntegrationService } from '../src/jiraIntegration.js';
+import { JiraApiClient } from '../src/client.js';
+import { JiraIntegrationConfig, PerfTraceTicketInput, JiraWebhookEvent } from '../src/types.js';
+
+const baseConfig: JiraIntegrationConfig = {
+  baseUrl: 'https://example.atlassian.net',
+  email: 'bot@example.com',
+  apiToken: 'token',
+  projectKey: 'PERF',
+  issueTypeId: '10001',
+  customFieldMap: {
+    environment: 'customfield_1',
+    regressionWindow: 'customfield_2',
+    owners: 'customfield_3',
+    perfMetric: 'customfield_4',
+    baselineValue: 'customfield_5',
+    currentValue: 'customfield_6'
+  },
+  priorityMapping: {
+    blocker: { priorityId: '1', severityFieldId: 'customfield_10', severityValue: 'Blocker' },
+    critical: { priorityId: '2', severityFieldId: 'customfield_10', severityValue: 'Critical' },
+    high: { priorityId: '3', severityFieldId: 'customfield_10', severityValue: 'High' },
+    medium: { priorityId: '4', severityFieldId: 'customfield_10', severityValue: 'Medium' },
+    low: { priorityId: '5', severityFieldId: 'customfield_10', severityValue: 'Low' },
+    info: { priorityId: '6', severityFieldId: 'customfield_10', severityValue: 'Info' }
+  },
+  workflowTransitions: {
+    Triaged: 'In Progress',
+    Resolved: 'In Review'
+  }
+};
+
+describe('JiraIntegrationService', () => {
+  const ticketInput: PerfTraceTicketInput = {
+    summary: 'Perf regression in checkout',
+    description: 'Latency increase detected in checkout flow.',
+    severity: 'critical',
+    environment: 'prod',
+    regressionWindow: '24h',
+    owners: ['owner-account-id'],
+    perfMetric: 'checkout_latency',
+    baselineValue: 120,
+    currentValue: 210,
+    attachments: [
+      {
+        fileName: 'perf.csv',
+        contentType: 'text/csv',
+        data: Buffer.from('col1,col2')
+      }
+    ],
+    relatedIssueKeys: ['PERF-100'],
+    labels: ['perf', 'trace']
+  };
+
+  it('creates tickets with attachments and links', async () => {
+    const auditLogger = new InMemoryAuditLogger();
+    const requestMock = jest
+      .fn()
+      .mockResolvedValueOnce({ id: '1', key: 'PERF-1', self: 'self' })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+
+    const client = { request: requestMock } as unknown as JiraApiClient;
+    const service = new JiraIntegrationService(baseConfig, client, auditLogger);
+
+    const ticket = await service.createPerfTraceTicket(ticketInput);
+
+    expect(ticket.key).toBe('PERF-1');
+    expect(requestMock).toHaveBeenNthCalledWith(
+      1,
+      '/rest/api/3/issue',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(requestMock).toHaveBeenNthCalledWith(
+      2,
+      '/rest/api/3/issue/1/attachments',
+      expect.objectContaining({ headers: expect.objectContaining({ 'X-Atlassian-Token': 'no-check' }) })
+    );
+    expect(requestMock).toHaveBeenNthCalledWith(
+      3,
+      '/rest/api/3/issueLink',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(auditLogger.getAll()).toHaveLength(3);
+  });
+
+  it('transitions workflow when mapping exists', async () => {
+    const auditLogger = new InMemoryAuditLogger();
+    const requestMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        transitions: [
+          { id: '10', name: 'In Progress' }
+        ]
+      })
+      .mockResolvedValueOnce({});
+    const client = { request: requestMock } as unknown as JiraApiClient;
+
+    const service = new JiraIntegrationService(baseConfig, client, auditLogger);
+    const result = await service.syncWorkflow('1', 'Triaged');
+
+    expect(result.transitioned).toBe(true);
+    expect(result.targetState).toBe('In Progress');
+    expect(requestMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns no transition when status not mapped', async () => {
+    const service = new JiraIntegrationService(
+      baseConfig,
+      { request: jest.fn() } as unknown as JiraApiClient,
+      new InMemoryAuditLogger()
+    );
+
+    const result = await service.syncWorkflow('1', 'Unmapped');
+    expect(result.transitioned).toBe(false);
+  });
+
+  it('processes webhook events and logs audit entries', () => {
+    const auditLogger = new InMemoryAuditLogger();
+    const service = new JiraIntegrationService(
+      baseConfig,
+      { request: jest.fn() } as unknown as JiraApiClient,
+      auditLogger
+    );
+
+    const webhook: JiraWebhookEvent = {
+      issue: {
+        id: '1',
+        key: 'PERF-1',
+        fields: {
+          status: { name: 'Triaged' },
+          summary: 'Perf issue'
+        }
+      },
+      webhookEvent: 'jira:issue_updated',
+      changelog: {
+        items: [
+          {
+            field: 'status',
+            fromString: 'Open',
+            toString: 'Triaged'
+          }
+        ]
+      }
+    };
+
+    const result = service.handleWebhook(webhook);
+    expect(result?.transitioned).toBe(true);
+    expect(auditLogger.getAll()).toHaveLength(1);
+  });
+
+  it('continues bulk operations when one ticket fails', async () => {
+    const auditLogger = new InMemoryAuditLogger();
+    const requestMock = jest
+      .fn()
+      .mockResolvedValueOnce({ id: '1', key: 'PERF-1', self: 'self' })
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValue({});
+    const client = { request: requestMock } as unknown as JiraApiClient;
+    const service = new JiraIntegrationService(baseConfig, client, auditLogger);
+
+    const results = await service.bulkCreatePerfTraceTickets([ticketInput, ticketInput]);
+    expect(results).toHaveLength(1);
+    expect(auditLogger.getAll().filter((entry) => entry.status === 'error')).toHaveLength(1);
+  });
+});

--- a/packages/jira-integration/docs/integration-guide.md
+++ b/packages/jira-integration/docs/integration-guide.md
@@ -1,0 +1,85 @@
+# PerfTrace Jira Integration Guide
+
+This guide describes how to roll out the PerfTrace Jira automation within Summit deployments.
+
+## 1. Prerequisites
+
+1. Jira Cloud site with REST API access enabled.
+2. Service account with project-level permissions to create issues, add attachments, and manage issue links.
+3. API token generated for the service account.
+4. Identified project key and issue type for PerfTrace tickets.
+5. Custom fields provisioned for environment, regression window, owners, baseline/current metrics, and severity.
+
+## 2. Installation
+
+1. Add the package to the Summit monorepo workspace dependencies if not already available.
+2. Configure environment variables for the Jira credentials and endpoints.
+3. Update CI secrets to inject the Jira API token for automated runs.
+
+```bash
+npm install
+npm run --workspace=@summit/jira-integration build
+```
+
+## 3. Configuration Checklist
+
+| Setting | Description | Example |
+| --- | --- | --- |
+| `baseUrl` | Jira site base URL | `https://example.atlassian.net` |
+| `email` | Service account email | `perftrace-bot@example.com` |
+| `apiToken` | Jira API token | Inject from secrets manager |
+| `projectKey` | PerfTrace project key | `PERF` |
+| `issueTypeId` | Custom PerfTrace issue type | `10057` |
+| `customFieldMap` | Field map for environment, owners, metrics | `customfield_10201` |
+| `priorityMapping` | Severity-to-priority translation | `critical -> P1` |
+| `workflowTransitions` | Status-to-transition mapping | `Triaged -> In Progress` |
+
+## 4. CI/CD Integration
+
+- Add `npm run --workspace=@summit/jira-integration test` to the CI pipeline.
+- Enforce linting with `npm run lint` prior to packaging.
+- Require >80% coverage by checking the Jest summary output.
+- Publish generated audit logs to your observability store (e.g., CloudWatch or ELK) for compliance.
+
+## 5. Webhook Setup
+
+1. Configure a Jira webhook pointing to your Summit webhook gateway.
+2. Subscribe to `jira:issue_created` and `jira:issue_updated` events.
+3. Pass incoming payloads to `integration.handleWebhook(event)`.
+4. Use the returned `WorkflowSyncResult` to trigger additional automation, such as notifying PerfTrace owners.
+
+## 6. Operational Runbook
+
+- **Retry Handling**: API calls automatically retry with exponential backoff. Persistent failures are logged in the audit trail.
+- **Audit Logging**: All requests and state changes emit structured logs; export them daily for compliance.
+- **Bulk Operations**: Use `bulkCreatePerfTraceTickets` for ingestion pipelines. Failures are isolated per ticket to avoid batch aborts.
+- **Attachments**: Attachments are uploaded using multipart form data. Ensure the Jira project allows attachments and respects size quotas.
+- **Issue Linking**: Related issues can be auto-linked using `linkIssues`. Define `Relates` or custom link types per project requirements.
+
+## 7. Security Considerations
+
+- Store Jira credentials in your secrets manager; never commit tokens.
+- Scope the service account permissions to the specific PerfTrace project when possible.
+- Rotate API tokens regularly and update CI secrets.
+
+## 8. Validation Checklist
+
+- [ ] Service account can create PerfTrace tickets.
+- [ ] Workflow transitions match the Summit lifecycle.
+- [ ] Attachments appear on created issues.
+- [ ] Related incidents are linked bidirectionally.
+- [ ] Webhooks trigger downstream automation without error.
+
+## 9. Troubleshooting
+
+| Symptom | Resolution |
+| --- | --- |
+| 401 Unauthorized | Verify email/token combo and Basic Auth header configuration. |
+| 415 Unsupported Media Type | Ensure attachments use multipart/form-data. |
+| Missing severity field | Confirm `priorityMapping` severity field IDs are correct. |
+| Tickets not transitioning | Check `workflowTransitions` for the source status name. |
+
+## 10. Further Reading
+
+- [Jira REST API documentation](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/)
+- [Jira issue link types](https://support.atlassian.com/jira-cloud-administration/docs/link-issues/)

--- a/packages/jira-integration/docs/templates/perftrace-ticket-templates.md
+++ b/packages/jira-integration/docs/templates/perftrace-ticket-templates.md
@@ -1,0 +1,84 @@
+# PerfTrace Ticket Template Examples
+
+Use the following templates when creating PerfTrace tickets with the Jira integration. Replace bracketed placeholders with project-specific values.
+
+## 1. Latency Regression
+
+- **Summary**: `[Service] latency regression detected in [environment]`
+- **Description**:
+  ```
+  h2. Summary
+  * Metric: {perfMetric}
+  * Baseline: {baselineValue} ms
+  * Current: {currentValue} ms
+  * Regression Window: {regressionWindow}
+
+  h2. Impact
+  * Affected transactions: {transactionVolume}
+  * Error budget impact: {errorBudgetImpact}
+
+  h2. Next Steps
+  # Investigate recent deployments in the regression window.
+  # Correlate PerfTrace anomalies with service logs.
+  # Provide remediation ETA.
+  ```
+- **Severity**: `critical`
+- **Labels**: `perftrace, latency`
+
+## 2. Throughput Degradation
+
+- **Summary**: `[Service] throughput degradation detected`
+- **Description**:
+  ```
+  h2. Summary
+  * Metric: {perfMetric}
+  * Baseline: {baselineValue} rps
+  * Current: {currentValue} rps
+  * Environment: {environment}
+
+  h2. Observations
+  * Notable incidents: {relatedIncidents}
+  * Linked dashboards: {dashboardUrl}
+
+  h2. Owner Checklist
+  # Validate capacity autoscaling.
+  # Confirm downstream dependencies are healthy.
+  # Attach supporting graphs.
+  ```
+- **Severity**: `high`
+- **Labels**: `perftrace, throughput`
+
+## 3. Error Rate Spike
+
+- **Summary**: `[Service] error rate spike requires investigation`
+- **Description**:
+  ```
+  h2. Summary
+  * Metric: {perfMetric}
+  * Baseline: {baselineValue}%
+  * Current: {currentValue}%
+  * Environment: {environment}
+
+  h2. Mitigation
+  * Initial triage owner: {owner}
+  * Rollback status: {rollbackStatus}
+
+  h2. Notes
+  # Link to recent deploy changes.
+  # Document temporary mitigations.
+  ```
+- **Severity**: `blocker`
+- **Labels**: `perftrace, reliability`
+
+## Custom Field Guidance
+
+| Field | Example Value |
+| --- | --- |
+| `environment` | `prod` |
+| `regressionWindow` | `24h` |
+| `owners` | `account-id-1` |
+| `perfMetric` | `checkout_latency_p95` |
+| `baselineValue` | `120` |
+| `currentValue` | `210` |
+
+These templates are compatible with the `createPerfTraceTicket` helper and can be supplied via `additionalFields` when extra structure is required.

--- a/packages/jira-integration/package.json
+++ b/packages/jira-integration/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@summit/jira-integration",
+  "version": "0.1.0",
+  "description": "PerfTrace Jira automation toolkit with workflow, field mapping, and audit logging.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint src __tests__ --ext .ts",
+    "test": "jest --coverage",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2"
+  }
+}

--- a/packages/jira-integration/src/client.ts
+++ b/packages/jira-integration/src/client.ts
@@ -1,0 +1,116 @@
+import fetch, { HeadersInit, RequestInit, Response } from 'node-fetch';
+import { createAuditEntry, AuditLogger } from './logger.js';
+import { JiraIntegrationConfig } from './types.js';
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_RETRY_DELAY_MS = 500;
+
+type FetchImplementation = (url: string, init?: RequestInit) => Promise<Response>;
+
+const sleep = async (delayMs: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+
+export class JiraApiError extends Error {
+  constructor(message: string, public readonly status?: number, public readonly body?: unknown) {
+    super(message);
+    this.name = 'JiraApiError';
+  }
+}
+
+export class JiraApiClient {
+  private readonly fetchImpl: FetchImplementation;
+
+  constructor(
+    private readonly config: JiraIntegrationConfig,
+    private readonly auditLogger: AuditLogger,
+    fetchImplementation?: FetchImplementation
+  ) {
+    this.fetchImpl = fetchImplementation ?? (globalThis.fetch as FetchImplementation) ?? fetch;
+  }
+
+  private get authHeader(): string {
+    const authToken = Buffer.from(`${this.config.email}:${this.config.apiToken}`).toString('base64');
+    return `Basic ${authToken}`;
+  }
+
+  private get retryConfig(): { attempts: number; delay: number } {
+    return {
+      attempts: this.config.maxRetries ?? DEFAULT_MAX_RETRIES,
+      delay: this.config.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS
+    };
+  }
+
+  async request<T>(path: string, init: RequestInit & { retryable?: boolean } = {}): Promise<T> {
+    const url = `${this.config.baseUrl}${path}`;
+    const { attempts, delay } = this.retryConfig;
+    const headers: HeadersInit = {
+      Authorization: this.authHeader,
+      Accept: 'application/json',
+      ...init.headers
+    };
+
+    let lastError: unknown;
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        const response = await this.fetchImpl(url, {
+          ...init,
+          headers,
+          body: init.body,
+          // enforce JSON content-type when sending objects
+          ...(init.body && typeof init.body === 'string'
+            ? {
+                headers: {
+                  'Content-Type': 'application/json',
+                  ...headers
+                }
+              }
+            : {})
+        });
+
+        if (!response.ok) {
+          const bodyText = await response.text();
+          throw new JiraApiError(`Jira API responded with ${response.status}`, response.status, bodyText);
+        }
+
+        this.auditLogger.record(
+          createAuditEntry('jira_api_request', 'success', {
+            entityId: url,
+            payload: { method: init.method ?? 'GET', attempt }
+          })
+        );
+
+        if (response.status === 204) {
+          return {} as T;
+        }
+
+        return (await response.json()) as T;
+      } catch (error: unknown) {
+        lastError = error;
+        const shouldRetry = attempt < attempts && (init.retryable ?? true);
+
+        this.auditLogger.record(
+          createAuditEntry('jira_api_request', 'error', {
+            entityId: url,
+            message: error instanceof Error ? error.message : 'Unknown error',
+            payload: { method: init.method ?? 'GET', attempt }
+          })
+        );
+
+        if (!shouldRetry) {
+          break;
+        }
+
+        await sleep(delay * attempt);
+      }
+    }
+
+    if (lastError instanceof JiraApiError) {
+      throw lastError;
+    }
+
+    throw new JiraApiError('Failed to execute Jira API request', undefined, lastError);
+  }
+}

--- a/packages/jira-integration/src/index.ts
+++ b/packages/jira-integration/src/index.ts
@@ -1,0 +1,4 @@
+export * from './client.js';
+export * from './jiraIntegration.js';
+export * from './logger.js';
+export * from './types.js';

--- a/packages/jira-integration/src/jiraIntegration.ts
+++ b/packages/jira-integration/src/jiraIntegration.ts
@@ -1,0 +1,231 @@
+import { Blob } from 'node:buffer';
+import { JiraApiClient, JiraApiError } from './client.js';
+import { AuditLogger, createAuditEntry } from './logger.js';
+import {
+  AttachmentPayload,
+  JiraIntegrationConfig,
+  JiraLinkRequest,
+  JiraTicket,
+  JiraWebhookEvent,
+  PerfTraceTicketInput,
+  WorkflowSyncResult
+} from './types.js';
+
+interface CreateIssueResponse {
+  readonly id: string;
+  readonly key: string;
+  readonly self: string;
+}
+
+interface TransitionResponse {
+  readonly transitions: readonly {
+    readonly id: string;
+    readonly name: string;
+  }[];
+}
+
+export class JiraIntegrationService {
+  constructor(
+    private readonly config: JiraIntegrationConfig,
+    private readonly client: JiraApiClient,
+    private readonly auditLogger: AuditLogger
+  ) {}
+
+  private buildCustomFields(input: PerfTraceTicketInput): Record<string, unknown> {
+    const fields: Record<string, unknown> = {};
+    Object.entries(this.config.customFieldMap).forEach(([logicalField, jiraField]) => {
+      const value = (input as Record<string, unknown>)[logicalField];
+      if (value === undefined) {
+        return;
+      }
+
+      if (logicalField === 'owners') {
+        fields[jiraField] = (input.owners ?? []).map((email) => ({ accountId: email }));
+        return;
+      }
+
+      fields[jiraField] = value;
+    });
+
+    const priorityEntry = this.config.priorityMapping[input.severity];
+    fields.priority = { id: priorityEntry.priorityId };
+    fields[priorityEntry.severityFieldId] = priorityEntry.severityValue;
+
+    if (input.labels && input.labels.length > 0) {
+      fields.labels = [...input.labels, 'perftrace'];
+    } else {
+      fields.labels = ['perftrace'];
+    }
+
+    if (input.additionalFields) {
+      Object.assign(fields, input.additionalFields);
+    }
+
+    return fields;
+  }
+
+  async createPerfTraceTicket(input: PerfTraceTicketInput): Promise<JiraTicket> {
+    const fields = this.buildCustomFields(input);
+    const body = JSON.stringify({
+      fields: {
+        project: { key: this.config.projectKey },
+        issuetype: { id: this.config.issueTypeId },
+        summary: input.summary,
+        description: input.description,
+        ...fields
+      }
+    });
+
+    const ticket = await this.client.request<CreateIssueResponse>('/rest/api/3/issue', {
+      method: 'POST',
+      body
+    });
+
+    this.auditLogger.record(
+      createAuditEntry('create_ticket', 'success', {
+        entityId: ticket.key,
+        payload: { severity: input.severity, environment: input.environment }
+      })
+    );
+
+    if (input.attachments && input.attachments.length > 0) {
+      await this.addAttachments(ticket.id, input.attachments);
+    }
+
+    if (input.relatedIssueKeys && input.relatedIssueKeys.length > 0) {
+      await this.linkIssues(ticket.key, input.relatedIssueKeys);
+    }
+
+    return ticket;
+  }
+
+  async addAttachments(issueId: string, attachments: readonly AttachmentPayload[]): Promise<void> {
+    const formData = new FormData();
+    attachments.forEach((attachment) => {
+      const blob = new Blob([attachment.data], { type: attachment.contentType });
+      formData.append('file', blob, attachment.fileName);
+    });
+
+    await this.client.request(`/rest/api/3/issue/${issueId}/attachments`, {
+      method: 'POST',
+      body: formData as unknown as BodyInit,
+      headers: {
+        'X-Atlassian-Token': 'no-check'
+      }
+    });
+
+    this.auditLogger.record(
+      createAuditEntry('add_attachments', 'success', {
+        entityId: issueId,
+        payload: { count: attachments.length }
+      })
+    );
+  }
+
+  async transitionTicket(issueId: string, targetState: string): Promise<WorkflowSyncResult> {
+    const available = await this.client.request<TransitionResponse>(`/rest/api/3/issue/${issueId}/transitions`);
+    const transition = available.transitions.find((item) => item.name === targetState);
+
+    if (!transition) {
+      throw new JiraApiError(`Transition ${targetState} not available`, 404);
+    }
+
+    await this.client.request(`/rest/api/3/issue/${issueId}/transitions`, {
+      method: 'POST',
+      body: JSON.stringify({ transition: { id: transition.id } })
+    });
+
+    this.auditLogger.record(
+      createAuditEntry('transition_ticket', 'success', {
+        entityId: issueId,
+        payload: { targetState }
+      })
+    );
+
+    return { issueId, transitioned: true, targetState };
+  }
+
+  async syncWorkflow(issueId: string, currentStatus: string): Promise<WorkflowSyncResult> {
+    const targetState = this.config.workflowTransitions[currentStatus];
+    if (!targetState) {
+      return { issueId, transitioned: false };
+    }
+
+    return this.transitionTicket(issueId, targetState);
+  }
+
+  async linkIssues(sourceIssueKey: string, relatedIssueKeys: readonly string[], linkType = 'Relates'): Promise<void> {
+    const payloads: JiraLinkRequest[] = relatedIssueKeys.map((relatedKey) => ({
+      type: { name: linkType },
+      inwardIssue: { key: sourceIssueKey },
+      outwardIssue: { key: relatedKey }
+    }));
+
+    await Promise.all(
+      payloads.map((payload) =>
+        this.client.request('/rest/api/3/issueLink', {
+          method: 'POST',
+          body: JSON.stringify(payload)
+        })
+      )
+    );
+
+    this.auditLogger.record(
+      createAuditEntry('link_issues', 'success', {
+        entityId: sourceIssueKey,
+        payload: { related: relatedIssueKeys }
+      })
+    );
+  }
+
+  async bulkCreatePerfTraceTickets(inputs: readonly PerfTraceTicketInput[]): Promise<readonly JiraTicket[]> {
+    const results: JiraTicket[] = [];
+    for (const input of inputs) {
+      try {
+        const ticket = await this.createPerfTraceTicket(input);
+        results.push(ticket);
+      } catch (error: unknown) {
+        this.auditLogger.record(
+          createAuditEntry('create_ticket', 'error', {
+            message: error instanceof Error ? error.message : 'Unknown error',
+            payload: { summary: input.summary }
+          })
+        );
+      }
+    }
+
+    return results;
+  }
+
+  handleWebhook(event: JiraWebhookEvent): WorkflowSyncResult | undefined {
+    if (event.webhookEvent !== 'jira:issue_updated' || !event.changelog) {
+      return undefined;
+    }
+
+    const statusChange = event.changelog.items.find((item) => item.field === 'status');
+    if (!statusChange || !statusChange.toString) {
+      return undefined;
+    }
+
+    const mappedTarget = this.config.workflowTransitions[statusChange.toString];
+
+    const result: WorkflowSyncResult = {
+      issueId: event.issue.id,
+      transitioned: Boolean(mappedTarget),
+      targetState: mappedTarget
+    };
+
+    this.auditLogger.record(
+      createAuditEntry('webhook_processed', 'success', {
+        entityId: event.issue.key,
+        payload: {
+          previous: statusChange.fromString,
+          current: statusChange.toString,
+          mappedTarget
+        }
+      })
+    );
+
+    return result;
+  }
+}

--- a/packages/jira-integration/src/logger.ts
+++ b/packages/jira-integration/src/logger.ts
@@ -1,0 +1,43 @@
+export interface AuditLogEntry {
+  readonly timestamp: string;
+  readonly action: string;
+  readonly entityId?: string;
+  readonly payload?: unknown;
+  readonly status: 'success' | 'error';
+  readonly message?: string;
+}
+
+export interface AuditLogger {
+  record(entry: AuditLogEntry): void;
+}
+
+export class InMemoryAuditLogger implements AuditLogger {
+  private readonly entries: AuditLogEntry[] = [];
+
+  record(entry: AuditLogEntry): void {
+    this.entries.push(entry);
+  }
+
+  getAll(): readonly AuditLogEntry[] {
+    return this.entries;
+  }
+}
+
+export class ConsoleAuditLogger implements AuditLogger {
+  record(entry: AuditLogEntry): void {
+    const serialized = JSON.stringify(entry);
+    // eslint-disable-next-line no-console
+    console.info(`[jira-audit] ${serialized}`);
+  }
+}
+
+export const createAuditEntry = (
+  action: string,
+  status: AuditLogEntry['status'],
+  details: Omit<AuditLogEntry, 'action' | 'status' | 'timestamp'> = {}
+): AuditLogEntry => ({
+  timestamp: new Date().toISOString(),
+  action,
+  status,
+  ...details
+});

--- a/packages/jira-integration/src/types.ts
+++ b/packages/jira-integration/src/types.ts
@@ -1,0 +1,101 @@
+export type JiraPriorityLevel = 'blocker' | 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+export interface PriorityMappingEntry {
+  readonly priorityId: string;
+  readonly severityFieldId: string;
+  readonly severityValue: string;
+}
+
+export interface WorkflowTransitionMapping {
+  readonly [key: string]: string;
+}
+
+export interface PerfTraceCustomFieldMap {
+  readonly environment: string;
+  readonly regressionWindow: string;
+  readonly owners: string;
+  readonly perfMetric: string;
+  readonly baselineValue: string;
+  readonly currentValue: string;
+  readonly [additionalKey: string]: string;
+}
+
+export interface JiraIntegrationConfig {
+  readonly baseUrl: string;
+  readonly email: string;
+  readonly apiToken: string;
+  readonly projectKey: string;
+  readonly issueTypeId: string;
+  readonly customFieldMap: PerfTraceCustomFieldMap;
+  readonly priorityMapping: Readonly<Record<JiraPriorityLevel, PriorityMappingEntry>>;
+  readonly workflowTransitions: WorkflowTransitionMapping;
+  readonly maxRetries?: number;
+  readonly retryDelayMs?: number;
+}
+
+export interface PerfTraceTicketInput {
+  readonly summary: string;
+  readonly description: string;
+  readonly severity: JiraPriorityLevel;
+  readonly environment: string;
+  readonly regressionWindow: string;
+  readonly owners: readonly string[];
+  readonly perfMetric?: string;
+  readonly baselineValue?: number;
+  readonly currentValue?: number;
+  readonly attachments?: readonly AttachmentPayload[];
+  readonly relatedIssueKeys?: readonly string[];
+  readonly labels?: readonly string[];
+  readonly additionalFields?: Readonly<Record<string, unknown>>;
+}
+
+export interface AttachmentPayload {
+  readonly fileName: string;
+  readonly contentType: string;
+  readonly data: Buffer;
+}
+
+export interface JiraTicket {
+  readonly id: string;
+  readonly key: string;
+  readonly self: string;
+}
+
+export interface JiraWebhookEvent {
+  readonly issue: {
+    readonly id: string;
+    readonly key: string;
+    readonly fields: {
+      readonly status: {
+        readonly name: string;
+      };
+      readonly summary: string;
+    };
+  };
+  readonly changelog?: {
+    readonly items: readonly {
+      readonly field: string;
+      readonly fromString?: string | null;
+      readonly toString?: string | null;
+    }[];
+  };
+  readonly webhookEvent: string;
+}
+
+export interface WorkflowSyncResult {
+  readonly issueId: string;
+  readonly transitioned: boolean;
+  readonly targetState?: string;
+}
+
+export interface JiraLinkRequest {
+  readonly type: {
+    readonly name: string;
+  };
+  readonly inwardIssue: {
+    readonly key: string;
+  };
+  readonly outwardIssue: {
+    readonly key: string;
+  };
+}

--- a/packages/jira-integration/tsconfig.json
+++ b/packages/jira-integration/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "strict": true,
+    "noImplicitAny": true,
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022"
+  },
+  "include": ["src/**/*", "__tests__/**/*"],
+  "references": []
+}


### PR DESCRIPTION
## Summary
- add a new `@summit/jira-integration` package for PerfTrace ticket automation with workflow, attachments, links, and webhook utilities
- implement resilient Jira API client with retry, audit logging, and priority/custom field mapping helpers
- document setup with integration guide and PerfTrace ticket templates

## Testing
- not run (repository dependencies unavailable in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e33d538a5483338d77038a689cefe7