### PR TITLE
docs: add codex issue task briefs

### DIFF
--- a/docs/project_management/github-issues-manifest.md
+++ b/docs/project_management/github-issues-manifest.md
@@ -1,0 +1,35 @@
+# Codex UI GitHub Issues Manifest
+
+This manifest captures the prioritized Codex UI workstream initiatives and the metadata required to track them as GitHub issues. Use it to synchronize project planning tools, ensure consistent labeling, and provide quick visibility into go-to-market critical paths.
+
+## How to Use This Manifest
+
+- Create or update GitHub issues using the _Issue Title_ values below.
+- Apply the provided labels to standardize priority, domain, and program alignment.
+- Reference the described outcomes and dependencies when authoring acceptance criteria.
+- Update the **Status** column as execution progresses to maintain a reliable source of truth.
+
+## Prioritized Issue Tracker
+
+| Issue Title | Priority | Domain / Program Tags | Desired Outcome | Status |
+| --- | --- | --- | --- | --- |
+| Reliability & Chaos Program (GA Blocker) | P1 | `reliability`, `chaos-engineering`, `ga-blocker` | Comprehensive chaos and resilience testing framework executed with automated reporting, ensuring GA readiness. | To Do |
+| CompanyOS SDK Parity & Ecosystem Bridges | P0 | `sdk`, `integration`, `ecosystem` | Feature parity across CompanyOS SDKs with bridges for strategic ecosystem integrations. | To Do |
+| Advanced AI/ML Extraction Pipeline | P1 | `ai-ml`, `data-pipeline`, `extraction` | AI/ML-powered extraction pipeline delivering reliable structured outputs and monitoring. | To Do |
+| Air-Gap Offline Deploy v1 | P1 | `deployment`, `air-gap`, `infrastructure` | First production-ready offline deployment pattern for isolated environments with documentation. | To Do |
+| Analyst Assist v0.2 | P1 | `analyst-experience`, `assistants`, `product` | Analyst assistance experience v0.2 delivered with workflow tooling upgrades. | In Progress |
+| IGAC/Provenance Governance: Pin Policy Bundle SHAs to Releases | P1 | `governance`, `security`, `policy` | Policy bundle SHA pinning baked into release workflows with validation gates. | To Do |
+| GTM Enablement (Cross-Cutting) | P1 | `gtm`, `enablement`, `cross-cutting` | Coordinated go-to-market readiness plan with aligned collateral, demos, and training. | In Progress |
+| Compliance Evidence Automation | P0/P1 | `compliance`, `automation`, `evidence` | Automated evidence collection and reporting pipeline supporting compliance obligations. | Blocked |
+| Critical Blocker Resolution | P0 | `ga-blocker`, `stability`, `triage` | All critical issues blocking GA resolved with documented mitigations. | In Progress |
+| Policy & Security Hardening | P0 | `security`, `policy`, `hardening` | Hardened policy enforcement and security controls rolled out across services. | To Do |
+| CompanyOS Q0 Foundation | P0 | `companyos`, `foundation`, `platform` | Foundational CompanyOS Q0 capabilities implemented with baseline SLAs. | To Do |
+
+## Triage & Synchronization Notes
+
+- **Standup Review:** Incorporate this manifest into Codex UI standups to track movement and surface blockers quickly.
+- **Dashboard Integration:** Mirror priority and status fields into the Codex UI roadmap dashboard for stakeholder transparency.
+- **Label Hygiene:** Ensure consistency of labels; discrepancies should be reconciled within 24 hours of discovery.
+- **Dependency Tracking:** Highlight cross-team dependencies (e.g., security sign-off, infra readiness) directly in the associated GitHub issues.
+
+_Last updated: 2025-10-06_

