### PR TITLE
ci(py): add pytest-cov and install extras; fix coverage args

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,9 +1,7 @@
 name: IntelGraph Python CI
-
 on:
   push:
   pull_request:
-
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,13 +14,12 @@ jobs:
         with:
           python-version: '3.11'
           cache: 'pip'
-      - name: Install
+      - name: Install (editable with extras)
         run: |
-          python -m pip install -U pip
-          pip install -e .[dev]
+          python -m pip install -U pip setuptools wheel
+          pip install -e ".[dev,test]"
       - name: Tests
         run: pytest -q
-
   data-pipelines:
     runs-on: ubuntu-latest
     defaults:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,6 +9,7 @@ description = "IntelGraph Python core: models, storage, connectors, analytics"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "IntelGraph" }]
+
 dependencies = [
   "neo4j>=5.20",
   "streamlit>=1.36",
@@ -34,9 +35,14 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "pytest>=8.0.0",
+  "pytest-cov>=4.1",
   "pyvis>=0.3.2",
   "networkx>=3.3",
   "dask[distributed]>=2024.5.0",
+]
+test = [
+  "pytest>=8.0.0",
+  "pytest-cov>=4.1",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
Fix `pytest: error: unrecognized arguments: --cov` by adding `pytest-cov` to dev/test extras and installing extras in CI.

## Why
Coverage flags come from `pytest-cov`; jobs were failing without it.

## Changes
- **python/pyproject.toml**: add `pytest-cov` in `dev` and `test` extras
- **Python CI**: install with `pip install -e ".[dev,test]"`

## Risk
Low (dev/test deps only).

## Validation
Python jobs should pass with coverage enabled.