### PR TITLE
chore: streamline lint and typecheck workflows

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,7 +1,13 @@
-dist/
-build/
-coverage/
-node_modules/
+**/node_modules/**
+**/dist/**
+**/.next/**
+**/build/**
+**/.turbo/**
+**/.cache/**
+**/coverage/**
+**/*.gen.ts
+**/*.d.ts
+**/generated/**
 public/
 *.min.js
 .github/workflows/compliance-automation.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,64 @@
 name: CI
 on:
-  pull_request: { branches: [ main ] }
-  push:         { branches: [ main ] }
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
 permissions:
   contents: read
 jobs:
-  build-test:
+  lint-typecheck:
+    timeout-minutes: 12
     runs-on: ubuntu-latest
-    strategy: { matrix: { node: [18, 20] } }
+    strategy:
+      fail-fast: false
+      matrix:
+        scope: [client, server, apps, packages, services]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: { node-version: ${{ matrix.node }}, cache: 'pnpm' }
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install
+        run: pnpm i --frozen-lockfile || npm ci
+      - name: Restore ESLint cache
+        uses: actions/cache@v4
+        with:
+          path: .eslintcache
+          key: eslint-${{ runner.os }}-${{ hashFiles('**/*.ts','**/*.tsx','**/*.js','**/*.jsx','eslint.config.js') }}
+      - name: Lint (changed first)
+        run: pnpm run lint:changed || true
+      - name: Lint (scoped, typed only where needed)
+        run: |
+          case "${{ matrix.scope }}" in
+            client) pnpm exec eslint client/src --cache --cache-location .eslintcache ;;
+            server) pnpm exec eslint server/src --cache --cache-location .eslintcache ;;
+            apps) pnpm exec eslint apps --cache --cache-location .eslintcache ;;
+            packages) pnpm exec eslint packages --cache --cache-location .eslintcache ;;
+            services) pnpm exec eslint services --cache --cache-location .eslintcache ;;
+          esac
+      - name: Lint (python)
+        if: matrix.scope == 'client'
+        run: pnpm run lint:python
+      - name: Typecheck (incremental)
+        if: matrix.scope == 'client'
+        run: pnpm run typecheck
+  build-test:
+    needs: lint-typecheck
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [18, 20]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'pnpm'
       - run: corepack enable
       - run: pnpm i --frozen-lockfile
-      - name: Typecheck
-        run: pnpm -w run typecheck || npx tsc -p .
-      - name: Lint
-        run: pnpm -w run lint
       - name: Unit tests (Jest+SWC)
         run: pnpm -w exec jest --ci --maxWorkers=50% --coverage

--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,4 @@ neo4j/data/
 neo4j/import/
 neo4j/logs/
 neo4j/backups/
+.tsbuildinfo

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,31 +1,13 @@
 {
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "allowJs": true,
-    "skipLibCheck": true,
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "strict": true,
-    "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": true,
+    "composite": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true,
-    "jsx": "react-jsx"
+    "moduleResolution": "Bundler",
+    "allowJs": true,
+    "noEmit": true
   },
-  "include": [
-    "src/**/*",
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "src/**/*.js",
-    "src/**/*.jsx"
-  ],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "build"
-  ]
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "build"]
 }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,46 +1,104 @@
-// ESLint v9 flat-config root
-// Applies base JS/TS rules across the monorepo; package-level configs refine further.
+process.env.TS_NODE_TRANSPILE_ONLY = '1';
+process.env.TS_ESLINT_DISABLE_SIZE_LIMIT = '1';
+
 import js from '@eslint/js';
-import * as tseslint from 'typescript-eslint';
+import globals from 'globals';
 import prettier from 'eslint-config-prettier';
-import path from 'node:path';
+import ts from 'typescript-eslint';
+
+const TYPED_SOURCE_GLOBS = [
+  'apps/**/src/**/*.{ts,tsx}',
+  'packages/**/src/**/*.{ts,tsx}',
+  'client/src/**/*.{ts,tsx}',
+  'server/src/**/*.{ts,tsx}',
+  'services/**/src/**/*.{ts,tsx}'
+];
+
+const TYPED_IGNORES = [
+  '**/*.test.{ts,tsx}',
+  '**/*.spec.{ts,tsx}',
+  '**/tests/**',
+  '**/e2e/**'
+];
 
 const IGNORE = [
   '**/node_modules/**',
   '**/dist/**',
   '**/build/**',
-  '**/coverage/**',
-  '**/.vite/**',
   '**/.next/**',
+  '**/.turbo/**',
   '**/.cache/**',
+  '**/.vite/**',
+  '**/coverage/**',
+  '**/*.d.ts',
+  '**/*.gen.ts',
   '**/generated/**',
-  'frontend/.vite/**' // legacy build artifacts
+  'frontend/.vite/**'
 ];
 
 export default [
   { ignores: IGNORE },
   js.configs.recommended,
-  ...tseslint.configs.recommended, // type-agnostic rules; package configs can opt into type-aware if desired
+  ...ts.configs.disableTypeChecked,
+  ...ts.configs.recommended,
   {
     languageOptions: {
       ecmaVersion: 2022,
       sourceType: 'module',
-      parserOptions: {
-        // Avoid project-based type checking here to keep root fast
-        ecmaFeatures: { jsx: true }
+      globals: {
+        ...globals.browser,
+        ...globals.node
       }
-    },
-    settings: {
-      react: { version: 'detect' },
     },
     rules: {
       'no-console': 'warn',
       'no-debugger': 'error',
-      'no-unused-vars': 'off', // handled by @typescript-eslint/no-unused-vars
+      'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
       'no-undef': 'off'
     }
   },
-  // Disable formatting-related rules in favor of Prettier
+  {
+    files: TYPED_SOURCE_GLOBS,
+    ignores: TYPED_IGNORES,
+    languageOptions: {
+      parserOptions: {
+        project: ['./tsconfig.eslint.json'],
+        tsconfigRootDir: import.meta.dirname
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.node
+      }
+    },
+    rules: {
+      '@typescript-eslint/no-misused-promises': 'error',
+      '@typescript-eslint/await-thenable': 'error',
+      '@typescript-eslint/no-floating-promises': 'error',
+      '@typescript-eslint/no-unnecessary-condition': 'warn',
+      '@typescript-eslint/consistent-type-imports': ['warn', { prefer: 'type-imports' }]
+    }
+  },
+  {
+    files: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}', '**/tests/**/*'],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+        ...globals.node
+      }
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-unsafe-assignment': 'off'
+    }
+  },
+  {
+    files: ['**/e2e/**/*.{ts,tsx}'],
+    languageOptions: {
+      globals: {
+        ...globals.node
+      }
+    }
+  },
   prettier
 ];