--- a/docs/project_management/issues/advanced_ai_ml_extraction_pipeline.md
+++ b/docs/project_management/issues/advanced_ai_ml_extraction_pipeline.md
@@ -1,0 +1,35 @@
+# Codex Task: Advanced AI/ML Extraction Pipeline
+
+**Priority:** P1  
+**Labels:** `ai-ml`, `data-pipeline`, `extraction`, `codex-task`
+
+## Desired Outcome
+AI/ML-powered extraction pipeline delivering reliable structured outputs and monitoring.
+
+## Workstreams
+- Design multi-stage extraction architecture combining LLM, deterministic parsing, and human-in-the-loop validation.
+- Train and fine-tune models using labeled corpora with drift detection and continuous evaluation.
+- Build scalable data processing pipeline (batch + streaming) with observability and error remediation loops.
+- Expose APIs and UI surfaces for analysts to review, correct, and export structured extractions.
+
+## Key Deliverables
+- Extraction architecture blueprint and data contracts.
+- Model training assets: datasets, prompt templates, evaluation harness, and performance benchmarks.
+- Production-grade pipeline deployment with monitoring dashboards and alerting thresholds.
+- Analyst workflow enhancements (review queues, feedback capture, export formats).
+
+## Acceptance Criteria
+- Extractions achieve ≥95% precision on critical entities and relations in benchmark set.
+- Pipeline processes priority document volumes within agreed latency SLOs.
+- Analyst feedback loop reduces manual correction rate by ≥40% after pilot.
+
+## Dependencies & Risks
+- Access to labeled data and annotation resources.
+- Alignment with Analyst Assist v0.2 to reuse review workflows.
+- Model drift risk requiring guardrails and fallback strategies.
+
+## Milestones
+- **Week 1:** Finalize architecture, data requirements, and evaluation plan.
+- **Week 2-3:** Train/fine-tune models and build evaluation harness.
+- **Week 4:** Deploy pipeline to staging with monitoring and feedback UX.
+- **Week 5:** Pilot with analysts, collect metrics, and prep for GA rollout.

--- a/docs/project_management/issues/air_gap_offline_deploy_v1.md
+++ b/docs/project_management/issues/air_gap_offline_deploy_v1.md
@@ -1,0 +1,35 @@
+# Codex Task: Air-Gap Offline Deploy v1
+
+**Priority:** P1  
+**Labels:** `deployment`, `air-gap`, `infrastructure`, `codex-task`
+
+## Desired Outcome
+First production-ready offline deployment pattern for isolated environments with documentation.
+
+## Workstreams
+- Define air-gapped reference architecture, including network topology, package repos, and secret handling.
+- Containerize and bundle required services with deterministic builds and signed artifacts.
+- Develop offline installer toolkit (scripts, Terraform modules, validation checks) for infrastructure bring-up.
+- Document operational guidance covering updates, patching, and incident response within disconnected environments.
+
+## Key Deliverables
+- Air-gap deployment blueprint with hardware/software prerequisites.
+- Artifact mirror (OCI registry snapshot, package bundles) with checksum manifest.
+- Offline deployment toolkit and automated validation report template.
+- Operations manual and training materials for customer admins.
+
+## Acceptance Criteria
+- Successful end-to-end deployment executed in controlled air-gapped lab without internet access.
+- Security review completed for artifact signing, key management, and supply-chain controls.
+- Documentation approved by support and enablement teams for customer distribution.
+
+## Dependencies & Risks
+- Access to secure build pipeline and signing infrastructure.
+- Coordination with Security for threat modeling of offline posture.
+- Hardware availability to simulate customer environment.
+
+## Milestones
+- **Week 1:** Finalize architecture and component inventory.
+- **Week 2-3:** Produce signed artifacts and build offline toolkit.
+- **Week 4:** Execute lab deployment and remediate gaps.
+- **Week 5:** Publish documentation and handoff to support/enablement.

--- a/docs/project_management/issues/analyst_assist_v0_2.md
+++ b/docs/project_management/issues/analyst_assist_v0_2.md
@@ -1,0 +1,35 @@
+# Codex Task: Analyst Assist v0.2
+
+**Priority:** P1  
+**Labels:** `analyst-experience`, `assistants`, `product`, `codex-task`
+
+## Desired Outcome
+Analyst assistance experience v0.2 delivered with workflow tooling upgrades.
+
+## Workstreams
+- Define v0.2 feature set (guided investigations, contextual insights, suggested actions) informed by analyst feedback.
+- Enhance UI/UX with inline assistant panel, notification surfaces, and configurable workflows.
+- Integrate with underlying AI services (extraction pipeline, knowledge graph) for context-aware recommendations.
+- Instrument usage analytics and feedback capture loops to drive continuous improvement.
+
+## Key Deliverables
+- Product requirements brief and experience storyboard for v0.2.
+- Updated UI components, interaction flows, and design system artifacts.
+- Backend/AI integration endpoints with contract tests and monitoring.
+- Analyst feedback reports and adoption metrics dashboard.
+
+## Acceptance Criteria
+- v0.2 capabilities validated in usability testing with ≥80% satisfaction score.
+- Assistant recommendations reduce manual workflow time by ≥25% in pilot teams.
+- Telemetry dashboards track engagement, accuracy, and feedback submissions.
+
+## Dependencies & Risks
+- Coordination with Advanced AI/ML Extraction Pipeline for contextual data feeds.
+- UX research availability and analyst participation in pilots.
+- Change management and training for analysts adopting new workflows.
+
+## Milestones
+- **Week 1:** Finalize product brief and UX prototypes.
+- **Week 2-3:** Implement UI/UX enhancements and backend integrations.
+- **Week 4:** Run usability sessions, iterate on feedback.
+- **Week 5:** Launch pilot cohort and monitor adoption metrics.

