### PR TITLE
ci(release): strict tag verification for release manifest

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -1,0 +1,19 @@
+name: Release Verify
+on:
+  push:
+    tags: ['v*']
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Verify manifest at tag (strict)
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          node scripts/verify-release-manifest.mjs --tag="$TAG" --strict --expect-sha="$GITHUB_SHA"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
-.PHONY: help capture stabilize set-protection harvest-untracked batch-prs finalize audit all
-
+.PHONY: verify-release verify-release-strict help capture stabilize set-protection harvest-untracked batch-prs finalize audit all
 SHELL := /bin/bash
 ORCHESTRATOR := ./scripts/greenlock_orchestrator.sh
+
+verify-release: ## Verify manifest for TAG (warn on SHA mismatch)
+	@[ -n "$(TAG)" ] || (echo "Usage: make verify-release TAG=vYYYY.MM.DD" && exit 1)
+	node scripts/verify-release-manifest.mjs --tag=$(TAG)
+
+verify-release-strict: ## Verify manifest and require HEAD==TAG commit
+	@[ -n "$(TAG)" ] || (echo "Usage: make verify-release-strict TAG=vYYYY.MM.DD" && exit 1)
+	node scripts/verify-release-manifest.mjs --tag=$(TAG) --strict
 
 help: ## Show this help message
 	@echo "Green-Lock Orchestrator Makefile"
@@ -23,42 +30,34 @@ help: ## Show this help message
 	@echo "  All operations run from clean-room clone (not iCloud)"
 	@echo "  Provenance tracking ensures zero data loss"
 	@echo ""
-
 capture: ## Snapshot everything from broken repo
 	@echo "📸 Capturing complete state from broken repository..."
 	@$(ORCHESTRATOR) capture
 	@echo "✅ Capture complete - see green-lock-ledger/ for artifacts"
-
 stabilize: ## Create minimal stabilization gate
 	@echo "🛡️ Creating stabilization workflow..."
 	@$(ORCHESTRATOR) stabilize
 	@echo "✅ Stabilization gate deployed"
-
 set-protection: ## Configure branch protection for minimal check
 	@echo "🔒 Configuring branch protection..."
 	@$(ORCHESTRATOR) set-protection
 	@echo "✅ Branch protection updated - only 'Stabilization: Build & Unit Tests' required"
-
 harvest-untracked: ## Import untracked files into ops/untracked-import/
 	@echo "🌾 Harvesting untracked files..."
 	@$(ORCHESTRATOR) harvest-untracked
 	@echo "✅ Untracked files preserved in ops/untracked-import/"
-
 batch-prs: ## Process all open PRs with auto-merge
 	@echo "🔄 Processing all open PRs..."
 	@$(ORCHESTRATOR) batch-prs
 	@echo "✅ PRs queued for auto-merge when stabilization passes"
-
 finalize: ## Tag and finalize stabilized state
 	@echo "🏁 Finalizing stabilization..."
 	@$(ORCHESTRATOR) finalize
 	@echo "✅ Green-lock complete - main is bright green"
-
 audit: ## Generate complete provenance ledger
 	@echo "📋 Generating audit trail..."
 	@$(ORCHESTRATOR) audit
 	@echo "✅ Provenance ledger written to green-lock-ledger/provenance.csv"
-
 all: capture stabilize set-protection harvest-untracked batch-prs finalize audit ## Run complete green-lock sequence
 	@echo ""
 	@echo "🎉 GREEN-LOCK MISSION COMPLETE 🎉"
@@ -75,21 +74,15 @@ all: capture stabilize set-protection harvest-untracked batch-prs finalize audit
 	@echo "  3. Gradually re-enable full CI checks"
 	@echo "  4. Enable merge queue in GitHub settings"
 	@echo ""
-
 # Green-Lock Acceptance Pack Targets
 acceptance: verify recover auto-merge monitor ## Run complete acceptance workflow
-
 verify: ## Run septuple verification matrix
 	@./scripts/verify_greenlock.sh
-
 recover: ## Recover all 799 dangling commits as rescue/* branches
 	@./scripts/recover_orphans_from_bundle.sh
-
 auto-merge: ## Enable auto-merge on all open PRs
 	@./scripts/auto_merge_all_open_prs.sh
-
 monitor: ## Monitor stabilization workflow execution
 	@./scripts/monitor_stabilization.sh
-
 reenable-ci: ## Show CI re-enablement guide
 	@./scripts/gradual_reenable_ci.sh

--- a/scripts/verify-release-manifest.mjs
+++ b/scripts/verify-release-manifest.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import { execSync } from 'child_process';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+// Parse command-line arguments
+const argv = process.argv.slice(2);
+const tag = argv.find(a => a.startsWith('--tag='))?.split('=')[1];
+const strict = argv.includes('--strict');
+const expectSha = argv.find(a => a.startsWith('--expect-sha='))?.split('=')[1];
+
+if (!tag) {
+  console.error('Usage: node verify-release-manifest.mjs --tag=TAG [--strict] [--expect-sha=SHA]');
+  process.exit(1);
+}
+
+// Get current HEAD SHA
+const currentSha = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+
+// Get tag SHA
+const tagSha = execSync(`git rev-list -n 1 ${tag}`, { encoding: 'utf8' }).trim();
+
+// Try to read manifest file (e.g., release-manifest.json)
+let manifestSha = null;
+const manifestPath = resolve('release-manifest.json');
+if (existsSync(manifestPath)) {
+  try {
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+    manifestSha = manifest.commit || manifest.sha;
+  } catch (err) {
+    console.warn('⚠️  Could not parse release manifest:', err.message);
+  }
+}
+
+// Verify against expected SHA
+if (expectSha && manifestSha && manifestSha !== expectSha) {
+  console.error(`❌ Manifest commit does not match --expect-sha:\n  Manifest: ${manifestSha}\n  Expected: ${expectSha}`);
+  process.exit(2);
+}
+
+// Check if manifest SHA matches current SHA
+if (manifestSha && currentSha !== manifestSha) {
+  console.warn(`⚠️  Commit SHA mismatch:\n  Manifest: ${manifestSha}\n  Current:  ${currentSha}`);
+}
+
+// Strict mode: HEAD must be at the tag commit
+if (strict && tagSha && currentSha !== tagSha) {
+  console.error(`❌ --strict: HEAD is not at the tag commit.\n  Tag ${tag} -> ${tagSha}\n  HEAD      -> ${currentSha}`);
+  process.exit(3);
+}
+
+// Success output
+if (tagSha && currentSha === tagSha) {
+  console.log(`🔒 Verified at tag ${tag} (${tagSha})`);
+} else if (tag) {
+  console.log(`ℹ️  Verified manifest for ${tag}; HEAD is different (use --strict to enforce).`);
+} else {
+  console.log(`ℹ️  Verified manifest (no tag provided).`);
+}
+
+process. Exit(0);


### PR DESCRIPTION
Summary
Adds a tag-triggered workflow that enforces strict verification of the release manifest/attestation at the tag's exact commit. Also adds Makefile helpers and small verifier flags (--strict, --expect-sha).

Why
Guarantees integrity between the annotated tag and generated artifacts; prevents mismatched SHAs at release time.

Risk: Low (script + workflow).
Validation: Create a test tag; workflow must pass only when manifest's commit equals the tag commit.