--- a/package.json
+++ b/package.json
@@ -50,10 +50,14 @@
     "deploy:staging": "scripts/deploy.sh staging",
     "deploy:prod": "scripts/deploy.sh prod",
     "backup": "scripts/backup.sh",
-    "lint": "eslint . && ruff .",
+    "lint": "eslint . --cache --cache-location .eslintcache --max-warnings=0 && ruff .",
+    "lint:eslint": "eslint . --cache --cache-location .eslintcache --max-warnings=0",
+    "lint:python": "ruff .",
     "lint:server": "cd server && npm run lint",
     "lint:client": "cd client && npm run lint",
+    "lint:changed": "git diff --name-only --diff-filter=ACMRTUXB origin/main...HEAD | grep -E '\\.(ts|tsx|js|jsx)$' | xargs -r eslint --cache --cache-location .eslintcache",
     "typecheck": "tsc -b --pretty false",
+    "typecheck:changed": "tsc -b --pretty false --verbose",
     "typecheck:server": "cd server && tsc --noEmit",
     "typecheck:client": "cd client && tsc --noEmit",
     "format": "prettier -w . && ruff format",
@@ -130,7 +134,9 @@
     "prettier": "^3.6.2",
     "semantic-release": "^24.2.7",
     "ts-jest": "^29.2.6",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "eslint": "^9.33.0",
+    "typescript-eslint": "^8.15.0"
   },
   "husky": {
     "hooks": {
@@ -140,7 +146,7 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
-      "eslint --fix",
+      "eslint --cache --cache-location .eslintcache --fix",
       "prettier -w"
     ],
     "*.py": [

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,24 +1,28 @@
 {
+  "extends": "../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "ESNext",
+    "composite": true,
     "moduleResolution": "node",
-    "rootDir": "./src",
     "outDir": "./dist",
-    "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": false,
-    "noImplicitAny": false,
-    "allowJs": true,
-    "skipLibCheck": true,
-    "resolveJsonModule": true,
-    "sourceMap": true,
-    "lib": ["ES2020"]
+    "rootDir": "./src",
+    "allowJs": false,
+    "noEmit": false,
+    "lib": [
+      "ES2022"
+    ],
+    "types": [
+      "node"
+    ],
+    "strict": false
   },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ],
   "ts-node": {
     "esm": true
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,21 +4,15 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "jsx": "react-jsx",
-    "strict": false,
-    "exactOptionalPropertyTypes": false,
-    "noUncheckedIndexedAccess": false,
-    "noImplicitOverride": false,
+    "strict": true,
+    "noEmit": true,
     "skipLibCheck": true,
-    "useUnknownInCatchVariables": false,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "composite": false,
+    "allowJs": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-
-    "typeRoots": ["./node_modules/@types"],
     "allowImportingTsExtensions": true,
-    "types": ["node", "jest", "dom", "dom.iterable"]
-  },
-  "exclude": ["**/dist", "**/build", "**/.turbo", "**/.next"]
+    "types": []
+  }
 }

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,11 +1,48 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./tsconfig.base.json",
   "include": [
-    "packages/**/src/**/*",
-    "conductor-ui/**/src/**/*",
-    "gateway/src/**/*",
-    "client/src/**/*",
-    "server/src/**/*"
+    "apps/**/src/**/*.{ts,tsx}",
+    "packages/**/src/**/*.{ts,tsx}",
+    "client/src/**/*.{ts,tsx}",
+    "server/src/**/*.{ts,tsx}",
+    "services/**/src/**/*.{ts,tsx}"
   ],
-  "exclude": ["**/dist/**", "**/build/**", "**/coverage/**", "**/node_modules/**", "docs-site/**"]
+  "exclude": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/.next/**",
+    "**/build/**",
+    "**/.turbo/**",
+    "**/.cache/**",
+    "**/coverage/**",
+    "**/*.test.{ts,tsx}",
+    "**/*.spec.{ts,tsx}",
+    "**/tests/**",
+    "**/e2e/**"
+  ],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@app/*": [
+        "src/*"
+      ],
+      "@ui/*": [
+        "client/src/*"
+      ],
+      "@server/*": [
+        "server/src/*"
+      ],
+      "@client/*": [
+        "client/src/*"
+      ]
+    },
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "types": [
+      "node"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- tighten the shared TypeScript configuration and add a scoped tsconfig for ESLint type-aware rules
- expand the flat ESLint config to isolate typed rules, update lint/typecheck scripts, and add cached fast-path helpers
- split the CI workflow to run cached lint/typecheck matrices and ensure Ruff still executes once per run

## Testing
- not run (Node tooling unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e56d3a7cdc8333a903ecb0313c709b