--- a/docs/project_management/issues/companyos_q0_foundation.md
+++ b/docs/project_management/issues/companyos_q0_foundation.md
@@ -1,0 +1,35 @@
+# Codex Task: CompanyOS Q0 Foundation
+
+**Priority:** P0  
+**Labels:** `companyos`, `foundation`, `platform`, `codex-task`
+
+## Desired Outcome
+Foundational CompanyOS Q0 capabilities implemented with baseline SLAs.
+
+## Workstreams
+- Define Q0 scope: core modules, data model, workflows, and SLA targets for availability and responsiveness.
+- Stand up baseline services (identity, workspace management, permissions) with integration tests and monitoring.
+- Migrate critical tenants into Q0 environment with rollout plan and rollback guardrails.
+- Establish operational playbooks covering on-call, incident response, and SLA reporting.
+
+## Key Deliverables
+- Q0 architecture and service dependency map.
+- Baseline service implementations with CI/CD pipelines and infrastructure as code.
+- Migration runbook and validation reports for early adopter tenants.
+- SLA dashboard and operational metrics for Q0 services.
+
+## Acceptance Criteria
+- Core Q0 services meet defined SLA targets for 30-day steady state.
+- Early adopters complete migration with no Sev-1 incidents and positive adoption feedback.
+- Operational playbooks approved and on-call rotations staffed.
+
+## Dependencies & Risks
+- Infrastructure capacity planning and environment readiness.
+- Coordination with GTM and Support for early adopter onboarding.
+- Potential integration debt with legacy CompanyOS components.
+
+## Milestones
+- **Week 1:** Finalize Q0 scope, architecture, and SLA definitions.
+- **Week 2-3:** Build and deploy baseline services with automated tests.
+- **Week 4:** Execute limited-scope tenant migrations and validation.
+- **Week 5:** Launch SLA dashboards and transition to steady-state operations.

--- a/docs/project_management/issues/companyos_sdk_parity_and_ecosystem_bridges.md
+++ b/docs/project_management/issues/companyos_sdk_parity_and_ecosystem_bridges.md
@@ -1,0 +1,35 @@
+# Codex Task: CompanyOS SDK Parity & Ecosystem Bridges
+
+**Priority:** P0  
+**Labels:** `sdk`, `integration`, `ecosystem`, `codex-task`
+
+## Desired Outcome
+Feature parity across CompanyOS SDKs with bridges for strategic ecosystem integrations.
+
+## Workstreams
+- Catalogue feature gaps across language SDKs (TypeScript, Python, Go) against the current API contract and UI workflows.
+- Deliver missing capability implementations, including auth flows, streaming, and offline caching, with shared conformance tests.
+- Publish ecosystem bridge adapters for top partner platforms (Salesforce, ServiceNow, Snowflake) with reference blueprints.
+- Stand up nightly compatibility CI to validate SDKs against the public API schema and contract tests.
+
+## Key Deliverables
+- SDK parity matrix with closure dates and owners.
+- vNext releases for each SDK including changelog and migration notes.
+- Ecosystem bridge samples and deployment guides.
+- Automated compatibility CI pipeline artifacts and dashboard entry.
+
+## Acceptance Criteria
+- All GA-critical features achieve parity across supported SDKs with passing contract test suite.
+- Partner bridge integrations demonstrate end-to-end data exchange in sandbox demos.
+- Documentation updated in developer portal with parity status and integration quickstarts.
+
+## Dependencies & Risks
+- Upstream API stability and versioning discipline.
+- Security review for third-party bridge adapters.
+- Partner sandbox access for integration validation.
+
+## Milestones
+- **Week 1:** Complete feature gap audit and align owners.
+- **Week 2-3:** Implement missing SDK features and add conformance tests.
+- **Week 4:** Release partner bridge adapters with validation demos.
+- **Week 5:** Enable compatibility CI and finalize documentation.

--- a/docs/project_management/issues/compliance_evidence_automation.md
+++ b/docs/project_management/issues/compliance_evidence_automation.md
@@ -1,0 +1,35 @@
+# Codex Task: Compliance Evidence Automation
+
+**Priority:** P0/P1  
+**Labels:** `compliance`, `automation`, `evidence`, `codex-task`
+
+## Desired Outcome
+Automated evidence collection and reporting pipeline supporting compliance obligations.
+
+## Workstreams
+- Map regulatory controls (FedRAMP, SOC 2, ISO 27001) to required evidence artifacts and data sources.
+- Build connectors to ingest logs, configs, and attestations from Codex services and third-party platforms.
+- Implement rules engine to evaluate control coverage, flag gaps, and generate auditor-ready packages.
+- Deliver self-service portal workflow for compliance teams to schedule exports and monitor status.
+
+## Key Deliverables
+- Control-to-evidence data model and source inventory.
+- Automated ingestion jobs with storage, retention, and tamper-evident hashing.
+- Evidence automation runbook, including exception handling and manual override steps.
+- Compliance dashboard widgets showing control coverage and outstanding actions.
+
+## Acceptance Criteria
+- ≥90% of priority controls automatically collect current evidence with timestamped provenance.
+- Exported evidence bundles meet auditor format requirements (PDF/CSV manifests) and include integrity checks.
+- Alerts raised within 24 hours for missing or stale evidence signals.
+
+## Dependencies & Risks
+- Access to production telemetry and configuration stores.
+- Legal review of data retention and privacy implications.
+- Coordination with Policy & Security Hardening workstream for control definitions.
+
+## Milestones
+- **Week 1:** Finalize control mappings and prioritize data sources.
+- **Week 2-3:** Implement ingestion connectors and evidence storage.
+- **Week 4:** Launch rules engine with alerting, perform pilot audit dry run.
+- **Week 5:** Release self-service portal workflow and documentation.

--- a/docs/project_management/issues/critical_blocker_resolution.md
+++ b/docs/project_management/issues/critical_blocker_resolution.md
@@ -1,0 +1,35 @@
+# Codex Task: Critical Blocker Resolution
+
+**Priority:** P0  
+**Labels:** `ga-blocker`, `stability`, `triage`, `codex-task`
+
+## Desired Outcome
+All critical issues blocking GA resolved with documented mitigations.
+
+## Workstreams
+- Establish war-room triage cadence with severity matrix and on-call ownership.
+- Drive root cause analysis for each GA blocker, capturing fix-forward and prevention actions.
+- Validate fixes in staging with regression tests and observability verification.
+- Communicate status to leadership via twice-weekly updates and unblock dependencies.
+
+## Key Deliverables
+- GA blocker register with severity, owner, ETA, and mitigation notes.
+- RCA documents and post-incident reviews for each resolved blocker.
+- Verification evidence (test results, dashboards) proving stability post-fix.
+- Executive summary highlighting risk burn-down and remaining watch items.
+
+## Acceptance Criteria
+- No P0/P1 open issues blocking GA exit criteria.
+- Each resolved blocker has validated fix, monitoring guardrail, and documented prevention.
+- Stakeholders acknowledge readiness via sign-off in GA dashboard.
+
+## Dependencies & Risks
+- Cross-team responsiveness for services owning defects.
+- Test environment parity with production configuration.
+- Potential discovery of new blockers during hardening.
+
+## Milestones
+- **Daily:** Run blocker standup, update register.
+- **Within 48h of discovery:** Complete interim mitigation and assign RCA owner.
+- **Weekly:** Publish risk burn-down report to GA leadership.
+- **GA-2 weeks:** Confirm zero open blockers and freeze change window.

--- a/docs/project_management/issues/gtm_enablement_cross_cutting.md
+++ b/docs/project_management/issues/gtm_enablement_cross_cutting.md
@@ -1,0 +1,35 @@
+# Codex Task: GTM Enablement (Cross-Cutting)
+
+**Priority:** P1  
+**Labels:** `gtm`, `enablement`, `cross-cutting`, `codex-task`
+
+## Desired Outcome
+Coordinated go-to-market readiness plan with aligned collateral, demos, and training.
+
+## Workstreams
+- Align GTM narrative and positioning with product/marketing stakeholders, capturing key differentiators and proof points.
+- Produce sales and solution engineering collateral (pitch decks, one-pagers, ROI calculators, demo scripts).
+- Build demo environments and guided walkthroughs showcasing prioritized use cases and value stories.
+- Deliver enablement program: training sessions, certification, and feedback loops for GTM teams.
+
+## Key Deliverables
+- GTM messaging framework and positioning brief.
+- Collateral kit including decks, datasheets, battlecards, and ROI tools.
+- Demo environment runbooks, recordings, and live tenant management plan.
+- Enablement schedule with attendance tracking, certification rubric, and satisfaction survey summary.
+
+## Acceptance Criteria
+- GTM teams report ≥90% readiness in enablement survey.
+- Demo environment uptime ≥99% during launch window with scripted flows validated.
+- Collateral approved by legal/compliance and versioned for distribution.
+
+## Dependencies & Risks
+- Coordination with Product Marketing, Sales, and Support for consistent messaging.
+- Availability of stable product features aligned with demos.
+- Need for localization or vertical-specific messaging (track as follow-on work).
+
+## Milestones
+- **Week 1:** Finalize positioning and messaging brief.
+- **Week 2-3:** Produce collateral and configure demo environments.
+- **Week 4:** Run enablement sessions and capture feedback.
+- **Week 5:** Iterate collateral, finalize distribution plan, and open ongoing support channels.

--- a/docs/project_management/issues/igac_provenance_governance_policy_bundle_sha_pinning.md
+++ b/docs/project_management/issues/igac_provenance_governance_policy_bundle_sha_pinning.md
@@ -1,0 +1,35 @@
+# Codex Task: IGAC/Provenance Governance – Policy Bundle SHA Pinning
+
+**Priority:** P1  
+**Labels:** `governance`, `security`, `policy`, `codex-task`
+
+## Desired Outcome
+Policy bundle SHA pinning baked into release workflows with validation gates.
+
+## Workstreams
+- Define governance requirements for policy bundle versioning, signing, and release approvals.
+- Implement tooling to pin policy bundle SHAs in CI/CD pipelines with automated verification.
+- Extend provenance ledger to record bundle metadata, change history, and release provenance.
+- Provide documentation and training for release managers and security stakeholders.
+
+## Key Deliverables
+- Governance specification outlining pinning rules, exception handling, and audit trails.
+- CI/CD integrations (GitHub Actions, deployment scripts) enforcing SHA pinning with policy checks.
+- Provenance ledger updates and dashboards exposing bundle lineage and deployment state.
+- Release process documentation and enablement sessions.
+
+## Acceptance Criteria
+- All production releases reference immutable policy bundle SHAs enforced by automated gates.
+- Governance audits can trace bundle changes with complete provenance records.
+- Exception workflows documented with approval records in governance system.
+
+## Dependencies & Risks
+- Alignment with Policy & Security Hardening for bundle content readiness.
+- Coordination with DevOps for CI/CD integration and rollout.
+- Potential friction from teams needing expedited hotfixes; requires exception guardrails.
+
+## Milestones
+- **Week 1:** Finalize governance specification and stakeholder alignment.
+- **Week 2-3:** Build/enforce SHA pinning automation and ledger updates.
+- **Week 4:** Pilot in staging releases, gather feedback, adjust policies.
+- **Week 5:** Roll out to production release workflow with training completion.

--- a/docs/project_management/issues/policy_and_security_hardening.md
+++ b/docs/project_management/issues/policy_and_security_hardening.md
@@ -1,0 +1,35 @@
+# Codex Task: Policy & Security Hardening
+
+**Priority:** P0  
+**Labels:** `security`, `policy`, `hardening`, `codex-task`
+
+## Desired Outcome
+Hardened policy enforcement and security controls rolled out across services.
+
+## Workstreams
+- Inventory existing policy enforcement points and assess coverage against GA requirements.
+- Implement missing controls (OPA policies, fine-grained RBAC, rate limiting, audit logging) with automated tests.
+- Conduct threat modeling and penetration testing to validate control effectiveness.
+- Update security runbooks, incident response procedures, and training materials.
+
+## Key Deliverables
+- Policy coverage matrix with remediation backlog and ownership.
+- Hardened policy bundles versioned with release notes and SHA references.
+- Security validation report summarizing pen test, chaos, and red team findings.
+- Updated runbooks, playbooks, and security awareness collateral.
+
+## Acceptance Criteria
+- All GA-tier services enforcing updated policies with passing integration and security tests.
+- Critical findings from pen tests closed or risk-accepted with compensating controls.
+- Policy bundles signed and pinned for release with automated drift detection.
+
+## Dependencies & Risks
+- Coordination with IGAC/Provenance governance initiative for policy bundle management.
+- Availability of security tooling and test environments.
+- Potential performance impact of new controls requiring tuning.
+
+## Milestones
+- **Week 1:** Complete policy coverage audit and prioritize gaps.
+- **Week 2-3:** Implement remediations and expand automated security tests.
+- **Week 4:** Execute validation exercises (pen test, chaos scenarios).
+- **Week 5:** Finalize documentation, approvals, and release sign-off.


### PR DESCRIPTION
## Summary
- add a Codex UI GitHub issues manifest covering prioritized reliability, compliance, and platform initiatives
- document usage guidance, labeling conventions, and synchronization practices for Codex UI planning
- add Codex task briefs for the remaining GA-critical manifest items to guide issue creation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c913e15883339e8eb64792f86d8c